### PR TITLE
avoid one media clearing the feedback of another media

### DIFF
--- a/src/media/inner.rs
+++ b/src/media/inner.rs
@@ -1010,9 +1010,6 @@ impl MediaInner {
             return None;
         }
 
-        // Since we're making new sender/receiver reports, clear out previous.
-        feedback.retain(|r| !matches!(r, Rtcp::SenderReport(_) | Rtcp::ReceiverReport(_)));
-
         if self.dir.is_sending() {
             for s in &mut self.sources_tx {
                 let sr = s.create_sender_report(now);


### PR DESCRIPTION
Happens while generating for feedback of all medias because `&mut feedback` is stored at session level.

I could have moved it in `session` but I think we don't need to clear the old feedback. It should be consumed way sooner and if it isn't I don't see why loose the information.