### PR TITLE
fix quantized_size index of out bounds

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -29,6 +29,9 @@ pub(crate) const DATAGRAM_MTU: usize = 1150;
 /// Warn if any packet we are about to send is above this size.
 pub(crate) const DATAGRAM_MTU_WARN: usize = 1280;
 
+/// Max UDP packet size
+pub(crate) const DATAGRAM_MAX_PACKET_SIZE: usize = 2000;
+
 /// Max expected RTP header over, with full extensions etc.
 pub const MAX_RTP_OVERHEAD: usize = 80;
 

--- a/src/rtp/header.rs
+++ b/src/rtp/header.rs
@@ -356,7 +356,10 @@ impl Default for RtpHeader {
 
 #[cfg(test)]
 mod test {
-    use crate::rtp_::{Extension, MediaTime};
+    use crate::{
+        io::DATAGRAM_MAX_PACKET_SIZE,
+        rtp_::{Extension, MediaTime},
+    };
 
     use super::*;
 
@@ -443,7 +446,7 @@ mod test {
                 },
                 ..Default::default()
             };
-            let mut buf = vec![0; 2000];
+            let mut buf = vec![0; DATAGRAM_MAX_PACKET_SIZE];
             let n = header.write_to(&mut buf[..], exts);
             buf.truncate(n);
 

--- a/src/streams/rtx_cache.rs
+++ b/src/streams/rtx_cache.rs
@@ -2,13 +2,13 @@ use std::collections::BTreeMap;
 use std::time::Duration;
 use std::time::Instant;
 
-use crate::io::DATAGRAM_MTU;
+use crate::io::DATAGRAM_MAX_PACKET_SIZE;
 use crate::rtp_::SeqNo;
 
 use super::RtpPacket;
 
 const RTX_CACHE_SIZE_QUANTIZER: usize = 25;
-const RTX_CACHE_QUANTIZE_SLOTS: usize = DATAGRAM_MTU / RTX_CACHE_SIZE_QUANTIZER;
+const RTX_CACHE_QUANTIZE_SLOTS: usize = DATAGRAM_MAX_PACKET_SIZE / RTX_CACHE_SIZE_QUANTIZER;
 
 #[derive(Debug)]
 pub(crate) struct RtxCache {

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 
 use crate::format::CodecConfig;
 use crate::format::PayloadParams;
+use crate::io::DATAGRAM_MAX_PACKET_SIZE;
 use crate::io::DATAGRAM_MTU_WARN;
 use crate::io::MAX_RTP_OVERHEAD;
 use crate::media::KeyframeRequestKind;
@@ -378,7 +379,7 @@ impl StreamTx {
         header.ext_vals.transport_cc = Some(*twcc as u16);
         *twcc += 1;
 
-        buf.resize(2000, 0);
+        buf.resize(DATAGRAM_MAX_PACKET_SIZE, 0);
 
         let header_len = header.write_to(buf, exts);
         assert!(header_len % 4 == 0, "RTP header must be multiple of 4");


### PR DESCRIPTION
```
thread 'tokio-runtime-worker' panicked at 'range end index 48 out of range for slice of length 46', /home/ubuntu/work/lookback/str0m/src/streams/rtx_cache.rs:53:22
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
./bin/dev.sh: line 12:  2131 Aborted                 (core dumped) cargo run -- --watch --enable-simulcast
```