### PR TITLE
Clear queue state cache on direction change

### DIFF
--- a/src/media/inner.rs
+++ b/src/media/inner.rs
@@ -1137,6 +1137,8 @@ impl MediaInner {
             self.mid, self.dir, new_dir
         );
 
+        // Clear cache
+        self.queue_state = None;
         self.need_changed_event = true;
 
         let was_receiving = self.dir.is_receiving();


### PR DESCRIPTION
Without this the after setting the direction back to send the pacer
would believe it could send padding, but since we clear all the media
state this is not true.
