### PR TITLE
Extend MediaTime

### DIFF
--- a/src/media/sender.rs
+++ b/src/media/sender.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use crate::rtp::{extend_seq, Descriptions, InstantExt, MediaTime, Mid, ReceptionReport};
+use crate::rtp::{extend_u16, Descriptions, InstantExt, MediaTime, Mid, ReceptionReport};
 use crate::rtp::{ReportList, Rid, Sdes, SdesType, SenderInfo};
 use crate::rtp::{SenderReport, SeqNo, Ssrc};
 
@@ -150,7 +150,7 @@ impl SenderSource {
         let ext_seq = {
             let prev = self.losses.last().map(|s| s.0).unwrap_or(r.max_seq as u64);
             let next = (r.max_seq & 0xffff) as u16;
-            extend_seq(Some(prev), next)
+            extend_u16(Some(prev), next)
         };
 
         self.losses

--- a/src/rtp/header.rs
+++ b/src/rtp/header.rs
@@ -253,14 +253,14 @@ impl RtpHeader {
     /// The logic detects wrap-arounds of the 16-bit RTP sequence number.
     #[doc(hidden)]
     pub fn sequence_number(&self, previous: Option<SeqNo>) -> SeqNo {
-        let e_seq = extend_seq(previous.map(|v| *v), self.sequence_number);
+        let e_seq = extend_u16(previous.map(|v| *v), self.sequence_number);
         e_seq.into()
     }
 }
 
 /// "extend" a 16 bit sequence number into a 64 bit by
 /// using the knowledge of the previous such sequence number.
-pub fn extend_seq(prev_ext_seq: Option<u64>, seq: u16) -> u64 {
+pub fn extend_u16(prev_ext_seq: Option<u64>, seq: u16) -> u64 {
     // We define the index of the SRTP packet corresponding to a given
     // ROC and RTP sequence number to be the 48-bit quantity
     //       i = 2^16 * ROC + SEQ.
@@ -320,19 +320,19 @@ mod test {
 
     #[test]
     fn extend_seq_wrap_around() {
-        assert_eq!(extend_seq(None, 0), 0);
-        assert_eq!(extend_seq(Some(0), 1), 1);
-        assert_eq!(extend_seq(Some(65_535), 0), 65_536);
-        assert_eq!(extend_seq(Some(65_500), 2), 65_538);
-        assert_eq!(extend_seq(Some(2), 1), 1);
-        assert_eq!(extend_seq(Some(65_538), 1), 65_537);
-        assert_eq!(extend_seq(Some(3), 3), 3);
-        assert_eq!(extend_seq(Some(65_500), 65_500), 65_500);
+        assert_eq!(extend_u16(None, 0), 0);
+        assert_eq!(extend_u16(Some(0), 1), 1);
+        assert_eq!(extend_u16(Some(65_535), 0), 65_536);
+        assert_eq!(extend_u16(Some(65_500), 2), 65_538);
+        assert_eq!(extend_u16(Some(2), 1), 1);
+        assert_eq!(extend_u16(Some(65_538), 1), 65_537);
+        assert_eq!(extend_u16(Some(3), 3), 3);
+        assert_eq!(extend_u16(Some(65_500), 65_500), 65_500);
     }
 
     #[test]
     fn extend_33k_with_0_prev() {
-        assert_eq!(extend_seq(Some(0), 33_000), 281474976678120);
+        assert_eq!(extend_u16(Some(0), 33_000), 281474976678120);
     }
 
     #[test]

--- a/src/rtp/mod.rs
+++ b/src/rtp/mod.rs
@@ -20,7 +20,7 @@ mod mtime;
 pub use mtime::{InstantExt, MediaTime};
 
 mod header;
-pub use header::{extend_u16, RtpHeader};
+pub use header::{extend_u16, extend_u32, RtpHeader};
 
 mod srtp;
 pub use srtp::{SrtpContext, SrtpKey};

--- a/src/rtp/mod.rs
+++ b/src/rtp/mod.rs
@@ -20,7 +20,7 @@ mod mtime;
 pub use mtime::{InstantExt, MediaTime};
 
 mod header;
-pub use header::{extend_seq, RtpHeader};
+pub use header::{extend_u16, RtpHeader};
 
 mod srtp;
 pub use srtp::{SrtpContext, SrtpKey};

--- a/src/rtp/rtcp/mod.rs
+++ b/src/rtp/rtcp/mod.rs
@@ -42,7 +42,7 @@ pub use twcc::{Twcc, TwccRecvRegister, TwccSendRecord, TwccSendRegister};
 mod rtcpfb;
 pub use rtcpfb::RtcpFb;
 
-pub use super::extend_seq;
+pub use super::extend_u16;
 pub use super::Bitrate;
 pub use super::MediaTime;
 pub use super::SeqNo;

--- a/src/rtp/rtcp/nack.rs
+++ b/src/rtp/rtcp/nack.rs
@@ -1,4 +1,4 @@
-use super::extend_seq;
+use super::extend_u16;
 use super::{FeedbackMessageType, ReportList, RtcpHeader, RtcpPacket, SeqNo};
 use super::{RtcpType, Ssrc, TransportType};
 
@@ -113,7 +113,7 @@ impl Iterator for NackEntryIterator {
                 }
             }
         };
-        let l = extend_seq(Some(*self.2), seq_16);
+        let l = extend_u16(Some(*self.2), seq_16);
         Some(l.into())
     }
 }

--- a/src/rtp/rtcp/twcc.rs
+++ b/src/rtp/rtcp/twcc.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::ops::RangeInclusive;
 use std::time::{Duration, Instant};
 
-use super::{extend_seq, FeedbackMessageType, RtcpHeader, RtcpPacket};
+use super::{extend_u16, FeedbackMessageType, RtcpHeader, RtcpPacket};
 use super::{RtcpType, SeqNo, Ssrc, TransportType};
 
 #[derive(Clone, PartialEq, Eq)]
@@ -31,7 +31,7 @@ impl Twcc {
     pub fn into_iter(self, time_zero: Instant, extend_from: SeqNo) -> TwccIter {
         let millis = self.reference_time as u64 * 64;
         let time_base = time_zero + Duration::from_millis(millis);
-        let base_seq = extend_seq(Some(*extend_from), self.base_seq);
+        let base_seq = extend_u16(Some(*extend_from), self.base_seq);
         TwccIter {
             base_seq,
             time_base,

--- a/src/session.rs
+++ b/src/session.rs
@@ -9,7 +9,7 @@ use crate::packet::{
     LeakyBucketPacer, NullPacer, Pacer, PacerImpl, PollOutcome, RtpMeta, SendSideBandwithEstimator,
 };
 use crate::rtp::SRTCP_OVERHEAD;
-use crate::rtp::{extend_seq, RtpHeader, SessionId, TwccRecvRegister, TwccSendRegister};
+use crate::rtp::{extend_u16, RtpHeader, SessionId, TwccRecvRegister, TwccSendRegister};
 use crate::rtp::{Bitrate, ExtensionMap, MediaTime, Mid, Rtcp, RtcpFb};
 use crate::rtp::{SrtpContext, SrtpKey, Ssrc};
 use crate::stats::StatsSnapshot;
@@ -330,7 +330,7 @@ impl Session {
         trace!("Handle RTP: {:?}", header);
         if let Some(transport_cc) = header.ext_vals.transport_cc {
             let prev = self.twcc_rx_register.max_seq();
-            let extended = extend_seq(Some(*prev), transport_cc);
+            let extended = extend_u16(Some(*prev), transport_cc);
             self.twcc_rx_register.update_seq(extended.into(), now);
         }
 


### PR DESCRIPTION
This fixes a bug where the `MediaData::time` is not extended. The intention is that time will just keep going up.