### PR TITLE
make it more likely to find spurious padding

### DIFF
--- a/src/packet/buffer_tx.rs
+++ b/src/packet/buffer_tx.rs
@@ -302,8 +302,8 @@ impl PacketizingBuffer {
         self.by_size
             .range(..=key)
             .rev()
+            .flat_map(|(_, id)| self.queue.get(*id))
             .next()
-            .and_then(|(_, id)| self.queue.get(*id))
     }
 
     pub fn ssrc(&self) -> Ssrc {


### PR DESCRIPTION
This helps especially in the case of smaller buffer size