### PR TITLE
Fix overflow in FIR seq no

### DIFF
--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -387,7 +387,7 @@ impl StreamRx {
 
     fn next_fir_seq_no(&mut self) -> u8 {
         let x = self.fir_seq_no;
-        self.fir_seq_no += 1;
+        self.fir_seq_no = self.fir_seq_no.wrapping_add(1);
         x
     }
 


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc5104#section-4.3.1

     Seq nr. (8 bits): Command sequence number.  The sequence number
              space is unique for each pairing of the SSRC of command
              source and the SSRC of the command target.  The sequence
              number **SHALL be increased by 1 modulo 256** for each new
              command.  A repetition SHALL NOT increase the sequence
              number.  The initial value is arbitrary.

This was not implemented correctly and would panic(with overflow checks
enabled).
