### PR TITLE
fix/nack register rollover

### DIFF
--- a/src/streams/register.rs
+++ b/src/streams/register.rs
@@ -108,7 +108,9 @@ impl ReceiverRegister {
         if did_wrap {
             // The indices wrapped around the end of `packet_status`, we clear any entries between
             // the current sequence number and nack_check_from.
-            let start = (*seq - self.packet_index(*seq) as u64).into();
+            let start = (*seq - self.packet_index(*seq) as u64)
+                .saturating_sub(self.packet_status.len() as u64)
+                .into();
             let end = self.nack_check_from;
             trace!(
                 "ReceiveRegister wrapped, clearing all entries from {start} to {end} on receiving {seq}"

--- a/src/streams/register.rs
+++ b/src/streams/register.rs
@@ -94,17 +94,6 @@ impl ReceiverRegister {
         let did_wrap = (*seq / self.packet_status.len() as u64)
             != (seq.saturating_sub(forward_delta) / self.packet_status.len() as u64);
 
-        let pos = self.packet_index(*seq);
-        let was_set = self.packet_status[pos].received;
-        self.packet_status[pos].received = true;
-
-        if self.packet_status[pos].received && self.packet_status[pos].nack_count > 0 {
-            debug!(
-                "Received packet {} after {} NACKs",
-                seq, self.packet_status[pos].nack_count
-            );
-        }
-
         if did_wrap {
             // The indices wrapped around the end of `packet_status`, we clear any entries between
             // the current sequence number and nack_check_from.
@@ -117,6 +106,17 @@ impl ReceiverRegister {
             );
 
             self.reset_receceived(start, end);
+        }
+
+        let pos = self.packet_index(*seq);
+        let was_set = self.packet_status[pos].received;
+        self.packet_status[pos].received = true;
+
+        if self.packet_status[pos].received && self.packet_status[pos].nack_count > 0 {
+            debug!(
+                "Received packet {} after {} NACKs",
+                seq, self.packet_status[pos].nack_count
+            );
         }
 
         // Move nack_check_from forward


### PR DESCRIPTION
- rx register: fix start index for wrap reset
- rx register: mark received after wrap reset
- add test for out of order packets on rollover
