### PR TITLE
Writer payload params bugfix

### DIFF
--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -789,7 +789,8 @@ fn ensure_stream_tx(session: &mut Session) {
         let has_rtx = session
             .codec_config
             .iter()
-            .any(|p| p.resend().is_some() && media.remote_pts().contains(&p.pt));
+            .filter(|p| media.remote_pts().contains(&p.pt))
+            .any(|p| p.resend().is_some());
 
         for rid in rids {
             // If we already have the stream, we don't make any new one.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1635,7 +1635,7 @@ impl Rtc {
         n
     }
 
-    /// The codec configs for sending/receiving data..
+    /// The codec configs for sending/receiving data.
     ///
     /// The configurations can be set with [`RtcConfig`] before setting up the session, and they
     /// might be further updated by SDP negotiation.
@@ -1786,7 +1786,7 @@ impl RtcConfig {
         self.ice_lite
     }
 
-    /// Lower level access to precis configuration of codecs (payload types).
+    /// Lower level access to precise configuration of codecs (payload types).
     pub fn codec_config(&mut self) -> &mut CodecConfig {
         &mut self.codec_config
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,7 @@
 //! let writer = rtc.writer(mid).unwrap();
 //!
 //! // Get the payload type (pt) for the wanted codec.
-//! let pt = writer.payload_params()[0].pt();
+//! let pt = writer.payload_params().nth(0).unwrap().pt();
 //!
 //! // Write the data
 //! let wallclock = todo!();   // Absolute time of the data


### PR DESCRIPTION
As in #345, a regression was introduced by a recent refactoring where only payload params for a given mid should be produced but all payload params were being used instead.