### PR TITLE
channel: improve Debug output for ChannelData text

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -63,19 +63,31 @@ impl fmt::Debug for ChannelData {
         ds.field("id", &self.id);
         ds.field("binary", &self.binary);
 
+        let len = &self.data.len();
         if self.binary {
-            ds.field("data", &self.data.len());
+            ds.field("data", len);
         } else {
             match str::from_utf8(&self.data) {
                 Ok(s) => {
+                    const MAX_LINE_WIDTH: usize = 79;
+                    const REST_OF_LINE_WIDTH: usize =
+                        "ChannelData { id: ChannelId(0), binary: false, data: \"\" }".len();
+                    const TUPLE_WIDTH: usize = "(xxx, ..)".len();
+                    const DATA_WIDTH: usize = MAX_LINE_WIDTH - REST_OF_LINE_WIDTH;
+                    const PREFIX_WIDTH: usize = DATA_WIDTH - TUPLE_WIDTH;
                     if s.is_ascii() {
-                        ds.field("data", &s);
+                        if len > &DATA_WIDTH {
+                            let trunc: String = s.chars().take(PREFIX_WIDTH).collect();
+                            ds.field("data", &format_args!("({}, \"{}\"..)", len, trunc));
+                        } else {
+                            ds.field("data", &s);
+                        }
                     } else {
-                        ds.field("data", &self.data.len());
+                        ds.field("data", len);
                     }
                 }
                 Err(e) => {
-                    ds.field("data", &e);
+                    ds.field("data", &format_args!("{:?}", (len, &e)));
                 }
             }
         }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,6 +1,6 @@
 //! Data channel related types.
 
-use std::{fmt, time::Instant};
+use std::{fmt, str, time::Instant};
 
 use crate::sctp::RtcSctp;
 use crate::util::already_happened;
@@ -58,11 +58,29 @@ impl<'a> Channel<'a> {
 
 impl fmt::Debug for ChannelData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ChannelData")
-            .field("id", &self.id)
-            .field("binary", &self.binary)
-            .field("data", &self.data.len())
-            .finish()
+        let mut ds = f.debug_struct("ChannelData");
+
+        ds.field("id", &self.id);
+        ds.field("binary", &self.binary);
+
+        if self.binary {
+            ds.field("data", &self.data.len());
+        } else {
+            match str::from_utf8(&self.data) {
+                Ok(s) => {
+                    if s.is_ascii() {
+                        ds.field("data", &s);
+                    } else {
+                        ds.field("data", &self.data.len());
+                    }
+                }
+                Err(e) => {
+                    ds.field("data", &e);
+                }
+            }
+        }
+
+        ds.finish()
     }
 }
 


### PR DESCRIPTION
This patch improves the `Debug` output for `ChannelData` containing text. If the text parses as UTF-8 and is also ASCII, it will be included in the output. Otherwise, if the text does not parse as UTF-8, an error is shown or if it's non-ASCII, the length is presented as before.