### PR TITLE
vp8: avoid waiting for intentionally unmet NACKs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -766,6 +766,8 @@ pub enum Input<'a> {
 }
 
 /// Output produced by [`Rtc::poll_output()`]
+
+#[allow(clippy::large_enum_variant)]
 pub enum Output {
     /// When the [`Rtc`] instance expects an [`Input::Timeout`].
     Timeout(Instant),

--- a/src/media/register.rs
+++ b/src/media/register.rs
@@ -5,7 +5,7 @@ use crate::rtp::{Nack, NackEntry, ReceptionReport, ReportList, SeqNo};
 const MAX_DROPOUT: u64 = 3000;
 const MAX_MISORDER: u64 = 100;
 const MIN_SEQUENTIAL: u64 = 2;
-const MISORDER_DELAY: u64 = 4;
+const MISORDER_DELAY: u64 = 1;
 
 #[derive(Debug)]
 pub struct ReceiverRegister {

--- a/src/media/register.rs
+++ b/src/media/register.rs
@@ -756,7 +756,7 @@ mod test {
             reg.update_seq((*i).into());
         }
         assert!(reg.nack_reports().is_empty());
-        assert_eq!(reg.nack_check_from, 125.into());
+        assert_eq!(reg.nack_check_from, (129 - MISORDER_DELAY).into());
     }
 
     #[test]
@@ -768,7 +768,7 @@ mod test {
             reg.update_seq((*i).into());
         }
         assert!(reg.nack_reports().is_empty());
-        assert_eq!(reg.nack_check_from, 101.into());
+        assert_eq!(reg.nack_check_from, (105 - MISORDER_DELAY).into());
 
         for i in &[
             106, 108, 109, 110, 111, 112, 113, 114, 115, //
@@ -785,7 +785,7 @@ mod test {
             nacks.is_empty(),
             "Expected no NACKs to be generated after repairing the stream, got {nacks:?}"
         );
-        assert_eq!(reg.nack_check_from, 111.into());
+        assert_eq!(reg.nack_check_from, (115 - MISORDER_DELAY).into());
     }
 
     #[test]
@@ -797,7 +797,7 @@ mod test {
             reg.update_seq((*i).into());
         }
         assert!(reg.nack_reports().is_empty());
-        assert_eq!(reg.nack_check_from, 101.into());
+        assert_eq!(reg.nack_check_from, (105 - MISORDER_DELAY).into());
 
         for i in &[
             106, 108, 109, 110, 111, 112, 113, 114, 115, //
@@ -809,12 +809,12 @@ mod test {
 
         reg.update_seq(107.into()); // Got 107 via RTX
 
-        assert_eq!(reg.nack_check_from, 111.into());
+        assert_eq!(reg.nack_check_from, (115 - MISORDER_DELAY).into());
 
         for i in 116..3106 {
             reg.update_seq(i.into());
         }
-        assert_eq!(reg.nack_check_from, 3101.into());
+        assert_eq!(reg.nack_check_from, (3105 - MISORDER_DELAY).into());
 
         for i in &[
             106, 108, 109, 110, 111, 112, 113, 114, 115, //
@@ -848,13 +848,13 @@ mod test {
     }
 
     #[test]
-    fn nack_check_forward_at_boundary() {
+    fn nack_check_forward_at_boukdary() {
         let mut reg = ReceiverRegister::new(2996.into());
         for i in 2996..=3003 {
             reg.update_seq((i).into());
         }
         assert!(reg.nack_reports().is_empty());
-        assert_eq!(reg.nack_check_from, 2999.into());
+        assert_eq!(reg.nack_check_from, (3003 - MISORDER_DELAY).into());
 
         for i in 3004..=3008 {
             reg.update_seq((i).into());
@@ -862,7 +862,7 @@ mod test {
 
         let nacks = reg.nack_reports();
         assert!(nacks.is_empty(), "Expected empty NACKs got {nacks:?}");
-        assert_eq!(reg.nack_check_from, 3004.into());
+        assert_eq!(reg.nack_check_from, (3008 - MISORDER_DELAY).into());
     }
 
     #[test]
@@ -872,7 +872,7 @@ mod test {
             reg.update_seq((i).into());
         }
         assert!(reg.nack_reports().is_empty());
-        assert_eq!(reg.nack_check_from, 65530.into());
+        assert_eq!(reg.nack_check_from, (65534 - MISORDER_DELAY).into());
 
         for i in 65536..=65566 {
             reg.update_seq((i).into());
@@ -888,7 +888,7 @@ mod test {
         reg.update_seq(65535.into());
 
         assert!(reg.nack_reports().is_empty());
-        assert_eq!(reg.nack_check_from, 65662.into());
+        assert_eq!(reg.nack_check_from, (65666 - MISORDER_DELAY).into());
     }
 
     #[test]

--- a/src/media/register.rs
+++ b/src/media/register.rs
@@ -95,6 +95,13 @@ impl ReceiverRegister {
         let was_set = self.packet_status[pos].received;
         self.packet_status[pos].received = true;
 
+        if self.packet_status[pos].received && self.packet_status[pos].nack_count > 0 {
+            debug!(
+                "Received packet {} after {} NACKs",
+                seq, self.packet_status[pos].nack_count
+            );
+        }
+
         if did_wrap {
             // The indices wrapped around the end of `packet_status`, we clear any entries between
             // the current sequence number and nack_check_from.

--- a/src/media/register.rs
+++ b/src/media/register.rs
@@ -167,6 +167,13 @@ impl ReceiverRegister {
     fn reset_receceived(&mut self, start: SeqNo, end: SeqNo) {
         for seq in *start..*end {
             let index = self.packet_index(seq);
+
+            let status = self.packet_status[index];
+
+            if status.nack_count > 0 && !status.received {
+                debug!("Seq no was nacked but not resent {}", seq);
+            }
+
             // Reset state
             self.packet_status[index] = PacketStatus::default();
         }

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -202,7 +202,7 @@ impl DepacketizingBuffer {
                     if allowed {
                         let last = self.queue.get(stop).expect("entry for stop index");
                         trace!(
-                            "gap allowed Seq: {} - {}, PIDs: {} - {}",
+                            "Depack gap allowed for Seq: {} - {}, PIDs: {} - {}",
                             last_seq,
                             last.meta.seq_no,
                             prev_pid,

--- a/src/packet/vp8.rs
+++ b/src/packet/vp8.rs
@@ -14,6 +14,10 @@ pub struct Vp8CodecExtra {
     /// Index of the vp8 temporal layer.
     /// Only 2 layers are possible in WebRTC
     pub layer_index: u8,
+    /// picture id if present
+    // TODO: use an *extended* format so the consumer of this api does not have to handle wrapping
+    // which would otherwise depend on whether this is represented as 8 or 16 bits
+    pub picture_id: Option<u16>,
 }
 
 /// Packetizes VP8 RTP packets.
@@ -247,6 +251,11 @@ impl Depacketizer for Vp8Depacketizer {
             discardable: self.n == 1,
             sync: self.y == 1,
             layer_index: self.tid,
+            picture_id: if self.i == 1 {
+                Some(self.picture_id)
+            } else {
+                None
+            },
         });
         Ok(())
     }

--- a/src/rtp/header.rs
+++ b/src/rtp/header.rs
@@ -304,6 +304,7 @@ macro_rules! mk_extend {
     };
 }
 
+mk_extend!(extend_u8, u8);
 mk_extend!(extend_u16, u16);
 mk_extend!(extend_u32, u32);
 

--- a/src/rtp/mod.rs
+++ b/src/rtp/mod.rs
@@ -22,7 +22,7 @@ pub use mtime::MediaTime;
 
 mod header;
 pub use header::RtpHeader;
-pub(crate) use header::{extend_u16, extend_u32};
+pub(crate) use header::{extend_u16, extend_u32, extend_u8};
 
 mod srtp;
 pub(crate) use srtp::{SrtpContext, SrtpKey};

--- a/src/session.rs
+++ b/src/session.rs
@@ -22,7 +22,7 @@ use super::{MediaInner, PolledPacket};
 /// Minimum time we delay between sending nacks. This should be
 /// set high enough to not cause additional problems in very bad
 /// network conditions.
-const NACK_MIN_INTERVAL: Duration = Duration::from_millis(100);
+const NACK_MIN_INTERVAL: Duration = Duration::from_millis(33);
 
 /// Delay between reports of TWCC. This is deliberately very low.
 const TWCC_INTERVAL: Duration = Duration::from_millis(100);


### PR DESCRIPTION
Chrome does not seem to answer nacks for frames on vp8 temporal layer 1 (since they are not vital). This means with some loss on the connection we introduce the highest delay possible (w.r.t. the configured amount of buffered video samples).

Here we aim at avoiding this