### PR TITLE
New argument to add_media for setting stream_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ rtc.add_local_candidate(candidate);
 let mut change = rtc.sdp_api();
 
 // Do some change. A valid OFFER needs at least one "m-line" (media).
-let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None);
+let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None);
 
 // Get the offer.
 let (offer, pending) = change.apply().unwrap();

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -428,7 +428,9 @@ impl Client {
         for track in &mut self.tracks_out {
             if let TrackOutState::ToOpen = track.state {
                 if let Some(track_in) = track.track_in.upgrade() {
-                    let mid = change.add_media(track_in.kind, Direction::SendOnly, None);
+                    let stream_id = track_in.origin.to_string();
+                    let mid =
+                        change.add_media(track_in.kind, Direction::SendOnly, Some(stream_id), None);
                     track.state = TrackOutState::Negotiating(mid);
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@
 //! let mut change = rtc.sdp_api();
 //!
 //! // Do some change. A valid OFFER needs at least one "m-line" (media).
-//! let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None);
+//! let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None);
 //!
 //! // Get the offer.
 //! let (offer, pending) = change.apply().unwrap();
@@ -923,8 +923,8 @@ impl Rtc {
     /// let mut rtc = Rtc::new();
     ///
     /// let mut changes = rtc.sdp_api();
-    /// let mid_audio = changes.add_media(MediaKind::Audio, Direction::SendOnly, None);
-    /// let mid_video = changes.add_media(MediaKind::Video, Direction::SendOnly, None);
+    /// let mid_audio = changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None);
+    /// let mid_video = changes.add_media(MediaKind::Video, Direction::SendOnly, None, None);
     ///
     /// let (offer, pending) = changes.apply().unwrap();
     /// let json = serde_json::to_vec(&offer).unwrap();

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -197,6 +197,10 @@ pub enum SessionAttribute {
         typ: String,    // BUNDLE, LS etc
         mids: Vec<Mid>, // 0 1 2 3
     },
+    MsidSemantic {
+        semantic: String, // WMS
+        stream_ids: Vec<String>,
+    },
     IceLite,
     IceUfrag(String),
     IcePwd(String),
@@ -1232,6 +1236,17 @@ impl fmt::Display for SessionAttribute {
             Group { typ, mids } => {
                 let mids: Vec<_> = mids.iter().map(|m| m.to_string()).collect();
                 write!(f, "a=group:{} {}\r\n", typ, mids.join(" "))?;
+            }
+            MsidSemantic {
+                semantic,
+                stream_ids,
+            } => {
+                write!(
+                    f,
+                    "a=msid-semantic: {} {}\r\n",
+                    semantic,
+                    stream_ids.join(" ")
+                )?;
             }
             IceLite => write!(f, "a=ice-lite\r\n")?,
             IceUfrag(v) => write!(f, "a=ice-ufrag:{v}\r\n")?,

--- a/src/sdp/parser.rs
+++ b/src/sdp/parser.rs
@@ -124,6 +124,23 @@ where
     )
     .map(|(typ, _, mids)| SessionAttribute::Group { typ, mids });
 
+    // a=msid-semantic: WMS 9ce81ef6-c7cb-4da5-8f5f-3e7cc9b5f9b0
+    let msid_semantic = attribute_line(
+        "msid-semantic",
+        (
+            optional(token(' ')),
+            not_sp(),
+            token(' '),
+            sep_by1(not_sp(), token(' ')),
+        ),
+    )
+    .map(
+        |(_, semantic, _, stream_ids)| SessionAttribute::MsidSemantic {
+            semantic,
+            stream_ids,
+        },
+    );
+
     // a=ice-lite
     let ice_lite = attribute_line_flag("ice-lite").map(|_| SessionAttribute::IceLite);
 
@@ -171,6 +188,7 @@ where
 
     choice((
         attempt(group),
+        attempt(msid_semantic),
         attempt(ice_lite),
         attempt(ice_ufrag),
         attempt(ice_pwd),
@@ -973,7 +991,10 @@ mod test {
                                 ]
                             }),
                             SessionAttribute::IceOptions("trickle".to_string()),
-                            SessionAttribute::Unused("msid-semantic:WMS *".into())
+                            SessionAttribute::MsidSemantic {
+                                semantic: "WMS".into(),
+                                stream_ids: vec!["*".into()]
+                            },
                         ]
                     },
                     media_lines: vec![]

--- a/tests/bidirectional.rs
+++ b/tests/bidirectional.rs
@@ -22,7 +22,7 @@ pub fn bidirectional_same_m_line() -> Result<(), RtcError> {
     r.add_local_candidate(host2);
 
     let mut change = l.sdp_api();
-    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None);
+    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None);
     let (offer, pending) = change.apply().unwrap();
 
     let answer = r.rtc.sdp_api().accept_offer(offer)?;

--- a/tests/unidirectional.rs
+++ b/tests/unidirectional.rs
@@ -22,7 +22,7 @@ pub fn unidirectional() -> Result<(), RtcError> {
     r.add_local_candidate(host2);
 
     let mut change = l.sdp_api();
-    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None);
+    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None);
     let (offer, pending) = change.apply().unwrap();
 
     let answer = r.rtc.sdp_api().accept_offer(offer)?;


### PR DESCRIPTION
The stream id is part of the msid mechanism for identifying streams that belong together and therefore should be synced.