### PR TITLE
Merge stats for a given (mid, rid) pair

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -154,14 +154,7 @@ impl MediaIngressStats {
     /// Merge `other` into `self`, mutating `self`.
     ///
     /// **Panics** if called with stats that don't have the same `(mid, rid)` pair.
-    pub(crate) fn merge(&mut self, other: &Self) {
-        *self = self.merged(other);
-    }
-
-    /// Merge `self` and `other` returning a new `Self` of the result.
-    ///
-    /// **Panics** if called with stats that don't have the same `(mid, rid)` pair.
-    fn merged(&self, other: &Self) -> Self {
+    pub(crate) fn merge_by_mid_rid(&mut self, other: &Self) {
         assert!(
             self.mid == other.mid,
             "Cannot merge MediaIngressStats for different mids"
@@ -176,7 +169,7 @@ impl MediaIngressStats {
             (other.rtt, other.loss)
         };
 
-        Self {
+        *self = Self {
             mid: self.mid,
             rid: self.rid,
             bytes: self.bytes + other.bytes,
@@ -187,7 +180,7 @@ impl MediaIngressStats {
             rtt,
             loss,
             timestamp: self.timestamp.max(other.timestamp),
-        }
+        };
     }
 }
 

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -582,7 +582,7 @@ impl StreamRxStats {
         snapshot
             .ingress
             .entry(key)
-            .and_modify(|s| s.merge(&stats))
+            .and_modify(|s| s.merge_by_mid_rid(&stats))
             .or_insert(stats);
     }
 }


### PR DESCRIPTION
A given (mid, rid) pair can use multiple SSRCs. Not only is there an RTX
SSRC and a main SSRC, which was already handled prior to this commit,
but during the lifetime of an RTP Session new SSRCs (RTX and main) can be
created for the same (mid, rid) pair. In particular, Firefox does this
when a transceiver transitions from send to inactive, and back to send.
When media is resumed the original SSRCs are not used, instead new SSRCs
are created.
