### PR TITLE
Respect `ssrc-group` simulcast signalling

### DIFF
--- a/src/rtp/ext.rs
+++ b/src/rtp/ext.rs
@@ -438,6 +438,22 @@ impl ExtensionMap {
         }
     }
 
+    pub(crate) fn remove(&mut self, ext: Extension) {
+        let maybe_entry = self.0.iter_mut().find_map(|e| {
+            if e.as_mut().map(|e| e.ext == ext).unwrap_or(false) {
+                Some(e)
+            } else {
+                None
+            }
+        });
+
+        let Some(entry) = maybe_entry else {
+            return;
+        };
+
+        let _ = entry.take();
+    }
+
     fn swap(&mut self, id: u8, ext: &Extension) {
         if id < 1 || id > 14 {
             return;

--- a/src/session.rs
+++ b/src/session.rs
@@ -466,8 +466,6 @@ impl Session {
         let media = self.medias.iter_mut().find(|m| m.mid() == mid).unwrap();
         let stream = self.streams.stream_rx(&ssrc).unwrap();
 
-        // If the header ssrc differs from the main, it's a repair stream.
-        let is_repair = header.ssrc != ssrc;
         let params = match main_payload_params(&self.codec_config, header.payload_type) {
             Some(p) => p,
             None => {
@@ -480,6 +478,7 @@ impl Session {
         };
         let clock_rate = params.spec().clock_rate;
         let pt = params.pt();
+        let is_repair = pt != header.payload_type;
 
         // is_repair controls whether update is updating the main register or the RTX register.
         // Either way we get a seq_no_outer which is used to decrypt the SRTP.

--- a/tests/sdp-negotiation.rs
+++ b/tests/sdp-negotiation.rs
@@ -230,6 +230,9 @@ fn answer_remaps() {
     let a_l: Vec<_> = l.exts().iter(true).collect();
     let a_r: Vec<_> = r.exts().iter(true).collect();
 
+    // NB: `RtpStreamId` and `RepairedStreamId` are not negotiated because str0m disables them if
+    // the offering side uses `a=ssrc-group:FID {main} {rtx}`, which str0m does.
+
     // L locks 3 and changes it from 14
     // R keeps 3 and changes it from 14.
     assert_eq!(
@@ -238,8 +241,6 @@ fn answer_remaps() {
             (2, &AbsoluteSendTime),
             (3, &TransportSequenceNumber),
             (4, &RtpMid),
-            (10, &RtpStreamId),
-            (11, &RepairedRtpStreamId),
             (13, &VideoOrientation)
         ]
     );
@@ -254,8 +255,6 @@ fn answer_remaps() {
             (2, &AbsoluteSendTime),
             (3, &TransportSequenceNumber),
             (4, &RtpMid),
-            (10, &RtpStreamId),
-            (11, &RepairedRtpStreamId)
         ]
     );
     assert_eq!(a_r, vec![(3, &TransportSequenceNumber), (12, &AudioLevel)]);


### PR DESCRIPTION
Firefox has bugs with dynamically establishing the mappings of SSRCs for
simulcast using the rid and repaired-rid RTP header, however it does
send the `ssrc-group` correctly in SDPs. To workaround these bugs we
need to give preference to the mapping signalled via ssrc-group, if
enabled.
