### PR TITLE
Remove probing concept

### DIFF
--- a/src/packet/bwe/mod.rs
+++ b/src/packet/bwe/mod.rs
@@ -103,10 +103,6 @@ impl SendSideBandwithEstimator {
         self.last_estimate
     }
 
-    pub(crate) fn set_is_probing(&mut self, is_probing: bool) {
-        self.rate_control.set_is_probing(is_probing);
-    }
-
     fn add_max_rtt(&mut self, max_rtt: Duration) {
         while self.max_rtt_history.len() > MAX_RTT_HISTORY_WINDOW {
             self.max_rtt_history.pop_front();

--- a/src/rtp/bandwidth.rs
+++ b/src/rtp/bandwidth.rs
@@ -48,6 +48,10 @@ impl Bitrate {
     pub fn clamp(&self, min: Self, max: Self) -> Self {
         Self(self.0.clamp(min.0, max.0))
     }
+
+    pub(crate) fn min(&self, other: Self) -> Self {
+        Self(self.0.min(other.0))
+    }
 }
 
 impl From<u64> for Bitrate {

--- a/src/session.rs
+++ b/src/session.rs
@@ -828,17 +828,12 @@ impl Session {
         const PADDING_FACTOR: f64 = 1.03;
 
         if let Some(bwe) = &mut self.bwe {
-            let padding_rate = match bwe.last_estimate() {
-                // If the estimate exceeds the desired bitrate we don't need to use probing to
-                // discover a higher bitrate.
-                Some(estimate) if estimate > desired_bitrate => Bitrate::ZERO,
-                Some(estimate) => estimate * PADDING_FACTOR,
-                // Before we have the first we don't do any padding.
-                None => Bitrate::ZERO,
-            };
+            let padding_rate = bwe
+                .last_estimate()
+                .map(|bwe| (bwe * PADDING_FACTOR).min(desired_bitrate))
+                .unwrap_or(Bitrate::ZERO);
 
             self.pacer.set_padding_rate(padding_rate);
-            bwe.set_is_probing(padding_rate > Bitrate::ZERO);
         }
     }
 }


### PR DESCRIPTION
I added the explicit probing idea during development, but it's not
actually needed. By controlling the max padding rate we get the correct
behaviour without runaway padding when the desired rate is reached.
