### PR TITLE
Implement missing features needeed for WebRTC Direct

### DIFF
--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -52,6 +52,11 @@ impl<'a> DirectApi<'a> {
         self.rtc.ice.local_credentials().clone()
     }
 
+    /// Sets the local ICE credentials.
+    pub fn set_local_ice_credentials(&mut self, local_ice_credentials: IceCreds) {
+        self.rtc.ice.set_local_credentials(local_ice_credentials);
+    }
+
     /// Sets the remote ICE credentials.
     pub fn set_remote_ice_credentials(&mut self, remote_ice_credentials: IceCreds) {
         self.rtc.ice.set_remote_credentials(remote_ice_credentials);

--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -70,6 +70,11 @@ impl<'a> DirectApi<'a> {
         self.rtc.dtls.local_fingerprint().clone()
     }
 
+    /// Returns a reference to the remote DTLS fingerprint used by this peer connection.
+    pub fn remote_dtls_fingerprint(&self) -> Option<Fingerprint> {
+        self.rtc.dtls.remote_fingerprint().clone()
+    }
+
     /// Sets the remote DTLS fingerprint.
     pub fn set_remote_fingerprint(&mut self, dtls_fingerprint: Fingerprint) {
         self.rtc.remote_fingerprint = Some(dtls_fingerprint);

--- a/src/dtls/mod.rs
+++ b/src/dtls/mod.rs
@@ -136,6 +136,9 @@ pub struct Dtls {
     /// The fingerprint of the certificate.
     fingerprint: Fingerprint,
 
+    /// Remote fingerprint.
+    remote_fingerprint: Option<Fingerprint>,
+
     /// Context belongs together with Fingerprint.
     ///
     /// This just needs to be kept alive since it pins the entire openssl context
@@ -178,6 +181,7 @@ impl Dtls {
         Ok(Dtls {
             _cert: cert,
             fingerprint,
+            remote_fingerprint: None,
             _context: context,
             tls: TlsStream::new(ssl, IoBuffer::default()),
             events: VecDeque::new(),
@@ -209,6 +213,11 @@ impl Dtls {
     /// To be communicated in SDP offers sent to the remote peer.
     pub fn local_fingerprint(&self) -> &Fingerprint {
         &self.fingerprint
+    }
+
+    /// Remote fingerprint.
+    pub fn remote_fingerprint(&self) -> &Option<Fingerprint> {
+        &self.remote_fingerprint
     }
 
     /// Poll for the next datagram to send.
@@ -284,6 +293,7 @@ impl Dtls {
                 .take_srtp_keying_material()
                 .expect("Exported keying material");
 
+            self.remote_fingerprint = Some(fingerprint.clone());
             self.events
                 .push_back(DtlsEvent::RemoteFingerprint(fingerprint));
 

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -269,6 +269,14 @@ impl IceAgent {
         &self.local_credentials
     }
 
+    /// Sets the local ice credentials.
+    pub fn set_local_credentials(&mut self, r: IceCreds) {
+        if self.local_credentials != r {
+            info!("Set local credentials: {:?}", r);
+            self.local_credentials = r;
+        }
+    }
+
     /// Local ice candidates.
     ///
     /// The candidates have their ufrag filled out to the local credentials.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1598,6 +1598,12 @@ impl RtcConfig {
         &self.dtls_cert
     }
 
+    /// Set DTLS certification.
+    pub fn set_dtls_cert(mut self, dtls_cert: DtlsCert) -> Self {
+        self.dtls_cert = dtls_cert;
+        self
+    }
+
     /// Toggle ice lite. Ice lite is a mode for WebRTC servers with public IP address.
     /// An [`Rtc`] instance in ice lite mode will not make STUN binding requests, but only
     /// answer to requests from the remote peer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -908,7 +908,8 @@ impl Rtc {
         Rtc {
             alive: true,
             ice,
-            dtls: Dtls::new(config.dtls_cert).expect("DTLS to init without problem"),
+            dtls: Dtls::new(config.dtls_cert, config.fingerprint_verification)
+                .expect("DTLS to init without problem"),
             session,
             sctp: RtcSctp::new(),
             chan: ChannelHandler::default(),
@@ -1566,6 +1567,7 @@ impl Rtc {
 pub struct RtcConfig {
     local_ice_credentials: IceCreds,
     dtls_cert: DtlsCert,
+    fingerprint_verification: bool,
     ice_lite: bool,
     codec_config: CodecConfig,
     exts: ExtensionMap,
@@ -1613,6 +1615,26 @@ impl RtcConfig {
     /// [1]: https://www.rfc-editor.org/rfc/rfc8445#page-13
     pub fn set_ice_lite(mut self, enabled: bool) -> Self {
         self.ice_lite = enabled;
+        self
+    }
+
+    /// Get fingerprint verification mode.
+    ///
+    /// ```
+    /// # use str0m::RtcConfig;
+    ///
+    /// // Verify that fingerprint verification is enabled by default.
+    /// assert!(RtcConfig::default().fingerprint_verification());
+    /// ```
+    pub fn fingerprint_verification(&self) -> bool {
+        self.fingerprint_verification
+    }
+
+    /// Toggle certificate fingerprint verification.
+    ///
+    /// By default the certificate fingerprint is verified.
+    pub fn set_fingerprint_verification(mut self, enabled: bool) -> Self {
+        self.fingerprint_verification = enabled;
         self
     }
 
@@ -1950,6 +1972,7 @@ impl Default for RtcConfig {
         Self {
             local_ice_credentials: IceCreds::new(),
             dtls_cert: DtlsCert::new(),
+            fingerprint_verification: true,
             ice_lite: false,
             codec_config: CodecConfig::new_with_defaults(),
             exts: ExtensionMap::standard(),


### PR DESCRIPTION
This commit introduces few minor changes to `str0m`:
  * allow user to set local ICE credentials
  * allow user to disable certificate fingerprint verification
  * allow user to fetch remote's certificate fingerprint

These changes allow implementing WebRTC Direct [1] using `str0m`

[1] https://github.com/libp2p/specs/blob/master/webrtc/webrtc-direct.md

---
Related to #166 

cc @thomaseizinger @xnorpx 