### PR TITLE
Use `Into<Vec<u8>>` instead of `&[u8]` in `Writer::write`

### DIFF
--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -557,7 +557,7 @@ impl Client {
             return;
         };
 
-        if let Err(e) = writer.write(pt, data.network_time, data.time, &data.data) {
+        if let Err(e) = writer.write(pt, data.network_time, data.time, data.data.clone()) {
             warn!("Client ({}) failed: {:?}", *self.id, e);
             self.rtc.disconnect();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1082,7 +1082,7 @@ impl Rtc {
     /// // Match incoming PT to an outgoing PT.
     /// let pt = writer.match_params(data.params).unwrap();
     ///
-    /// writer.write(pt, data.network_time, data.time, &data.data).unwrap();
+    /// writer.write(pt, data.network_time, data.time, data.data).unwrap();
     /// ```
     ///
     /// This is a sample level API: For RTP level see [`DirectApi::stream_tx()`] and [`DirectApi::stream_rx()`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,7 @@
 //! // Write the data
 //! let wallclock = todo!();  // Absolute time of the data
 //! let media_time = todo!(); // Media time, in RTP time
-//! let data = todo!();       // Actual data
+//! let data: Vec<u8> = todo!();       // Actual data
 //! writer.write(pt, wallclock, media_time, data).unwrap();
 //! ```
 //!

--- a/src/media/writer.rs
+++ b/src/media/writer.rs
@@ -96,12 +96,12 @@ impl<'a> Writer<'a> {
     /// If you write media before `IceConnectionState` is `Connected` it will be dropped.
     ///
     /// Panics if [`RtcConfig::set_rtp_mode()`][crate::RtcConfig::set_rtp_mode] is `true`.
-    pub fn write<T: Into<Vec<u8>>>(
+    pub fn write(
         self,
         pt: Pt,
         wallclock: Instant,
         rtp_time: MediaTime,
-        data: T,
+        data: impl Into<Vec<u8>>,
     ) -> Result<(), RtcError> {
         let media = media_by_mid_mut(&mut self.session.medias, self.mid);
 

--- a/src/media/writer.rs
+++ b/src/media/writer.rs
@@ -96,12 +96,12 @@ impl<'a> Writer<'a> {
     /// If you write media before `IceConnectionState` is `Connected` it will be dropped.
     ///
     /// Panics if [`RtcConfig::set_rtp_mode()`][crate::RtcConfig::set_rtp_mode] is `true`.
-    pub fn write(
+    pub fn write<T: Into<Vec<u8>>>(
         self,
         pt: Pt,
         wallclock: Instant,
         rtp_time: MediaTime,
-        data: &[u8],
+        data: T,
     ) -> Result<(), RtcError> {
         let media = media_by_mid_mut(&mut self.session.medias, self.mid);
 
@@ -114,6 +114,8 @@ impl<'a> Writer<'a> {
                 return Err(RtcError::UnknownRid(rid));
             }
         }
+
+        let data: Vec<u8> = data.into();
 
         trace!(
             "write {:?} {:?} {:?} time: {:?} len: {}",
@@ -129,7 +131,7 @@ impl<'a> Writer<'a> {
             rid: self.rid,
             wallclock,
             rtp_time,
-            data: data.into(),
+            data,
             ext_vals: self.ext_vals,
         };
 

--- a/tests/bidirectional.rs
+++ b/tests/bidirectional.rs
@@ -50,13 +50,17 @@ pub fn bidirectional_same_m_line() -> Result<(), RtcError> {
         {
             let wallclock = l.start + l.duration();
             let time = l.duration().into();
-            l.writer(mid).unwrap().write(pt, wallclock, time, &data_a)?;
+            l.writer(mid)
+                .unwrap()
+                .write(pt, wallclock, time, data_a.clone())?;
         }
 
         {
             let wallclock = r.start + r.duration();
             let time = l.duration().into();
-            r.writer(mid).unwrap().write(pt, wallclock, time, &data_b)?;
+            r.writer(mid)
+                .unwrap()
+                .write(pt, wallclock, time, data_b.clone())?;
         }
 
         progress(&mut l, &mut r)?;

--- a/tests/unidirectional-r-create-media.rs
+++ b/tests/unidirectional-r-create-media.rs
@@ -57,7 +57,9 @@ pub fn unidirectional_r_create_media() -> Result<(), RtcError> {
     loop {
         let wallclock = l.start + l.duration();
         let time = l.duration().into();
-        l.writer(mid).unwrap().write(pt, wallclock, time, &data_a)?;
+        l.writer(mid)
+            .unwrap()
+            .write(pt, wallclock, time, data_a.clone())?;
 
         progress(&mut l, &mut r)?;
         progress(&mut l, &mut r)?;

--- a/tests/unidirectional.rs
+++ b/tests/unidirectional.rs
@@ -49,7 +49,9 @@ pub fn unidirectional() -> Result<(), RtcError> {
     loop {
         let wallclock = l.start + l.duration();
         let time = l.duration().into();
-        l.writer(mid).unwrap().write(pt, wallclock, time, &data_a)?;
+        l.writer(mid)
+            .unwrap()
+            .write(pt, wallclock, time, data_a.clone())?;
 
         progress(&mut l, &mut r)?;
 

--- a/tests/user-rtp-header-extension.rs
+++ b/tests/user-rtp-header-extension.rs
@@ -131,7 +131,7 @@ pub fn user_rtp_header_extension() -> Result<(), RtcError> {
             .unwrap()
             // Set my bespoke RTP header value.
             .user_extension_value(MyValue(42))
-            .write(pt, wallclock, time, &data_a)?;
+            .write(pt, wallclock, time, data_a.clone())?;
 
         progress(&mut l, &mut r)?;
 


### PR DESCRIPTION
In #339 was decided to change `Writer::write` `data` parameter to be `Into<Vec<u8>>` instead of `&[u8]`, because it will allow the caller to pass either a `Vec<u8>` (without cloning) or something else. 

Also it will be more obvious that this method needs owned `data`.