### PR TITLE
Handle different RTX availability among answering sendonly mlines

### DIFF
--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -743,7 +743,11 @@ fn ensure_stream_tx(session: &mut Session) {
 
         // If any payload param has RTX, we need to prepare for RTX. This is because we always
         // communicate a=ssrc lines, which need to be complete with main and RTX SSRC.
-        let has_rtx = session.codec_config.iter().any(|p| p.resend().is_some());
+        let has_rtx = session
+            .codec_config
+            .iter()
+            .filter(|p| media.remote_pts().contains(&p.pt))
+            .any(|p| p.resend().is_some());
 
         for rid in rids {
             // If we already have the stream, we don't make any new one.

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -27,6 +27,7 @@ pub use writer::Writer;
 pub use crate::packet::MediaKind;
 pub use crate::rtp_::{Direction, ExtensionValues, MediaTime, Mid, Pt, Rid};
 
+#[derive(Debug)]
 /// Information about some configured media.
 pub struct Media {
     // ========================================= RTP level =========================================
@@ -143,6 +144,7 @@ impl Rids {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct ToPayload {
     pub pt: Pt,
     pub rid: Option<Rid>,


### PR DESCRIPTION
I'm relatively new to rust, WebRTC, and str0m so please forgive me if my thinking is wrong. I really appreciate any advice you might have.

I am prototyping a new streaming solution using str0m and I found that when a browser client generates a recvonly SDP 'offer' for audio and video streams, str0m will answer both the video and the audio mlines with multiple ssrcs even when only the video mline has any payload types with RTX available. This then causes an error like

```
[28394:25603:0911/135240.480561:ERROR:sdp_offer_answer.cc(911)] Failed to set remote answer sdp: Failed to add remote stream ssrc: 1990811668 to {mid: 1, media_type: audio}
```

in Safari and Chrome (both are libwebrtc users? probably rejected by others?) as they have an SDP answer validation routine that checks for the presence of exactly one ssrc for audio streams.

I've now changed the computation for RTX availability in the SDP response to take into account only those payloads for the current media stream under consideration for ssrc addition. To my eye, this seems to indicate that the type design for sessions/codec config/media descriptions is incorrect as I'd expect the data structure to have already indexed codec config under media streams such that this bug would be impossible. As I said, I'm relatively new to all of these technologies so I'd be very grateful for an explanation why this is or isn't the case.

I suppose that another solution would be to set up some session parameters manually during the negotiation to suppress this SDP response or munge the answer after generation but both of these seems less satisfactory than preventing the default str0m behaviour from being rejected by clients.

Please let me know if you'd like tests or documentation or discussion via zulip or anything else before merging (if the change is acceptable).

Thanks!