### PR TITLE
MediaData time tweaks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -766,6 +766,7 @@ pub enum Input<'a> {
 }
 
 /// Output produced by [`Rtc::poll_output()`]
+#[allow(clippy::large_enum_variant)]
 pub enum Output {
     /// When the [`Rtc`] instance expects an [`Input::Timeout`].
     Timeout(Instant),

--- a/src/media/event.rs
+++ b/src/media/event.rs
@@ -108,7 +108,7 @@ pub struct MediaData {
     /// For audio the timebase is 48kHz for video it is 90kHz.
     pub time: MediaTime,
 
-    /// The time of the [`Input::Receive`][crate::Input::Receive] that caused this MediaData.
+    /// The time of the [`Input::Receive`][crate::Input::Receive] of the first packet that caused this MediaData.
     ///
     /// In simple SFU setups this can be used as wallclock for [`Writer::write`][crate::media::Writer].
     pub network_time: Instant,

--- a/src/media/event.rs
+++ b/src/media/event.rs
@@ -1,5 +1,5 @@
 use std::ops::RangeInclusive;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::rtp::{Direction, ExtensionValues, MediaTime, Mid, Pt, Rid, SeqNo};
 use crate::sdp::Simulcast as SdpSimulcast;
@@ -112,6 +112,10 @@ pub struct MediaData {
     ///
     /// In simple SFU setups this can be used as wallclock for [`Writer::write`][crate::media::Writer].
     pub network_time: Instant,
+
+    /// The delay caused by building this [`MediaData`] from RTP packets i.e. the difference
+    /// between when the first and last RTP packet that makes up this data was received.
+    pub buffer_delay: Duration,
 
     /// The (RTP) sequence numbers that made up this data.
     pub seq_range: RangeInclusive<SeqNo>,

--- a/src/media/inner.rs
+++ b/src/media/inner.rs
@@ -1229,7 +1229,7 @@ impl MediaInner {
                         rid: *rid,
                         params: codec,
                         time: dep.time,
-                        network_time: dep.network_time(),
+                        network_time: dep.first_network_time(),
                         seq_range: dep.seq_range(),
                         contiguous: dep.contiguous,
                         ext_vals: dep.ext_vals(),

--- a/src/media/inner.rs
+++ b/src/media/inner.rs
@@ -1230,6 +1230,7 @@ impl MediaInner {
                         params: codec,
                         time: dep.time,
                         network_time: dep.first_network_time(),
+                        buffer_delay: dep.buffer_delay(),
                         seq_range: dep.seq_range(),
                         contiguous: dep.contiguous,
                         ext_vals: dep.ext_vals(),

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 use std::fmt;
 use std::ops::RangeInclusive;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::rtp::{ExtensionValues, MediaTime, RtpHeader, SeqNo};
 
@@ -37,6 +37,16 @@ impl Depacketized {
             .min()
             .expect("a depacketized to consist of at least one packet")
     }
+
+    pub fn buffer_delay(&self) -> Duration {
+        let last_network_time = self
+            .meta
+            .iter()
+            .map(|m| m.received)
+            .max()
+            .expect("a depacketized to consist of at least one packet");
+
+        last_network_time.duration_since(self.first_network_time())
     }
 
     pub fn seq_range(&self) -> RangeInclusive<SeqNo> {

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -30,8 +30,13 @@ pub struct Depacketized {
 }
 
 impl Depacketized {
-    pub fn network_time(&self) -> Instant {
-        self.meta[0].received
+    pub fn first_network_time(&self) -> Instant {
+        self.meta
+            .iter()
+            .map(|m| m.received)
+            .min()
+            .expect("a depacketized to consist of at least one packet")
+    }
     }
 
     pub fn seq_range(&self) -> RangeInclusive<SeqNo> {


### PR DESCRIPTION
Ensure `MediaData::network_time` is correct and add a new field `MediaData::buffer_delay` that measures the delay taken to construct the media data from RTP packets