### PR TITLE
sctp/data channel refactoring

### DIFF
--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -1,7 +1,9 @@
+use crate::channel::ChannelId;
 use crate::dtls::Fingerprint;
 use crate::ice::IceCreds;
 use crate::rtp::Direction;
 use crate::rtp::Mid;
+use crate::sctp::ChannelConfig;
 use crate::Rtc;
 use crate::RtcError;
 
@@ -29,7 +31,7 @@ impl<'a> DirectApi<'a> {
     ///
     /// If `controlling` is `false`, this peer connection is set as the ICE controlled agent,
     /// meaning it will respond to connectivity checks sent by the controlling agent.
-    pub fn ice_controlling(&mut self, controlling: bool) {
+    pub fn set_ice_controlling(&mut self, controlling: bool) {
         self.rtc.ice.set_controlling(controlling);
     }
 
@@ -37,12 +39,12 @@ impl<'a> DirectApi<'a> {
     ///
     /// The ICE credentials consist of the username and password used by the ICE agent during
     /// the ICE session to authenticate and exchange connectivity checks with the remote peer.
-    pub fn local_ice_credentials(&self) -> &IceCreds {
-        self.rtc.ice.local_credentials()
+    pub fn local_ice_credentials(&self) -> IceCreds {
+        self.rtc.ice.local_credentials().clone()
     }
 
     /// Sets the remote ICE credentials.
-    pub fn remote_ice_credentials(&mut self, remote_ice_credentials: IceCreds) {
+    pub fn set_remote_ice_credentials(&mut self, remote_ice_credentials: IceCreds) {
         self.rtc.ice.set_remote_credentials(remote_ice_credentials);
     }
 
@@ -50,13 +52,13 @@ impl<'a> DirectApi<'a> {
     ///
     /// The DTLS fingerprint is a hash of the local SSL/TLS certificate used to authenticate the
     /// peer connection and establish a secure communication channel between the peers.
-    pub fn local_dtls_fingerprint(&self) -> &Fingerprint {
-        self.rtc.dtls.local_fingerprint()
+    pub fn local_dtls_fingerprint(&self) -> Fingerprint {
+        self.rtc.dtls.local_fingerprint().clone()
     }
 
     /// Sets the remote DTLS fingerprint.
-    pub fn remote_fingerprint(&mut self, dtls_fingerprint: &Fingerprint) {
-        self.rtc.remote_fingerprint = Some(dtls_fingerprint.clone());
+    pub fn set_remote_fingerprint(&mut self, dtls_fingerprint: Fingerprint) {
+        self.rtc.remote_fingerprint = Some(dtls_fingerprint);
     }
 
     /// Set direction on some media.
@@ -80,5 +82,17 @@ impl<'a> DirectApi<'a> {
     /// Start the SCTP over DTLS.
     pub fn start_sctp(&mut self, client: bool) {
         self.rtc.init_sctp(client)
+    }
+
+    /// Create a new data channel.
+    pub fn create_data_channel(&mut self, config: ChannelConfig) -> ChannelId {
+        let id = self.rtc.chan.new_channel(&config);
+        self.rtc.chan.confirm(id, config);
+        id
+    }
+
+    /// Set whether to enable ice-lite.
+    pub fn set_ice_lite(&mut self, ice_lite: bool) {
+        self.rtc.ice.set_ice_lite(ice_lite);
     }
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,10 +1,20 @@
 //! Data channel related types.
 
-use std::fmt;
+use std::{fmt, time::Instant};
 
-pub use crate::rtp::ChannelId;
-
+use crate::sctp::RtcSctp;
+use crate::util::already_happened;
 use crate::{Rtc, RtcError};
+
+pub use crate::sctp::ChannelConfig;
+pub use crate::sctp::Reliability;
+
+/// Identifier of a data channel.
+///
+/// This is NOT the SCTP stream id.
+// Deliberately not Deref or From to avoid this Id being created outside of this module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ChannelId(usize);
 
 /// Data channel data from remote peer.
 ///
@@ -28,18 +38,21 @@ pub struct ChannelData {
 ///
 /// Get this handle from [`Rtc::channel()`][crate::Rtc::channel()].
 pub struct Channel<'a> {
-    sctp_channel: u16,
+    sctp_stream_id: u16,
     rtc: &'a mut Rtc,
 }
 
 impl<'a> Channel<'a> {
-    pub(crate) fn new(sctp_channel: u16, rtc: &'a mut Rtc) -> Self {
-        Channel { rtc, sctp_channel }
+    pub(crate) fn new(sctp_stream_id: u16, rtc: &'a mut Rtc) -> Self {
+        Channel {
+            rtc,
+            sctp_stream_id,
+        }
     }
 
     /// Write data to the remote peer and indicate whether it's text or binary.
     pub fn write(&mut self, binary: bool, buf: &[u8]) -> Result<usize, RtcError> {
-        Ok(self.rtc.sctp.write(self.sctp_channel, binary, buf)?)
+        Ok(self.rtc.sctp.write(self.sctp_stream_id, binary, buf)?)
     }
 }
 
@@ -50,5 +63,175 @@ impl fmt::Debug for ChannelData {
             .field("binary", &self.binary)
             .field("data", &self.data.len())
             .finish()
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ChannelHandler {
+    allocations: Vec<ChannelAllocation>,
+}
+
+#[derive(Debug)]
+struct ChannelAllocation {
+    id: ChannelId,
+
+    /// Stream id, when it is known. This might be delayed awaiting sctp initialization to
+    /// know if we are client or server.
+    sctp_stream_id: Option<u16>,
+
+    /// Holds the config until it is used in handle_timeout.
+    config: Option<ChannelConfig>,
+}
+
+impl ChannelHandler {
+    pub fn new_channel(&mut self, config: &ChannelConfig) -> ChannelId {
+        let id = ChannelId(self.allocations.len());
+
+        // For out-of-band negotiated, the id is already set.
+        let sctp_stream_id = config.negotiated;
+        if let Some(sctp_stream_id) = sctp_stream_id {
+            let exists = self
+                .allocations
+                .iter()
+                .any(|a| a.sctp_stream_id == Some(sctp_stream_id));
+            assert!(
+                !exists,
+                "sctp_stream_id ({}) exists already",
+                sctp_stream_id
+            );
+        }
+
+        let alloc = ChannelAllocation {
+            id,
+            sctp_stream_id,
+            // The config is none until we confirm we definitely want this channel.
+            config: None,
+        };
+
+        debug!("Allocate channel id: {:?}", id);
+        self.allocations.push(alloc);
+
+        id
+    }
+
+    pub fn confirm(&mut self, id: ChannelId, config: ChannelConfig) {
+        let a = self
+            .allocations
+            .iter_mut()
+            .find(|a| a.id == id)
+            .expect("Entry for issued channel id");
+        a.config = Some(config);
+    }
+
+    /// For translating sctp stream id to ChannelId. Any event out of sctp goes via this.
+    pub fn channel_id_by_stream_id(&self, sctp_stream_id: u16) -> Option<ChannelId> {
+        self.allocations
+            .iter()
+            .find(|a| a.sctp_stream_id == Some(sctp_stream_id))
+            .map(|a| a.id)
+    }
+
+    /// Look up sctp stream id for channel id.
+    pub fn stream_id_by_channel_id(&self, id: ChannelId) -> Option<u16> {
+        self.allocations
+            .iter()
+            .find(|a| a.id == id)
+            .and_then(|a| a.sctp_stream_id)
+    }
+
+    pub(crate) fn handle_timeout(&mut self, _now: Instant, sctp: &mut RtcSctp) {
+        if !sctp.is_inited() {
+            return;
+        }
+
+        // Allocate sctp channel ids for ones that are missing.
+        self.do_allocations(sctp);
+
+        // After do_allocations so we get a channel for any confirmed.
+        self.open_channels(sctp);
+    }
+
+    fn need_allocation(&self) -> bool {
+        self.allocations.iter().any(|a| a.sctp_stream_id.is_none())
+    }
+
+    fn need_open(&self) -> bool {
+        self.allocations.iter().any(|a| a.config.is_some())
+    }
+
+    // Do automatic allocations of sctp stream id.
+    fn do_allocations(&mut self, sctp: &mut RtcSctp) {
+        if !self.need_allocation() {
+            return;
+        }
+
+        // RFC 8831
+        // Unless otherwise defined or negotiated, the
+        // streams are picked based on the DTLS role (the client picks even
+        // stream identifiers, and the server picks odd stream identifiers).
+        let base = if sctp.is_client() { 0 } else { 1 };
+
+        let mut taken: Vec<u16> = self
+            .allocations
+            .iter()
+            .filter_map(|a| a.sctp_stream_id)
+            .collect();
+
+        for a in &mut self.allocations {
+            if a.sctp_stream_id.is_some() {
+                continue;
+            }
+            // We need to allocate
+            let mut proposed = base;
+
+            while taken.contains(&proposed) {
+                proposed += 2
+            }
+
+            // Found the next free.
+            debug!("Associate stream id {:?} => {}", a.id, proposed);
+            a.sctp_stream_id = Some(proposed);
+            taken.push(proposed);
+        }
+    }
+
+    // Actually open channels.
+    fn open_channels(&mut self, sctp: &mut RtcSctp) {
+        for a in &mut self.allocations {
+            let Some(config) = a.config.take() else {
+                continue;
+            };
+            let Some(sctp_stream_id) = a.sctp_stream_id else {
+                continue;
+            };
+
+            debug!("Open stream for: {:?}", a.id);
+            sctp.open_stream(sctp_stream_id, config);
+        }
+    }
+
+    pub fn poll_timeout(&self, sctp: &RtcSctp) -> Option<Instant> {
+        if sctp.is_inited() && (self.need_allocation() || self.need_open()) {
+            Some(already_happened())
+        } else {
+            None
+        }
+    }
+
+    pub fn ensure_channel_id_for(&mut self, sctp_stream_id: u16) {
+        let exists = self
+            .allocations
+            .iter()
+            .any(|a| a.sctp_stream_id == Some(sctp_stream_id));
+
+        if !exists {
+            let id = ChannelId(self.allocations.len());
+            let alloc = ChannelAllocation {
+                id,
+                sctp_stream_id: Some(sctp_stream_id),
+                config: None,
+            };
+            self.allocations.push(alloc);
+        }
     }
 }

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -852,7 +852,7 @@ impl IceAgent {
                 trace!("Handle next triggered pair: {:?}", pair);
                 self.stun_client_binding_request(now, idx);
             } else {
-                trace!("Next triggered pair is in the future: {:?}", deadline - now);
+                // trace!("Next triggered pair is in the future: {:?}", deadline - now);
             }
         }
     }
@@ -876,8 +876,11 @@ impl IceAgent {
         // if we never called handle_timeout, there will be no current time.
         let last_now = self.last_now?;
 
-        // We must empty the queued replies as soon as possible.
-        if !self.stun_server_queue.is_empty() {
+        let has_request = !self.stun_server_queue.is_empty();
+        let has_transmit = !self.transmit.is_empty();
+
+        // We must empty the queued replies or stuff to send as soon as possible.
+        if has_request || has_transmit {
             return Some(last_now + TIMING_ADVANCE);
         }
 

--- a/src/rtp/id.rs
+++ b/src/rtp/id.rs
@@ -115,7 +115,6 @@ num_id!(Ssrc, u32);
 num_id!(Pt, u8);
 num_id!(SessionId, u64);
 num_id!(SeqNo, u64);
-num_id!(ChannelId, u16);
 
 impl SeqNo {
     pub fn is_next(&self, other: SeqNo) -> bool {

--- a/src/rtp/mod.rs
+++ b/src/rtp/mod.rs
@@ -8,7 +8,7 @@ use openssl::error::ErrorStack;
 use thiserror::Error;
 
 mod id;
-pub use id::{ChannelId, Mid, Pt, Rid, SeqNo, SessionId, Ssrc};
+pub use id::{Mid, Pt, Rid, SeqNo, SessionId, Ssrc};
 
 mod ext;
 pub use ext::{ExtMap, Extension, ExtensionValues, Extensions, VideoOrientation};

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -39,7 +39,8 @@ pub fn progress(l: &mut TestRtc, r: &mut TestRtc) -> Result<(), RtcError> {
 
         match f.span.in_scope(|| f.rtc.poll_output())? {
             Output::Timeout(v) => {
-                f.last = (f.last + Duration::from_millis(100)).min(v);
+                let tick = f.last + Duration::from_millis(100);
+                f.last = if v == f.last { tick } else { tick.min(v) };
                 break;
             }
             Output::Transmit(v) => {

--- a/tests/data-channel-direct.rs
+++ b/tests/data-channel-direct.rs
@@ -1,0 +1,80 @@
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+use str0m::channel::ChannelConfig;
+use str0m::{Candidate, RtcError};
+use tracing::info_span;
+
+mod common;
+use common::{init_log, progress, TestRtc};
+
+#[test]
+pub fn data_channel_direct() -> Result<(), RtcError> {
+    init_log();
+
+    let mut l = TestRtc::new(info_span!("L"));
+    let mut r = TestRtc::new(info_span!("R"));
+
+    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into())?;
+    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into())?;
+    l.add_local_candidate(host1.clone());
+    l.add_remote_candidate(host2.clone());
+    r.add_local_candidate(host2);
+    r.add_remote_candidate(host1);
+
+    let finger_l = l.direct_api().local_dtls_fingerprint();
+    let finger_r = r.direct_api().local_dtls_fingerprint();
+
+    l.direct_api().set_remote_fingerprint(finger_r);
+    r.direct_api().set_remote_fingerprint(finger_l);
+
+    let creds_l = l.direct_api().local_ice_credentials();
+    let creds_r = r.direct_api().local_ice_credentials();
+
+    l.direct_api().set_remote_ice_credentials(creds_r);
+    r.direct_api().set_remote_ice_credentials(creds_l);
+
+    l.direct_api().set_ice_controlling(true);
+    r.direct_api().set_ice_controlling(false);
+
+    l.direct_api().start_dtls(true).unwrap();
+    r.direct_api().start_dtls(false).unwrap();
+
+    l.direct_api().start_sctp(true);
+    r.direct_api().start_sctp(false);
+
+    let config = ChannelConfig {
+        negotiated: Some(1),
+        ..Default::default()
+    };
+    let cid = l.direct_api().create_data_channel(config.clone());
+    r.direct_api().create_data_channel(config);
+
+    loop {
+        if l.ice_connection_state().is_connected() || r.ice_connection_state().is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r)?;
+    }
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    loop {
+        if let Some(mut chan) = l.channel(cid) {
+            chan.write(false, "Hello world! ".as_bytes())
+                .expect("to write string");
+        }
+
+        progress(&mut l, &mut r)?;
+
+        if l.duration() > Duration::from_secs(10) {
+            break;
+        }
+    }
+
+    assert!(r.events.len() > 120);
+
+    Ok(())
+}


### PR DESCRIPTION
This tidies up the init sequence for data channels in anticipation of direct api needs.

The correct sequence is:

```
self.rtc.chan.new_channel(&config);
self.rtc.chan.confirm(id, config);
```

There is a new `ChannelConfig` object to configure all the options of the data channel.