### PR TITLE
One target rate for pacer and smooth BWE output

### DIFF
--- a/src/media/receiver.rs
+++ b/src/media/receiver.rs
@@ -143,7 +143,7 @@ impl ReceiverSource {
             nack.ssrc = self.ssrc;
         }
 
-        info!("Send nacks: {:?}", nacks);
+        debug!("Send nacks: {:?}", nacks);
         Some(nacks)
     }
 

--- a/src/rtp/bandwidth.rs
+++ b/src/rtp/bandwidth.rs
@@ -72,6 +72,14 @@ impl From<f64> for Bitrate {
     }
 }
 
+impl Add<Bitrate> for Bitrate {
+    type Output = Bitrate;
+
+    fn add(self, rhs: Bitrate) -> Self::Output {
+        Bitrate(self.0 + rhs.0)
+    }
+}
+
 impl Mul<Duration> for Bitrate {
     type Output = DataSize;
 

--- a/src/util/value_history.rs
+++ b/src/util/value_history.rs
@@ -34,13 +34,21 @@ where
         self.drain(t);
     }
 
-    /// Returns the sum of the values more recent than given Instant
-    pub fn sum_since(&self, t: Instant) -> T {
+    fn timed_values_since(&self, t: Instant) -> impl Iterator<Item = T> + '_ {
         self.history
             .iter()
-            .filter(|(vt, _)| vt >= &t)
+            .rev()
+            .take_while(move |(vt, _)| *vt >= t)
             .map(|(_, v)| *v)
-            .sum()
+    }
+
+    /// Returns the sum of the values more recent than given Instant
+    pub fn sum_since(&self, t: Instant) -> T {
+        self.timed_values_since(t).sum()
+    }
+
+    pub fn count_since(&self, t: Instant) -> usize {
+        self.timed_values_since(t).count()
     }
 
     fn drain(&mut self, t: Instant) -> Option<()> {


### PR DESCRIPTION
This PR has two parts.

1. Reduce the input to Pacer to one target rate.
2. Use a weighted average of the BWE as event and input to Pacer.
