### PR TITLE
egress loss: average stats from intermediate receiver reports

### DIFF
--- a/str0m/src/media/mline.rs
+++ b/str0m/src/media/mline.rs
@@ -982,11 +982,11 @@ impl MLine {
         (self.sources_tx.len() as isize - self.sources_rx.len() as isize).unsigned_abs()
     }
 
-    pub fn visit_stats(&self, now: Instant, snapshot: &mut StatsSnapshot) {
+    pub fn visit_stats(&mut self, now: Instant, snapshot: &mut StatsSnapshot) {
         for s in &self.sources_rx {
             s.visit_stats(now, self.mid, snapshot);
         }
-        for s in &self.sources_tx {
+        for s in &mut self.sources_tx {
             s.visit_stats(now, self.mid, snapshot);
         }
     }

--- a/str0m/src/stats.rs
+++ b/str0m/src/stats.rs
@@ -93,7 +93,8 @@ pub struct MediaEgressStats {
     pub nacks: u64,
     /// Round-trip-time (ms) extracted from the last RTCP receiver report.
     pub rtt: Option<f32>,
-    /// Fraction of packets lost extracted from the last RTCP receiver report.
+    /// Fraction of packets lost averaged from the RTCP receiver reports received.
+    /// `None` if no reports have been received since the last event
     pub loss: Option<f32>,
     /// Timestamp when this event was generated
     pub timestamp: Instant,


### PR DESCRIPTION
Before this commit we were calculating stats from latest RR received. Turns out browsers send RRs much more frequently especially in case of network problems (10+ per second). Downsampling to the latest every second looses a lot of information considering that each RR reports the fraction lost from the previous one.

With this patch we are averaging the values weighted against the amount of packet seen by the receiver, which makes much more sense in the case of a periodic update.