### PR TITLE
Fix MTU-clamping

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -27,7 +27,10 @@ pub(crate) use id::Id;
 pub(crate) const DATAGRAM_MTU: usize = 1150;
 
 /// Warn if any packet we are about to send is above this size.
-pub(crate) const DATAGRAM_MTU_WARN: usize = 1200;
+pub(crate) const DATAGRAM_MTU_WARN: usize = 1280;
+
+/// Max expected RTP header over, with full extensions etc.
+pub const MAX_RTP_OVERHEAD: usize = 80;
 
 /// Errors from parsing network data.
 #[derive(Debug, Error)]

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 use std::time::Instant;
 
 use crate::format::PayloadParams;
+use crate::io::DATAGRAM_MTU_WARN;
+use crate::io::MAX_RTP_OVERHEAD;
 use crate::media::KeyframeRequestKind;
 use crate::packet::QueuePriority;
 use crate::packet::QueueSnapshot;
@@ -528,7 +530,7 @@ impl StreamTx {
             if self.padding > MIN_SPURIOUS_PADDING_SIZE {
                 // Find a historic packet that is smaller than this max size. The max size
                 // is a headroom since we can accept slightly larger padding than asked for.
-                let max_size = (self.padding).min(1200) * 2;
+                let max_size = (self.padding * 2).min(DATAGRAM_MTU_WARN - MAX_RTP_OVERHEAD);
 
                 let Some(pkt) = self.rtx_cache.get_cached_packet_smaller_than(max_size) else {
                     // Couldn't find spurious packet, try a blank packet instead.


### PR DESCRIPTION
This fixes two problems.

1. We slightly increase the MTU warning to 1280.
2. We ensure the spurious padding doesn't exceed that value.
