### PR TITLE
Prepare for release 0.1.0

### DIFF
--- a/dtls/Cargo.toml
+++ b/dtls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "dtls"
-version = "0.1.0"
+name = "str0m-dtls"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]
@@ -10,4 +10,4 @@ thiserror = "1"
 openssl = { version = "0.10", features = ["vendored"] }
 openssl-sys = "^0.9"
 #
-net = { path = "../net" }
+net = { path = "../net", package = "str0m-net", version = "0.0.1" }

--- a/dtls/src/lib.rs
+++ b/dtls/src/lib.rs
@@ -1,3 +1,7 @@
+//! This crate is an internal detail of [str0m](https://crates.io/crates/str0m).
+//!
+//! No guarantees are made about the stability of the API. Do not use.
+
 #[macro_use]
 extern crate tracing;
 

--- a/ice/Cargo.toml
+++ b/ice/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "ice"
-version = "0.1.0"
+name = "str0m-ice"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]
@@ -8,7 +8,7 @@ tracing = "0.1"
 thiserror = "1"
 rand = "0.8"
 #
-net = { path = "../net" }
+net = { path = "../net", package = "str0m-net", version = "0.0.1" }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "std"] }

--- a/ice/src/lib.rs
+++ b/ice/src/lib.rs
@@ -1,3 +1,7 @@
+//! This crate is an internal detail of [str0m](https://crates.io/crates/str0m).
+//!
+//! No guarantees are made about the stability of the API. Do not use.
+
 #![allow(clippy::new_without_default)]
 #![allow(clippy::bool_to_int_with_if)]
 

--- a/ice/tests/common.rs
+++ b/ice/tests/common.rs
@@ -3,8 +3,8 @@ use std::net::{Ipv4Addr, SocketAddr};
 use std::ops::{Deref, DerefMut};
 use std::time::{Duration, Instant};
 
-use ice::{Candidate, IceAgent, IceAgentEvent};
 use net::Receive;
+use str0m_ice::{Candidate, IceAgent, IceAgentEvent};
 use tracing::Span;
 
 pub fn init_log() {
@@ -147,7 +147,7 @@ pub fn progress(a1: &mut TestAgent, a2: &mut TestAgent) {
 
     while let Some(v) = t.span.in_scope(|| t.agent.poll_event()) {
         println!("Polled event: {v:?}");
-        use ice::IceAgentEvent::*;
+        use str0m_ice::IceAgentEvent::*;
         f.span.in_scope(|| {
             if let IceRestart(v) = &v {
                 f.agent.set_remote_credentials(v.clone())

--- a/ice/tests/drop-host.rs
+++ b/ice/tests/drop-host.rs
@@ -1,4 +1,4 @@
-use ice::IceAgentStats;
+use str0m_ice::IceAgentStats;
 use tracing::info_span;
 
 mod common;

--- a/ice/tests/host-host-dc.rs
+++ b/ice/tests/host-host-dc.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use ice::{IceAgentEvent, IceAgentStats, IceConnectionState};
+use str0m_ice::{IceAgentEvent, IceAgentStats, IceConnectionState};
 use tracing::info_span;
 
 mod common;

--- a/ice/tests/host-host.rs
+++ b/ice/tests/host-host.rs
@@ -1,4 +1,4 @@
-use ice::IceAgentStats;
+use str0m_ice::IceAgentStats;
 use tracing::info_span;
 
 mod common;

--- a/ice/tests/ice-lite-no-conn.rs
+++ b/ice/tests/ice-lite-no-conn.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use ice::IceAgentStats;
+use str0m_ice::IceAgentStats;
 use tracing::info_span;
 
 mod common;

--- a/ice/tests/prflx-host.rs
+++ b/ice/tests/prflx-host.rs
@@ -1,4 +1,4 @@
-use ice::IceAgentStats;
+use str0m_ice::IceAgentStats;
 use tracing::info_span;
 
 mod common;

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "net"
-version = "0.1.0"
+name = "str0m-net"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -1,3 +1,7 @@
+//! This crate is an internal detail of [str0m](https://crates.io/crates/str0m).
+//!
+//! No guarantees are made about the stability of the API. Do not use.
+
 #![allow(clippy::manual_range_contains)]
 #![allow(clippy::new_without_default)]
 

--- a/packet/Cargo.toml
+++ b/packet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "packet"
-version = "0.1.0"
+name = "str0m-packet"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]
@@ -8,5 +8,5 @@ tracing = "0.1"
 thiserror = "1"
 rand = "0.8"
 #
-rtp = { path = "../rtp" }
-sdp = { path = "../sdp" }
+rtp = { path = "../rtp", package = "str0m-rtp", version = "0.0.1" }
+sdp = { path = "../sdp", package = "str0m-sdp", version = "0.0.1" }

--- a/packet/src/buffer_rx.rs
+++ b/packet/src/buffer_rx.rs
@@ -33,6 +33,7 @@ struct Entry {
 }
 
 impl RtpMeta {
+    #[doc(hidden)]
     pub fn new(received: Instant, time: MediaTime, seq_no: SeqNo, header: RtpHeader) -> Self {
         RtpMeta {
             received,

--- a/packet/src/lib.rs
+++ b/packet/src/lib.rs
@@ -1,3 +1,7 @@
+//! This crate is an internal detail of [str0m](https://crates.io/crates/str0m).
+//!
+//! No guarantees are made about the stability of the API. Do not use.
+
 #![allow(clippy::type_complexity)]
 
 #[macro_use]

--- a/rtp/Cargo.toml
+++ b/rtp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "rtp"
-version = "0.1.0"
+name = "str0m-rtp"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]
@@ -16,8 +16,8 @@ openssl-sys = "^0.9"
 # if we moved IDs geneartion to a "util" subcrate, serde dep would move out too
 serde = { version = "1", features=["derive"] }
 #
-dtls = { path = "../dtls" }
-net = { path = "../net" }
+dtls = { path = "../dtls", package = "str0m-dtls", version = "0.0.1" }
+net = { path = "../net", package = "str0m-net", version = "0.0.1" }
 
 [target.'cfg(fuzzing)'.dev-dependencies]
 fuzzcheck = "0.12"

--- a/rtp/src/ext.rs
+++ b/rtp/src/ext.rs
@@ -695,11 +695,16 @@ impl fmt::Debug for Extensions {
     }
 }
 
+/// How the video is rotated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VideoOrientation {
+    /// Not rotated.
     Deg0 = 0,
+    /// 90 degress clockwise.
     Deg90 = 3,
+    /// Upside down.
     Deg180 = 2,
+    /// 90 degrees counter clockwise.
     Deg270 = 1,
 }
 

--- a/rtp/src/header.rs
+++ b/rtp/src/header.rs
@@ -3,6 +3,7 @@
 use crate::ext::{ExtensionValues, Extensions};
 use crate::{Pt, SeqNo, Ssrc};
 
+/// Parsed header from an RTP packet.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RtpHeader {
     pub version: u8,
@@ -20,6 +21,7 @@ pub struct RtpHeader {
 }
 
 impl RtpHeader {
+    #[doc(hidden)]
     pub fn write_to(&self, buf: &mut [u8], exts: &Extensions) -> usize {
         buf[0] = 0b10_0_0_0000
             | if self.has_padding { 1 << 5 } else { 0 }
@@ -51,6 +53,7 @@ impl RtpHeader {
         16 + ext_len
     }
 
+    #[doc(hidden)]
     pub fn pad_packet(
         buf: &mut [u8],
         header_len: usize,
@@ -76,6 +79,7 @@ impl RtpHeader {
         pad
     }
 
+    #[doc(hidden)]
     pub fn parse(buf: &[u8], exts: &Extensions) -> Option<RtpHeader> {
         let orig_len = buf.len();
         if buf.len() < 12 {
@@ -182,18 +186,21 @@ impl RtpHeader {
     }
 
     /// For RTX the original sequence number is inserted before the RTP payload.
+    #[doc(hidden)]
     pub fn read_original_sequence_number(buf: &[u8], seq_no: &mut u16) -> usize {
         *seq_no = u16::from_be_bytes([buf[0], buf[1]]);
         2
     }
 
     /// For RTX the original sequence number is inserted before the RTP payload.
+    #[doc(hidden)]
     pub fn write_original_sequence_number(buf: &mut [u8], seq_no: SeqNo) -> usize {
         let seq_u16 = (*seq_no) as u16;
         buf[0..2].copy_from_slice(&seq_u16.to_be_bytes());
         2
     }
 
+    #[doc(hidden)]
     pub fn is_rtx_null_packet(buf: &[u8]) -> bool {
         buf[0..10] == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     }
@@ -201,6 +208,7 @@ impl RtpHeader {
     /// Sequencer number of this RTP header given the previous number.
     ///
     /// The logic detects wrap-arounds of the 16-bit RTP sequence number.
+    #[doc(hidden)]
     pub fn sequence_number(&self, previous: Option<SeqNo>) -> SeqNo {
         let e_seq = extend_seq(previous.map(|v| *v), self.sequence_number);
         e_seq.into()

--- a/rtp/src/lib.rs
+++ b/rtp/src/lib.rs
@@ -1,3 +1,7 @@
+//! This crate is an internal detail of [str0m](https://crates.io/crates/str0m).
+//!
+//! No guarantees are made about the stability of the API. Do not use.
+
 #![cfg_attr(fuzzing, feature(no_coverage))]
 #![allow(clippy::manual_range_contains)]
 #![allow(clippy::new_without_default)]

--- a/sctp/Cargo.toml
+++ b/sctp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "sctp"
-version = "0.1.0"
+name = "str0m-sctp"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]

--- a/sctp/src/lib.rs
+++ b/sctp/src/lib.rs
@@ -1,3 +1,7 @@
+//! This crate is an internal detail of [str0m](https://crates.io/crates/str0m).
+//!
+//! No guarantees are made about the stability of the API. Do not use.
+
 #![allow(clippy::new_without_default)]
 
 #[macro_use]

--- a/sdp/Cargo.toml
+++ b/sdp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "sdp"
-version = "0.1.0"
+name = "str0m-sdp"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]
@@ -9,9 +9,9 @@ thiserror = "1"
 serde = "1"
 combine = "4"
 #
-dtls = { path = "../dtls" }
-ice = { path = "../ice" }
-rtp = { path = "../rtp" }
+dtls = { path = "../dtls", package = "str0m-dtls", version = "0.0.1" }
+ice = { path = "../ice", package = "str0m-ice", version = "0.0.1" }
+rtp = { path = "../rtp", package = "str0m-rtp", version = "0.0.1" }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/sdp/src/lib.rs
+++ b/sdp/src/lib.rs
@@ -1,3 +1,7 @@
+//! This crate is an internal detail of [str0m](https://crates.io/crates/str0m).
+//!
+//! No guarantees are made about the stability of the API. Do not use.
+
 #[macro_use]
 extern crate tracing;
 

--- a/str0m/Cargo.toml
+++ b/str0m/Cargo.toml
@@ -12,8 +12,8 @@ serde = "1"
 #
 dtls = { path = "../dtls", package = "str0m-dtls", version = "0.0.1" }
 ice = { path = "../ice", package = "str0m-ice", version = "0.0.1" }
-net_ = { package = "str0m-net", path = "../net", version = "0.0.1" }
-rtp = { path = "../rtp", package = "str0m-rtp", version = "0.0.1" }
+net_ = { path = "../net", package = "str0m-net", pversion = "0.0.1" }
+rtp_ = { path = "../rtp", package = "str0m-rtp", version = "0.0.1" }
 sdp = { path = "../sdp", package = "str0m-sdp", version = "0.0.1" }
 packet = { path = "../packet", package = "str0m-packet", version = "0.0.1" }
 sctp = { path = "../sctp", package = "str0m-sctp", version = "0.0.1" }

--- a/str0m/Cargo.toml
+++ b/str0m/Cargo.toml
@@ -10,13 +10,13 @@ rand = "0.8"
 once_cell = "1"
 serde = "1"
 #
-dtls = { path = "../dtls" }
-ice = { path = "../ice" }
-net_ = { package = "net", path = "../net" }
-rtp = { path = "../rtp" }
-sdp = { path = "../sdp" }
-packet = { path = "../packet" }
-sctp = { path = "../sctp" }
+dtls = { path = "../dtls", package = "str0m-dtls", version = "0.0.1" }
+ice = { path = "../ice", package = "str0m-ice", version = "0.0.1" }
+net_ = { package = "str0m-net", path = "../net", version = "0.0.1" }
+rtp = { path = "../rtp", package = "str0m-rtp", version = "0.0.1" }
+sdp = { path = "../sdp", package = "str0m-sdp", version = "0.0.1" }
+packet = { path = "../packet", package = "str0m-packet", version = "0.0.1" }
+sctp = { path = "../sctp", package = "str0m-sctp", version = "0.0.1" }
 
 [dev-dependencies]
 rouille = { version = "3.5.0", features = ["ssl"] }

--- a/str0m/src/change.rs
+++ b/str0m/src/change.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use net_::Id;
-use rtp::{ChannelId, Direction, Extensions, Mid, Ssrc};
+use rtp_::{ChannelId, Direction, Extensions, Mid, Ssrc};
 use sctp::{DcepOpen, ReliabilityType};
 use sdp::{MediaLine, Msid, Offer};
 

--- a/str0m/src/channel.rs
+++ b/str0m/src/channel.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-pub use rtp::ChannelId;
+pub use rtp_::ChannelId;
 
 use crate::{Rtc, RtcError};
 

--- a/str0m/src/lib.rs
+++ b/str0m/src/lib.rs
@@ -66,7 +66,7 @@ use dtls::{Dtls, DtlsEvent, Fingerprint};
 use ice::IceAgent;
 use ice::IceAgentEvent;
 use net_::DatagramRecv;
-use rtp::InstantExt;
+use rtp_::{InstantExt, Ssrc};
 use sctp::{RtcSctp, SctpEvent};
 use sdp::{Sdp, Setup};
 use stats::{MediaEgressStats, MediaIngressStats, PeerStats, Stats, StatsEvent};
@@ -88,7 +88,7 @@ pub mod error {
     pub use ice::IceError;
     pub use net_::NetError;
     pub use packet::PacketError;
-    pub use rtp::RtpError;
+    pub use rtp_::RtpError;
     pub use sctp::{ProtoError, SctpError};
     pub use sdp::SdpError;
 }
@@ -99,7 +99,7 @@ use channel::{Channel, ChannelData, ChannelId};
 pub mod media;
 use media::{CodecConfig, Direction, KeyframeRequest, Media};
 use media::{KeyframeRequestKind, MediaChanged, MediaData};
-use media::{MLine, MediaAdded, Mid, Pt, Rid, Ssrc};
+use media::{MLine, MediaAdded, Mid, Pt, Rid};
 
 pub use packet::{CodecExtra, Vp8CodecExtra};
 

--- a/str0m/src/media/app.rs
+++ b/str0m/src/media/app.rs
@@ -1,4 +1,4 @@
-use rtp::Mid;
+use rtp_::Mid;
 use sdp::MediaLine;
 
 /// m=application m-line. There can only be one of these in the SDP.

--- a/str0m/src/media/codec.rs
+++ b/str0m/src/media/codec.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use sdp::{CodecSpec, PayloadParams as SdpPayloadParams};
 
-use rtp::Pt;
+use rtp_::Pt;
 use sdp::{Codec, FormatParams};
 
 use super::MediaKind;

--- a/str0m/src/media/event.rs
+++ b/str0m/src/media/event.rs
@@ -1,8 +1,7 @@
 use std::time::Instant;
 
-use packet::CodecExtra;
-pub use packet::RtpMeta;
-pub use rtp::{Direction, ExtensionValues, MediaTime, Mid, Pt, Rid, Ssrc};
+use packet::{CodecExtra, RtpMeta};
+use rtp_::{Direction, ExtensionValues, MediaTime, Mid, Pt, Rid};
 pub use sdp::{Codec, FormatParams};
 
 use sdp::Simulcast as SdpSimulcast;

--- a/str0m/src/media/mline.rs
+++ b/str0m/src/media/mline.rs
@@ -2,15 +2,14 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::{Duration, Instant};
 
 use net_::{Id, DATAGRAM_MTU};
-use packet::{
-    DepacketizingBuffer, Packetized, PacketizedMeta, PacketizingBuffer, QueueId, QueueState,
-};
-use rtp::{Extensions, Fir, FirEntry, NackEntry, Pli, Rtcp};
-use rtp::{RtcpFb, RtpHeader, SdesType};
-use rtp::{SeqNo, SRTP_BLOCK_SIZE, SRTP_OVERHEAD};
+use packet::{DepacketizingBuffer, PacketKind, Packetized};
+use packet::{PacketizedMeta, PacketizingBuffer, QueueId, QueueState};
+use rtp_::{Extensions, Fir, FirEntry, NackEntry, Pli, Rtcp};
+use rtp_::{RtcpFb, RtpHeader, SdesType};
+use rtp_::{SeqNo, SRTP_BLOCK_SIZE, SRTP_OVERHEAD};
 
-pub use packet::{PacketKind, RtpMeta};
-pub use rtp::{Direction, ExtensionValues, MediaTime, Mid, Pt, Rid, Ssrc};
+pub use packet::RtpMeta;
+pub use rtp_::{Direction, ExtensionValues, MediaTime, Mid, Pt, Rid, Ssrc};
 pub use sdp::{Codec, FormatParams};
 
 use sdp::{MediaLine, MediaType, Msid, Simulcast as SdpSimulcast};

--- a/str0m/src/media/mod.rs
+++ b/str0m/src/media/mod.rs
@@ -2,10 +2,9 @@
 
 use std::time::Instant;
 
-use rtp::VideoOrientation;
+pub use rtp_::VideoOrientation;
 
-pub use packet::RtpMeta;
-pub use rtp::{Direction, ExtensionValues, MediaTime, Mid, Pt, Rid, Ssrc};
+pub use rtp_::{Direction, ExtensionValues, MediaTime, Mid, Pt, Rid};
 pub use sdp::{Codec, FormatParams};
 
 use crate::{Input, Rtc, RtcError};
@@ -27,6 +26,12 @@ mod register;
 
 mod mline;
 pub(crate) use mline::{MLine, Source};
+
+/// Half internal structures regarding RTP level.
+pub mod rtp {
+    pub use packet::RtpMeta;
+    pub use rtp_::{ExtensionValues, RtpHeader, SeqNo, Ssrc};
+}
 
 /// Audio or video media. An m-line in the SDP.
 ///

--- a/str0m/src/media/receiver.rs
+++ b/str0m/src/media/receiver.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use rtp::{
+use rtp_::{
     DlrrItem, ExtendedReport, InstantExt, MediaTime, Mid, Nack, ReceiverReport, ReportBlock,
     ReportList, Rid, Rrtr, RtpHeader, SenderInfo, SeqNo, Ssrc,
 };

--- a/str0m/src/media/register.rs
+++ b/str0m/src/media/register.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use rtp::{Nack, NackEntry, ReceptionReport, ReportList, SeqNo};
+use rtp_::{Nack, NackEntry, ReceptionReport, ReportList, SeqNo};
 
 const MAX_DROPOUT: u64 = 3000;
 const MAX_MISORDER: u64 = 100;

--- a/str0m/src/media/sender.rs
+++ b/str0m/src/media/sender.rs
@@ -1,10 +1,10 @@
 use std::time::Instant;
 
-use rtp::{
+use rtp_::{
     extend_seq, Descriptions, InstantExt, MediaTime, Mid, ReceptionReport, ReportList, Rid, Sdes,
     SdesType, SenderInfo,
 };
-use rtp::{SenderReport, SeqNo, Ssrc};
+use rtp_::{SenderReport, SeqNo, Ssrc};
 
 use crate::{
     stats::{MediaEgressStats, StatsSnapshot},
@@ -218,7 +218,7 @@ impl SenderSource {
         }
     }
 
-    pub fn update_clocks(&mut self, rtp_time: rtp::MediaTime, wallclock: Instant) {
+    pub fn update_clocks(&mut self, rtp_time: MediaTime, wallclock: Instant) {
         self.rtp_and_wallclock = Some((rtp_time, wallclock));
     }
 }

--- a/str0m/src/session.rs
+++ b/str0m/src/session.rs
@@ -4,10 +4,10 @@ use std::time::{Duration, Instant};
 use dtls::KeyingMaterial;
 use net_::{DatagramSend, DATAGRAM_MTU, DATAGRAM_MTU_WARN};
 use packet::{NullPacer, Pacer, PacerImpl, PollOutcome, RtpMeta};
-use rtp::SRTCP_OVERHEAD;
-use rtp::{extend_seq, RtpHeader, SessionId, TwccRecvRegister, TwccSendRegister};
-use rtp::{Extensions, MediaTime, Mid, Rtcp, RtcpFb};
-use rtp::{SrtpContext, SrtpKey, Ssrc};
+use rtp_::SRTCP_OVERHEAD;
+use rtp_::{extend_seq, RtpHeader, SessionId, TwccRecvRegister, TwccSendRegister};
+use rtp_::{Extensions, MediaTime, Mid, Rtcp, RtcpFb};
+use rtp_::{SrtpContext, SrtpKey, Ssrc};
 
 use crate::media::{App, CodecConfig, MediaAdded, MediaChanged, Source};
 use crate::session_sdp::AsMediaLine;

--- a/str0m/src/session_sdp.rs
+++ b/str0m/src/session_sdp.rs
@@ -1,6 +1,6 @@
 use dtls::Fingerprint;
 use ice::{Candidate, IceCreds};
-use rtp::{Extension, Mid};
+use rtp_::{Extension, Mid};
 use sdp::{Answer, MediaAttribute, MediaLine, MediaType, SimulcastGroups, SimulcastOption};
 use sdp::{Offer, Proto, Sdp, SessionAttribute, Setup};
 

--- a/str0m/src/stats.rs
+++ b/str0m/src/stats.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use crate::Mid;
-use rtp::Rid;
+use rtp_::Rid;
 
 pub(crate) struct Stats {
     last_now: Instant,


### PR DESCRIPTION
We're going to keep str0m as a workspace, and release subcrates that are not actually stand-alone crates. They are not intended to be used by others and come with a qualifying warning:

```
//! This crate is an internal detail of [str0m](https://crates.io/crates/str0m).
//!
//! No guarantees are made about the stability of the API. Do not use.
```

* str0m-dtls
* str0m-ice
* str0m-net
* str0m-packet
* str0m-rtp
* str0m-sctp
* str0m-sdp

Furthermore the intention is to forever keep them on version numbers 0.0.x, to indicate they are internal details, not full releases. I.e. even when str0m man crate graduates to 1.0.0, we keep the sub-crates on 0.0.x.

The only documentation that matters is that of str0m, the doc is a combo of re-exports and local items.

The best way I found to view the doc that will be in the release, is to:

1. `cd <workspace top>`
2. `cargo clean`
3. `(cd str0m && cargo doc --no-deps --open)`