### PR TITLE
Fix RTX

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -965,7 +965,11 @@ pub struct PacketReceipt {
 }
 
 fn get_params(c: &CodecConfig, pt: Pt) -> Option<&PayloadParams> {
-    c.iter().find(|p| p.pt() == pt)
+    if let p @ Some(_) = c.iter().find(|p| p.pt() == pt) {
+        return p;
+    }
+
+    main_payload_type_for(c, pt).and_then(|pt| c.iter().find(|p| p.pt == pt))
 }
 
 fn main_payload_type_for(c: &CodecConfig, pt: Pt) -> Option<Pt> {

--- a/src/session.rs
+++ b/src/session.rs
@@ -455,7 +455,7 @@ impl Session {
             Some(p) => p,
             None => {
                 trace!(
-                    "No codec params could be found(wether main or RTX) for {:?}",
+                    "No payload params could be found (main or RTX) for {:?}",
                     header.payload_type
                 );
                 return;


### PR DESCRIPTION
Packets with incoming RTX payload types were not correctly handled and
went ignored, resulting in no retransmissions.
