### PR TITLE
[WIP] Drop media packets before ice connection 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1198,6 +1198,10 @@ impl Rtc {
                 };
                 return Ok(Output::Transmit(t));
             }
+        } else {
+            while let Some(_) = self.session.poll_datagram(self.last_now) {
+                // flush all packets until we have send_addr
+            }
         }
 
         let time_and_reason = (None, "<not happening>")

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -283,6 +283,8 @@ impl<'a> Writer<'a> {
     ///
     /// Notice that incorrect [`Pt`] values would surface as an error here, not when
     /// doing [`Media::writer()`].
+    ///
+    /// If you write media before `IceConnectionState` is `Connected` it will be dropped.
     pub fn write(
         mut self,
         wallclock: Instant,

--- a/src/session.rs
+++ b/src/session.rs
@@ -661,7 +661,7 @@ impl Session {
         Some(protected.into())
     }
 
-    fn poll_packet(&mut self, now: Instant) -> Option<DatagramSend> {
+    pub fn poll_packet(&mut self, now: Instant) -> Option<DatagramSend> {
         let srtp_tx = self.srtp_tx.as_mut()?;
 
         // Figure out which, if any, queue to poll


### PR DESCRIPTION
Zulip stream: https://str0m.zulipchat.com/#narrow/stream/377845-general/topic/Writing.20media.20before.20ice.20connection.20causes.20delay.3F

Update: my initial test show this fix did not fix the problem. I fixed this in my app code to not write media until state is not disconnected or new and fixed my issue. But we should handle this in str0m.