### PR TITLE
media: (re-)introduce a builder pattern for sending media

### DIFF
--- a/packet/src/buffer_tx.rs
+++ b/packet/src/buffer_tx.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 use std::fmt;
 
-use rtp::{MediaTime, Rid, SeqNo, Ssrc};
+use rtp::{ExtensionValues, MediaTime, Rid, SeqNo, Ssrc};
 
 use crate::{CodecPacketizer, PacketError, Packetizer};
 
@@ -12,6 +12,7 @@ pub struct Packetized {
     pub last: bool,
     pub ssrc: Ssrc,
     pub rid: Option<Rid>,
+    pub exts: ExtensionValues,
 
     /// Set when packet is first sent. This is so we can resend.
     pub seq_no: Option<SeqNo>,
@@ -41,6 +42,7 @@ impl PacketizingBuffer {
         data: &[u8],
         ssrc: Ssrc,
         rid: Option<Rid>,
+        ext_vals: ExtensionValues,
         mtu: usize,
     ) -> Result<(), PacketError> {
         let chunks = self.pack.packetize(mtu, data)?;
@@ -59,6 +61,7 @@ impl PacketizingBuffer {
                 last,
                 ssrc,
                 rid,
+                exts: ext_vals,
                 seq_no: None,
             };
 

--- a/rtp/src/header.rs
+++ b/rtp/src/header.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unusual_byte_groupings)]
 
 use crate::ext::{ExtensionValues, Extensions};
-use crate::{MediaTime, Pt, SeqNo, Ssrc};
+use crate::{Pt, SeqNo, Ssrc};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RtpHeader {
@@ -20,21 +20,6 @@ pub struct RtpHeader {
 }
 
 impl RtpHeader {
-    pub fn new(pt: Pt, seq_no: SeqNo, ts: MediaTime, ssrc: Ssrc) -> Self {
-        RtpHeader {
-            version: 2,
-            has_padding: false,
-            has_extension: true,
-            marker: false,
-            payload_type: pt,
-            sequence_number: *seq_no as u16,
-            timestamp: ts.numer() as u32,
-            ssrc,
-            ext_vals: ExtensionValues::default(),
-            header_len: 16,
-        }
-    }
-
     pub fn write_to(&self, buf: &mut [u8], exts: &Extensions) -> usize {
         buf[0] = 0b10_0_0_0000
             | if self.has_padding { 1 << 5 } else { 0 }
@@ -260,16 +245,16 @@ pub fn extend_seq(prev_ext_seq: Option<u64>, seq: u16) -> u64 {
 impl Default for RtpHeader {
     fn default() -> Self {
         Self {
-            version: Default::default(),
-            has_padding: Default::default(),
-            has_extension: Default::default(),
-            marker: Default::default(),
+            version: 2,
+            has_padding: false,
+            has_extension: true,
+            marker: false,
             payload_type: 1.into(),
-            sequence_number: Default::default(),
-            timestamp: Default::default(),
+            sequence_number: 0,
+            timestamp: 0,
             ssrc: 0.into(),
-            ext_vals: Default::default(),
-            header_len: Default::default(),
+            ext_vals: ExtensionValues::default(),
+            header_len: 16,
         }
     }
 }

--- a/rtp/src/lib.rs
+++ b/rtp/src/lib.rs
@@ -14,7 +14,7 @@ mod id;
 pub use id::{ChannelId, Mid, Pt, Rid, SeqNo, SessionId, Ssrc};
 
 mod ext;
-pub use ext::{ExtMap, Extension, Extensions};
+pub use ext::{ExtMap, Extension, ExtensionValues, Extensions, VideoOrientation};
 
 mod dir;
 pub use dir::Direction;

--- a/str0m/examples/chat.html
+++ b/str0m/examples/chat.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <title>WebRTC Post example</title>
+    <title>WebRTC Chat example</title>
     <style>
         body {
             background: black;

--- a/str0m/examples/chat.rs
+++ b/str0m/examples/chat.rs
@@ -540,7 +540,7 @@ impl Client {
             return;
         };
 
-        if let Err(e) = media.write(pt, None, data.time, &data.data) {
+        if let Err(e) = media.writer(pt).write(data.time, &data.data) {
             warn!("Client ({}) failed: {:?}", *self.id, e);
             self.rtc.disconnect();
         }

--- a/str0m/src/lib.rs
+++ b/str0m/src/lib.rs
@@ -954,7 +954,7 @@ impl Rtc {
     /// regardless of current direction.
     ///
     /// Apart from inspecting information about the media, there are two fundamental
-    /// operations. One is [`Media::write()`] for writing outgoing media data, the other
+    /// operations. One is [`Media::writer()`] for writing outgoing media data, the other
     /// is [`Media::request_keyframe()`] to request a PLI/FIR keyframe for incoming media data.
     ///
     /// All media rows are announced via the [`Event::MediaAdded`] event. This function

--- a/str0m/tests/bidirectional.rs
+++ b/str0m/tests/bidirectional.rs
@@ -54,7 +54,11 @@ pub fn bidirectional_same_m_line() -> Result<(), RtcError> {
     loop {
         let dur_l: Duration = time_l.into();
         while l.duration() > dur_l {
-            let free = l.media(mid).unwrap().write(pt, None, time_l, &data_a)?;
+            let free = l
+                .media(mid)
+                .map(|m| m.writer(pt))
+                .unwrap()
+                .write(time_l, &data_a)?;
             time_l = time_l + STEP;
             if free == 0 {
                 break;
@@ -63,7 +67,11 @@ pub fn bidirectional_same_m_line() -> Result<(), RtcError> {
 
         let dur_r: Duration = time_r.into();
         while r.duration() > dur_r {
-            let free = r.media(mid).unwrap().write(pt, None, time_r, &data_b)?;
+            let free = r
+                .media(mid)
+                .map(|m| m.writer(pt))
+                .unwrap()
+                .write(time_r, &data_b)?;
             time_r = time_r + STEP;
             if free == 0 {
                 break;

--- a/str0m/tests/unidirectional.rs
+++ b/str0m/tests/unidirectional.rs
@@ -51,7 +51,11 @@ pub fn unidirectional() -> Result<(), RtcError> {
     loop {
         let dur_l: Duration = time_l.into();
         while l.duration() > dur_l {
-            let free = l.media(mid).unwrap().write(pt, None, time_l, &data_a)?;
+            let free = l
+                .media(mid)
+                .map(|m| m.writer(pt))
+                .unwrap()
+                .write(time_l, &data_a)?;
             time_l = time_l + STEP;
             if free == 0 {
                 break;


### PR DESCRIPTION
This commit reintroduces a media::Writer as a builder pattern to allow for adding metadata to the data being sent. Rid, audio level, voice activity and video orientation are optional metadata.

Close #23 