### PR TITLE
Fix duration to ms conversion

### DIFF
--- a/src/media/inner.rs
+++ b/src/media/inner.rs
@@ -523,9 +523,9 @@ impl MediaInner {
         };
         buf.truncate(header_len + body_len);
 
-        #[cfg(feature = "_internal_dont_uselog_stats")]
+        #[cfg(feature = "_internal_dont_use_log_stats")]
         if let Some(delay) = next.body.queued_at().map(|i| now.duration_since(i)) {
-            crate::log_stat!("QUEUE_DELAY", header.ssrc, delay.as_millis());
+            crate::log_stat!("QUEUE_DELAY", header.ssrc, delay.as_secs_f64() * 1000.0);
         }
 
         Some(PolledPacket {

--- a/src/packet/bwe/arrival_group.rs
+++ b/src/packet/bwe/arrival_group.rs
@@ -88,8 +88,8 @@ impl ArrivalGroup {
         let first_seq_no = self.first.map(|(s, _, _)| s)?;
         let last_seq_no = self.last_seq_no?;
 
-        let arrival_delta = self.arrival_delta(other)?.as_secs_f64() / 1000.0;
-        let departure_delta = self.departure_delta(other)?.as_secs_f64() / 1000.0;
+        let arrival_delta = self.arrival_delta(other)?.as_secs_f64() * 1000.0;
+        let departure_delta = self.departure_delta(other)?.as_secs_f64() * 1000.0;
 
         assert!(arrival_delta >= 0.0);
 

--- a/src/packet/bwe/trendline_estimator.rs
+++ b/src/packet/bwe/trendline_estimator.rs
@@ -115,7 +115,7 @@ impl TrendlineEstimator {
         let remote_recv_time = variation.last_remote_recv_time - zero_time;
         let timing = Timing {
             at: now,
-            remote_recv_time_ms: remote_recv_time.as_secs_f64() / 1000.0,
+            remote_recv_time_ms: remote_recv_time.as_secs_f64() * 1000.0,
             smoothed_delay_ms: self.smoothed_delay,
         };
 


### PR DESCRIPTION
We were dividing by 1000 instead of multiplying, however this was done
consistently which is why everything sill worked well. We will see if
this makes BWE as a whole more robust, especially under poor network
conditions.
