### PR TITLE
add Vp8 codec extra

### DIFF
--- a/packet/src/h265.rs
+++ b/packet/src/h265.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::all)]
 
-use crate::{Depacketizer, PacketError};
+use crate::{CodecExtra, Depacketizer, PacketError};
 
 ///
 /// Network Abstraction Unit Header implementation
@@ -736,7 +736,12 @@ impl H265Depacketizer {
 
 impl Depacketizer for H265Depacketizer {
     /// depacketize parses the passed byte slice and stores the result in the H265Packet this method is called upon
-    fn depacketize(&mut self, packet: &[u8], out: &mut Vec<u8>) -> Result<(), PacketError> {
+    fn depacketize(
+        &mut self,
+        packet: &[u8],
+        out: &mut Vec<u8>,
+        _: &mut CodecExtra,
+    ) -> Result<(), PacketError> {
         if packet.len() <= H265NALU_HEADER_SIZE {
             return Err(PacketError::ErrShortPacket);
         }
@@ -1628,7 +1633,8 @@ mod test {
             }
 
             let mut out = Vec::new();
-            let result = pck.depacketize(&cur.raw, &mut out);
+            let mut extra = CodecExtra::None;
+            let result = pck.depacketize(&cur.raw, &mut out, &mut extra);
 
             if cur.expected_err.is_some() && result.is_ok() {
                 assert!(false, "should error");
@@ -1684,7 +1690,8 @@ mod test {
         for cur in tests {
             let mut pck = H265Depacketizer::default();
             let mut out = Vec::new();
-            let _ = pck.depacketize(&cur, &mut out)?;
+            let mut extra = CodecExtra::None;
+            let _ = pck.depacketize(&cur, &mut out, &mut extra)?;
         }
 
         Ok(())

--- a/packet/src/opus.rs
+++ b/packet/src/opus.rs
@@ -1,4 +1,4 @@
-use crate::{Depacketizer, PacketError, Packetizer};
+use crate::{CodecExtra, Depacketizer, PacketError, Packetizer};
 
 /// Packetizes Opus RTP packets.
 #[derive(Default, Debug, Copy, Clone)]
@@ -28,7 +28,12 @@ impl Packetizer for OpusPacketizer {
 pub struct OpusDepacketizer;
 
 impl Depacketizer for OpusDepacketizer {
-    fn depacketize(&mut self, packet: &[u8], out: &mut Vec<u8>) -> Result<(), PacketError> {
+    fn depacketize(
+        &mut self,
+        packet: &[u8],
+        out: &mut Vec<u8>,
+        _: &mut CodecExtra,
+    ) -> Result<(), PacketError> {
         if packet.is_empty() {
             Err(PacketError::ErrShortPacket)
         } else {
@@ -53,17 +58,18 @@ mod test {
     #[test]
     fn test_opus_unmarshal() -> Result<(), PacketError> {
         let mut pck = OpusDepacketizer::default();
+        let mut extra = CodecExtra::None;
 
         // Empty packet
         let empty_bytes = &[];
         let mut out = Vec::new();
-        let result = pck.depacketize(empty_bytes, &mut out);
+        let result = pck.depacketize(empty_bytes, &mut out, &mut extra);
         assert!(result.is_err(), "Result should be err in case of error");
 
         // Normal packet
         let raw_bytes: &[u8] = &[0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x90];
         let mut out = Vec::new();
-        pck.depacketize(raw_bytes, &mut out)?;
+        pck.depacketize(raw_bytes, &mut out, &mut extra)?;
         assert_eq!(raw_bytes, &out, "Payload must be same");
 
         Ok(())

--- a/str0m/src/lib.rs
+++ b/str0m/src/lib.rs
@@ -101,6 +101,8 @@ use media::{CodecConfig, Direction, KeyframeRequest, Media};
 use media::{KeyframeRequestKind, MediaChanged, MediaData};
 use media::{MLine, MediaAdded, Mid, Pt, Rid, Ssrc};
 
+pub use packet::{CodecExtra, Vp8CodecExtra};
+
 mod change;
 pub use change::ChangeSet;
 

--- a/str0m/src/media/event.rs
+++ b/str0m/src/media/event.rs
@@ -1,5 +1,6 @@
 use std::time::Instant;
 
+use packet::CodecExtra;
 pub use packet::RtpMeta;
 pub use rtp::{Direction, ExtensionValues, MediaTime, Mid, Pt, Rid, Ssrc};
 pub use sdp::{Codec, FormatParams};
@@ -142,6 +143,9 @@ pub struct MediaData {
 
     /// The individual packet metadata that were part of making the Sample in `data`.
     pub meta: Vec<RtpMeta>,
+
+    /// Additional codec specific information
+    pub codec_extra: CodecExtra,
 }
 
 /// Details for an incoming a keyframe request (PLI or FIR).

--- a/str0m/src/media/mline.rs
+++ b/str0m/src/media/mline.rs
@@ -918,6 +918,7 @@ impl MLine {
                         data: dep.data,
                         ext_vals: dep.meta[0].header.ext_vals,
                         meta: dep.meta,
+                        codec_extra: dep.codec_extra,
                     })
                     .map_err(|e| RtcError::Packet(self.mid, *pt, e)),
                 );


### PR DESCRIPTION
Example use case: A user (of the lib) can decide to
- avoid packaging discardable frames to save bandwidth
- switch off VP8 layer 1 to save bandwidth

Internally str0m could use such information for an internal congestion control to compensate the overhead cause by answering Nacks