### PR TITLE
fix how we avoid sending empty stats

### DIFF
--- a/str0m/src/media/mod.rs
+++ b/str0m/src/media/mod.rs
@@ -1200,15 +1200,11 @@ impl Media {
     }
 
     pub fn visit_stats(&self, snapshot: &mut StatsSnapshot) {
-        if self.direction().is_receiving() {
-            for s in &self.sources_rx {
-                s.visit_stats(self.mid, snapshot);
-            }
+        for s in &self.sources_rx {
+            s.visit_stats(self.mid, snapshot);
         }
-        if self.direction().is_sending() {
-            for s in &self.sources_tx {
-                s.visit_stats(self.mid, snapshot);
-            }
+        for s in &self.sources_tx {
+            s.visit_stats(self.mid, snapshot);
         }
     }
 }

--- a/str0m/src/media/receiver.rs
+++ b/str0m/src/media/receiver.rs
@@ -135,6 +135,9 @@ impl ReceiverSource {
 
     pub fn visit_stats(&self, mid: Mid, snapshot: &mut StatsSnapshot) {
         let key = (mid, self.rid);
+        if self.bytes_rx == 0 {
+            return;
+        }
         if let Some(v) = snapshot.ingress.get_mut(&key) {
             *v += self.bytes_rx;
         } else {

--- a/str0m/src/media/sender.rs
+++ b/str0m/src/media/sender.rs
@@ -85,6 +85,9 @@ impl SenderSource {
 
     pub fn visit_stats(&self, mid: Mid, snapshot: &mut StatsSnapshot) {
         let key = (mid, self.rid);
+        if self.bytes_tx == 0 {
+            return;
+        }
         let bytes_tx = self.bytes_tx + self.bytes_tx_resent;
         if let Some(v) = snapshot.egress.get_mut(&key) {
             *v += bytes_tx;


### PR DESCRIPTION
It's wrong to not count m-lines that are not sending or receiving because what we want to count is also the total peer traffic.
If we exclude a track on a change of direction the byte counts would decrease as if there was a negative traffic, which does not make sense.

With this patch we simply avoid outputting stats related to sender / receiver sources with no traffic