### PR TITLE
Delay packetizer enqueue until handle_timeout

### DIFF
--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -551,10 +551,9 @@ impl Client {
             return;
         };
 
-        if let Err(e) =
-            media
-                .writer(pt, Instant::now())
-                .write(data.network_time, data.time, &data.data)
+        if let Err(e) = media
+            .writer(pt)
+            .write(data.network_time, data.time, &data.data)
         {
             warn!("Client ({}) failed: {:?}", *self.id, e);
             self.rtc.disconnect();

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -6,7 +6,7 @@ use crate::format::PayloadParams;
 pub use crate::rtp::VideoOrientation;
 pub use crate::rtp::{Direction, ExtensionValues, MediaTime, Mid, Pt, Rid};
 
-use crate::{Input, Rtc, RtcError};
+use crate::{Rtc, RtcError};
 
 mod event;
 pub use event::*;
@@ -106,10 +106,6 @@ impl Media<'_> {
     /// parameters with the configured ones in this `Media` instance. It's also possible to
     /// manually match the codec using [`Media::payload_params()`].
     ///
-    /// The `now` parameter is required to know the exact time the data is enqueued. This has a
-    /// side effect of driving the time of the `Rtc` instance forward. I.e. passing the `now` here
-    /// is the same driving time forward with `handle_input()`.
-    ///
     /// `rid` is [Rtp Stream Identifier][1]. In classic RTP, individual RTP packets are identified
     /// via an RTP header value `SSRC` (Synchronization Source). However it's been proposed to send
     /// the RID in a header extension as an alternative way, making SSRC less important. Currently
@@ -123,7 +119,6 @@ impl Media<'_> {
     /// # use str0m::Rtc;
     /// # use str0m::media::{MediaData, Mid};
     /// # use str0m::format::PayloadParams;
-    /// # use std::time::Instant;
     /// let mut rtc = Rtc::new();
     ///
     /// // add candidates, do SDP negotiation
@@ -137,11 +132,11 @@ impl Media<'_> {
     /// // Match incoming PT to an outgoing PT.
     /// let pt = media.match_params(data.params).unwrap();
     ///
-    /// media.writer(pt, Instant::now()).write(data.network_time, data.time, &data.data).unwrap();
+    /// media.writer(pt).write(data.network_time, data.time, &data.data).unwrap();
     /// ```
     ///
     /// [1]: https://datatracker.ietf.org/doc/html/rfc8852
-    pub fn writer(&mut self, pt: Pt, now: Instant) -> Writer<'_> {
+    pub fn writer(&mut self, pt: Pt) -> Writer<'_> {
         let media = Media {
             rtc: self.rtc,
             mid: self.mid,
@@ -149,7 +144,6 @@ impl Media<'_> {
 
         Writer {
             media,
-            now,
             pt,
             rid: None,
             ext_vals: ExtensionValues::default(),
@@ -215,7 +209,6 @@ impl Media<'_> {
 /// # use str0m::Rtc;
 /// # use str0m::media::{MediaData, Mid};
 /// # use str0m::format::PayloadParams;
-/// # use std::time::Instant;
 /// let mut rtc = Rtc::new();
 ///
 /// // add candidates, do SDP negotiation
@@ -231,13 +224,12 @@ impl Media<'_> {
 /// let pt = media.match_params(data.params).unwrap();
 ///
 /// // Send data with video orientation added.
-/// media.writer(pt, Instant::now())
+/// media.writer(pt)
 ///     .video_orientation(video_orientation)
 ///     .write(data.network_time, data.time, &data.data).unwrap();
 /// ```
 pub struct Writer<'a> {
     media: Media<'a>,
-    now: Instant,
     pt: Pt,
     rid: Option<Rid>,
     ext_vals: ExtensionValues,
@@ -267,7 +259,7 @@ impl<'a> Writer<'a> {
         self
     }
 
-    /// Do the actual write of media. This consumed the builder.
+    /// Do the actual write of media.
     ///
     /// Regarding `wallclock` and `rtp_time`, the wallclock is the real world time that corresponds to
     /// the `MediaTime`. For an SFU, this can be hard to know, since RTP packets typically only
@@ -278,32 +270,16 @@ impl<'a> Writer<'a> {
     ///
     /// Notice that incorrect [`Pt`] values would surface as an error here, not when
     /// doing [`Media::writer()`].
-    ///
-    /// If you write media before `IceConnectionState` is `Connected` it will be dropped.
     pub fn write(
         mut self,
         wallclock: Instant,
         rtp_time: MediaTime,
         data: &[u8],
-    ) -> Result<usize, RtcError> {
+    ) -> Result<(), RtcError> {
         let media = self.media.inner_mut();
 
-        let n = media.write(
-            self.now,
-            self.pt,
-            wallclock,
-            rtp_time,
-            data,
-            self.rid,
-            self.ext_vals,
-        )?;
+        media.write(self.pt, wallclock, rtp_time, data, self.rid, self.ext_vals)?;
 
-        // Handle_input with a Input::Timeout can't fail, hence the expect.
-        self.media
-            .rtc
-            .handle_input(Input::Timeout(self.now))
-            .expect("handle_input with Timeout to not panic");
-
-        Ok(n)
+        Ok(())
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -199,9 +199,9 @@ impl Session {
         self.srtp_tx = Some(ctx_tx);
     }
 
-    pub fn handle_timeout(&mut self, now: Instant) {
+    pub fn handle_timeout(&mut self, now: Instant) -> Result<(), RtcError> {
         for m in &mut self.medias {
-            m.handle_timeout(now);
+            m.handle_timeout(now)?;
         }
 
         let sender_ssrc = self.first_ssrc_local();
@@ -239,6 +239,8 @@ impl Session {
         if let Some(bwe) = self.bwe.as_mut() {
             bwe.handle_timeout(now);
         }
+
+        Ok(())
     }
 
     fn create_twcc_feedback(&mut self, sender_ssrc: Ssrc, now: Instant) -> Option<()> {

--- a/tests/bidirectional.rs
+++ b/tests/bidirectional.rs
@@ -2,8 +2,8 @@ use std::net::Ipv4Addr;
 use std::time::Duration;
 
 use str0m::format::Codec;
-use str0m::media::{Direction, MediaKind, MediaTime};
-use str0m::{Candidate, RtcError};
+use str0m::media::{Direction, MediaKind};
+use str0m::{Candidate, Event, RtcError};
 use tracing::info_span;
 
 mod common;
@@ -42,51 +42,51 @@ pub fn bidirectional_same_m_line() -> Result<(), RtcError> {
     let params = l.media(mid).unwrap().payload_params()[0];
     assert_eq!(params.spec().codec, Codec::Opus);
     let pt = params.pt();
-    const STEP: MediaTime = MediaTime::new(960, 48_000);
-
-    let mut time_l: MediaTime = l.duration().into();
-    time_l = time_l.rebase(48_000);
-    let mut time_r: MediaTime = r.duration().into();
-    time_r = time_r.rebase(48_000);
 
     let data_a = vec![1_u8; 80];
     let data_b = vec![2_u8; 80];
 
     loop {
-        let dur_l: Duration = time_l.into();
-        while l.duration() > dur_l {
-            let wallclock = l.start + Duration::from_micros(time_l.as_micros() as u64);
-            let now = wallclock; // NB these are not the same in actual code.
-            let free = l
-                .media(mid)
-                .map(|mut m| m.writer(pt, now).write(wallclock, time_l, &data_a))
-                .unwrap()?;
-            time_l = time_l + STEP;
-            if free == 0 {
-                break;
-            };
+        {
+            let wallclock = l.start + l.duration();
+            let time = l.duration().into();
+            l.media(mid)
+                .unwrap()
+                .writer(pt)
+                .write(wallclock, time, &data_a)?;
         }
 
-        let dur_r: Duration = time_r.into();
-        while r.duration() > dur_r {
-            let wallclock = r.start + Duration::from_micros(time_r.as_micros() as u64);
-            let now = wallclock; // NB these are not the same in actual code.
-            let free = r
-                .media(mid)
-                .map(|mut m| m.writer(pt, now).write(wallclock, time_r, &data_b))
-                .unwrap()?;
-            time_r = time_r + STEP;
-            if free == 0 {
-                break;
-            };
+        {
+            let wallclock = r.start + r.duration();
+            let time = l.duration().into();
+            r.media(mid)
+                .unwrap()
+                .writer(pt)
+                .write(wallclock, time, &data_b)?;
         }
 
         progress(&mut l, &mut r)?;
 
-        if time_l > MediaTime::from_seconds(10) {
+        if l.duration() > Duration::from_secs(10) {
             break;
         }
     }
+
+    let media_count_r = r
+        .events
+        .iter()
+        .filter(|e| matches!(e, Event::MediaData(_)))
+        .count();
+
+    assert!(media_count_r > 180);
+
+    let media_count_l = l
+        .events
+        .iter()
+        .filter(|e| matches!(e, Event::MediaData(_)))
+        .count();
+
+    assert!(media_count_l > 180);
 
     Ok(())
 }

--- a/tests/unidirectional.rs
+++ b/tests/unidirectional.rs
@@ -2,8 +2,8 @@ use std::net::Ipv4Addr;
 use std::time::Duration;
 
 use str0m::format::Codec;
-use str0m::media::{Direction, MediaKind, MediaTime};
-use str0m::{Candidate, RtcError};
+use str0m::media::{Direction, MediaKind};
+use str0m::{Candidate, Event, RtcError};
 use tracing::info_span;
 
 mod common;
@@ -42,34 +42,31 @@ pub fn unidirectional() -> Result<(), RtcError> {
     let params = l.media(mid).unwrap().payload_params()[0];
     assert_eq!(params.spec().codec, Codec::Opus);
     let pt = params.pt();
-    const STEP: MediaTime = MediaTime::new(960, 48_000);
-
-    let mut time_l: MediaTime = l.duration().into();
-    time_l = time_l.rebase(48_000);
 
     let data_a = vec![1_u8; 80];
 
     loop {
-        let dur_l: Duration = time_l.into();
-        while l.duration() > dur_l {
-            let wallclock = l.start + Duration::from_micros(time_l.as_micros() as u64);
-            let now = wallclock; // NB these are not the same in actual code.
-            let free = l
-                .media(mid)
-                .map(|mut m| m.writer(pt, now).write(wallclock, time_l, &data_a))
-                .unwrap()?;
-            time_l = time_l + STEP;
-            if free == 0 {
-                break;
-            };
-        }
+        let wallclock = l.start + l.duration();
+        let time = l.duration().into();
+        l.media(mid)
+            .unwrap()
+            .writer(pt)
+            .write(wallclock, time, &data_a)?;
 
         progress(&mut l, &mut r)?;
 
-        if time_l > MediaTime::from_seconds(10) {
+        if l.duration() > Duration::from_secs(10) {
             break;
         }
     }
+
+    let media_count = r
+        .events
+        .iter()
+        .filter(|e| matches!(e, Event::MediaData(_)))
+        .count();
+
+    assert!(media_count > 180);
 
     Ok(())
 }


### PR DESCRIPTION
Enqueing to the PacketizingBuffer requires a "queued_at" field which is "now". We don't want write() to drive time forward, which means we are temporarily storing the packets until next handle_timeout.

The expected behavior is:
1. MediaWriter::write()
2. to_packetize.push()
3. poll_output -> timeout straight away
4. handle_timeout(straight away)
5. to_packetize.pop()