### PR TITLE
Cheaper queue state

### DIFF
--- a/src/media/inner.rs
+++ b/src/media/inner.rs
@@ -1121,8 +1121,8 @@ impl MediaInner {
 
         let state = QueueState {
             mid: self.mid,
-            is_audio: self.kind == MediaKind::Audio,
-            use_for_padding: self.has_tx_rtx(),
+            is_audio: self.kind.is_audio(),
+            use_for_padding: self.kind.is_video() && self.has_tx_rtx(),
             snapshot,
         };
 

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -49,16 +49,16 @@ pub mod rtp {
 /// ```
 pub struct Media<'a> {
     rtc: &'a mut Rtc,
-    index: usize,
+    mid: Mid,
 }
 
 impl Media<'_> {
     fn inner(&self) -> &MediaInner {
-        self.rtc.media_inner(self.index)
+        self.rtc.media_inner(self.mid)
     }
 
     fn inner_mut(&mut self) -> &mut MediaInner {
-        self.rtc.media_inner_mut(self.index)
+        self.rtc.media_inner_mut(self.mid)
     }
 
     /// Identifier of the media.
@@ -68,7 +68,7 @@ impl Media<'_> {
 
     /// The index of the line in the SDP. Once negotiated this cannot change.
     pub fn index(&self) -> usize {
-        self.index
+        self.inner().index()
     }
 
     /// Current direction. This can be changed using
@@ -148,7 +148,7 @@ impl Media<'_> {
     pub fn writer(&mut self, pt: Pt, now: Instant) -> Writer<'_> {
         let media = Media {
             rtc: self.rtc,
-            index: self.index,
+            mid: self.mid,
         };
 
         Writer {
@@ -205,8 +205,8 @@ impl Media<'_> {
         self.inner_mut().request_keyframe(rid, kind)
     }
 
-    pub(crate) fn new(rtc: &mut Rtc, index: usize) -> Media {
-        Media { rtc, index }
+    pub(crate) fn new(rtc: &mut Rtc, mid: Mid) -> Media {
+        Media { rtc, mid }
     }
 }
 

--- a/src/packet/buffer_tx.rs
+++ b/src/packet/buffer_tx.rs
@@ -175,7 +175,7 @@ impl PacketizingBuffer {
             created_at: now,
             size: self.total.unsent_size,
             packet_count: self.total.unsent_count as u32,
-            total_queue_time: self.total.queue_time,
+            total_queue_time_origin: self.total.queue_time,
             last_emitted: self.last_emit,
             first_unsent: self.queue.get(self.emit_next).map(|p| p.meta.queued_at),
         }

--- a/src/packet/buffer_tx.rs
+++ b/src/packet/buffer_tx.rs
@@ -236,9 +236,13 @@ impl PacketizingBuffer {
 //                       +-+
 #[derive(Debug, Default)]
 struct TotalQueue {
+    /// Number of unsent packets.
     unsent_count: usize,
+    /// The data size (bytes) of the unsent packets.
     unsent_size: usize,
+    /// When we last added some value to `queue_time`.
     last: Option<Instant>,
+    /// The total queue time of all the unsent packets.
     queue_time: Duration,
 }
 
@@ -270,9 +274,9 @@ impl TotalQueue {
         self.unsent_size -= size;
         self.queue_time -= queue_time;
         if self.unsent_count == 0 {
-            self.unsent_size = 0;
+            assert!(self.unsent_size == 0);
+            assert!(self.queue_time == Duration::ZERO);
             self.last = None;
-            self.queue_time = Duration::ZERO;
         }
     }
 }

--- a/src/packet/g7xx.rs
+++ b/src/packet/g7xx.rs
@@ -31,10 +31,6 @@ impl Packetizer for G7xxPacketizer {
 
         Ok(payloads)
     }
-
-    fn media_kind(&self) -> MediaKind {
-        MediaKind::Audio
-    }
 }
 
 #[cfg(test)]

--- a/src/packet/h264.rs
+++ b/src/packet/h264.rs
@@ -187,10 +187,6 @@ impl Packetizer for H264Packetizer {
 
         Ok(payloads)
     }
-
-    fn media_kind(&self) -> MediaKind {
-        MediaKind::Video
-    }
 }
 
 /// Depacketizes H264 RTP packets.

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -47,6 +47,18 @@ pub enum MediaKind {
     Video,
 }
 
+impl MediaKind {
+    /// Tests if this is `MediaKind::Audio`
+    pub fn is_audio(&self) -> bool {
+        *self == MediaKind::Audio
+    }
+
+    /// Tests if this is `MediaKind::Video`
+    pub fn is_video(&self) -> bool {
+        *self == MediaKind::Video
+    }
+}
+
 /// Packetizes some bytes for use as RTP packet.
 pub trait Packetizer: fmt::Debug {
     /// Chunk the data up into RTP packets.

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -35,7 +35,8 @@ mod bwe;
 pub use bwe::SendSideBandwithEstimator;
 
 mod pacer;
-pub use pacer::{LeakyBucketPacer, NullPacer, Pacer, PacerImpl, PollOutcome, QueueId, QueueState};
+pub use pacer::{LeakyBucketPacer, NullPacer, Pacer, PacerImpl, PollOutcome};
+pub use pacer::{QueueSnapshot, QueueState};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// Types of media.
@@ -50,9 +51,6 @@ pub enum MediaKind {
 pub trait Packetizer: fmt::Debug {
     /// Chunk the data up into RTP packets.
     fn packetize(&mut self, mtu: usize, b: &[u8]) -> Result<Vec<Vec<u8>>, PacketError>;
-
-    /// What kind of packetizer this is. Audio or Video.
-    fn media_kind(&self) -> MediaKind;
 }
 
 /// Codec specific information
@@ -213,19 +211,6 @@ impl Packetizer for CodecPacketizer {
             Vp8(v) => v.packetize(mtu, b),
             Vp9(v) => v.packetize(mtu, b),
             Boxed(v) => v.packetize(mtu, b),
-        }
-    }
-
-    fn media_kind(&self) -> MediaKind {
-        use CodecPacketizer::*;
-        match self {
-            G711(v) => v.media_kind(),
-            G722(v) => v.media_kind(),
-            H264(v) => v.media_kind(),
-            Opus(v) => v.media_kind(),
-            Vp8(v) => v.media_kind(),
-            Vp9(v) => v.media_kind(),
-            Boxed(v) => v.media_kind(),
         }
     }
 }

--- a/src/packet/opus.rs
+++ b/src/packet/opus.rs
@@ -21,10 +21,6 @@ impl Packetizer for OpusPacketizer {
 
         Ok(out)
     }
-
-    fn media_kind(&self) -> MediaKind {
-        MediaKind::Audio
-    }
 }
 
 /// Depacketizes Opus RTP packets.

--- a/src/packet/vp8.rs
+++ b/src/packet/vp8.rs
@@ -110,10 +110,6 @@ impl Packetizer for Vp8Packetizer {
 
         Ok(payloads)
     }
-
-    fn media_kind(&self) -> MediaKind {
-        MediaKind::Video
-    }
 }
 
 /// Depacketizes VP8 RTP packets.

--- a/src/packet/vp9.rs
+++ b/src/packet/vp9.rs
@@ -127,10 +127,6 @@ impl Packetizer for Vp9Packetizer {
 
         Ok(payloads)
     }
-
-    fn media_kind(&self) -> MediaKind {
-        MediaKind::Video
-    }
 }
 
 /// Depacketizes VP9 RTP packets.

--- a/src/session.rs
+++ b/src/session.rs
@@ -163,6 +163,10 @@ impl Session {
         &self.app
     }
 
+    pub fn media_by_mid(&self, mid: Mid) -> Option<&MediaInner> {
+        self.medias.iter().find(|m| m.mid() == mid)
+    }
+
     pub fn media_by_mid_mut(&mut self, mid: Mid) -> Option<&mut MediaInner> {
         self.medias.iter_mut().find(|m| m.mid() == mid)
     }
@@ -815,20 +819,6 @@ impl Session {
         snapshot.tx = snapshot.egress.values().map(|s| s.bytes).sum();
         snapshot.rx = snapshot.ingress.values().map(|s| s.bytes).sum();
         snapshot.bwe_tx = self.bwe.as_ref().and_then(|bwe| bwe.last_estimate());
-    }
-
-    pub fn media_by_index(&self, index: usize) -> &MediaInner {
-        self.medias
-            .iter()
-            .find(|m| m.index() == index)
-            .expect("index is media")
-    }
-
-    pub fn media_by_index_mut(&mut self, index: usize) -> &mut MediaInner {
-        self.medias
-            .iter_mut()
-            .find(|m| m.index() == index)
-            .expect("index is media")
     }
 
     pub fn set_bwe_current_bitrate(&mut self, current_bitrate: Bitrate) {

--- a/src/session.rs
+++ b/src/session.rs
@@ -145,7 +145,7 @@ impl Session {
         self.id
     }
 
-    pub(crate) fn set_app(&mut self, mid: Mid, index: usize) -> Result<(), String> {
+    pub fn set_app(&mut self, mid: Mid, index: usize) -> Result<(), String> {
         if let Some((mid_existing, index_existing)) = self.app {
             if mid_existing != mid {
                 return Err(format!("App mid changed {} != {}", mid, mid_existing,));
@@ -798,7 +798,7 @@ impl Session {
         }
     }
 
-    pub(crate) fn enable_twcc_feedback(&mut self) {
+    pub fn enable_twcc_feedback(&mut self) {
         if !self.enable_twcc_feedback {
             debug!("Enable TWCC feedback");
             self.enable_twcc_feedback = true;
@@ -828,13 +828,13 @@ impl Session {
             .expect("index is media")
     }
 
-    pub(crate) fn set_bwe_current_bitrate(&mut self, current_bitrate: Bitrate) {
+    pub fn set_bwe_current_bitrate(&mut self, current_bitrate: Bitrate) {
         let pacing_rate = current_bitrate * PACING_FACTOR;
 
         self.pacer.set_pacing_rate(pacing_rate);
     }
 
-    pub(crate) fn set_bwe_desired_bitrate(&mut self, desired_bitrate: Bitrate) {
+    pub fn set_bwe_desired_bitrate(&mut self, desired_bitrate: Bitrate) {
         if let Some(bwe) = &mut self.bwe {
             let padding_rate = bwe
                 .last_estimate()
@@ -845,15 +845,15 @@ impl Session {
         }
     }
 
-    pub(crate) fn line_count(&self) -> usize {
+    pub fn line_count(&self) -> usize {
         self.medias.len() + if self.app.is_some() { 1 } else { 0 }
     }
 
-    pub(crate) fn add_media(&mut self, media: MediaInner) {
+    pub fn add_media(&mut self, media: MediaInner) {
         self.medias.push(media);
     }
 
-    pub(crate) fn medias(&self) -> &[MediaInner] {
+    pub fn medias(&self) -> &[MediaInner] {
         &self.medias
     }
 


### PR DESCRIPTION
This PR aims to reduce the number of QueueState calculations to see if we can improve the flamegraph of where code time is spent.

This splits QueueState into two halves, QueueState/QueueSnapshot and
the snapshot is used on the PacketizingBuffer level and QueueState on
the MediaInner level.  This is to avoid needing all knowledge about
what kind of data we're handling inside the PacketizingBuffer.

The more important change is adding an internal TotalQueue struct in
PacketizingBuffer that continuously keeps track of the total queue
duration in the buffer. This way we can avoid an expensive
recalculation on every MediaInner::queue_state() call.