### PR TITLE
Configurable stats interval

### DIFF
--- a/str0m/examples/chat.rs
+++ b/str0m/examples/chat.rs
@@ -78,7 +78,10 @@ fn web_request(request: &Request, addr: SocketAddr, tx: SyncSender<Rtc>) -> Resp
     let mut data = request.data().expect("body to be available");
 
     let offer: Offer = serde_json::from_reader(&mut data).expect("serialized offer");
-    let mut rtc = Rtc::builder().ice_lite(true).build();
+    let mut rtc = Rtc::builder()
+        .ice_lite(true)
+        .set_stats_interval(Duration::from_secs(5))
+        .build();
 
     // Add the shared UDP socket as a host candidate
     let candidate = Candidate::host(addr).expect("a host candidate");

--- a/str0m/examples/chat.rs
+++ b/str0m/examples/chat.rs
@@ -360,6 +360,18 @@ impl Client {
                     Propagated::Noop
                 }
                 Event::ChannelData(data) => self.handle_channel_data(data),
+                Event::MediaIngressStats(data) => {
+                    info!("{:?}", data);
+                    Propagated::Noop
+                }
+                Event::MediaEgressStats(data) => {
+                    info!("{:?}", data);
+                    Propagated::Noop
+                }
+                Event::PeerStats(data) => {
+                    info!("{:?}", data);
+                    Propagated::Noop
+                }
                 _ => Propagated::Noop,
             },
         }

--- a/str0m/src/lib.rs
+++ b/str0m/src/lib.rs
@@ -58,7 +58,7 @@
 extern crate tracing;
 
 use std::net::SocketAddr;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use std::{fmt, io};
 
 use change::Changes;
@@ -355,7 +355,7 @@ impl Rtc {
             setup: Setup::ActPass,
             session: Session::new(config.codec_config, config.ice_lite),
             sctp: RtcSctp::new(),
-            stats: Stats::new(),
+            stats: Stats::new(config.stats_interval),
             next_sctp_channel: 0, // Goes 0, 1, 2 for both DTLS server or client
             remote_fingerprint: None,
             pending: None,
@@ -1181,6 +1181,7 @@ impl<'a> PendingChanges<'a> {
 pub struct RtcConfig {
     ice_lite: bool,
     codec_config: CodecConfig,
+    stats_interval: Duration,
 }
 
 impl RtcConfig {
@@ -1267,6 +1268,15 @@ impl RtcConfig {
         &mut self.codec_config
     }
 
+    /// Set the interval between statistics events
+    /// This includes Event::MediaEgressStats, Event::MediaIngressStats, Event::MediaEgressStats
+    ///
+    /// Defaults to `Duration::from_secs(1)`.
+    pub fn set_stats_interval(mut self, interval: Duration) -> Self {
+        self.stats_interval = interval;
+        self
+    }
+
     /// Create a [`Rtc`] from the configuration.
     pub fn build(self) -> Rtc {
         Rtc::new_from_config(self)
@@ -1278,6 +1288,7 @@ impl Default for RtcConfig {
         Self {
             ice_lite: Default::default(),
             codec_config: CodecConfig::new_with_defaults(),
+            stats_interval: Duration::from_secs(1),
         }
     }
 }


### PR DESCRIPTION
I wanted to add stats to the chat example, but I found it too aggressive to simply log out events every seconds, so I made the interval configurable.