### PR TITLE
Media events after DTLS and Rtc::is_connected()

### DIFF
--- a/src/dtls/mod.rs
+++ b/src/dtls/mod.rs
@@ -251,6 +251,10 @@ impl Dtls {
             Ok(true)
         }
     }
+
+    pub(crate) fn is_connected(&self) -> bool {
+        self.tls.is_connected()
+    }
 }
 
 #[derive(Default)]

--- a/src/dtls/ossl.rs
+++ b/src/dtls/ossl.rs
@@ -180,6 +180,10 @@ where
         self.active
     }
 
+    pub fn is_connected(&self) -> bool {
+        matches!(self.state, State::Established(_))
+    }
+
     pub fn set_active(&mut self, active: bool) {
         assert!(
             self.active.is_none(),

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -99,6 +99,10 @@ struct StunRequest {
 const REMOTE_PEER_REFLEXIVE_TEMP_FOUNDATION: &str = "tmp_prflx";
 
 /// States the ICE connection can be in.
+///
+/// More details on connection states can be found in the [ICE RFC][1].
+///
+/// [1]: https://www.rfc-editor.org/rfc/rfc8445
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IceConnectionState {
     /// The ICE agent is gathering addresses.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1159,9 +1159,6 @@ impl Rtc {
                 };
                 return Ok(Output::Transmit(t));
             }
-        } else {
-            // Keep send buffers empty until we have ice connected.
-            self.session.clear_send_buffers();
         }
 
         let time_and_reason = (None, "<not happening>")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -895,23 +895,12 @@ impl Rtc {
         self.ice.add_remote_candidate(c);
     }
 
-    /// Checks current connection state. This state is also obtained via
-    /// [`Event::IceConnectionStateChange`].
+    /// Checks if we are connected.
     ///
-    /// More details on connection states can be found in the [ICE RFC][1].
-    /// ```
-    /// # use str0m::{Rtc, IceConnectionState};
-    /// let mut rtc = Rtc::new();
+    /// This tests both if we have ICE connection and DTLS is ready.
     ///
-    /// assert_eq!(rtc.ice_connection_state(), IceConnectionState::New);
-    /// ```
-    ///
-    /// [1]: https://www.rfc-editor.org/rfc/rfc8445
-    // TODO decide if we actually want this both as an event and as a call.
-    // If we have this as a call, why don't we also have the DTLS and SCTP states?
-    #[doc(hidden)]
-    pub fn ice_connection_state(&self) -> IceConnectionState {
-        self.ice.state()
+    pub fn is_connected(&self) -> bool {
+        self.ice.state().is_connected() && self.dtls.is_connected()
     }
 
     /// Make changes to the Rtc session via SDP.

--- a/src/session.rs
+++ b/src/session.rs
@@ -583,6 +583,11 @@ impl Session {
             return Some(MediaEvent::EgressBitrateEstimate(bitrate_estimate));
         }
 
+        // If we're not ready to flow media, don't send any events.
+        if !self.ready_for_srtp() {
+            return None;
+        }
+
         for media in &mut self.medias {
             if media.need_open_event {
                 media.need_open_event = false;
@@ -620,6 +625,10 @@ impl Session {
         }
 
         None
+    }
+
+    fn ready_for_srtp(&self) -> bool {
+        self.srtp_rx.is_some() && self.srtp_tx.is_some()
     }
 
     pub fn poll_datagram(&mut self, now: Instant) -> Option<net::DatagramSend> {

--- a/src/session.rs
+++ b/src/session.rs
@@ -847,12 +847,6 @@ impl Session {
         &self.medias
     }
 
-    pub(crate) fn clear_send_buffers(&mut self) {
-        for m in &mut self.medias {
-            m.clear_send_buffers();
-        }
-    }
-
     fn configure_pacer_padding(&mut self) {
         let Some(bwe) = self.bwe.as_ref() else {
             return;

--- a/tests/bidirectional.rs
+++ b/tests/bidirectional.rs
@@ -29,7 +29,7 @@ pub fn bidirectional_same_m_line() -> Result<(), RtcError> {
     l.rtc.sdp_api().accept_answer(pending, answer)?;
 
     loop {
-        if l.ice_connection_state().is_connected() || r.ice_connection_state().is_connected() {
+        if l.is_connected() || r.is_connected() {
             break;
         }
         progress(&mut l, &mut r)?;

--- a/tests/data-channel-direct.rs
+++ b/tests/data-channel-direct.rs
@@ -51,7 +51,7 @@ pub fn data_channel_direct() -> Result<(), RtcError> {
     r.direct_api().create_data_channel(config);
 
     loop {
-        if l.ice_connection_state().is_connected() || r.ice_connection_state().is_connected() {
+        if l.is_connected() || r.is_connected() {
             break;
         }
         progress(&mut l, &mut r)?;

--- a/tests/data-channel.rs
+++ b/tests/data-channel.rs
@@ -27,7 +27,7 @@ pub fn data_channel() -> Result<(), RtcError> {
     l.rtc.sdp_api().accept_answer(pending, answer)?;
 
     loop {
-        if l.ice_connection_state().is_connected() || r.ice_connection_state().is_connected() {
+        if l.is_connected() || r.is_connected() {
             break;
         }
         progress(&mut l, &mut r)?;

--- a/tests/unidirectional.rs
+++ b/tests/unidirectional.rs
@@ -29,7 +29,7 @@ pub fn unidirectional() -> Result<(), RtcError> {
     l.rtc.sdp_api().accept_answer(pending, answer)?;
 
     loop {
-        if l.ice_connection_state().is_connected() || r.ice_connection_state().is_connected() {
+        if l.is_connected() || r.is_connected() {
             break;
         }
         progress(&mut l, &mut r)?;


### PR DESCRIPTION
This PR does four things:

* Emits a new `Connected` event when both ICE and DTLS are established.
* Replaces the (hidden) `Rtc::ice_connection_state()` with `Rtc::is_connected()`
* Delays emitting `MediaAdded` and media events until after DTLS is established.
* Removes the auto-clearing of send buffers before connection, since this is a user concern.

