### PR TITLE
Remove all use of unsafe and forbid it

### DIFF
--- a/src/dtls/ossl.rs
+++ b/src/dtls/ossl.rs
@@ -25,9 +25,9 @@ const DTLS_SRTP: &str = "SRTP_AES128_CM_SHA1_80";
 const DTLS_EC_CURVE: Nid = Nid::X9_62_PRIME256V1;
 const DTLS_KEY_LABEL: &str = "EXTRACTOR-dtls_srtp";
 
-extern "C" {
-    pub fn DTLSv1_2_method() -> *const openssl_sys::SSL_METHOD;
-}
+// extern "C" {
+//     pub fn DTLSv1_2_method() -> *const openssl_sys::SSL_METHOD;
+// }
 
 /// Certificate used for DTLS.
 #[derive(Debug, Clone)]
@@ -87,8 +87,11 @@ impl DtlsCert {
 }
 
 pub fn dtls_create_ctx(cert: &DtlsCert) -> Result<SslContext, DtlsError> {
-    let method = unsafe { SslMethod::from_ptr(DTLSv1_2_method()) };
-    let mut ctx = SslContextBuilder::new(method)?;
+    // TODO: Technically we want to disallow DTLS < 1.2, but that requires
+    // us to use this commented out unsafe. We depend on browsers disallowing
+    // it instead.
+    // let method = unsafe { SslMethod::from_ptr(DTLSv1_2_method()) };
+    let mut ctx = SslContextBuilder::new(SslMethod::dtls())?;
 
     ctx.set_cipher_list(DTLS_CIPHERS)?;
     ctx.set_tlsext_use_srtp(DTLS_SRTP)?;

--- a/src/io/id.rs
+++ b/src/io/id.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::str::from_utf8_unchecked;
+use std::str::from_utf8;
 
 use rand::Rng;
 
@@ -33,8 +33,7 @@ impl<const L: usize> Default for Id<L> {
 
 impl<const L: usize> fmt::Display for Id<L> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // SAFETY: we know this is ascii chars.
-        let s = unsafe { from_utf8_unchecked(&self.0) };
+        let s = from_utf8(&self.0).expect("ascii characters");
         write!(f, "{s}")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -484,6 +484,7 @@
 //! [x-chat]:     https://github.com/algesten/str0m/blob/main/examples/chat.rs
 //! [intg]:       https://github.com/algesten/str0m/blob/main/tests/unidirectional.rs#L12
 
+#![forbid(unsafe_code)]
 #![allow(clippy::new_without_default)]
 #![allow(clippy::bool_to_int_with_if)]
 #![allow(clippy::assertions_on_constants)]

--- a/src/rtp/id.rs
+++ b/src/rtp/id.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 use std::ops::Deref;
-use std::str::from_utf8_unchecked;
+use std::str::from_utf8;
 
 use serde::{Deserialize, Serialize};
 
@@ -43,8 +43,7 @@ macro_rules! str_id {
             type Target = str;
 
             fn deref(&self) -> &Self::Target {
-                // SAFETY: We know the mid is ascii alphanumeric
-                unsafe { from_utf8_unchecked(&self.0) }.trim()
+                from_utf8(&self.0).expect("ascii id").trim()
             }
         }
 


### PR DESCRIPTION
This removes a bad `*const u8 as *mut u8` which breaks in nightly.

Further more we remove all use of `unsafe` and slap on the forbid directive.