### PR TITLE
reduce unwrap and create vector utils for handle special unwrap cases

### DIFF
--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -6,6 +6,7 @@ use crate::media::Media;
 use crate::rtp_::{Direction, ExtensionMap, Mid, Rid, Ssrc};
 use crate::sctp::ChannelConfig;
 use crate::streams::{StreamRx, StreamTx, DEFAULT_RTX_CACHE_DURATION};
+use crate::util::vector::VecExtended;
 use crate::Rtc;
 use crate::RtcError;
 
@@ -147,8 +148,7 @@ impl<'a> DirectApi<'a> {
 
         let m = Media::from_direct_api(mid, next_index, dir, exts, params, is_audio);
 
-        self.rtc.session.medias.push(m);
-        self.rtc.session.medias.last_mut().unwrap()
+        self.rtc.session.medias.push_get_last_mut(m)
     }
 
     /// Remove `Media`.

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -218,13 +218,16 @@ impl ChannelHandler {
         }
     }
 
-    pub fn ensure_channel_id_for(&mut self, sctp_stream_id: u16) {
-        let exists = self
+    pub fn ensure_channel_id_for(&mut self, sctp_stream_id: u16) -> ChannelId {
+        let channel_id = self
             .allocations
             .iter()
-            .any(|a| a.sctp_stream_id == Some(sctp_stream_id));
+            .find(|a| a.sctp_stream_id == Some(sctp_stream_id))
+            .map(|a| a.id);
 
-        if !exists {
+        if let Some(channel_id) = channel_id {
+            channel_id
+        } else {
             let id = ChannelId(self.allocations.len());
             let alloc = ChannelAllocation {
                 id,
@@ -232,6 +235,7 @@ impl ChannelHandler {
                 config: None,
             };
             self.allocations.push(alloc);
+            id
         }
     }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -531,11 +531,17 @@ impl CodecConfig {
         for (i, p) in self.params.iter_mut().enumerate() {
             if let Some(index) = assigneds.get(&p.pt) {
                 if i != *index {
-                    // This PT has been reassigned. This unwrap is ok
+                    // This PT has been reassigned. This check
                     // because we can't have replaced something without
                     // also get the old PT out.
-                    let r = replaceds.pop().unwrap();
-                    p.pt = r;
+                    if let Some(r) = replaceds.pop() {
+                        p.pt = r;
+                    } else {
+                        debug_assert!(
+                            false,
+                            "This PT has been reassigned, but we have no replacement PT"
+                        );
+                    }
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1187,8 +1187,7 @@ impl Rtc {
                     }
                 }
                 SctpEvent::Open { id, label } => {
-                    self.chan.ensure_channel_id_for(id);
-                    let id = self.chan.channel_id_by_stream_id(id).unwrap();
+                    let id = self.chan.ensure_channel_id_for(id);
                     return Ok(Output::Event(Event::ChannelOpen(id, label)));
                 }
                 SctpEvent::Close { id } => {

--- a/src/media/writer.rs
+++ b/src/media/writer.rs
@@ -31,7 +31,10 @@ impl<'a> Writer<'a> {
     ///
     /// For the [`Writer::write()`] call, the `pt` must be set correctly.
     pub fn payload_params(&self) -> &[PayloadParams] {
-        media_by_mid(&self.session.medias, self.mid).payload_params()
+        match media_by_mid(&self.session.medias, self.mid) {
+            Some(media) => media.payload_params(),
+            None => &[],
+        }
     }
 
     /// Match the given parameters to the configured parameters for this [`Media`].
@@ -43,7 +46,7 @@ impl<'a> Writer<'a> {
     /// This call performs matching and if a match is found, returns the _local_ PT
     /// that can be used for sending media.
     pub fn match_params(&self, params: PayloadParams) -> Option<Pt> {
-        media_by_mid(&self.session.medias, self.mid).match_params(params)
+        media_by_mid(&self.session.medias, self.mid)?.match_params(params)
     }
 
     /// Add on an Rtp Stream Id. This is typically used to separate simulcast layers.
@@ -88,7 +91,9 @@ impl<'a> Writer<'a> {
         rtp_time: MediaTime,
         data: &[u8],
     ) -> Result<(), RtcError> {
-        let media = media_by_mid_mut(&mut self.session.medias, self.mid);
+        let Some(media) = media_by_mid_mut(&mut self.session.medias, self.mid) else {
+            return Err(RtcError::NoSenderSource);
+        };
 
         if !media.has_pt(pt) {
             return Err(RtcError::UnknownPt(pt));
@@ -120,7 +125,10 @@ impl<'a> Writer<'a> {
     /// a=rtcp-fb:96 nack pli
     /// ```
     pub fn is_request_keyframe_possible(&self, kind: KeyframeRequestKind) -> bool {
-        media_by_mid(&self.session.medias, self.mid).is_request_keyframe_possible(kind)
+        match media_by_mid(&self.session.medias, self.mid) {
+            Some(m) => m.is_request_keyframe_possible(kind),
+            None => false,
+        }
     }
 
     /// Request a keyframe from a remote peer sending media data.
@@ -166,10 +174,10 @@ impl<'a> Writer<'a> {
     }
 }
 
-fn media_by_mid(medias: &[Media], mid: Mid) -> &Media {
-    medias.iter().find(|m| m.mid() == mid).unwrap()
+fn media_by_mid(medias: &[Media], mid: Mid) -> Option<&Media> {
+    medias.iter().find(|m| m.mid() == mid)
 }
 
-fn media_by_mid_mut(medias: &mut [Media], mid: Mid) -> &mut Media {
-    medias.iter_mut().find(|m| m.mid() == mid).unwrap()
+fn media_by_mid_mut(medias: &mut [Media], mid: Mid) -> Option<&mut Media> {
+    medias.iter_mut().find(|m| m.mid() == mid)
 }

--- a/src/packet/bwe/trendline_estimator.rs
+++ b/src/packet/bwe/trendline_estimator.rs
@@ -196,9 +196,7 @@ impl TrendlineEstimator {
                         // sample.
                         time_overusing: variation.send_delta / 2,
                     };
-                    self.overuse = Some(new_overuse);
-
-                    self.overuse.as_mut().unwrap()
+                    self.overuse.insert(new_overuse)
                 }
             };
 

--- a/src/rtp/rtcp/list.rs
+++ b/src/rtp/rtcp/list.rs
@@ -72,7 +72,9 @@ impl<T: private::WordSized> ReportList<T> {
             }
 
             // first borrow item from other, to check the item size will fit.
-            let item = other.0[i].as_ref().unwrap();
+            let Some(item) = other.0[i].as_ref() else {
+                break;
+            };
             let item_size = item.word_size();
 
             // can we fit one more item?

--- a/src/rtp/rtcp/mod.rs
+++ b/src/rtp/rtcp/mod.rs
@@ -147,7 +147,9 @@ impl Rtcp {
             }
 
             // We definitely can fit the next RTCP item.
-            let fb = feedback.pop_front().unwrap();
+            let Some(fb) = feedback.pop_front() else {
+                break;
+            };
             let written = fb.write_to(&mut buf[offset..]);
 
             assert_eq!(
@@ -264,7 +266,9 @@ impl Rtcp {
             }
 
             let (pack_into, pack_from) = feedback.make_contiguous().split_at_mut(i + 1);
-            let fb_a = pack_into.last_mut().unwrap();
+            let Some(fb_a) = pack_into.last_mut() else {
+                break;
+            };
 
             // abort if fb_a won't fit in the spare capacity.
             if word_capacity < fb_a.length_words() {

--- a/src/rtp/rtcp/twcc.rs
+++ b/src/rtp/rtcp/twcc.rs
@@ -1081,11 +1081,14 @@ impl TwccSendRegister {
     /// Returns a range of the sequence numbers for the applied packets if the report was
     /// successfully applied.
     pub fn apply_report(&mut self, twcc: Twcc, now: Instant) -> Option<RangeInclusive<SeqNo>> {
-        if self.time_zero.is_none() {
-            self.time_zero = Some(now);
-        }
+        let time_zero = match self.time_zero {
+            Some(v) => v,
+            None => {
+                self.time_zero = Some(now);
+                now
+            }
+        };
 
-        let time_zero = self.time_zero.unwrap();
         let head_seq = self.queue.front().map(|r| r.seq)?;
 
         let mut iter = twcc

--- a/src/rtp/rtcp/xr.rs
+++ b/src/rtp/rtcp/xr.rs
@@ -170,7 +170,7 @@ impl<'a> TryFrom<&'a [u8]> for ExtendedReport {
             return Err("Less than 4 bytes for ExtendedReport");
         }
 
-        let ssrc = u32::from_be_bytes(buf[..4].try_into().unwrap()).into();
+        let ssrc = u32::from_be_bytes(buf[..4].try_into().map_err(|_| "")?).into();
 
         let mut blocks: Vec<ReportBlock> = Vec::new();
         let mut buf = &buf[4..];
@@ -213,7 +213,7 @@ impl<'a> TryFrom<&'a [u8]> for Rrtr {
     type Error = &'static str;
 
     fn try_from(buf: &'a [u8]) -> Result<Self, Self::Error> {
-        let ntp_time = u64::from_be_bytes(buf[4..4 + 8].try_into().unwrap());
+        let ntp_time = u64::from_be_bytes(buf[4..4 + 8].try_into().map_err(|_| "")?);
         let ntp_time = MediaTime::from_ntp_64(ntp_time);
 
         Ok(Rrtr { ntp_time })
@@ -225,7 +225,7 @@ impl<'a> TryFrom<&'a [u8]> for Dlrr {
 
     fn try_from(buf: &'a [u8]) -> Result<Self, Self::Error> {
         let words_per_block = 3;
-        let blocks = u16::from_be_bytes(buf[2..4].try_into().unwrap()) / words_per_block;
+        let blocks = u16::from_be_bytes(buf[2..4].try_into().map_err(|_| "")?) / words_per_block;
 
         let mut items: Vec<DlrrItem> = Vec::with_capacity(blocks as usize);
 
@@ -233,9 +233,9 @@ impl<'a> TryFrom<&'a [u8]> for Dlrr {
         let mut buf = &buf[4..];
 
         for _ in 0..blocks {
-            let ssrc = u32::from_be_bytes(buf[0..4].try_into().unwrap()).into();
-            let last_rr_time = u32::from_be_bytes(buf[4..8].try_into().unwrap());
-            let last_rr_delay = u32::from_be_bytes(buf[8..12].try_into().unwrap());
+            let ssrc = u32::from_be_bytes(buf[0..4].try_into().map_err(|_| "")?).into();
+            let last_rr_time = u32::from_be_bytes(buf[4..8].try_into().map_err(|_| "")?);
+            let last_rr_delay = u32::from_be_bytes(buf[8..12].try_into().map_err(|_| "")?);
             items.push(DlrrItem {
                 ssrc,
                 last_rr_time,

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -14,6 +14,7 @@ use crate::format::FormatParams;
 use crate::format::PayloadParams;
 use crate::ice::{Candidate, IceCreds};
 use crate::rtp_::{Direction, Extension, Mid, Pt, Rid, SessionId, Ssrc};
+use crate::util::vector::VecExtended;
 use crate::VERSION;
 
 use super::parser::sdp_parser;
@@ -621,11 +622,10 @@ impl MediaLine {
             if let Some(pos) = v.iter().position(|i| i.ssrc == ssrc) {
                 &mut v[pos]
             } else {
-                v.push(SsrcInfo {
+                v.push_get_last_mut(SsrcInfo {
                     ssrc,
                     ..Default::default()
-                });
-                v.last_mut().unwrap()
+                })
             }
         }
 

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -508,7 +508,7 @@ impl StreamTx {
         };
 
         // Borrow checker gymnastics.
-        let pkt = self.rtx_cache.get_cached_packet_by_seq_no(seq_no).unwrap();
+        let pkt = self.rtx_cache.get_cached_packet_by_seq_no(seq_no)?;
 
         let len = pkt.payload.len() as u64;
         self.stats.update_packet_counts(len, true);
@@ -901,7 +901,7 @@ impl StreamTxStats {
             let mut total_weight = 0_u64;
 
             // just in case we received RRs out of order
-            self.losses.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+            self.losses.sort_by(|a, b| a.0.cmp(&b.0));
 
             // average known RR losses weighted by their number of packets
             for it in self.losses.windows(2) {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 use once_cell::sync::Lazy;
 
 pub(crate) mod value_history;
+pub(crate) mod vector;
 
 pub(crate) fn not_happening() -> Instant {
     const YEARS_100: Duration = Duration::from_secs(60 * 60 * 24 * 365 * 100);

--- a/src/util/vector.rs
+++ b/src/util/vector.rs
@@ -1,0 +1,42 @@
+use std::collections::VecDeque;
+
+pub trait VecExtended<T> {
+    fn push_get_last_mut(&mut self, item: T) -> &mut T;
+    fn found_or_insert<F, C>(&mut self, compare: F, creator: C) -> &mut T
+    where
+        F: FnMut(&T) -> bool,
+        C: FnMut() -> T;
+}
+
+impl<T> VecExtended<T> for Vec<T> {
+    fn push_get_last_mut(&mut self, item: T) -> &mut T {
+        self.push(item);
+        self.last_mut()
+            .expect("should get last because of just pushed")
+    }
+
+    fn found_or_insert<F, C>(&mut self, compare: F, mut creator: C) -> &mut T
+    where
+        F: FnMut(&T) -> bool,
+        C: FnMut() -> T,
+    {
+        let idx = self.iter().position(compare);
+        if let Some(idx) = idx {
+            self.get_mut(idx).unwrap()
+        } else {
+            let e = creator();
+            self.push_get_last_mut(e)
+        }
+    }
+}
+pub trait VecDequeExtended<T> {
+    fn push_last_get_mut(&mut self, item: T) -> &mut T;
+}
+
+impl<T> VecDequeExtended<T> for VecDeque<T> {
+    fn push_last_get_mut(&mut self, item: T) -> &mut T {
+        self.push_back(item);
+        self.back_mut()
+            .expect("should get last because of just pushed")
+    }
+}


### PR DESCRIPTION
For better development in the feature, I think we should avoid using unwrap in logic code, which can cause server crashes (I think this is the main goal of str0m).

In this PR, I trying to move out some special unwrap cases (like push then get last_mut) to utils, which can be easier for controlling. Some code also can rewrite without unwrap version.