### PR TITLE
Add an identifier of str0m to the `o=` line in SDP

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -558,6 +558,8 @@ pub mod error {
     pub use crate::sdp::SdpError;
 }
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 /// Errors for the whole Rtc engine.
 #[derive(Debug, Error)]
 #[non_exhaustive]

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -14,6 +14,7 @@ use crate::format::FormatParams;
 use crate::format::PayloadParams;
 use crate::ice::{Candidate, IceCreds};
 use crate::rtp_::{Direction, Extension, Mid, Pt, Rid, SessionId, Ssrc};
+use crate::VERSION;
 
 use super::parser::sdp_parser;
 use super::SdpError;
@@ -1227,7 +1228,7 @@ impl fmt::Display for Sdp {
 impl fmt::Display for Session {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "v=0\r\n")?;
-        write!(f, "o=- {} 2 IN IP4 0.0.0.0\r\n", self.id)?;
+        write!(f, "o=str0m-{} {} 2 IN IP4 0.0.0.0\r\n", VERSION, self.id)?;
         write!(f, "s=-\r\n")?;
         if let Some(bw) = &self.bw {
             write!(f, "b={}:{}\r\n", bw.typ, bw.val)?;
@@ -1487,6 +1488,7 @@ impl<'a> std::fmt::Display for FingerprintFmt<'a> {
 #[cfg(test)]
 mod test {
     use crate::rtp_::Extension;
+    use crate::VERSION;
 
     use super::*;
 
@@ -1589,8 +1591,8 @@ mod test {
                         MediaAttribute::Ssrc { ssrc: 3_948_621_874.into(), attr: "label".into(), value: "f78dde68-7055-4e20-bb37-433803dd1ed1".into() }],
             }],
         };
-        assert_eq!(&format!("{sdp}"), "v=0\r\n\
-            o=- 5058682828002148772 2 IN IP4 0.0.0.0\r\n\
+        assert_eq!(&format!("{sdp}"), &format!("v=0\r\n\
+            o=str0m-{VERSION} 5058682828002148772 2 IN IP4 0.0.0.0\r\n\
             s=-\r\n\
             t=0 0\r\n\
             a=group:BUNDLE 0\r\n\
@@ -1620,6 +1622,6 @@ mod test {
             a=ssrc:3948621874 msid:5UUdwiuY7OML2EkQtF38pJtNP5v7In1LhjEK f78dde68-7055-4e20-bb37-433803dd1ed1\r\n\
             a=ssrc:3948621874 mslabel:5UUdwiuY7OML2EkQtF38pJtNP5v7In1LhjEK\r\n\
             a=ssrc:3948621874 label:f78dde68-7055-4e20-bb37-433803dd1ed1\r\n\
-            ");
+            "));
     }
 }

--- a/src/sdp/mod.rs
+++ b/src/sdp/mod.rs
@@ -233,6 +233,7 @@ sdp_ser!(SdpAnswer, "Answer", "answer");
 #[cfg(test)]
 mod test {
     use crate::rtp_::SessionId;
+    use crate::VERSION;
 
     use super::*;
 
@@ -252,7 +253,7 @@ mod test {
         let offer = SdpOffer(sdp());
         let json = serde_json::to_string(&offer).unwrap();
 
-        assert_eq!(json, "{\"type\":\"offer\",\"sdp\":\"v=0\\r\\no=- 123 2 IN IP4 0.0.0.0\\r\\ns=-\\r\\nt=0 0\\r\\n\"}");
+        assert_eq!(json, format!("{{\"type\":\"offer\",\"sdp\":\"v=0\\r\\no=str0m-{VERSION} 123 2 IN IP4 0.0.0.0\\r\\ns=-\\r\\nt=0 0\\r\\n\"}}"));
 
         let offer2: SdpOffer = serde_json::from_str(&json).unwrap();
 
@@ -264,7 +265,7 @@ mod test {
         let answer = SdpAnswer(sdp());
         let json = serde_json::to_string(&answer).unwrap();
 
-        assert_eq!(json, "{\"type\":\"answer\",\"sdp\":\"v=0\\r\\no=- 123 2 IN IP4 0.0.0.0\\r\\ns=-\\r\\nt=0 0\\r\\n\"}");
+        assert_eq!(json, format!("{{\"type\":\"answer\",\"sdp\":\"v=0\\r\\no=str0m-{VERSION} 123 2 IN IP4 0.0.0.0\\r\\ns=-\\r\\nt=0 0\\r\\n\"}}"));
 
         let answer2: SdpAnswer = serde_json::from_str(&json).unwrap();
 


### PR DESCRIPTION
This is useful to help identify our SDPs. Inspired by Firefox's o= line:

  o=mozilla...THIS_IS_SDPARTA-83.0 7052848360639826063 0 IN IP4 0.0.0.0\r\n\

Like Firefox this data occupies the `<username>` component of the o=
line.

See https://www.rfc-editor.org/rfc/rfc4566#section-5.2
