### PR TITLE
BWE tweaks

### DIFF
--- a/src/media/inner.rs
+++ b/src/media/inner.rs
@@ -1128,9 +1128,7 @@ impl MediaInner {
         let state = QueueState {
             mid: self.mid,
             is_audio: self.kind.is_audio(),
-            use_for_padding: self.kind.is_video()
-                && self.has_tx_rtx()
-                && snapshot.last_emitted.is_some(),
+            use_for_padding: self.kind.is_video() && self.has_tx_rtx() && snapshot.has_ever_sent(),
             snapshot,
         };
 

--- a/src/media/inner.rs
+++ b/src/media/inner.rs
@@ -1128,7 +1128,9 @@ impl MediaInner {
         let state = QueueState {
             mid: self.mid,
             is_audio: self.kind.is_audio(),
-            use_for_padding: self.kind.is_video() && self.has_tx_rtx(),
+            use_for_padding: self.kind.is_video()
+                && self.has_tx_rtx()
+                && snapshot.last_emitted.is_some(),
             snapshot,
         };
 

--- a/src/packet/pacer.rs
+++ b/src/packet/pacer.rs
@@ -11,7 +11,7 @@ const MAX_BITRATE: Bitrate = Bitrate::gbps(10);
 const MAX_DEBT_IN_TIME: Duration = Duration::from_millis(500);
 const MAX_PADDING_PACKET_SIZE: DataSize = DataSize::bytes(224);
 const PADDING_BURST_INTERVAL: Duration = Duration::from_millis(5);
-const MAX_CONSECUTIVE_PADDING_PACKETS: usize = 5_000;
+const MAX_CONSECUTIVE_PADDING_PACKETS: usize = 1 << 16;
 
 pub enum PacerImpl {
     Null(NullPacer),

--- a/src/packet/pacer.rs
+++ b/src/packet/pacer.rs
@@ -1295,7 +1295,7 @@ mod test {
                 QueueState {
                     mid: self.mid,
                     is_audio: self.is_audio,
-                    use_for_padding: !self.is_audio,
+                    use_for_padding: !self.is_audio && self.last_send_time.is_some(),
                     snapshot: QueueSnapshot {
                         created_at: now,
                         size: self.queue.iter().map(QueuedPacket::size).sum(),

--- a/src/packet/pacer.rs
+++ b/src/packet/pacer.rs
@@ -11,7 +11,7 @@ const MAX_BITRATE: Bitrate = Bitrate::gbps(10);
 const MAX_DEBT_IN_TIME: Duration = Duration::from_millis(500);
 const MAX_PADDING_PACKET_SIZE: DataSize = DataSize::bytes(224);
 const PADDING_BURST_INTERVAL: Duration = Duration::from_millis(5);
-const MAX_CONSECUTIVE_PADDING_PACKETS: usize = 1 << 16;
+const MAX_CONSECUTIVE_PADDING_PACKETS: usize = u16::MAX as usize;
 
 pub enum PacerImpl {
     Null(NullPacer),
@@ -115,6 +115,15 @@ pub struct QueueSnapshot {
     pub last_emitted: Option<Instant>,
     /// Time the first unsent packet has spent in the queue.
     pub first_unsent: Option<Instant>,
+}
+
+impl QueueSnapshot {
+    /// Whether anything has ever been sent on this queue.
+    ///
+    /// Used to ensure we don't send padding before sending the first bits of media.
+    pub fn has_ever_sent(&self) -> bool {
+        self.last_emitted.is_some()
+    }
 }
 
 impl Default for QueueSnapshot {

--- a/src/rtp/bandwidth.rs
+++ b/src/rtp/bandwidth.rs
@@ -49,8 +49,14 @@ impl Bitrate {
         Self(self.0.clamp(min.0, max.0))
     }
 
-    pub(crate) fn min(&self, other: Self) -> Self {
+    /// Return the minimum bitrate between `self` and `other`.
+    pub fn min(&self, other: Self) -> Self {
         Self(self.0.min(other.0))
+    }
+
+    /// Return the maximum bitrate between `self` and `other`.
+    pub fn max(&self, other: Self) -> Self {
+        Self(self.0.max(other.0))
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -873,6 +873,13 @@ impl Session {
             .unwrap_or(Bitrate::ZERO);
 
         self.pacer.set_padding_rate(padding_rate);
+
+        // We pad up to the pacing rate, therefore we need to increase pacing if the estimate, and
+        // thus the padding rate, exceeds the current bitrate adjusted with the pacing factor.
+        // Otherwise we can have a case where the current bitrate is 250Kbit/s resulting in a
+        // pacing rate of 275KBit/s which means we'll only ever pad about 25Kbit/s. If the estimate
+        // is actually 600Kbit/s we need to use that for the pacing rate to ensure we send as much as
+        // we think the link capacity can sustain, if not the estimate is a lie.
         let pacing_rate = (bwe.current_bitrate * PACING_FACTOR).max(padding_rate);
         self.pacer.set_pacing_rate(pacing_rate);
     }


### PR DESCRIPTION
- Don't use queues for padding before first media
- Increase max consecutive padding packets
- Tweak pacing and padding rates
