### PR TITLE
Restrict periodic BWE adjustments

### DIFF
--- a/src/packet/bwe/rate_control.rs
+++ b/src/packet/bwe/rate_control.rs
@@ -98,13 +98,7 @@ impl RateControl {
     }
 
     fn increase(&mut self, observed_bitrate: Bitrate, now: Instant) {
-        let last_estimate_update = match self.last_estimate_update {
-            Some(n) => n,
-            None => {
-                self.last_estimate_update = Some(now);
-                now
-            }
-        };
+        let last_estimate_update = *self.last_estimate_update.get_or_insert(now);
 
         if self
             .averaged_observed_bitrate


### PR DESCRIPTION
We never stopped periodically adjusting BWE based on the current
trendline hypothesis, regardless of how old the hypothesis was. This
meant that if we had a hypothesis of underuse and stopped receiving TWCC
we would indefinitely increase the bandwidth estimate.

With this change we'll only consider a trendline hypothesis valid for a
while after the TWCC report that updated it.
