### PR TITLE
Make PayloadParams, CodecSpec and Codec public API

### DIFF
--- a/src/change/mod.rs
+++ b/src/change/mod.rs
@@ -6,3 +6,6 @@ pub use sdp::{SdpAnswer, SdpApi, SdpOffer, SdpPendingOffer};
 
 mod direct;
 pub use direct::DirectApi;
+
+pub use crate::dtls::Fingerprint;
+pub use crate::ice::IceCreds;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -481,12 +481,15 @@ mod rtp;
 mod sctp;
 mod sdp;
 
+pub mod format;
+
 use std::fmt;
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 
 use change::{DirectApi, SdpApi};
 use dtls::{Dtls, DtlsEvent};
+use format::CodecConfig;
 use ice::IceAgent;
 use ice::IceAgentEvent;
 use io::DatagramRecv;
@@ -522,7 +525,7 @@ pub mod channel;
 use channel::{Channel, ChannelData, ChannelHandler, ChannelId};
 
 pub mod media;
-use media::{CodecConfig, Direction, KeyframeRequest, Media};
+use media::{Direction, KeyframeRequest, Media};
 use media::{KeyframeRequestKind, MediaChanged, MediaData};
 use media::{MediaAdded, MediaInner, Mid, Pt, Rid};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,6 +487,7 @@ use std::fmt;
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 
+use change::Fingerprint;
 use change::{DirectApi, SdpApi};
 use dtls::{Dtls, DtlsEvent};
 use format::CodecConfig;
@@ -499,9 +500,8 @@ use sctp::{RtcSctp, SctpEvent};
 use stats::{MediaEgressStats, MediaIngressStats, PeerStats, Stats, StatsEvent};
 use thiserror::Error;
 
-pub use ice::{IceConnectionState, IceCreds};
+pub use ice::IceConnectionState;
 
-pub use dtls::Fingerprint;
 pub use ice::Candidate;
 pub use rtp::Bitrate;
 

--- a/src/media/event.rs
+++ b/src/media/event.rs
@@ -3,8 +3,6 @@ use std::time::Instant;
 use crate::rtp::{Direction, ExtensionValues, MediaTime, Mid, Pt, Rid};
 use crate::sdp::Simulcast as SdpSimulcast;
 
-pub use crate::sdp::{Codec, FormatParams};
-
 use super::PayloadParams;
 use crate::media::rtp::{CodecExtra, RtpMeta};
 

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -123,7 +123,8 @@ impl Media<'_> {
     ///
     /// ```no_run
     /// # use str0m::Rtc;
-    /// # use str0m::media::{PayloadParams, MediaData, Mid};
+    /// # use str0m::media::{MediaData, Mid};
+    /// # use str0m::format::PayloadParams;
     /// # use std::time::Instant;
     /// let mut rtc = Rtc::new();
     ///
@@ -214,7 +215,8 @@ impl Media<'_> {
 ///
 /// ```no_run
 /// # use str0m::Rtc;
-/// # use str0m::media::{PayloadParams, MediaData, Mid};
+/// # use str0m::media::{MediaData, Mid};
+/// # use str0m::format::PayloadParams;
 /// # use std::time::Instant;
 /// let mut rtc = Rtc::new();
 ///

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -2,17 +2,14 @@
 
 use std::time::Instant;
 
+use crate::format::PayloadParams;
 pub use crate::rtp::VideoOrientation;
 pub use crate::rtp::{Direction, ExtensionValues, MediaTime, Mid, Pt, Rid};
-pub use crate::sdp::{Codec, FormatParams};
 
 use crate::{Input, Rtc, RtcError};
 
 mod event;
 pub use event::*;
-
-mod codec;
-pub use codec::{CodecConfig, PayloadParams};
 
 mod receiver;
 

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -4,7 +4,8 @@
 use std::fmt;
 use thiserror::Error;
 
-use crate::sdp::{Codec, MediaType};
+use crate::format::Codec;
+use crate::sdp::MediaType;
 
 mod g7xx;
 use g7xx::{G711Packetizer, G722Packetizer};

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -309,7 +309,9 @@ impl MediaLine {
             for (pt, values) in fmtps.iter() {
                 // find matching a=fmtp line, if it exists.
                 if **pt == p.pt {
-                    p.spec.format.set_attributes(values);
+                    for param in values.iter() {
+                        p.spec.format.set_param(param);
+                    }
                 }
 
                 // find resend pt, if there is one.
@@ -907,50 +909,6 @@ impl MediaAttribute {
     pub fn is_direction(&self) -> bool {
         use MediaAttribute::*;
         matches!(self, RecvOnly | SendRecv | SendOnly | Inactive)
-    }
-}
-
-impl FormatParams {
-    fn set_attributes(&mut self, values: &[FormatParam]) {
-        use FormatParam::*;
-        for v in values {
-            match v {
-                MinPTime(v) => self.min_p_time = Some(*v),
-                UseInbandFec(v) => self.use_inband_fec = Some(*v),
-                LevelAsymmetryAllowed(v) => self.level_asymmetry_allowed = Some(*v),
-                PacketizationMode(v) => self.packetization_mode = Some(*v),
-                ProfileLevelId(v) => self.profile_level_id = Some(*v),
-                ProfileId(v) => self.profile_id = Some(*v),
-                Apt(_) => {}
-                Unknown => {}
-            }
-        }
-    }
-
-    pub(crate) fn to_format_param(self) -> Vec<FormatParam> {
-        use FormatParam::*;
-        let mut r = Vec::with_capacity(5);
-
-        if let Some(v) = self.min_p_time {
-            r.push(MinPTime(v));
-        }
-        if let Some(v) = self.use_inband_fec {
-            r.push(UseInbandFec(v));
-        }
-        if let Some(v) = self.level_asymmetry_allowed {
-            r.push(LevelAsymmetryAllowed(v));
-        }
-        if let Some(v) = self.packetization_mode {
-            r.push(PacketizationMode(v));
-        }
-        if let Some(v) = self.profile_level_id {
-            r.push(ProfileLevelId(v));
-        }
-        if let Some(v) = self.profile_id {
-            r.push(ProfileId(v));
-        }
-
-        r
     }
 }
 

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -8,6 +8,10 @@ use std::ops::Deref;
 use std::str::FromStr;
 
 use crate::dtls::Fingerprint;
+use crate::format::Codec;
+use crate::format::CodecSpec;
+use crate::format::FormatParams;
+use crate::format::PayloadParams;
 use crate::ice::{Candidate, IceCreds};
 use crate::rtp::{Direction, ExtMap, Mid, Pt, SessionId, Ssrc};
 
@@ -263,8 +267,8 @@ impl MediaLine {
             .attrs
             .iter()
             .filter_map(|a| {
-                if let MediaAttribute::RtpMap(c) = a {
-                    Some(c)
+                if let MediaAttribute::RtpMap { pt, value: c } = a {
+                    Some((*pt, *c))
                 } else {
                     None
                 }
@@ -297,25 +301,25 @@ impl MediaLine {
 
         let mut params: Vec<_> = rtp_maps
             .iter()
-            .filter(|c| c.codec.is_audio() | c.codec.is_video())
-            .map(|c| PayloadParams::new(**c))
+            .filter(|(_, c)| c.codec.is_audio() | c.codec.is_video())
+            .map(|(pt, c)| PayloadParams::new(*pt, None, (*c).into()))
             .collect();
 
         for p in &mut params {
             for (pt, values) in fmtps.iter() {
                 // find matching a=fmtp line, if it exists.
-                if **pt == p.codec.pt {
-                    p.fmtps.set_attributes(values);
+                if **pt == p.pt {
+                    p.spec.format.set_attributes(values);
                 }
 
                 // find resend pt, if there is one.
                 for fp in values.iter() {
                     if let FormatParam::Apt(v) = fp {
-                        if *v == p.codec.pt {
+                        if *v == p.pt {
                             // ensure this is a rtx
                             let is_rtx = rtp_maps
                                 .iter()
-                                .any(|c| c.pt == **pt && c.codec == Codec::Rtx);
+                                .any(|(cpt, c)| cpt == *pt && c.codec == Codec::Rtx);
                             if is_rtx {
                                 p.resend = Some(**pt);
                             }
@@ -326,7 +330,7 @@ impl MediaLine {
 
             // rtcp feedback mechanisms
             for (pt, value) in fbs.iter() {
-                if **pt == p.codec.pt {
+                if **pt == p.pt {
                     match &value[..] {
                         "goog-remb" => {
                             //
@@ -400,8 +404,8 @@ impl MediaLine {
                 .attrs
                 .iter()
                 .filter(|a| {
-                    if let MediaAttribute::RtpMap(c) = a {
-                        c.pt == *m
+                    if let MediaAttribute::RtpMap { pt, value: _ } = a {
+                        pt == m
                     } else {
                         false
                     }
@@ -857,7 +861,10 @@ pub enum MediaAttribute {
     RtcpRsize,
     Candidate(Candidate),
     EndOfCandidates,
-    RtpMap(CodecSpec),
+    RtpMap {
+        pt: Pt,
+        value: RtpMap,
+    },
     // rtcp-fb RTCP feedback parameters, repeated
     RtcpFb {
         pt: Pt,        // 111
@@ -903,49 +910,6 @@ impl MediaAttribute {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct CodecSpec {
-    pub pt: Pt,
-    pub codec: Codec,
-    pub clock_rate: u32,
-    pub channels: Option<u8>,
-}
-
-/// Codec specific format parameters.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
-pub struct FormatParams {
-    /// Opus specific parameter.
-    ///
-    /// The minimum duration of media represented by a packet.
-    pub min_p_time: Option<u8>,
-
-    /// Opus specific parameter.
-    ///
-    /// Specifies that the decoder can do Opus in-band FEC
-    pub use_inband_fec: Option<bool>,
-
-    /// Whether h264 sending media encoded at a different level in the offerer-to-answerer
-    /// direction than the level in the answerer-to-offerer direction, is allowed.
-    pub level_asymmetry_allowed: Option<bool>,
-
-    /// What h264 packetization mode is used.
-    ///
-    /// * 0 - single nal.
-    /// * 1 - STAP-A, FU-A is allowed. Non-interleaved.
-    pub packetization_mode: Option<u8>,
-
-    /// H264 profile level.
-    ///
-    /// * 42 00 1f - 4200=baseline (B)              1f=level 3.1
-    /// * 42 e0 1f - 42e0=constrained baseline (CB) 1f=level 3.1
-    /// * 4d 00 1f - 4d00=main (M)                  1f=level 3.1
-    /// * 64 00 1f - 6400=high (H)                  1f=level 3.1
-    pub profile_level_id: Option<u32>,
-
-    /// VP9 profile id.
-    pub profile_id: Option<u32>,
-}
-
 impl FormatParams {
     fn set_attributes(&mut self, values: &[FormatParam]) {
         use FormatParam::*;
@@ -963,7 +927,7 @@ impl FormatParams {
         }
     }
 
-    fn to_format_param(self) -> Vec<FormatParam> {
+    pub(crate) fn to_format_param(self) -> Vec<FormatParam> {
         use FormatParam::*;
         let mut r = Vec::with_capacity(5);
 
@@ -988,97 +952,6 @@ impl FormatParams {
 
         r
     }
-}
-
-impl fmt::Display for FormatParams {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = self
-            .to_format_param()
-            .into_iter()
-            .map(|f| f.to_string())
-            .collect::<Vec<_>>()
-            .join(";");
-        write!(f, "{s}")
-    }
-}
-
-/// Known codecs.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-#[allow(missing_docs)]
-pub enum Codec {
-    Opus,
-    H264,
-    // TODO show this when we support h265.
-    #[doc(hidden)]
-    H265,
-    Vp8,
-    Vp9,
-    // TODO show this when we support Av1.
-    #[doc(hidden)]
-    Av1,
-    /// Technically not a codec, but used in places where codecs go
-    /// in `a=rtpmap` lines.
-    #[doc(hidden)]
-    Rtx,
-    #[doc(hidden)]
-    Unknown,
-}
-
-impl Codec {
-    /// Tells if codec is audio.
-    pub fn is_audio(&self) -> bool {
-        use Codec::*;
-        matches!(self, Opus)
-    }
-
-    /// Tells if codec is video.
-    pub fn is_video(&self) -> bool {
-        use Codec::*;
-        matches!(self, H264 | Vp8 | Vp9 | Av1)
-    }
-}
-
-impl<'a> From<&'a str> for Codec {
-    fn from(v: &'a str) -> Self {
-        let lc = v.to_ascii_lowercase();
-        match &lc[..] {
-            "opus" => Codec::Opus,
-            "h264" => Codec::H264,
-            "h265" => Codec::H265,
-            "vp8" => Codec::Vp8,
-            "vp9" => Codec::Vp9,
-            "av1" => Codec::Av1,
-            "rtx" => Codec::Rtx, // resends
-            _ => Codec::Unknown,
-        }
-    }
-}
-
-impl fmt::Display for Codec {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Codec::Opus => write!(f, "opus"),
-            Codec::H264 => write!(f, "H264"),
-            Codec::H265 => write!(f, "H265"),
-            Codec::Vp8 => write!(f, "VP8"),
-            Codec::Vp9 => write!(f, "VP9"),
-            Codec::Av1 => write!(f, "AV1"),
-            Codec::Rtx => write!(f, "rtx"),
-            Codec::Unknown => write!(f, "unknown"),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct PayloadParams {
-    pub codec: CodecSpec,
-    pub fmtps: FormatParams,
-    pub resend: Option<Pt>,
-    pub fb_transport_cc: bool,
-    pub fb_fir: bool,
-    pub fb_nack: bool,
-    pub fb_pli: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1189,65 +1062,86 @@ impl fmt::Display for FormatParam {
 }
 
 impl PayloadParams {
-    fn new(codec: CodecSpec) -> Self {
-        PayloadParams {
-            codec,
-            fmtps: FormatParams::default(),
-            resend: None,
-            fb_transport_cc: false,
-            fb_fir: false,
-            fb_nack: false,
-            fb_pli: false,
-        }
-    }
-
-    pub fn as_media_attrs(&self, attrs: &mut Vec<MediaAttribute>) {
-        attrs.push(MediaAttribute::RtpMap(self.codec));
+    pub(crate) fn as_media_attrs(&self, attrs: &mut Vec<MediaAttribute>) {
+        attrs.push(MediaAttribute::RtpMap {
+            pt: self.pt,
+            value: self.spec.into(),
+        });
 
         if self.fb_transport_cc {
             attrs.push(MediaAttribute::RtcpFb {
-                pt: self.codec.pt,
+                pt: self.pt,
                 value: "transport-cc".into(),
             });
         }
         if self.fb_fir {
             attrs.push(MediaAttribute::RtcpFb {
-                pt: self.codec.pt,
+                pt: self.pt,
                 value: "ccm fir".into(),
             });
         }
         if self.fb_nack {
             attrs.push(MediaAttribute::RtcpFb {
-                pt: self.codec.pt,
+                pt: self.pt,
                 value: "nack".into(),
             });
         }
         if self.fb_pli {
             attrs.push(MediaAttribute::RtcpFb {
-                pt: self.codec.pt,
+                pt: self.pt,
                 value: "nack pli".into(),
             });
         }
 
-        let fmtps = self.fmtps.to_format_param();
+        let fmtps = self.spec.format.to_format_param();
         if !fmtps.is_empty() {
             attrs.push(MediaAttribute::Fmtp {
-                pt: self.codec.pt,
+                pt: self.pt,
                 values: fmtps,
             });
         }
 
         if let Some(pt) = self.resend {
-            attrs.push(MediaAttribute::RtpMap(CodecSpec {
+            attrs.push(MediaAttribute::RtpMap {
                 pt,
-                codec: Codec::Rtx,
-                clock_rate: self.codec.clock_rate,
-                channels: None,
-            }));
+                value: RtpMap {
+                    codec: Codec::Rtx,
+                    clock_rate: self.spec.clock_rate,
+                    channels: None,
+                },
+            });
             attrs.push(MediaAttribute::Fmtp {
                 pt,
-                values: vec![FormatParam::Apt(self.codec.pt)],
+                values: vec![FormatParam::Apt(self.pt)],
             });
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RtpMap {
+    pub codec: Codec,
+    pub clock_rate: u32,
+    pub channels: Option<u8>,
+}
+
+impl From<RtpMap> for CodecSpec {
+    fn from(v: RtpMap) -> Self {
+        CodecSpec {
+            codec: v.codec,
+            clock_rate: v.clock_rate,
+            channels: v.channels,
+            format: FormatParams::default(),
+        }
+    }
+}
+
+impl From<CodecSpec> for RtpMap {
+    fn from(v: CodecSpec) -> Self {
+        RtpMap {
+            codec: v.codec,
+            clock_rate: v.clock_rate,
+            channels: v.channels,
         }
     }
 }
@@ -1489,8 +1383,8 @@ impl fmt::Display for MediaAttribute {
             RtcpRsize => write!(f, "a=rtcp-rsize\r\n")?,
             Candidate(c) => write!(f, "{c}")?,
             EndOfCandidates => write!(f, "a=end-of-candidates\r\n")?,
-            RtpMap(c) => {
-                write!(f, "a=rtpmap:{} {}/{}", c.pt, c.codec, c.clock_rate)?;
+            RtpMap { pt, value: c } => {
+                write!(f, "a=rtpmap:{} {}/{}", pt, c.codec, c.clock_rate)?;
                 if let Some(e) = c.channels {
                     write!(f, "/{e}")?;
                 }
@@ -1649,16 +1543,40 @@ mod test {
 
     #[test]
     fn write_sdp() {
-        let sdp = Sdp { session: Session { id: 5_058_682_828_002_148_772.into(),
-            bw: None, attrs:
-            vec![SessionAttribute::Group { typ: "BUNDLE".into(), mids: vec!["0".into()] }, SessionAttribute::Unused("msid-semantic: WMS 5UUdwiuY7OML2EkQtF38pJtNP5v7In1LhjEK".into())] },
-            media_lines: vec![
-                MediaLine {
-                    typ: MediaType::Audio,
-                    proto: Proto::Srtp,
-                    pts: vec![111.into(), 103.into(), 104.into(), 9.into(), 0.into(), 8.into(), 106.into(), 105.into(), 13.into(), 110.into(), 112.into(), 113.into(), 126.into()],
-                    bw: None,
-                    attrs: vec![
+        let sdp = Sdp {
+            session: Session {
+                id: 5_058_682_828_002_148_772.into(),
+                bw: None,
+                attrs: vec![
+                    SessionAttribute::Group {
+                        typ: "BUNDLE".into(),
+                        mids: vec!["0".into()],
+                    },
+                    SessionAttribute::Unused(
+                        "msid-semantic: WMS 5UUdwiuY7OML2EkQtF38pJtNP5v7In1LhjEK".into(),
+                    ),
+                ],
+            },
+            media_lines: vec![MediaLine {
+                typ: MediaType::Audio,
+                proto: Proto::Srtp,
+                pts: vec![
+                    111.into(),
+                    103.into(),
+                    104.into(),
+                    9.into(),
+                    0.into(),
+                    8.into(),
+                    106.into(),
+                    105.into(),
+                    13.into(),
+                    110.into(),
+                    112.into(),
+                    113.into(),
+                    126.into(),
+                ],
+                bw: None,
+                attrs: vec![
                         MediaAttribute::Rtcp("9 IN IP4 0.0.0.0".into()),
                         MediaAttribute::IceUfrag("S5hk".into()),
                         MediaAttribute::IcePwd("0zV/Yu3y8aDzbHgqWhnVQhqP".into()),
@@ -1675,13 +1593,15 @@ mod test {
                         MediaAttribute::SendRecv,
                         MediaAttribute::Msid(Msid { stream_id: "5UUdwiuY7OML2EkQtF38pJtNP5v7In1LhjEK".into(), track_id: "f78dde68-7055-4e20-bb37-433803dd1ed1".into() }),
                         MediaAttribute::RtcpMux,
-                        MediaAttribute::RtpMap( CodecSpec { pt: 111.into(), codec: "opus".into(), clock_rate: 48_000, channels: Some(2) }),
+                        MediaAttribute::RtpMap { pt: 111.into(), value: RtpMap {  codec: "opus".into(), clock_rate: 48_000, channels: Some(2) }},
                         MediaAttribute::RtcpFb { pt: 111.into(), value: "transport-cc".into() },
                         MediaAttribute::Fmtp { pt: 111.into(), values: vec![FormatParam::MinPTime(10), FormatParam::UseInbandFec(true)] },
                         MediaAttribute::Ssrc { ssrc: 3_948_621_874.into(), attr: "cname".into(), value: "xeXs3aE9AOBn00yJ".into() },
                         MediaAttribute::Ssrc { ssrc: 3_948_621_874.into(), attr: "msid".into(), value: "5UUdwiuY7OML2EkQtF38pJtNP5v7In1LhjEK f78dde68-7055-4e20-bb37-433803dd1ed1".into() },
                         MediaAttribute::Ssrc { ssrc: 3_948_621_874.into(), attr: "mslabel".into(), value: "5UUdwiuY7OML2EkQtF38pJtNP5v7In1LhjEK".into() },
-                        MediaAttribute::Ssrc { ssrc: 3_948_621_874.into(), attr: "label".into(), value: "f78dde68-7055-4e20-bb37-433803dd1ed1".into() }] }] };
+                        MediaAttribute::Ssrc { ssrc: 3_948_621_874.into(), attr: "label".into(), value: "f78dde68-7055-4e20-bb37-433803dd1ed1".into() }],
+            }],
+        };
         assert_eq!(&format!("{sdp}"), "v=0\r\n\
             o=- 5058682828002148772 2 IN IP4 0.0.0.0\r\n\
             s=-\r\n\

--- a/src/sdp/mod.rs
+++ b/src/sdp/mod.rs
@@ -6,8 +6,8 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
 mod data;
-pub use data::{Codec, CodecSpec, FormatParams, Sdp, Session, SessionAttribute, Setup};
-pub use data::{MediaAttribute, MediaLine, MediaType, Msid, PayloadParams, Proto, SsrcInfo};
+pub use data::{MediaAttribute, MediaLine, MediaType, Msid, Proto, SsrcInfo};
+pub use data::{Sdp, Session, SessionAttribute, Setup};
 pub use data::{Simulcast, SimulcastGroup, SimulcastGroups, SimulcastOption};
 
 mod parser;

--- a/src/sdp/mod.rs
+++ b/src/sdp/mod.rs
@@ -6,8 +6,8 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
 mod data;
+pub use data::{FormatParam, Sdp, Session, SessionAttribute, Setup};
 pub use data::{MediaAttribute, MediaLine, MediaType, Msid, Proto, SsrcInfo};
-pub use data::{Sdp, Session, SessionAttribute, Setup};
 pub use data::{Simulcast, SimulcastGroup, SimulcastGroups, SimulcastOption};
 
 mod parser;

--- a/src/sdp/parser.rs
+++ b/src/sdp/parser.rs
@@ -512,12 +512,14 @@ where
     )
     .map(|(pt, _, codec, _, clock_rate, opt_channels)| {
         let channels = opt_channels.map(|(_, e)| e);
-        MediaAttribute::RtpMap(CodecSpec {
+        MediaAttribute::RtpMap {
             pt,
-            codec: codec.as_str().into(),
-            clock_rate,
-            channels,
-        })
+            value: RtpMap {
+                codec: codec.as_str().into(),
+                clock_rate,
+                channels,
+            },
+        }
     });
 
     // a=rtcp-fb:111 transport-cc

--- a/tests/bidirectional.rs
+++ b/tests/bidirectional.rs
@@ -1,7 +1,8 @@
 use std::net::Ipv4Addr;
 use std::time::Duration;
 
-use str0m::media::{Codec, Direction, MediaKind, MediaTime};
+use str0m::format::Codec;
+use str0m::media::{Direction, MediaKind, MediaTime};
 use str0m::{Candidate, RtcError};
 use tracing::info_span;
 
@@ -39,7 +40,7 @@ pub fn bidirectional_same_m_line() -> Result<(), RtcError> {
     r.last = max;
 
     let params = l.media(mid).unwrap().payload_params()[0];
-    assert_eq!(params.codec(), Codec::Opus);
+    assert_eq!(params.spec().codec, Codec::Opus);
     let pt = params.pt();
     const STEP: MediaTime = MediaTime::new(960, 48_000);
 

--- a/tests/unidirectional.rs
+++ b/tests/unidirectional.rs
@@ -1,7 +1,8 @@
 use std::net::Ipv4Addr;
 use std::time::Duration;
 
-use str0m::media::{Codec, Direction, MediaKind, MediaTime};
+use str0m::format::Codec;
+use str0m::media::{Direction, MediaKind, MediaTime};
 use str0m::{Candidate, RtcError};
 use tracing::info_span;
 
@@ -39,7 +40,7 @@ pub fn unidirectional() -> Result<(), RtcError> {
     r.last = max;
 
     let params = l.media(mid).unwrap().payload_params()[0];
-    assert_eq!(params.codec(), Codec::Opus);
+    assert_eq!(params.spec().codec, Codec::Opus);
     let pt = params.pt();
     const STEP: MediaTime = MediaTime::new(960, 48_000);
 


### PR DESCRIPTION
This splits out the codec configuration related structs from the sdp module, making it clearer what is about SDP parsing/serializing and what is generic config of the session.