### PR TITLE
Time fixes

### DIFF
--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -170,6 +170,10 @@ impl<'a> DirectApi<'a> {
         mid: Mid,
         rid: Option<Rid>,
     ) -> &mut StreamRx {
+        let Some(_media) = self.rtc.session.media_by_mid(mid) else {
+            panic!("No media declared for mid: {}", mid);
+        };
+
         self.rtc
             .session
             .streams

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -510,6 +510,7 @@ use std::time::{Duration, Instant};
 use streams::RtpPacket;
 use streams::StreamPaused;
 use thiserror::Error;
+use util::InstantExt;
 
 mod dtls;
 use dtls::DtlsCert;
@@ -530,7 +531,7 @@ mod packet;
 #[path = "rtp/mod.rs"]
 mod rtp_;
 use rtp_::Bitrate;
-use rtp_::{Extension, ExtensionMap, InstantExt};
+use rtp_::{Extension, ExtensionMap};
 
 /// Low level RTP access.
 pub mod rtp {

--- a/src/rtp/mod.rs
+++ b/src/rtp/mod.rs
@@ -14,7 +14,6 @@ mod dir;
 pub use dir::Direction;
 
 mod mtime;
-pub(crate) use mtime::InstantExt;
 pub use mtime::MediaTime;
 
 mod header;

--- a/src/rtp/rtcp/mod.rs
+++ b/src/rtp/rtcp/mod.rs
@@ -455,6 +455,8 @@ fn pad_bytes_to_word(n: usize) -> usize {
 mod test {
     use std::time::{Duration, Instant};
 
+    use crate::rtp_::MediaTime;
+
     use super::twcc::{Delta, PacketChunk, PacketStatus};
     use super::*;
 
@@ -590,7 +592,7 @@ mod test {
             sender_info: SenderInfo {
                 ssrc: ssrc.into(),
                 ntp_time,
-                rtp_time: 4,
+                rtp_time: MediaTime::new(4, 1),
                 sender_packet_count: 5,
                 sender_octet_count: 6,
             },

--- a/src/rtp/rtcp/sr.rs
+++ b/src/rtp/rtcp/sr.rs
@@ -1,4 +1,8 @@
-use super::{FeedbackMessageType, MediaTime, RtcpType, Ssrc};
+use std::time::Instant;
+
+use crate::util::InstantExt;
+
+use super::{FeedbackMessageType, RtcpType, Ssrc};
 use super::{ReceptionReport, ReportList, RtcpHeader, RtcpPacket};
 
 /// A report of packets sent.
@@ -16,7 +20,7 @@ pub struct SenderReport {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SenderInfo {
     pub ssrc: Ssrc,
-    pub ntp_time: MediaTime,
+    pub ntp_time: Instant,
     pub rtp_time: u32,
     pub sender_packet_count: u32,
     pub sender_octet_count: u32,
@@ -110,7 +114,7 @@ impl<'a> TryFrom<&'a [u8]> for SenderInfo {
         let ntp_time = u64::from_be_bytes([
             buf[4], buf[5], buf[6], buf[7], buf[8], buf[9], buf[10], buf[11],
         ]);
-        let ntp_time = MediaTime::from_ntp_64(ntp_time);
+        let ntp_time = Instant::from_ntp_64(ntp_time);
 
         // https://www.cs.columbia.edu/~hgs/rtp/faq.html#timestamp-computed
         // For video, time clock rate is fixed at 90 kHz. The timestamps generated

--- a/src/rtp/rtcp/xr.rs
+++ b/src/rtp/rtcp/xr.rs
@@ -1,4 +1,8 @@
-use super::{FeedbackMessageType, MediaTime, RtcpType, Ssrc};
+use std::time::Instant;
+
+use crate::util::InstantExt;
+
+use super::{FeedbackMessageType, RtcpType, Ssrc};
 use super::{RtcpHeader, RtcpPacket};
 
 //   0                   1                   2                   3
@@ -46,7 +50,7 @@ pub enum ReportBlock {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(missing_docs)]
 pub struct Rrtr {
-    pub ntp_time: MediaTime,
+    pub ntp_time: Instant,
 }
 
 //   0                   1                   2                   3
@@ -223,7 +227,7 @@ impl<'a> TryFrom<&'a [u8]> for Rrtr {
 
     fn try_from(buf: &'a [u8]) -> Result<Self, Self::Error> {
         let ntp_time = u64::from_be_bytes(buf[4..4 + 8].try_into().unwrap());
-        let ntp_time = MediaTime::from_ntp_64(ntp_time);
+        let ntp_time = Instant::from_ntp_64(ntp_time);
 
         Ok(Rrtr { ntp_time })
     }

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -2,12 +2,12 @@ use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
 use crate::media::KeyframeRequestKind;
-use crate::rtp_::{
-    extend_u32, DlrrItem, ExtendedReport, Fir, FirEntry, InstantExt, MediaTime, Mid, Pli, Pt,
-    ReceiverReport, ReportBlock, ReportList, Rid, Rrtr, Rtcp, RtcpFb, RtpHeader, SenderInfo, SeqNo,
-};
+use crate::rtp_::{extend_u32, DlrrItem, ExtendedReport, Fir, FirEntry, MediaTime};
+use crate::rtp_::{Mid, Pli, Pt, ReceiverReport};
+use crate::rtp_::{ReportBlock, ReportList, Rid, Rrtr, Rtcp, RtcpFb, RtpHeader, SenderInfo, SeqNo};
 use crate::rtp_::{SdesType, Ssrc};
 use crate::stats::{MediaIngressStats, StatsSnapshot};
+use crate::util::InstantExt;
 use crate::util::{already_happened, calculate_rtt_ms};
 
 use super::register::ReceiverRegister;

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -463,7 +463,7 @@ impl StreamRx {
             let t = self
                 .sender_info
                 .map(|(_, s)| s.ntp_time)
-                .unwrap_or(MediaTime::ZERO);
+                .unwrap_or(already_happened());
 
             let t64 = t.as_ntp_64();
             (t64 >> 16) as u32
@@ -489,9 +489,7 @@ impl StreamRx {
     fn create_extended_receiver_report(&self, now: Instant) -> ExtendedReport {
         // we only want to report our time to measure RTT,
         // the source will answer with Dlrr feedback, allowing us to calculate RTT
-        let block = ReportBlock::Rrtr(Rrtr {
-            ntp_time: MediaTime::new_ntp_time(now),
-        });
+        let block = ReportBlock::Rrtr(Rrtr { ntp_time: now });
         ExtendedReport {
             ssrc: self.ssrc,
             blocks: vec![block],

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -737,7 +737,7 @@ impl StreamTx {
 
         SenderInfo {
             ssrc: self.ssrc,
-            ntp_time: MediaTime::new_ntp_time(now),
+            ntp_time: now,
             rtp_time: rtp_time as u32,
             sender_packet_count: self.stats.packets as u32,
             sender_octet_count: self.stats.bytes as u32,

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -13,7 +13,7 @@ use crate::media::MediaKind;
 use crate::packet::QueuePriority;
 use crate::packet::QueueSnapshot;
 use crate::packet::QueueState;
-use crate::rtp_::{extend_u16, Descriptions, InstantExt, ReportList, Rtcp};
+use crate::rtp_::{extend_u16, Descriptions, ReportList, Rtcp};
 use crate::rtp_::{ExtensionMap, ReceptionReport, RtpHeader};
 use crate::rtp_::{ExtensionValues, MediaTime, Mid, NackEntry};
 use crate::rtp_::{Pt, Rid, RtcpFb, SenderInfo, SenderReport, Ssrc};
@@ -23,6 +23,7 @@ use crate::session::PacketReceipt;
 use crate::stats::MediaEgressStats;
 use crate::stats::StatsSnapshot;
 use crate::util::value_history::ValueHistory;
+use crate::util::InstantExt;
 use crate::util::{already_happened, calculate_rtt_ms, not_happening};
 use crate::RtcError;
 

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -733,12 +733,12 @@ impl StreamTx {
     }
 
     fn sender_info(&self, now: Instant) -> SenderInfo {
-        let rtp_time = self.current_rtp_time(now).map(|t| t.numer()).unwrap_or(0);
+        let rtp_time = self.current_rtp_time(now).unwrap_or(MediaTime::ZERO);
 
         SenderInfo {
             ssrc: self.ssrc,
             ntp_time: now,
-            rtp_time: rtp_time as u32,
+            rtp_time,
             sender_packet_count: self.stats.packets as u32,
             sender_octet_count: self.stats.bytes as u32,
         }

--- a/src/util/time_tricks.rs
+++ b/src/util/time_tricks.rs
@@ -14,13 +14,26 @@ pub(crate) fn not_happening() -> Instant {
 // This is indeed a bit dodgy, but we want str0m's internal idea of time to be completely
 // driven from the external API using `Instant`. What works against us is that Instant can't
 // represent things like UNIX EPOCH (but SystemTime can).
-const HOURS_1: Duration = Duration::from_secs(60);
 static BEGINNING_OF_TIME: Lazy<(Instant, SystemTime)> = Lazy::new(|| {
     // These two should be "frozen" the same instant. Hopefully they are not differing too much.
     let now = Instant::now();
     let now_sys = SystemTime::now();
 
-    let beginning_of_time = now.checked_sub(HOURS_1).unwrap();
+    // Find an Instant in the past which is up to an hour back.
+    let beginning_of_time = {
+        let mut secs = 3600;
+        loop {
+            let dur = Duration::from_secs(secs);
+            if let Some(v) = now.checked_sub(dur) {
+                break v;
+            }
+            secs -= 1;
+            if secs == 0 {
+                panic!("Failed to find a beginning of time instant");
+            }
+        }
+    };
+
     // This might be less than 1 hour if the machine uptime is less.
     let since_beginning_of_time = Instant::now() - beginning_of_time;
 
@@ -29,6 +42,13 @@ static BEGINNING_OF_TIME: Lazy<(Instant, SystemTime)> = Lazy::new(|| {
     // This pair represents our "beginning of time" for the same moment.
     (beginning_of_time, beginning_of_time_sys)
 });
+
+fn epoch_to_beginning() -> Duration {
+    BEGINNING_OF_TIME
+        .1
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("beginning of time to be after epoch")
+}
 
 pub(crate) fn already_happened() -> Instant {
     BEGINNING_OF_TIME.0
@@ -42,9 +62,30 @@ pub trait InstantExt {
     /// panics if `time` goes backwards, i.e. we use this for one Instant and then an earlier Instant.
     fn to_unix_duration(&self) -> Duration;
 
+    /// Convert a unix duration to our relative Instant.
+    fn from_unix_duration(d: Duration) -> Self;
+
     /// Convert an Instant to a Duration for ntp time.
     fn to_ntp_duration(&self) -> Duration;
+
+    /// Convert an ntp_64 as seen in SR to an Instant.
+    fn from_ntp_64(v: u64) -> Self;
+
+    /// Convert instant to ntp_64
+    fn as_ntp_64(&self) -> u64;
 }
+
+// RTP spec "wallclock" uses NTP time, which starts at 1900-01-01.
+//
+// https://tools.ietf.org/html/rfc868
+//
+// 365 days * 70 years + 17 leap year days
+// (365 * 70 + 17) * 86400 = 2208988800
+const SECS_1900: u64 = 2_208_988_800;
+const MICROS_1900: u64 = SECS_1900 * 1_000_000;
+
+/// 2^32 as float.
+const F32: f64 = 4_294_967_296.0;
 
 impl InstantExt for Instant {
     fn to_unix_duration(&self) -> Duration {
@@ -63,16 +104,56 @@ impl InstantExt for Instant {
             .expect("clock to go forwards from unix epoch")
     }
 
-    fn to_ntp_duration(&self) -> Duration {
-        // RTP spec "wallclock" uses NTP time, which starts at 1900-01-01.
-        //
-        // https://tools.ietf.org/html/rfc868
-        //
-        // 365 days * 70 years + 17 leap year days
-        // (365 * 70 + 17) * 86400 = 2208988800
-        const MICROS_1900: Duration = Duration::from_micros(2_208_988_800 * 1_000_000 as u64);
+    fn from_unix_duration(d: Duration) -> Self {
+        let since_beginning_of_time = d.saturating_sub(epoch_to_beginning());
+        BEGINNING_OF_TIME.0 + since_beginning_of_time
+    }
 
-        self.to_unix_duration() + MICROS_1900
+    fn to_ntp_duration(&self) -> Duration {
+        self.to_unix_duration() + Duration::from_micros(MICROS_1900)
+    }
+
+    fn from_ntp_64(v: u64) -> Self {
+        // https://tools.ietf.org/html/rfc3550#section-4
+        // Wallclock time (absolute date and time) is represented using the
+        // timestamp format of the Network Time Protocol (NTP), which is in
+        // seconds relative to 0h UTC on 1 January 1900 [4]. The full
+        // resolution NTP timestamp is a 64-bit unsigned fixed-point number with
+        // the integer part in the first 32 bits and the fractional part in the
+        // last 32 bits.
+        let secs_ntp = (v as f64) / F32;
+
+        // Shift to UNIX EPOCH
+        let secs_epoch = secs_ntp - SECS_1900 as f64;
+
+        // Duration not allowed to be negative
+        let secs_dur = if secs_epoch <= 0.0 {
+            Duration::ZERO
+        } else {
+            Duration::from_secs_f64(secs_epoch)
+        };
+
+        // Time in SystemTime
+        let sys = SystemTime::UNIX_EPOCH + secs_dur;
+
+        // Relative duration from our beginning of time.
+        let since_beginning_of_time = sys
+            .duration_since(BEGINNING_OF_TIME.1)
+            .unwrap_or(Duration::ZERO);
+
+        // Translate relative to Instant
+        BEGINNING_OF_TIME.0 + since_beginning_of_time
+    }
+
+    fn as_ntp_64(&self) -> u64 {
+        let since_beginning_of_time = self.duration_since(BEGINNING_OF_TIME.0);
+
+        let since_epoch = since_beginning_of_time + epoch_to_beginning();
+        let secs_epoch = since_epoch.as_secs_f64();
+
+        let secs_ntp = secs_epoch + SECS_1900 as f64;
+
+        (secs_ntp * F32) as u64
     }
 }
 
@@ -95,5 +176,19 @@ mod test {
     #[test]
     fn already_happened_ne() {
         assert_ne!(not_happening(), already_happened())
+    }
+
+    #[test]
+    fn ntp_64_from_to() {
+        let now = Instant::now();
+        let ntp = now.as_ntp_64();
+        let now2 = Instant::from_ntp_64(ntp);
+        let abs = if now > now2 { now - now2 } else { now2 - now };
+        assert!(abs < Duration::from_millis(1));
+    }
+
+    #[test]
+    fn from_ntp_64() {
+        Instant::from_ntp_64(0);
     }
 }

--- a/src/util/time_tricks.rs
+++ b/src/util/time_tricks.rs
@@ -1,0 +1,104 @@
+use std::time::SystemTime;
+use std::time::{Duration, Instant};
+
+use once_cell::sync::Lazy;
+use once_cell::sync::OnceCell;
+
+pub(crate) fn not_happening() -> Instant {
+    const YEARS_100: Duration = Duration::from_secs(60 * 60 * 24 * 365 * 100);
+    static FUTURE: Lazy<Instant> = Lazy::new(|| Instant::now() + YEARS_100);
+    *FUTURE
+}
+
+// The goal here is to make a constant "beginning of time" in both Instant and SystemTime
+// that we can use as relative values for the rest of str0m.
+// This is indeed a bit dodgy, but we want str0m's internal idea of time to be completely
+// driven from the external API using `Instant`. What works against us is that Instant can't
+// represent things like UNIX EPOCH (but SystemTime can).
+const HOURS_1: Duration = Duration::from_secs(60);
+static PAST: Lazy<(Instant, SystemTime)> = Lazy::new(|| {
+    // These two should be "frozen" the same instant. Hopefully they are not differing too much.
+    let now = Instant::now();
+    let now_sys = SystemTime::now();
+
+    let beginning_of_time = now.checked_sub(HOURS_1).unwrap();
+    // This might be less than 1 hour if the machine uptime is less.
+    let since_beginning_of_time = Instant::now() - beginning_of_time;
+
+    let beginning_of_time_sys = now_sys - since_beginning_of_time;
+
+    // This pair represents our "beginning of time" for the same moment.
+    (beginning_of_time, beginning_of_time_sys)
+});
+
+pub(crate) fn already_happened() -> Instant {
+    PAST.0
+}
+pub trait InstantExt {
+    /// Convert an Instant to a Duration for unix time.
+    ///
+    /// First ever time must be "now".
+    ///
+    /// panics if `time` goes backwards, i.e. we use this for one Instant and then an earlier Instant.
+    fn to_unix_duration(&self) -> Duration;
+
+    /// Convert an Instant to a Duration for ntp time.
+    fn to_ntp_duration(&self) -> Duration;
+}
+
+impl InstantExt for Instant {
+    fn to_unix_duration(&self) -> Duration {
+        // This is a bit fishy. We "freeze" a moment in time for Instant and SystemTime,
+        // so we can make relative comparisons of Instant - Instant and translate that to
+        // SystemTime - unix epoch. Hopefully the error is quite small.
+        static TIME_START: OnceCell<(Instant, SystemTime)> = OnceCell::new();
+        let _ = TIME_START.set((*self, SystemTime::now()));
+
+        let tstart = TIME_START.get().unwrap();
+
+        if *self < tstart.0 {
+            warn!("Time went backwards from first ever Instant");
+        }
+
+        let duration_since_time_0 = self.duration_since(tstart.0);
+        let system_time = tstart.1 + duration_since_time_0;
+
+        system_time
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("clock to go forwards from unix epoch")
+    }
+
+    fn to_ntp_duration(&self) -> Duration {
+        // RTP spec "wallclock" uses NTP time, which starts at 1900-01-01.
+        //
+        // https://tools.ietf.org/html/rfc868
+        //
+        // 365 days * 70 years + 17 leap year days
+        // (365 * 70 + 17) * 86400 = 2208988800
+        const MICROS_1900: Duration = Duration::from_micros(2_208_988_800 * 1_000_000 as u64);
+
+        self.to_unix_duration() + MICROS_1900
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn not_happening_works() {
+        assert_eq!(not_happening(), not_happening());
+        assert!(Instant::now() < not_happening());
+    }
+
+    #[test]
+    fn already_happened_works() {
+        assert_eq!(already_happened(), already_happened());
+        assert!(Instant::now() > already_happened());
+    }
+
+    #[test]
+    fn already_happened_ne() {
+        assert_ne!(not_happening(), already_happened())
+    }
+}

--- a/src/util/time_tricks.rs
+++ b/src/util/time_tricks.rs
@@ -15,7 +15,7 @@ pub(crate) fn not_happening() -> Instant {
 // driven from the external API using `Instant`. What works against us is that Instant can't
 // represent things like UNIX EPOCH (but SystemTime can).
 const HOURS_1: Duration = Duration::from_secs(60);
-static PAST: Lazy<(Instant, SystemTime)> = Lazy::new(|| {
+static BEGINNING_OF_TIME: Lazy<(Instant, SystemTime)> = Lazy::new(|| {
     // These two should be "frozen" the same instant. Hopefully they are not differing too much.
     let now = Instant::now();
     let now_sys = SystemTime::now();
@@ -31,7 +31,7 @@ static PAST: Lazy<(Instant, SystemTime)> = Lazy::new(|| {
 });
 
 pub(crate) fn already_happened() -> Instant {
-    PAST.0
+    BEGINNING_OF_TIME.0
 }
 
 pub trait InstantExt {
@@ -51,12 +51,12 @@ impl InstantExt for Instant {
         // This is a bit fishy. We "freeze" a moment in time for Instant and SystemTime,
         // so we can make relative comparisons of Instant - Instant and translate that to
         // SystemTime - unix epoch. Hopefully the error is quite small.
-        if *self < PAST.0 {
+        if *self < BEGINNING_OF_TIME.0 {
             warn!("Time went backwards from beginning_of_time Instant");
         }
 
-        let duration_since_time_0 = self.duration_since(PAST.0);
-        let system_time = PAST.1 + duration_since_time_0;
+        let duration_since_time_0 = self.duration_since(BEGINNING_OF_TIME.0);
+        let system_time = BEGINNING_OF_TIME.1 + duration_since_time_0;
 
         system_time
             .duration_since(SystemTime::UNIX_EPOCH)


### PR DESCRIPTION
- Expand PAST constant to also have SystemTime
- Consolidate time tricks into util/time_tricks
- Refactor to_unix_duration to use beginning_of_time
- Rename PAST constant to BEGINNING_OF_TIME
- Instant::from_ntp_u64 and as_ntp_u64
