### PR TITLE
rx register rewrite

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -210,7 +210,7 @@ impl Session {
 
         let sender_ssrc = self.streams.first_ssrc_local();
 
-        let do_nack = Some(now) >= self.nack_at();
+        let do_nack = now >= self.nack_at();
 
         self.streams.handle_timeout(
             now,
@@ -785,7 +785,7 @@ impl Session {
 
     pub fn poll_timeout(&mut self) -> Option<Instant> {
         let regular_at = Some(self.regular_feedback_at());
-        let nack_at = self.nack_at();
+        let nack_at = Some(self.nack_at());
         let twcc_at = self.twcc_at();
         let pacing_at = self.pacer.poll_timeout();
         let packetize_at = self.medias.iter().flat_map(|m| m.poll_timeout()).next();
@@ -821,12 +821,8 @@ impl Session {
         self.streams.paused_at().unwrap_or_else(not_happening)
     }
 
-    fn nack_at(&mut self) -> Option<Instant> {
-        if self.streams.need_nack() {
-            Some(self.last_nack + NACK_MIN_INTERVAL)
-        } else {
-            None
-        }
+    fn nack_at(&mut self) -> Instant {
+        self.last_nack + NACK_MIN_INTERVAL
     }
 
     fn twcc_at(&self) -> Option<Instant> {

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -17,6 +17,7 @@ pub use self::send::StreamTx;
 
 mod receive;
 mod register;
+mod register_nack;
 mod rtx_cache;
 pub(crate) mod rtx_cache_buf;
 mod send;
@@ -210,10 +211,6 @@ impl Streams {
         let r = self.streams_rx.values().map(|s| s.receiver_report_at());
         let s = self.streams_tx.values().map(|s| s.sender_report_at());
         r.chain(s).min()
-    }
-
-    pub(crate) fn need_nack(&mut self) -> bool {
-        self.streams_rx.values_mut().any(|s| s.has_nack())
     }
 
     pub(crate) fn paused_at(&self) -> Option<Instant> {

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -536,9 +536,9 @@ impl StreamRx {
             return None;
         }
 
-        let mut nacks = self.register.as_mut().and_then(|r| r.nack_report())?;
+        let nacks = self.register.as_mut().and_then(|r| r.nack_report())?;
 
-        for nack in &mut nacks {
+        for mut nack in nacks {
             nack.sender_ssrc = sender_ssrc;
             nack.ssrc = self.ssrc;
 

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -543,14 +543,6 @@ impl StreamRx {
             nack.ssrc = self.ssrc;
 
             debug!("Created feedback NACK: {:?}", nack);
-            self.stats.nacks += 1;
-        }
-
-        if !nacks.is_empty() {
-            debug!("Send nacks: {:?}", nacks);
-        }
-
-        for nack in nacks {
             feedback.push_back(Rtcp::Nack(nack));
             self.stats.nacks += 1;
         }

--- a/src/streams/register.rs
+++ b/src/streams/register.rs
@@ -90,8 +90,8 @@ impl ReceiverRegister {
     }
 
     /// Generates a NACK report
-    pub fn nack_report(&mut self) -> Option<Vec<Nack>> {
-        self.nack.nack_report()
+    pub fn nack_report(&mut self) -> Option<impl Iterator<Item = Nack>> {
+        self.nack.nack_reports()
     }
 
     /// Create a new reception report.

--- a/src/streams/register.rs
+++ b/src/streams/register.rs
@@ -1,40 +1,21 @@
 use std::time::Instant;
 
-use crate::rtp_::{Nack, NackEntry, ReceptionReport, ReportList, SeqNo};
+use crate::rtp_::{Nack, ReceptionReport, SeqNo};
 
-const MAX_DROPOUT: u64 = 3000;
-const MAX_MISORDER: u64 = 100;
-const MIN_SEQUENTIAL: u64 = 2;
-const MISORDER_DELAY: u64 = 1;
+use super::register_nack::NackRegister;
 
 #[derive(Debug)]
 pub struct ReceiverRegister {
-    /// Keep track of packet status.
-    packet_status: Vec<PacketStatus>,
+    nack: NackRegister,
 
-    /// First ever sequence number observed.
-    base_seq: SeqNo,
+    /// First sequence number received
+    first: Option<SeqNo>,
 
-    /// Max ever observed sequence number.
-    max_seq: SeqNo,
+    /// Number of packets received
+    count: u64,
 
-    /// last 'bad' seq number + 1.
-    ///
-    /// This is set when we observe a large jump in sequence numbers (MAX_DROPOUT) that we
-    /// assume could indicate a restart of the sender sequence numbers.
-    bad_seq: Option<SeqNo>,
-
-    /// Sequential packets remaining until source is valid.
-    ///
-    /// This is not really useful in the presence of SRTP, since that cryptographically checks
-    /// the packets are from the origin, and not misaddressed.
-    ///
-    /// The value stay here, because that's the original algorithm in the RFC, but it has very
-    /// limited use.
-    probation: u64,
-
-    /// Counter of received packets.
-    received: i64,
+    /// Previously received time point.
+    time_point_prior: Option<TimePoint>,
 
     /// Expected at last reception report generation.
     expected_prior: i64,
@@ -45,203 +26,110 @@ pub struct ReceiverRegister {
     /// Estimated jitter. This is in the media time base, so divided by
     /// 90_000 or 48_000 to normalize.
     jitter: f32,
+}
 
-    /// Check nacks from this point.
-    ///
-    /// We've reported nack to here already.
-    nack_check_from: SeqNo,
+#[derive(Debug, Clone, Copy)]
+struct TimePoint {
+    arrival: Instant,
+    rtp_time: u32,
+    clock_rate: u32,
+}
 
-    /// Previously received time point.
-    time_point_prior: Option<TimePoint>,
+impl TimePoint {
+    fn is_same(&self, other: TimePoint) -> bool {
+        self.rtp_time == other.rtp_time
+    }
+
+    fn delta(&self, other: TimePoint) -> f32 {
+        // See
+        // https://www.rfc-editor.org/rfc/rfc3550#appendix-A.8
+        //
+        // rdur is often i 90kHz (for video) or 48kHz (for audio). we need
+        // a time unit of Duration, that is likely to give us an increase between
+        // 1 in rdur. milliseconds is thus "too coarse"
+        let rdur =
+            ((self.rtp_time as f32 - other.rtp_time as f32) * 1_000_000.0) / self.clock_rate as f32;
+
+        let tdur = (self.arrival - other.arrival).as_micros() as f32;
+
+        let d = (tdur - rdur).abs();
+
+        trace!("Timepoint delta: {}", d);
+
+        d
+    }
 }
 
 impl ReceiverRegister {
-    pub fn new(base_seq: SeqNo) -> Self {
+    pub fn new() -> Self {
         ReceiverRegister {
-            packet_status: vec![PacketStatus::default(); MAX_DROPOUT as usize],
-            base_seq,
-            // ensure first update_seq considers the first packet sequential
-            max_seq: base_seq.wrapping_sub(1).into(),
-            bad_seq: None,
-            probation: MIN_SEQUENTIAL,
-            received: 1,
+            nack: NackRegister::new(),
+            first: None,
+            count: 0,
+            time_point_prior: None,
             expected_prior: 0,
             received_prior: 0,
             jitter: 0.0,
-            nack_check_from: base_seq,
-            time_point_prior: None,
         }
     }
 
-    fn init_seq(&mut self, seq: SeqNo) {
-        self.base_seq = seq;
-        self.max_seq = seq;
-        self.bad_seq = None;
-        self.received = 0;
-        self.received_prior = 0;
-        self.expected_prior = 0;
-        self.jitter = 0.0;
-        self.packet_status.fill(PacketStatus::default());
-        self.record_received(seq);
-        self.nack_check_from = seq;
+    pub fn update(&mut self, seq: SeqNo, arrival: Instant, rtp_time: u32, clock_rate: u32) -> bool {
+        if self.first.is_none() {
+            self.first = Some(seq);
+        }
+
+        let new = self.nack.update(seq);
+
+        if new {
+            self.count += 1;
+        }
+
+        self.update_time(arrival, rtp_time, clock_rate);
+
+        new
+    }
+
+    /// Generates a NACK report
+    pub fn nack_report(&mut self) -> Option<Vec<Nack>> {
+        self.nack.nack_report()
+    }
+
+    /// Create a new reception report.
+    ///
+    /// This modifies the state since fraction_lost is calculated
+    /// since the last call to this function.
+    pub fn reception_report(&mut self) -> Option<ReceptionReport> {
+        let first = self.first?;
+        let last = self.max_seq()?;
+
+        let expected = expected(first, last);
+
+        Some(ReceptionReport {
+            ssrc: 0.into(),
+            fraction_lost: self.fraction_lost(expected, self.count as i64),
+            packets_lost: packets_lost(expected, self.count as i64),
+            max_seq: (*last % ((u32::MAX as u64) + 1_u64)) as u32,
+            jitter: self.jitter as u32,
+            last_sr_time: 0,
+            last_sr_delay: 0,
+        })
+    }
+
+    pub fn max_seq(&self) -> Option<SeqNo> {
+        self.nack.max_seq()
+    }
+
+    pub fn clear(&mut self) {
+        self.nack = NackRegister::new();
+        self.count = 0;
+        self.first = None;
         self.time_point_prior = None;
+        self.expected_prior = 0;
+        self.received_prior = 0;
+        self.jitter = 0.0;
     }
 
-    /// Set a bit indicating we've received a packet.
-    ///
-    /// Returns true if the packet received wasn't received before.
-    fn record_received(&mut self, seq: SeqNo) -> bool {
-        if seq < self.nack_check_from {
-            return false;
-        }
-
-        let pos = self.packet_index(*seq);
-        let was_set = self.packet_status[pos].received;
-        self.packet_status[pos].received = true;
-
-        if self.packet_status[pos].nack_count > 0 {
-            debug!(
-                "Received packet {} after {} NACKs",
-                seq, self.packet_status[pos].nack_count
-            );
-        }
-
-        // Move nack_check_from forward
-        let check_up_to = (*self.max_seq).saturating_sub(MISORDER_DELAY);
-        let new_nack_check_from: Option<SeqNo> = {
-            // Check if we can move forward because we have a consecutive run of packets
-            let consecutive_unil = (*self.nack_check_from..=check_up_to)
-                .take_while(|seq| self.packet_status[self.packet_index(*seq)].received)
-                .last()
-                .map(Into::into);
-
-            match consecutive_unil {
-                Some(new) if new != self.nack_check_from => {
-                    trace!(
-                        "Moving nack_check_from forward from {} to {} on consecutive packet run",
-                        self.nack_check_from,
-                        new
-                    );
-
-                    Some(new)
-                }
-                _ => {
-                    // No consecutive run, make sure we don't let nack_check_from fall too far
-                    if check_up_to.saturating_sub(*self.nack_check_from) > MAX_MISORDER {
-                        // If nack_check_from is falling too far behind bring it forward by discarding
-                        // older packets.
-                        let forced_nack_check_from = check_up_to - MAX_MISORDER;
-                        trace!(
-                        "Forcing nack_check_from forward from {} to {} on non-consecutive packet run",
-                        self.nack_check_from,forced_nack_check_from
-                    );
-
-                        Some(forced_nack_check_from.into())
-                    } else {
-                        None
-                    }
-                }
-            }
-        };
-
-        if let Some(new_nack_check_from) = new_nack_check_from {
-            self.reset_receceived(self.nack_check_from, new_nack_check_from);
-            self.nack_check_from = new_nack_check_from;
-        }
-
-        // if a bit flips from false -> true, we have received a new packet. dupe packets are
-        // not counted (i.e. true -> true) that can happen due to resends.
-        if !was_set {
-            self.received += 1;
-        }
-
-        !was_set
-    }
-
-    fn reset_receceived(&mut self, start: SeqNo, end: SeqNo) {
-        for seq in *start..*end {
-            let index = self.packet_index(seq);
-
-            let status = self.packet_status[index];
-
-            if status.nack_count > 0 && !status.received {
-                debug!("Seq no was nacked but not resent {}", seq);
-            }
-
-            // Reset state
-            self.packet_status[index] = PacketStatus::default();
-        }
-    }
-
-    /// Update a received sequence number.
-    ///
-    /// Returns true if we have not seen this sequence number before.
-    pub fn update_seq(&mut self, seq: SeqNo) -> bool {
-        if self.probation > 0 {
-            // Source is not valid until MIN_SEQUENTIAL packets with
-            // sequential sequence numbers have been received.
-            if *seq == self.max_seq.wrapping_add(1) {
-                self.probation -= 1;
-                self.max_seq = seq;
-                if self.probation == 0 {
-                    self.init_seq(seq);
-                }
-            } else {
-                self.probation = MIN_SEQUENTIAL - 1;
-                self.max_seq = seq;
-            }
-
-            // During probation, consider all packets as "recorded".
-            true
-        } else if *self.max_seq < *seq {
-            // Incoming seq is larger than we've seen before. This
-            // is the normal case, where we receive packets sequentially.
-            let udelta = *seq - *self.max_seq;
-
-            if udelta < MAX_DROPOUT {
-                // in order, with permissible gap
-                self.max_seq = seq;
-                self.bad_seq = None;
-                self.record_received(seq)
-            } else {
-                // the sequence number made a very large jump
-                self.maybe_seq_jump(seq);
-
-                // Optimistically assume the remote side seq jumped.
-                true
-            }
-        } else {
-            // duplicate or out of order packet
-            let udelta = *self.max_seq - *seq;
-
-            if udelta < MAX_MISORDER {
-                self.record_received(seq)
-            } else {
-                // the sequence number is too far in the past
-                self.maybe_seq_jump(seq);
-
-                // Optimistically assume the remote side seq jumped.
-                true
-            }
-        }
-    }
-
-    fn maybe_seq_jump(&mut self, seq: SeqNo) {
-        if self.bad_seq == Some(seq) {
-            // Two sequential packets -- assume that the other side
-            // restarted without telling us so just re-sync
-            // (i.e., pretend this was the first packet).
-            self.init_seq(seq);
-        } else {
-            self.bad_seq = Some((*seq + 1).into());
-        }
-    }
-
-    pub fn max_seq(&self) -> SeqNo {
-        self.max_seq
-    }
-
-    pub fn update_time(&mut self, arrival: Instant, rtp_time: u32, clock_rate: u32) {
+    fn update_time(&mut self, arrival: Instant, rtp_time: u32, clock_rate: u32) {
         let tp = TimePoint {
             arrival,
             rtp_time,
@@ -314,122 +202,14 @@ impl ReceiverRegister {
         self.time_point_prior = Some(tp);
     }
 
-    pub fn has_nack_report(&mut self) -> bool {
-        // No nack report during probation.
-        if self.probation > 0 {
-            return false;
-        }
-
-        // nack_check_from tracks where we create the next nack report from.
-        let start = *self.nack_check_from;
-        // MISORDER_DELAY gives us a "grace period" of receiving packets out of
-        // order without reporting it as a NACK straight away.
-        let stop = (*self.max_seq).saturating_sub(MISORDER_DELAY);
-
-        if stop < start {
-            return false;
-        }
-
-        (start..stop).any(|seq| self.packet_status[self.packet_index(seq)].should_nack())
-    }
-
-    pub fn nack_reports(&mut self) -> Vec<Nack> {
-        self.create_nack_reports()
-    }
-
-    fn create_nack_reports(&mut self) -> Vec<Nack> {
-        // No nack report during probation.
-        if self.probation > 0 {
-            return vec![];
-        }
-
-        // nack_check_from tracks where we create the next nack report from.
-        let start = *self.nack_check_from;
-        // MISORDER_DELAY gives us a "grace period" of receiving packets out of
-        // order without reporting it as a NACK straight away.
-        let stop = (*self.max_seq).saturating_sub(MISORDER_DELAY);
-        let u16max = u16::MAX as u64 + 1_u64;
-
-        if stop < start {
-            return vec![];
-        }
-
-        let mut nacks = vec![];
-        let mut first_missing = None;
-        let mut bitmask = 0;
-
-        for i in start..stop {
-            let j = self.packet_index(i);
-
-            let should_nack = self.packet_status[j].should_nack();
-
-            if let Some(first) = first_missing {
-                if should_nack {
-                    let o = (i - (first + 1)) as u16;
-                    bitmask |= 1 << o;
-                    self.packet_status[j].nack_count += 1;
-                }
-
-                if i - first == 16 {
-                    nacks.push(NackEntry {
-                        pid: (first % u16max) as u16,
-                        blp: bitmask,
-                    });
-                    bitmask = 0;
-                    first_missing = None;
-                }
-            } else if should_nack {
-                self.packet_status[j].nack_count += 1;
-                first_missing = Some(i);
-            }
-        }
-
-        if let Some(first) = first_missing {
-            nacks.push(NackEntry {
-                pid: (first % u16max) as u16,
-                blp: bitmask,
-            });
-        }
-
-        let reports = ReportList::lists_from_iter(nacks).into_iter();
-
-        reports
-            .map(|reports| {
-                Nack {
-                    sender_ssrc: 0.into(),
-                    ssrc: 0.into(), // changed when sending
-                    reports,
-                }
-            })
-            .collect()
-    }
-
-    /// Create a new reception report.
-    ///
-    /// This modifies the state since fraction_lost is calculated
-    /// since the last call to this function.
-    pub fn reception_report(&mut self) -> ReceptionReport {
-        ReceptionReport {
-            ssrc: 0.into(),
-            fraction_lost: self.fraction_lost(),
-            packets_lost: self.packets_lost(),
-            max_seq: (*self.max_seq % ((u32::MAX as u64) + 1_u64)) as u32,
-            jitter: self.jitter as u32,
-            last_sr_time: 0,
-            last_sr_delay: 0,
-        }
-    }
-
     // Calculations from here
     // https://www.rfc-editor.org/rfc/rfc3550#appendix-A.3
 
     /// Fraction lost since last call.
-    fn fraction_lost(&mut self) -> u8 {
-        let expected = self.expected();
+    fn fraction_lost(&mut self, expected: i64, received: i64) -> u8 {
         let expected_interval = expected - self.expected_prior;
         self.expected_prior = expected;
 
-        let received = self.received;
         let received_interval = received - self.received_prior;
         self.received_prior = received;
 
@@ -445,200 +225,36 @@ impl ReceiverRegister {
 
         lost
     }
+}
 
-    /// Absolute number of lost packets.
-    fn packets_lost(&self) -> u32 {
-        // Since this signed number is carried in 24 bits, it should be clamped
-        // at 0x7fffff for positive loss or 0x800000 for negative loss rather
-        // than wrapping around.
-        let lost_t = self.expected() - self.received;
-        if lost_t > 0x7fffff {
-            0x7fffff_u32
-        } else if lost_t < -0x7fffff {
-            0x8000000_u32
-        } else {
-            lost_t as u32
-        }
-    }
-
-    fn expected(&self) -> i64 {
-        *self.max_seq as i64 - *self.base_seq as i64 + 1
-    }
-
-    fn packet_index(&self, seq: u64) -> usize {
-        (seq % self.packet_status.len() as u64) as usize
-    }
-
-    pub(crate) fn clear(&mut self) {
-        self.packet_status.clear();
-        self.nack_check_from = self.max_seq;
+/// Absolute number of lost packets.
+fn packets_lost(expected: i64, received: i64) -> u32 {
+    // Since this signed number is carried in 24 bits, it should be clamped
+    // at 0x7fffff for positive loss or 0x800000 for negative loss rather
+    // than wrapping around.
+    let lost_t = expected - received;
+    if lost_t > 0x7fffff {
+        0x7fffff_u32
+    } else if lost_t < -0x7fffff {
+        0x8000000_u32
+    } else {
+        lost_t as u32
     }
 }
 
-/// Helper to keep a time point for jitter calculation.
-#[derive(Debug, Clone, Copy)]
-struct TimePoint {
-    arrival: Instant,
-    rtp_time: u32,
-    clock_rate: u32,
-}
-
-impl TimePoint {
-    fn is_same(&self, other: TimePoint) -> bool {
-        self.rtp_time == other.rtp_time
-    }
-
-    fn delta(&self, other: TimePoint) -> f32 {
-        // See
-        // https://www.rfc-editor.org/rfc/rfc3550#appendix-A.8
-        //
-        // rdur is often i 90kHz (for video) or 48kHz (for audio). we need
-        // a time unit of Duration, that is likely to give us an increase between
-        // 1 in rdur. milliseconds is thus "too coarse"
-        let rdur =
-            ((self.rtp_time as f32 - other.rtp_time as f32) * 1_000_000.0) / self.clock_rate as f32;
-
-        let tdur = (self.arrival - other.arrival).as_micros() as f32;
-
-        let d = (tdur - rdur).abs();
-
-        trace!("Timepoint delta: {}", d);
-
-        d
-    }
-}
-
-/// The max number of NACKs we perform for a single packet:
-const MAX_NACKS: u8 = 5;
-
-#[derive(Debug, Default, Clone, Copy)]
-struct PacketStatus {
-    received: bool,
-    nack_count: u8,
-}
-
-impl PacketStatus {
-    fn should_nack(&self) -> bool {
-        !self.received && self.nack_count < MAX_NACKS
-    }
+fn expected(first: SeqNo, last: SeqNo) -> i64 {
+    *last as i64 - *first as i64 + 1
 }
 
 #[cfg(test)]
 mod test {
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
-    use super::*;
-
-    #[test]
-    fn in_order() {
-        let mut reg = ReceiverRegister::new(14.into());
-        let new = reg.update_seq(14.into());
-        assert!(new);
-        assert_eq!(reg.probation, 1);
-        let new = reg.update_seq(15.into());
-        assert!(new);
-        assert_eq!(reg.probation, 0);
-        let new = reg.update_seq(16.into());
-        assert!(new);
-        let new = reg.update_seq(17.into());
-        assert!(new);
-        assert_eq!(reg.max_seq, 17.into());
-    }
-
-    #[test]
-    fn jump_during_probation() {
-        let mut reg = ReceiverRegister::new(14.into());
-        let new = reg.update_seq(14.into());
-        assert!(new);
-        assert_eq!(reg.probation, 1);
-        let new = reg.update_seq(16.into());
-        assert!(new);
-        assert_eq!(reg.probation, 1);
-        let new = reg.update_seq(17.into());
-        assert!(new);
-    }
-
-    #[test]
-    fn jump_within_max_dropout() {
-        let mut reg = ReceiverRegister::new(14.into());
-        reg.update_seq(14.into());
-        reg.update_seq(15.into());
-        assert_eq!(reg.max_seq, 15.into());
-
-        reg.update_seq(2500.into());
-        assert!(reg.bad_seq.is_none());
-        reg.update_seq(2501.into());
-        assert_eq!(reg.max_seq, 2501.into());
-    }
-
-    #[test]
-    fn jump_larger_than_max_dropout() {
-        let mut reg = ReceiverRegister::new(14.into());
-        reg.update_seq(14.into());
-        reg.update_seq(15.into());
-        assert_eq!(reg.max_seq, 15.into());
-
-        reg.update_seq(3500.into());
-        assert_eq!(reg.max_seq, 15.into()); // no jump yet
-        assert!(reg.bad_seq.is_some());
-        reg.update_seq(3501.into());
-        assert_eq!(reg.max_seq, 3501.into()); // reset
-        assert!(reg.bad_seq.is_none());
-    }
-
-    #[test]
-    fn old_packet_within_tolerance() {
-        let mut reg = ReceiverRegister::new(140.into());
-        reg.update_seq(140.into());
-        reg.update_seq(141.into());
-        assert_eq!(reg.max_seq, 141.into());
-
-        let new = reg.update_seq(120.into());
-        assert!(!new);
-        assert_eq!(reg.max_seq, 141.into()); // no jump
-        assert!(reg.bad_seq.is_none());
-        let new = reg.update_seq(121.into());
-        assert!(!new);
-        assert_eq!(reg.max_seq, 141.into()); // no jump
-    }
-
-    #[test]
-    fn old_packet_outside_tolerance() {
-        let mut reg = ReceiverRegister::new(140.into());
-        reg.update_seq(140.into());
-        reg.update_seq(141.into());
-        assert_eq!(reg.max_seq, 141.into());
-
-        let new = reg.update_seq(20.into());
-        assert!(new);
-        assert_eq!(reg.max_seq, 141.into()); // no jump yet
-        assert!(reg.bad_seq.is_some());
-        let new = reg.update_seq(21.into());
-        assert!(new);
-        assert_eq!(reg.max_seq, 21.into()); // reset
-        assert!(reg.bad_seq.is_none());
-    }
-
-    #[test]
-    fn repeated_packet() {
-        let mut reg = ReceiverRegister::new(140.into());
-        reg.update_seq(140.into());
-        reg.update_seq(141.into());
-        assert_eq!(reg.max_seq, 141.into());
-
-        let new = reg.update_seq(142.into());
-        assert!(new);
-
-        // Same packet, new should be false.
-        let new = reg.update_seq(142.into());
-        assert!(!new);
-    }
+    use crate::streams::register::{expected, packets_lost, ReceiverRegister};
 
     #[test]
     fn jitter_at_0() {
-        let mut reg = ReceiverRegister::new(14.into());
-        reg.update_seq(14.into());
-        reg.update_seq(15.into());
+        let mut r = ReceiverRegister::new();
 
         // 100 fps in clock rate 90kHz => 90_000/100 = 900 per frame
         // 1/100 * 1_000_000 = 10_000 microseconds per frame.
@@ -646,20 +262,16 @@ mod test {
         let start = Instant::now();
         let dur = Duration::from_micros(10_000);
 
-        reg.update_time(start + 4 * dur, 1234 + 4 * 900, 90_000);
-        reg.update_time(start + 5 * dur, 1234 + 5 * 900, 90_000);
-        reg.update_time(start + 6 * dur, 1234 + 6 * 900, 90_000);
-        reg.update_time(start + 7 * dur, 1234 + 7 * 900, 90_000);
-        assert_eq!(reg.jitter, 0.0);
-
-        //
+        r.update_time(start + 4 * dur, 1234 + 4 * 900, 90_000);
+        r.update_time(start + 5 * dur, 1234 + 5 * 900, 90_000);
+        r.update_time(start + 6 * dur, 1234 + 6 * 900, 90_000);
+        r.update_time(start + 7 * dur, 1234 + 7 * 900, 90_000);
+        assert_eq!(r.jitter, 0.0);
     }
 
     #[test]
     fn jitter_at_20() {
-        let mut reg = ReceiverRegister::new(14.into());
-        reg.update_seq(14.into());
-        reg.update_seq(15.into());
+        let mut r = ReceiverRegister::new();
 
         // 100 fps in clock rate 90kHz => 90_000/100 = 900 per frame
         // 1/100 * 1_000_000 = 10_000 microseconds per frame.
@@ -674,342 +286,49 @@ mod test {
             } else {
                 start + i * dur + off
             };
-            reg.update_time(arrival, 1234 + i * 900, 90_000);
+            r.update((i as u64).into(), arrival, 1234 + i * 900, 90_000);
         }
 
         // jitter should converge on 20.0
         assert!(
-            (20.0 - reg.jitter).abs() < 0.01,
+            (20.0 - r.jitter).abs() < 0.01,
             "Expected jitter to converge at 20.0, jitter was: {}",
-            reg.jitter
+            r.jitter
         );
+
+        // jitter is also present in reception report
+        let report = r.reception_report().expect("some report");
+        assert_eq!(report.jitter, r.jitter as u32);
     }
 
     #[test]
-    fn nack_reports_empty() {
-        let mut reg = ReceiverRegister::new(14.into());
-        for i in [100, 101, 102, 103, 104, 105, 106] {
-            reg.update_seq(i.into());
-        }
-        assert!(reg.nack_reports().is_empty());
-        assert!(reg.nack_reports().is_empty());
-        assert!(reg.nack_reports().is_empty());
-        assert!(reg.nack_reports().is_empty());
-    }
-
-    struct Test {
-        seq: &'static [u64],
-        missing: u16,
-        bitmask: u16,
-        check_from: u64,
-    }
-
-    fn nack_test(t: Test) {
-        let mut reg = ReceiverRegister::new(14.into());
-        for i in t.seq {
-            reg.update_seq((*i).into());
-        }
-        assert_eq!(
-            reg.nack_reports(),
-            vec![Nack {
-                sender_ssrc: 0.into(),
-                ssrc: 0.into(),
-                reports: NackEntry {
-                    pid: t.missing,
-                    blp: t.bitmask,
-                }
-                .into()
-            }]
-        );
-        assert_eq!(reg.nack_check_from, t.check_from.into());
+    fn expected_received_loss() {
+        let first = 14.into();
+        let last = 17.into();
+        let expected = expected(first, last);
+        assert_eq!(expected, 4);
+        // none of 4 was lost
+        assert_eq!(packets_lost(expected, 4), 0);
+        // one of 4 was lost:329
+        assert_eq!(packets_lost(expected, 3), 1);
     }
 
     #[test]
-    fn nack_report_one() {
-        nack_test(Test {
-            seq: &[100, 101, 103, 104, 105, 106, 107],
-            missing: 102,
-            bitmask: 0,
-            check_from: 101,
-        });
-    }
+    fn receiver_report() {
+        let mut r = ReceiverRegister::new();
+        let now = Instant::now();
+        let rtp_time = 0;
 
-    #[test]
-    fn nack_report_two() {
-        nack_test(Test {
-            seq: &[100, 101, 104, 105, 106, 107, 108],
-            missing: 102,
-            bitmask: 0b0000_0000_0000_0001,
-            check_from: 101,
-        });
-    }
-
-    #[test]
-    fn nack_report_with_hole() {
-        nack_test(Test {
-            seq: &[100, 101, 103, 105, 106, 107, 108, 109, 110],
-            missing: 102,
-            bitmask: 0b0000_0000_0000_0010,
-            check_from: 101,
-        });
-    }
-
-    #[test]
-    fn nack_report_stop_at_17() {
-        nack_test(Test {
-            seq: &[
-                100, 101, 103, 104, 105, 106, 107, 108, 109, 110, //
-                111, 112, 113, 114, 115, 116, 117, 118, 119, 120, //
-                121, 122, 123, 124, 125,
-            ],
-            missing: 102,
-            bitmask: 0b0000_0000_0000_0000,
-            check_from: 101,
-        });
-    }
-
-    #[test]
-    fn nack_report_hole_at_17() {
-        nack_test(Test {
-            seq: &[
-                100, 101, 103, 104, 105, 106, 107, 108, 109, 110, //
-                111, 112, 113, 114, 115, 116, 117, 119, 120, 121, //
-                122, 123, 124, 125, 126, 127, 128, 129,
-            ],
-            missing: 102,
-            bitmask: 0b1000_0000_0000_0000,
-            check_from: 101,
-        });
-    }
-
-    #[test]
-    fn nack_report_no_stop_all_there() {
-        let mut reg = ReceiverRegister::new(14.into());
-        for i in &[
-            100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, //
-            111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, //
-            122, 123, 124, 125, 126, 127, 128, 129,
-        ] {
-            reg.update_seq((*i).into());
+        // 50 % lost
+        for i in 10..14 {
+            r.update((i as u64).into(), now, rtp_time, 90_000);
         }
-        assert!(reg.nack_reports().is_empty());
-        assert_eq!(reg.nack_check_from, (129 - MISORDER_DELAY).into());
-    }
+        r.update(19.into(), now, rtp_time, 90_000);
 
-    #[test]
-    fn nack_report_rtx() {
-        let mut reg = ReceiverRegister::new(14.into());
-        for i in &[
-            100, 101, 102, 103, 104, 105, //
-        ] {
-            reg.update_seq((*i).into());
-        }
-        assert!(reg.nack_reports().is_empty());
-        assert_eq!(reg.nack_check_from, (105 - MISORDER_DELAY).into());
-
-        for i in &[
-            106, 108, 109, 110, 111, 112, 113, 114, 115, //
-        ] {
-            reg.update_seq((*i).into());
-        }
-        assert!(!reg.nack_reports().is_empty());
-        assert_eq!(reg.nack_check_from, 106.into());
-
-        reg.update_seq(107.into()); // Got 107 via RTX
-
-        let nacks = reg.nack_reports();
-        assert!(
-            nacks.is_empty(),
-            "Expected no NACKs to be generated after repairing the stream, got {nacks:?}"
-        );
-        assert_eq!(reg.nack_check_from, (115 - MISORDER_DELAY).into());
-    }
-
-    #[test]
-    fn nack_report_rollover_rtx() {
-        let mut reg = ReceiverRegister::new(14.into());
-        for i in &[
-            100, 101, 102, 103, 104, 105, //
-        ] {
-            reg.update_seq((*i).into());
-        }
-        assert!(reg.nack_reports().is_empty());
-        assert_eq!(reg.nack_check_from, (105 - MISORDER_DELAY).into());
-
-        for i in &[
-            106, 108, 109, 110, 111, 112, 113, 114, 115, //
-        ] {
-            reg.update_seq((*i).into());
-        }
-        assert!(!reg.nack_reports().is_empty());
-        assert_eq!(reg.nack_check_from, 106.into());
-
-        reg.update_seq(107.into()); // Got 107 via RTX
-
-        assert_eq!(reg.nack_check_from, (115 - MISORDER_DELAY).into());
-
-        for i in 116..3106 {
-            reg.update_seq(i.into());
-        }
-        assert_eq!(reg.nack_check_from, (3105 - MISORDER_DELAY).into());
-
-        for i in &[
-            106, 108, 109, 110, 111, 112, 113, 114, 115, //
-        ] {
-            reg.update_seq((*i + 3000).into()); // Missing 107 again
-        }
-
-        assert_eq!(reg.nack_check_from, 3106.into());
-    }
-
-    #[test]
-    fn nack_report_rollover_rtx_with_seq_jump() {
-        let mut reg = ReceiverRegister::new(3000.into());
-
-        // 2999 is missing
-        for i in 0..2999 {
-            reg.update_seq(i.into());
-        }
-
-        // 3002 is missing
-        reg.update_seq(3003.into());
-        reg.update_seq(3004.into());
-        reg.update_seq(3000.into());
-        reg.update_seq(3001.into());
-
-        let reports = reg.nack_reports();
-        assert_eq!(reports.len(), 1);
-        assert_eq!(reports[0].reports[0].pid, 2999);
-        assert_eq!(reports[0].reports[0].blp, 4);
-    }
-
-    #[test]
-    fn out_of_order_and_rollover() {
-        let mut reg = ReceiverRegister::new(0.into());
-
-        reg.update_seq(2998.into());
-        reg.update_seq(2999.into());
-
-        // receive older packet
-        reg.update_seq(2995.into());
-
-        // wrap
-        for i in 3000..5995 {
-            reg.update_seq(i.into());
-        }
-
-        // 5995 is missing
-
-        reg.update_seq(5996.into());
-        reg.update_seq(5997.into());
-
-        let reports = reg.create_nack_reports();
-        assert_eq!(reports.len(), 1);
-        assert_eq!(reports[0].reports[0].pid, 5995);
-    }
-
-    #[test]
-    fn nack_check_on_seq_rollover() {
-        let range = 65530..65541 + MISORDER_DELAY;
-        let missing = [65535_u64, 65536_u64, 65537_u64];
-        let expected = [65535_u16, 0_u16, 1_u16];
-
-        for (missing, expected) in missing.iter().zip(expected.iter()) {
-            let mut seqs: Vec<_> = range.clone().collect();
-            let mut reg = ReceiverRegister::new(seqs[0].into());
-
-            seqs.retain(|x| *x != *missing);
-            for i in seqs.as_slice() {
-                reg.update_seq((*i).into());
-            }
-
-            let reports = reg.create_nack_reports();
-            let nack = reports.get(0).unwrap();
-            let pid = nack.reports.get(0).unwrap().pid;
-            assert_eq!(pid, *expected);
-        }
-    }
-
-    #[test]
-    fn nack_check_forward_at_boundary() {
-        let mut reg = ReceiverRegister::new(2996.into());
-        for i in 2996..=3003 {
-            reg.update_seq((i).into());
-        }
-        assert!(reg.nack_reports().is_empty());
-        assert_eq!(reg.nack_check_from, (3003 - MISORDER_DELAY).into());
-
-        for i in 3004..=3008 {
-            reg.update_seq((i).into());
-        }
-
-        let nacks = reg.nack_reports();
-        assert!(nacks.is_empty(), "Expected empty NACKs got {nacks:?}");
-        assert_eq!(reg.nack_check_from, (3008 - MISORDER_DELAY).into());
-    }
-
-    #[test]
-    fn nack_check_forward_at_u16_boundary() {
-        let mut reg = ReceiverRegister::new(65500.into());
-        for i in 65500..=65534 {
-            reg.update_seq((i).into());
-        }
-        assert!(reg.nack_reports().is_empty());
-        assert_eq!(reg.nack_check_from, (65534 - MISORDER_DELAY).into());
-
-        for i in 65536..=65566 {
-            reg.update_seq((i).into());
-        }
-
-        assert!(!reg.nack_reports().is_empty());
-        assert_eq!(reg.nack_check_from, 65534.into());
-
-        for i in 65567..=65666 {
-            reg.update_seq((i).into());
-        }
-
-        reg.update_seq(65535.into());
-
-        assert!(reg.nack_reports().is_empty());
-        assert_eq!(reg.nack_check_from, (65666 - MISORDER_DELAY).into());
-    }
-
-    #[test]
-    fn expected_received_no_loss() {
-        let mut reg = ReceiverRegister::new(14.into());
-        reg.update_seq(14.into());
-        reg.update_seq(15.into());
-        reg.update_seq(16.into());
-        reg.update_seq(17.into());
-        // MIN_SEQUENTIAL=2, 14, 15 resets base_seq.
-        assert_eq!(reg.base_seq, 15.into());
-        assert_eq!(reg.max_seq, 17.into());
-        assert_eq!(reg.expected(), 3);
-        assert_eq!(reg.received, 3);
-        assert_eq!(reg.packets_lost(), 0);
-    }
-
-    #[test]
-    fn expected_received_with_loss() {
-        let mut reg = ReceiverRegister::new(14.into());
-        reg.update_seq(14.into());
-        reg.update_seq(15.into());
-        reg.update_seq(17.into());
-        // MIN_SEQUENTIAL=2, 14, 15 resets base_seq.
-        assert_eq!(reg.base_seq, 15.into());
-        assert_eq!(reg.max_seq, 17.into());
-        assert_eq!(reg.expected(), 3);
-        assert_eq!(reg.received, 2);
-        assert_eq!(reg.packets_lost(), 1);
-    }
-
-    #[test]
-    fn low_seq_no_dont_panic() {
-        let mut reg = ReceiverRegister::new(1.into());
-        reg.update_seq(2.into());
-        reg.update_seq(3.into());
-        // Don't panic.
-        let _ = reg.has_nack_report();
-        let _ = reg.create_nack_reports();
+        let report = r.reception_report().expect("some report");
+        assert_eq!(128, report.fraction_lost);
+        assert_eq!(5, report.packets_lost);
+        assert_eq!(19, report.max_seq);
+        assert_eq!(0, report.jitter);
     }
 }

--- a/src/streams/register_nack.rs
+++ b/src/streams/register_nack.rs
@@ -1,0 +1,560 @@
+use std::ops::Range;
+
+use crate::rtp_::{Nack, NackEntry, ReportList, SeqNo};
+
+/// How many sequence numbers we keep track of
+const MAX_DROPOUT: u64 = 3000;
+
+/// Number of out of order packets we keep track of for reports
+/// A suggested maximum value min is MAX_DROPOUT / 2
+const MAX_MISORDER: u64 = 100;
+
+const U16_MAX: u64 = u16::MAX as u64 + 1_u64;
+
+/// The max number of NACKs we perform for a single packet
+const MAX_NACKS: u8 = 5;
+
+#[derive(Debug)]
+pub struct NackRegister {
+    /// Status of packets indexed by wrapping SeqNo.
+    packets: Vec<PacketStatus>,
+
+    /// Range of seq numbers considered NACK reporting.
+    active: Option<Range<SeqNo>>,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct PacketStatus {
+    received: bool,
+    nack_count: u8,
+}
+
+impl PacketStatus {
+    fn needs_nack(&self) -> bool {
+        !self.received && self.nack_count < MAX_NACKS
+    }
+
+    fn mark_received(&mut self) -> bool {
+        let new = !self.received;
+        self.received = true;
+        new
+    }
+
+    fn reset(&mut self) {
+        self.received = false;
+        self.nack_count = 0;
+    }
+}
+
+impl NackRegister {
+    pub fn new() -> Self {
+        NackRegister {
+            packets: vec![PacketStatus::default(); MAX_DROPOUT as usize],
+            active: None,
+        }
+    }
+
+    pub fn update(&mut self, seq: SeqNo) -> bool {
+        let Some(active) = self.active.clone() else {
+            // automatically pick up the first seq number
+            self.active = Some(seq..seq);
+            self.packet(seq).mark_received();
+            return true;
+        };
+
+        if seq < active.start {
+            // skip old seq numbers, report as not new
+            return false;
+        }
+
+        let mut next_active = active.start..active.end.max(seq);
+
+        let new = self.packet(seq).mark_received();
+
+        next_active.start = {
+            let min = next_active.end.saturating_sub(MAX_MISORDER);
+            let mut start = (*next_active.start).max(min);
+            while start < *next_active.end {
+                if !self.packet(start.into()).received {
+                    break;
+                }
+                start += 1;
+            }
+            start.into()
+        };
+
+        // reset packets that are rolling our of the nack window
+        for s in *active.start..*next_active.start {
+            let p = self.packet(s.into());
+            if !p.received {
+                debug!("Seq no {} missing after {} attempts", seq, p.nack_count);
+            }
+            self.packet(s.into()).reset();
+        }
+
+        self.active = Some(next_active);
+
+        new
+    }
+
+    pub fn max_seq(&self) -> Option<SeqNo> {
+        self.active.as_ref().map(|a| a.end)
+    }
+
+    /// Create a new nack report
+    ///
+    /// This modifies the state as it counts how many times packets have been nacked
+    pub fn nack_report(&mut self) -> Option<Vec<Nack>> {
+        let active = self.active.as_ref()?;
+
+        if active.is_empty() {
+            return None;
+        }
+
+        let mut nacks = vec![];
+        let mut last_seq_added = 0;
+
+        for seq in *active.start..*active.end {
+            let packet = self.packet(seq.into());
+
+            if !packet.needs_nack() {
+                continue;
+            }
+
+            let distance = seq - last_seq_added;
+
+            let update_last = nacks.last().is_some() && distance <= 16;
+
+            if update_last {
+                let last: &mut NackEntry = nacks.last_mut().expect("last");
+                let pos = (distance - 1) as u16;
+                last.blp |= 1 << pos;
+            } else {
+                nacks.push(NackEntry {
+                    pid: (seq % U16_MAX) as u16,
+                    blp: 0,
+                });
+                last_seq_added = seq;
+            }
+
+            self.packet(seq.into()).nack_count += 1;
+        }
+
+        if nacks.is_empty() {
+            return None;
+        }
+
+        let reports = ReportList::lists_from_iter(nacks).into_iter();
+
+        Some(
+            reports
+                .map(|reports| {
+                    Nack {
+                        sender_ssrc: 0.into(),
+                        ssrc: 0.into(), // changed when sending
+                        reports,
+                    }
+                })
+                .collect(),
+        )
+    }
+
+    fn as_index(&self, seq: SeqNo) -> usize {
+        (*seq % self.packets.len() as u64) as usize
+    }
+
+    fn packet(&mut self, seq: SeqNo) -> &mut PacketStatus {
+        let index = self.as_index(seq);
+        &mut self.packets[index]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::ops::Range;
+
+    use crate::streams::register_nack::MAX_MISORDER;
+
+    use super::NackRegister;
+
+    fn assert_update(
+        reg: &mut NackRegister,
+        seq: u64,
+        expect_new: bool,
+        expect_received: bool,
+        expect_active: Range<u64>,
+    ) {
+        assert_eq!(
+            reg.update(seq.into()),
+            expect_new,
+            "seq {} was expected to{} be new",
+            seq,
+            if expect_new { "" } else { " NOT" }
+        );
+        let active = reg.active.clone().expect("nack range");
+        assert_eq!(
+            reg.packet(seq.into()).received,
+            expect_received,
+            "seq {} expected to{} be received in {:?}",
+            seq,
+            if expect_received { "" } else { " NOT" },
+            active
+        );
+        assert_eq!(active, expect_active.start.into()..expect_active.end.into());
+        assert_not_dirty(reg);
+    }
+
+    fn assert_not_dirty(reg: &NackRegister) {
+        // we should leave no dirty state outside of the nack window
+        let active = reg.active.clone().expect("nack range");
+        let active = (*active.start..=*active.end)
+            .map(|seq| reg.as_index(seq.into()))
+            .collect::<Vec<_>>();
+
+        for i in 0..reg.packets.len() {
+            if active.contains(&i) {
+                continue;
+            }
+            assert!(
+                !reg.packets[i].received && reg.packets[i].nack_count == 0,
+                "dirty state at index {} outside of nack window {:?}",
+                i,
+                active,
+            );
+        }
+    }
+
+    #[test]
+    fn active_window_sliding() {
+        let mut reg = NackRegister::new();
+
+        assert_update(&mut reg, 10, true, true, 10..10);
+
+        // packet before window start is ignored
+        assert_update(&mut reg, 9, false, false, 10..10);
+
+        // duped packet
+        assert_update(&mut reg, 10, false, true, 10..10);
+
+        // future packets accepted, window not sliding
+        let next = 10 + MAX_MISORDER;
+        assert_update(&mut reg, next, true, true, 11..next);
+        let next = 11 + MAX_MISORDER;
+        assert_update(&mut reg, next, true, true, 11..next);
+
+        // future packet accepted, sliding window
+        let next = 12 + MAX_MISORDER;
+        assert_update(&mut reg, next, true, true, 12..next);
+        assert!(!reg.packet(11.into()).received);
+
+        // older packet received within window
+        let next = 13;
+        assert_update(&mut reg, next, true, true, 12..(12 + MAX_MISORDER));
+
+        // future packet accepted, sliding window start skips over received
+        let next = 13 + MAX_MISORDER;
+        assert_update(&mut reg, next, true, true, 14..next);
+        assert!(!reg.packet(11.into()).received);
+
+        // older packet accepted, window star moves ahead
+        let next = 14;
+        assert_update(&mut reg, next, true, false, 15..(13 + MAX_MISORDER));
+    }
+
+    #[test]
+    fn nack_report_none() {
+        let mut reg = NackRegister::new();
+        assert!(reg.nack_report().is_none());
+
+        reg.update(110.into());
+        assert!(reg.nack_report().is_none());
+
+        reg.update(111.into());
+        assert!(reg.nack_report().is_none());
+    }
+
+    #[test]
+    fn nack_report_one() {
+        let mut reg = NackRegister::new();
+        assert!(reg.nack_report().is_none());
+
+        reg.update(110.into());
+        assert!(reg.nack_report().is_none());
+
+        reg.update(112.into());
+        let report = reg.nack_report().expect("some report");
+        assert!(report.len() == 1);
+        assert_eq!(report[0].reports.len(), 1);
+        assert_eq!(report[0].reports[0].pid, 111);
+        assert_eq!(report[0].reports[0].blp, 0);
+    }
+
+    #[test]
+    fn nack_report_two() {
+        let mut reg = NackRegister::new();
+        assert!(reg.nack_report().is_none());
+
+        reg.update(110.into());
+        assert!(reg.nack_report().is_none());
+
+        reg.update(113.into());
+        let report = reg.nack_report().expect("some report");
+        assert!(report.len() == 1);
+        assert_eq!(report[0].reports.len(), 1);
+        assert_eq!(report[0].reports[0].pid, 111);
+        assert_eq!(report[0].reports[0].blp, 0b1);
+    }
+
+    #[test]
+    fn nack_report_with_hole() {
+        let mut reg = NackRegister::new();
+
+        for i in &[100, 101, 103, 105, 106, 107, 108, 109, 110] {
+            reg.update((*i).into());
+        }
+
+        let report = reg.nack_report().expect("some report");
+        assert!(report.len() == 1);
+        assert_eq!(report[0].reports.len(), 1);
+        assert_eq!(report[0].reports[0].pid, 102);
+        assert_eq!(report[0].reports[0].blp, 0b10);
+    }
+
+    #[test]
+    fn nack_report_stop_at_17() {
+        let mut reg = NackRegister::new();
+
+        let seq = &[
+            100, 101, 103, 104, 105, 106, 107, 108, 109, 110, //
+            111, 112, 113, 114, 115, 116, 117, 118, 119, 120, //
+            121, 122, 123, 125,
+        ];
+
+        for i in seq {
+            reg.update((*i).into());
+        }
+
+        let report = reg.nack_report().expect("some report");
+        assert_eq!(report.len(), 1);
+        assert_eq!(report[0].reports.len(), 2);
+        assert_eq!(report[0].reports[0].pid, 102);
+        assert_eq!(report[0].reports[0].blp, 0);
+    }
+
+    #[test]
+    fn nack_report_hole_at_17() {
+        let mut reg = NackRegister::new();
+
+        let seq = &[
+            100, 101, 103, 104, 105, 106, 107, 108, 109, 110, //
+            111, 112, 113, 114, 115, 116, 117, 119, 120, 121, //
+            122, 123, 124, 125, 126, 127, 128, 129,
+        ];
+
+        for i in seq {
+            reg.update((*i).into());
+        }
+
+        let report = reg.nack_report().expect("some report");
+        assert_eq!(report.len(), 1);
+        assert_eq!(report[0].reports.len(), 1);
+        assert_eq!(report[0].reports[0].pid, 102);
+        assert_eq!(report[0].reports[0].blp, 0b1000_0000_0000_0000);
+    }
+
+    #[test]
+    fn nack_report_no_stop_all_there() {
+        let mut reg = NackRegister::new();
+
+        let seq = &[
+            100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, //
+            111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, //
+            122, 123, 124, 125, 126, 127, 128, 129,
+        ];
+
+        for i in seq {
+            reg.update((*i).into());
+        }
+
+        assert_eq!(reg.nack_report(), None);
+    }
+
+    #[test]
+    fn nack_report_rtx() {
+        let mut reg = NackRegister::new();
+        for i in &[
+            100, 101, 102, 103, 104, 105, //
+        ] {
+            reg.update((*i).into());
+        }
+        assert!(reg.nack_report().is_none());
+        let active = reg.active.clone().expect("nack range");
+        assert_eq!(*active.start, 105);
+
+        for i in &[
+            106, 108, 109, 110, 111, 112, 113, 114, 115, //
+        ] {
+            reg.update((*i).into());
+        }
+        assert!(reg.nack_report().is_some());
+        let active = reg.active.clone().expect("nack range");
+        assert_eq!(*active.start, 107);
+
+        reg.update(107.into()); // Got 107 via RTX
+
+        let nacks = reg.nack_report();
+        assert_eq!(
+            reg.nack_report(),
+            None,
+            "Expected no NACKs to be generated after repairing the stream, got {nacks:?}"
+        );
+        let active = reg.active.clone().expect("nack range");
+        assert_eq!(*active.start, 115);
+    }
+
+    #[test]
+    fn nack_report_rollover_rtx() {
+        // This test is checking that after rollover nacks are not skipped because of
+        // packet position that would remain marked as received from before the rollover
+        let mut reg = NackRegister::new();
+        for i in &[
+            100, 101, 102, 103, 104, 105, 106, 108, 109, 110, 111, 112, 113, 114, 115,
+        ] {
+            reg.update((*i).into());
+        }
+
+        reg.update(107.into()); // Got 107 via RTX
+        let active = reg.active.clone().expect("nack range");
+        assert_eq!(*active.start, 115);
+
+        for i in 116..3106 {
+            reg.update(i.into());
+        }
+        let active = reg.active.clone().expect("nack range");
+        assert_eq!(*active.start, 3105);
+
+        for i in &[3106, 3108, 3109, 3110, 3111, 3112, 3113, 3114, 3115] {
+            reg.update((*i).into()); // Missing at postion 107 again
+        }
+
+        let active = reg.active.clone().expect("nack range");
+        assert_eq!(*active.start, 3107);
+    }
+
+    #[test]
+    fn nack_report_rollover_rtx_with_seq_jump() {
+        let mut reg = NackRegister::new();
+
+        // 2999 is missing
+        for i in 0..2999 {
+            reg.update(i.into());
+        }
+
+        // 3002 is missing
+        reg.update(3003.into());
+        reg.update(3004.into());
+        reg.update(3000.into());
+        reg.update(3001.into());
+
+        let reports = reg.nack_report().expect("some report");
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].reports[0].pid, 2999);
+        assert_eq!(reports[0].reports[0].blp, 4);
+    }
+
+    #[test]
+    fn out_of_order_and_rollover() {
+        let mut reg = NackRegister::new();
+
+        reg.update(2998.into());
+        reg.update(2999.into());
+
+        // receive older packet
+        reg.update(2995.into());
+
+        // wrap
+        for i in 3000..5995 {
+            reg.update(i.into());
+        }
+
+        // 5995 is missing
+
+        reg.update(5996.into());
+        reg.update(5997.into());
+
+        let reports = reg.nack_report().expect("some report");
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].reports[0].pid, 5995);
+    }
+
+    #[test]
+    fn nack_check_on_seq_rollover() {
+        let range = 65530..65541;
+        let missing = [65535_u64, 65536_u64, 65537_u64];
+        let expected = [65535_u16, 0_u16, 1_u16];
+
+        for (missing, expected) in missing.iter().zip(expected.iter()) {
+            let mut seqs: Vec<_> = range.clone().collect();
+            let mut reg = NackRegister::new();
+
+            seqs.retain(|x| *x != *missing);
+            for i in seqs.as_slice() {
+                reg.update((*i).into());
+            }
+
+            let reports = reg.nack_report().expect("some report");
+            let pid = reports[0].reports[0].pid;
+            assert_eq!(pid, *expected);
+        }
+    }
+
+    #[test]
+    fn nack_check_forward_at_boundary() {
+        let mut reg = NackRegister::new();
+        for i in 2996..=3003 {
+            reg.update(i.into());
+        }
+
+        assert!(reg.nack_report().is_none());
+        let active = reg.active.clone().expect("nack range");
+        assert_eq!(*active.start, 3003);
+
+        for i in 3004..=3008 {
+            reg.update(i.into());
+        }
+
+        let report = reg.nack_report();
+        assert!(report.is_none(), "Expected empty NACKs got {:?}", report);
+        let active = reg.active.clone().expect("nack range");
+        assert_eq!(*active.start, 3008);
+    }
+
+    #[test]
+    fn nack_check_forward_at_u16_boundary() {
+        let mut reg = NackRegister::new();
+        for i in 65500..=65534 {
+            reg.update(i.into());
+        }
+        assert!(reg.nack_report().is_none());
+        let active = reg.active.clone().expect("nack range");
+        assert_eq!(*active.start, 65534);
+
+        for i in 65536..=65566 {
+            reg.update(i.into());
+        }
+
+        assert!(reg.nack_report().is_some());
+        let active = reg.active.clone().expect("nack range");
+        assert_eq!(*active.start, 65535);
+
+        for i in 65567..=65666 {
+            reg.update(i.into());
+        }
+
+        reg.update(65535.into());
+
+        assert!(reg.nack_report().is_none());
+        let active = reg.active.clone().expect("nack range");
+        assert_eq!(*active.start, 65666);
+    }
+}


### PR DESCRIPTION
- separate nack and RR generation
- remove misorder delay
- remove probation period
- simplify handing nack to avoiding unnecessary operations