### PR TITLE
Fix extraction of certain header extensions

### DIFF
--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -41,7 +41,9 @@ impl Depacketized {
     }
 
     pub fn ext_vals(&self) -> ExtensionValues {
-        self.meta[0].header.ext_vals
+        // We use the extensions from the last packet because certain extensions, such as video
+        // orientation, are only added on the last packet to save bytes.
+        self.meta[self.meta.len() - 1].header.ext_vals
     }
 }
 


### PR DESCRIPTION
Certain header extensions are only present on the last RTP packet that
makes up a sample. For example, Mobile Safari only sends video
orientation on the last packet of a sample.


It's unclear if this will break things in some other way, perhaps some extensions are only sent in the first packet of samples instead? 

A more sophisticated approach might surface all the header extensions from all packets or merge them somehow.