### PR TITLE
buffer_tx: add configurable duration threshold

### DIFF
--- a/src/packet/ring.rs
+++ b/src/packet/ring.rs
@@ -4,6 +4,7 @@ pub struct RingBuf<T> {
     max: u64,
     // This is an u64 since it is ever growing and used as an identifier.
     next: u64,
+    first: u64,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd)]
@@ -12,6 +13,10 @@ pub struct Ident(u64);
 impl Ident {
     pub fn increase(&self) -> Ident {
         Ident(self.0 + 1)
+    }
+
+    pub fn as_u64(&self) -> u64 {
+        self.0
     }
 }
 
@@ -27,6 +32,7 @@ impl<T> RingBuf<T> {
             buffer,
             max: max as u64,
             next: 0,
+            first: 0,
         }
     }
 
@@ -59,6 +65,11 @@ impl<T> RingBuf<T> {
     pub fn get_mut(&mut self, i: Ident) -> Option<&mut T> {
         let idx = self.in_scope(i)?;
         self.buffer[idx].as_mut()
+    }
+
+    pub fn take(&mut self, i: Ident) -> Option<T> {
+        let idx = self.in_scope(i)?;
+        self.buffer[idx].take()
     }
 
     pub fn first_ident(&self) -> Option<Ident> {

--- a/src/session.rs
+++ b/src/session.rs
@@ -47,8 +47,8 @@ pub(crate) struct Session {
 
     reordering_size_audio: usize,
     reordering_size_video: usize,
-    pub(crate) send_buffer_audio: usize,
-    pub(crate) send_buffer_video: usize,
+    pub(crate) send_buffer_audio: (usize, Duration),
+    pub(crate) send_buffer_video: (usize, Duration),
 
     /// Extension mappings are _per BUNDLE_, but we can only have one a=group BUNDLE
     /// in WebRTC (one ice connection), so they are effectively per session.


### PR DESCRIPTION
Allows the buffer to free packets that are older than a configured threshold. This refers to RTP time and acts within the boundaries of the buffer size without changing the size of the buffer itself.

When packets are evicted the Packetized::data Vec<u8> is dropped, therefore freeing up memory. This will be more efficient as we reduce the overhead of the Packetized structure itself.

Having a larger size and limiting by time allows to more efficiently accomodate spikes due to big keyframes (i.e. think of screenshares).