### PR TITLE
Remove redundant RtpPacket::pt field

### DIFF
--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 use std::time::Instant;
 
 use crate::media::KeyframeRequest;
+use crate::rtp_::MediaTime;
 use crate::rtp_::Ssrc;
-use crate::rtp_::{MediaTime, Pt};
 use crate::rtp_::{Mid, Rid, SeqNo};
 use crate::rtp_::{Rtcp, RtpHeader};
 use crate::util::already_happened;
@@ -44,9 +44,6 @@ pub struct RtpPacket {
     /// Extended sequence number to avoid having to deal with ROC.
     pub seq_no: SeqNo,
 
-    /// Payload type for this packet.
-    pt: Pt,
-
     /// Extended RTP time in the clock frequency of the codec. To avoid dealing with ROC.
     ///
     /// For a newly scheduled outgoing packet, the clock_rate is not correctly set until
@@ -74,7 +71,6 @@ impl RtpPacket {
     fn blank() -> RtpPacket {
         RtpPacket {
             seq_no: 0.into(),
-            pt: 0.into(),
             time: MediaTime::new(0, 90_000),
             header: RtpHeader::default(),
             payload: vec![], // This payload is never used. See RtpHeader::create_padding_packet
@@ -322,7 +318,6 @@ impl fmt::Debug for RtpPacket {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RtpPacket")
             .field("seq_no", &self.seq_no)
-            .field("pt", &self.pt)
             .field("time", &self.time)
             .field("header", &self.header)
             .field("payload", &self.payload.len())

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -267,7 +267,6 @@ impl StreamRx {
 
         let packet = RtpPacket {
             seq_no,
-            pt: header.payload_type,
             time,
             header,
             payload: data,

--- a/src/streams/rtx_cache.rs
+++ b/src/streams/rtx_cache.rs
@@ -156,11 +156,11 @@ mod test {
         let packet = |seq_no: SeqNo, millis_since_epoch: u32| RtpPacket {
             header: RtpHeader {
                 marker: false,
+                payload_type: 1.into(),
                 ssrc: 1.into(),
                 ..Default::default()
             },
             seq_no,
-            pt: 1.into(),
             time: MediaTime::new(0, 90_000),
             payload: millis_since_epoch.to_be_bytes().to_vec(),
             timestamp: after(millis_since_epoch),

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -249,7 +249,6 @@ impl StreamTx {
 
         let packet = RtpPacket {
             seq_no,
-            pt,
             time: media_time,
             header,
             payload,
@@ -302,13 +301,12 @@ impl StreamTx {
         // This is true also for RTX.
         header_ref.ext_vals.mid = Some(mid);
 
-        // Sanity check.
-        assert_eq!(header_ref.payload_type, next.pkt.pt);
+        let pt_main = header_ref.payload_type;
 
         // The pt in next.pkt is the "main" pt.
-        let Some(param) = params.iter().find(|p| p.pt() == next.pkt.pt) else {
+        let Some(param) = params.iter().find(|p| p.pt() == pt_main) else {
             // PT does not exist in the connected media.
-            warn!("Media is missing PT ({}) used in RTP packet", next.pkt.pt);
+            warn!("Media is missing PT ({}) used in RTP packet", pt_main);
             return None;
         };
 
@@ -548,7 +546,7 @@ impl StreamTx {
 
         let pkt = &mut self.blank_packet;
         pkt.seq_no = self.seq_no_rtx.inc();
-        pkt.pt = self
+        pkt.header.payload_type = self
             .pt
             .expect("Must have sent at least one packet before blank padding");
 


### PR DESCRIPTION
The information is present in RtpPacket::header::payload_type.