### PR TITLE
Fix incorrect delay variations

### DIFF
--- a/src/packet/bwe/arrival_group.rs
+++ b/src/packet/bwe/arrival_group.rs
@@ -89,8 +89,8 @@ impl ArrivalGroup {
         let first_seq_no = self.first.map(|(s, _, _)| s)?;
         let last_seq_no = self.last_seq_no?;
 
-        let arrival_delta = self.arrival_delta(other).as_millis() as f64;
-        let departure_delta = self.departure_delta(other).as_millis() as f64;
+        let arrival_delta = self.arrival_delta(other).as_secs_f64() / 1000.0;
+        let departure_delta = self.departure_delta(other).as_secs_f64() / 1000.0;
 
         assert!(arrival_delta >= 0.0);
 
@@ -185,7 +185,7 @@ impl ArrivalGroupAccumulator {
         // Variation between previous group and current.
         let delay_delta = self.inter_group_delay_delta();
         let send_delta = self.send_delta();
-        let last_remote_recv_time = self.previous_group.as_ref().map(|g| g.remote_recv_time());
+        let last_remote_recv_time = self.current_group.remote_recv_time();
 
         let current_group = mem::take(&mut self.current_group);
         self.previous_group = Some(current_group);

--- a/src/packet/bwe/arrival_group.rs
+++ b/src/packet/bwe/arrival_group.rs
@@ -195,7 +195,7 @@ impl ArrivalGroupAccumulator {
         Some(InterGroupDelayDelta {
             send_delta: send_delta?,
             delay_delta: delay_delta?,
-            last_remote_recv_time: last_remote_recv_time?,
+            last_remote_recv_time,
         })
     }
 

--- a/src/packet/bwe/mod.rs
+++ b/src/packet/bwe/mod.rs
@@ -138,7 +138,7 @@ pub struct AckedPacket {
     /// When we sent the packet
     local_send_time: Instant,
     /// When the packet was received at the remote, note this Instant is only usable with other
-    /// instants of the same type i..e those that represent a TWCC reported receive time for this
+    /// instants of the same type i.e. those that represent a TWCC reported receive time for this
     /// session.
     remote_recv_time: Instant,
 }

--- a/src/packet/bwe/trendline_estimator.rs
+++ b/src/packet/bwe/trendline_estimator.rs
@@ -115,7 +115,7 @@ impl TrendlineEstimator {
         let remote_recv_time = variation.last_remote_recv_time - zero_time;
         let timing = Timing {
             at: now,
-            remote_recv_time_ms: remote_recv_time.as_millis() as f64,
+            remote_recv_time_ms: remote_recv_time.as_secs_f64() / 1000.0,
             smoothed_delay_ms: self.smoothed_delay,
         };
 


### PR DESCRIPTION
- Add limit on received packets in burst
- Order TWCC acked packets
- twcc arrival group: fix arrival and departure times
- Fix precision of last_remote_recv_time
- Set initial BWE bitrates correctly
