### PR TITLE
VP8 L1T3 compat

### DIFF
--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -1,3 +1,4 @@
+use core::panic;
 use std::collections::VecDeque;
 use std::fmt;
 use std::ops::RangeInclusive;
@@ -5,7 +6,11 @@ use std::time::Instant;
 
 use crate::rtp_::{ExtensionValues, MediaTime, RtpHeader, SenderInfo, SeqNo};
 
-use super::{CodecDepacketizer, CodecExtra, Depacketizer, PacketError};
+use self::vp8_contiguity::Vp8Contiguity;
+
+use super::{CodecDepacketizer, CodecExtra, Depacketizer, PacketError, Vp8CodecExtra};
+
+mod vp8_contiguity;
 
 #[derive(Clone, PartialEq, Eq)]
 /// Holds metadata incoming RTP data.
@@ -80,6 +85,7 @@ pub struct DepacketizingBuffer {
     last_emitted: Option<(SeqNo, CodecExtra)>,
     max_time: Option<MediaTime>,
     depack_cache: Option<(SeqNo, Depacketized)>,
+    vp8_contiguity: vp8_contiguity::Vp8Contiguity,
 }
 
 impl DepacketizingBuffer {
@@ -92,6 +98,7 @@ impl DepacketizingBuffer {
             last_emitted: None,
             max_time: None,
             depack_cache: None,
+            vp8_contiguity: Vp8Contiguity::new(),
         }
     }
 
@@ -155,7 +162,7 @@ impl DepacketizingBuffer {
             last.meta.seq_no
         };
 
-        // depack ahead to check contiguity, even if we may not emit right away
+        // depack ahead, even if we may not emit right away
         let mut dep = match self.depacketize(start, stop, seq) {
             Ok(d) => d,
             Err(e) => {
@@ -167,80 +174,45 @@ impl DepacketizingBuffer {
             }
         };
 
-        let contiguous = self.contiguous(start, stop, &dep);
+        // If we have contiguity of seq numbers we emit right away,
+        // Otherwise, we wait for retransmissions up to `hold_back` frames
+        // and re-evaluate contiguity based on codec specific information
 
-        let is_more_than_hold_back = self.segments.len() >= self.hold_back;
+        let more_than_hold_back = self.segments.len() >= self.hold_back;
+        let contiguous_seq = self.is_following_last(start);
+        let wait_for_contiguity = !contiguous_seq && !more_than_hold_back;
 
-        let wait_for_contiguity = !contiguous && !is_more_than_hold_back;
-
-        // We prefer to just release samples because they are following the last emitted.
-        // However as fallback, we "hold back" samples to let RTX mechanics fill in potential
-        // gaps in the RTP sequences before letting go.
         if wait_for_contiguity {
-            // if we are not sending it, cache the depacked
+            // if we are not sending, cache the depacked
             self.depack_cache = Some((seq, dep));
             return None;
         }
 
-        if !contiguous {
-            trace!(
-                "Depacketized sample is not contiguous (seq: {}, {})",
-                start,
-                stop
-            );
-            dep.contiguous = false;
-        }
+        let (can_emit, contiguous_codec) = match dep.codec_extra {
+            CodecExtra::None => (true, contiguous_seq),
+            CodecExtra::Vp8(next) => self.vp8_contiguity.check(&next, contiguous_seq),
+        };
 
-        let last = self.queue.get(stop).expect("entry for stop index");
-        self.last_emitted = Some((last.meta.seq_no, dep.codec_extra));
+        dep.contiguous = contiguous_codec;
+
+        let last = self
+            .queue
+            .get(stop)
+            .expect("entry for stop index")
+            .meta
+            .seq_no;
 
         // We're not going to emit samples in the incorrect order, there's no point in keeping
         // stuff before the emitted range.
         self.queue.drain(0..=stop);
 
+        if !can_emit {
+            return None;
+        }
+
+        self.last_emitted = Some((last, dep.codec_extra));
+
         Some(Ok(dep))
-    }
-
-    fn contiguous(&self, start: usize, stop: usize, dep: &Depacketized) -> bool {
-        if self.is_following_last(start) {
-            return true;
-        }
-
-        let Some((last_seq, last_codec_extra)) = self.last_emitted else {
-            return true;
-        };
-
-        match (last_codec_extra, dep.codec_extra) {
-            (CodecExtra::Vp8(prev), CodecExtra::Vp8(next)) => {
-                // In the case of VP8 chrome doesn't answer nacks for frames that are on
-                // temporal layer1 Since VP8 frames are interleaved, we can tolerate a
-                // missing frame on layer 1 that its contiguous to two frames on layer 0
-
-                let Some(prev_pid) = prev.picture_id else {
-                    return false;
-                };
-                let Some(next_pid) = next.picture_id else {
-                    return false;
-                };
-
-                let allowed =
-                    prev.layer_index == 0 && next.layer_index == 0 && (prev_pid + 2 == next_pid);
-
-                if allowed {
-                    let last = self.queue.get(stop).expect("entry for stop index");
-                    trace!(
-                        "Depack gap allowed for Seq: {} - {}, PIDs: {} - {}",
-                        last_seq,
-                        last.meta.seq_no,
-                        prev_pid,
-                        next_pid
-                    );
-                }
-
-                allowed
-            }
-            _ => false,
-        }
     }
 
     fn depacketize(

--- a/src/packet/buffer_rx/vp8_contiguity.rs
+++ b/src/packet/buffer_rx/vp8_contiguity.rs
@@ -1,0 +1,210 @@
+use super::Vp8CodecExtra;
+use std::collections::VecDeque;
+
+#[derive(Debug)]
+pub struct Vp8Contiguity {
+    /// last picture id of layer 0 that we allowed emitting
+    last_tl0_picture_id: Option<u64>,
+    /// last picture id of any layer that we allowed emitting
+    last_picture_id: Option<u64>,
+}
+
+impl Vp8Contiguity {
+    pub fn new() -> Self {
+        Vp8Contiguity {
+            last_tl0_picture_id: None,
+            last_picture_id: None,
+        }
+    }
+
+    /// Called when depacketizing a new frame is ready to be emitted
+    ///
+    /// Returns whether we can emit suchfameh and whether it's decodable with contiguity
+    pub fn check(&mut self, next: &Vp8CodecExtra, contiguous_seq: bool) -> (bool, bool) {
+        let Some(picture_id) = next.picture_id else {
+            // picture id is not enabled or not progressing anyway
+            return (true, contiguous_seq);
+        };
+
+        let Some(tl0_picture_id) = next.tl0_picture_id else {
+            // at this point we expect to receive a tl0 picture id for this algo to work
+            panic!("missing tl0 picture id");
+        };
+
+        let (Some(last_tl0_picture_id), Some(last_picture_id)) =
+            (self.last_tl0_picture_id, self.last_picture_id)
+        else {
+            self.last_tl0_picture_id = Some(tl0_picture_id);
+            self.last_picture_id = Some(picture_id);
+            return (true, true);
+        };
+
+        // discard older pictures if any
+        if picture_id <= last_picture_id {
+            return (false, true);
+        }
+
+        if next.layer_index == 0 {
+            assert_ne!(
+                tl0_picture_id, last_tl0_picture_id,
+                "2 subsequent frames on layer zero must have different tl0 picture id"
+            );
+
+            // Frame on layer 0: always emit and report discontinuity if not subsequent
+            let emit = true;
+            let contiguous = tl0_picture_id == last_tl0_picture_id + 1;
+
+            self.last_tl0_picture_id = Some(tl0_picture_id);
+            self.last_picture_id = Some(picture_id);
+
+            return (emit, contiguous);
+        }
+
+        // Frame on layer 1 or 2: only emit if they refer to the current layer 0
+        // and they are subsequent
+        let emit = tl0_picture_id == last_tl0_picture_id && picture_id == last_picture_id + 1;
+
+        if emit {
+            self.last_picture_id = Some(picture_id);
+            assert!(
+                contiguous_seq,
+                "contiguous pictures imples contiguous seq numbers: encoding issue ?"
+            );
+        }
+
+        (emit, true)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use tracing_subscriber::layer;
+
+    use super::Vp8Contiguity;
+    const L1T3_LAYERS: &[u64] = &[0, 2, 1, 2];
+    const L1T2_LAYERS: &[u64] = &[0, 1, 0, 1];
+
+    #[test]
+    fn contiguous_l1t3() {
+        let mut contiguity = Vp8Contiguity::new();
+
+        for i in 0..100 {
+            let mut next = &crate::packet::Vp8CodecExtra {
+                discardable: false,
+                sync: true,
+                layer_index: L1T3_LAYERS[i as usize % 4] as u8,
+                picture_id: Some(i),
+                tl0_picture_id: Some(i / 4),
+            };
+
+            let res = contiguity.check(next, true);
+            assert_eq!(res, (true, true), "Failure at picture {} {:?}", i, next);
+        }
+    }
+
+    #[test]
+    fn contiguous_l1t3_no_l2_contig_l0() {
+        const L1T3_LAYERS: &[u64] = &[0, 2, 1, 2];
+
+        let mut contiguity = Vp8Contiguity::new();
+
+        for i in 0..100 {
+            let layer_index = L1T3_LAYERS[i as usize % 4] as u8;
+            if layer_index == 2 {
+                continue;
+            }
+
+            let mut next = &crate::packet::Vp8CodecExtra {
+                discardable: false,
+                sync: i % 8 == 0,
+                layer_index,
+                picture_id: Some(i),
+                tl0_picture_id: Some(i / 4),
+            };
+
+            let (emit, contiguous) = contiguity.check(next, true);
+
+            // all layer 0 are contiguous therefore no discontinuity
+            assert_eq!(emit, next.layer_index == 0);
+            assert!(contiguous);
+
+            if layer_index == 1 {
+                // frames on layer 1 are not emitted (could be improved tracking more deps)
+                // and we don't raise a discontinuity (stream still decodable)
+                assert!(!emit);
+                assert!(contiguous);
+            }
+        }
+    }
+
+    #[test]
+    fn contiguous_l1t3_no_l2_discontig_l0() {
+        const L1T3_LAYERS: &[u64] = &[0, 2, 1, 2];
+
+        let mut contiguity = Vp8Contiguity::new();
+
+        for i in 0..100 {
+            let layer_index = L1T3_LAYERS[i as usize % 4] as u8;
+            if layer_index == 2 {
+                continue;
+            }
+
+            let mut next = &crate::packet::Vp8CodecExtra {
+                discardable: false,
+                sync: i % 8 == 0,
+                layer_index,
+                picture_id: Some(i),
+                tl0_picture_id: Some(i),
+            };
+
+            let (emit, contiguous) = contiguity.check(next, true);
+
+            assert!(emit == (next.layer_index == 0));
+        }
+    }
+
+    #[test]
+    fn contiguous_l1t2() {
+        let mut contiguity = Vp8Contiguity::new();
+
+        for i in 0..100 {
+            let mut next = &crate::packet::Vp8CodecExtra {
+                discardable: false,
+                sync: true,
+                layer_index: L1T2_LAYERS[i as usize % 4] as u8,
+                picture_id: Some(i),
+                tl0_picture_id: Some(i / 2),
+            };
+
+            let res = contiguity.check(next, true);
+            assert_eq!(res, (true, true), "Failure at picture {} {:?}", i, next);
+        }
+    }
+
+    #[test]
+    fn contiguous_l1t1_no_l1_contig_l0() {
+        const L1T3_LAYERS: &[u64] = &[0, 2, 1, 2];
+
+        let mut contiguity = Vp8Contiguity::new();
+
+        for i in 0..100 {
+            let layer_index = L1T2_LAYERS[i as usize % 4] as u8;
+            if layer_index == 1 {
+                continue;
+            }
+
+            let mut next = &crate::packet::Vp8CodecExtra {
+                discardable: false,
+                sync: i % 8 == 0,
+                layer_index,
+                picture_id: Some(i),
+                tl0_picture_id: Some(i / 2),
+            };
+
+            let (emit, contiguous) = contiguity.check(next, true);
+
+            // all layer 0 are contiguous therefore can be emitted
+            assert_eq!(emit, next.layer_index == 0);
+        }
+    }
+}

--- a/src/packet/vp8.rs
+++ b/src/packet/vp8.rs
@@ -18,6 +18,8 @@ pub struct Vp8CodecExtra {
     pub layer_index: u8,
     /// extended picture id, if present
     pub picture_id: Option<u64>,
+    /// extended picture id of layer 0 frames, if present
+    pub tl0_picture_id: Option<u64>,
 }
 
 /// Packetizes VP8 RTP packets.
@@ -151,6 +153,8 @@ pub struct Vp8Depacketizer {
 
     /// 8 bits temporal level zero index
     pub tl0_pic_idx: u8,
+    /// extended version of picture_id of temporal layer 0
+    pub extended_tl0_pic_idx: Option<u64>,
     /// 2 bits temporal layer index
     pub tid: u8,
     /// 1 bit layer sync bit
@@ -227,6 +231,8 @@ impl Depacketizer for Vp8Depacketizer {
 
         if self.l == 1 {
             self.tl0_pic_idx = reader.get_u8();
+            self.extended_tl0_pic_idx =
+                Some(extend_u8(self.extended_tl0_pic_idx, self.tl0_pic_idx));
             payload_index += 1;
         }
 
@@ -257,6 +263,8 @@ impl Depacketizer for Vp8Depacketizer {
             sync: self.y == 1,
             layer_index: self.tid,
             picture_id: if self.i == 1 { self.extended_pid } else { None },
+            tl0_picture_id: if self.l == 1 {
+                self.extended_tl0_pic_idx
             } else {
                 None
             },

--- a/src/packet/vp8.rs
+++ b/src/packet/vp8.rs
@@ -147,7 +147,7 @@ pub struct Vp8Depacketizer {
     /// 8 or 16 bits, picture ID
     pub picture_id: u16,
     // extended picture id
-    pub extended_pid: u64,
+    pub extended_pid: Option<u64>,
 
     /// 8 bits temporal level zero index
     pub tl0_pic_idx: u8,
@@ -213,11 +213,11 @@ impl Depacketizer for Vp8Depacketizer {
             if b & 0x80 > 0 {
                 // M == 1, PID is 16bit
                 self.picture_id = (((b & 0x7f) as u16) << 8) | (reader.get_u8() as u16);
-                self.extended_pid = extend_u15(Some(self.extended_pid), self.picture_id);
+                self.extended_pid = Some(extend_u15(self.extended_pid, self.picture_id));
                 payload_index += 1;
             } else {
                 self.picture_id = b as u16;
-                self.extended_pid = extend_u7(Some(self.extended_pid), b);
+                self.extended_pid = Some(extend_u7(self.extended_pid, b));
             }
         }
 
@@ -256,8 +256,7 @@ impl Depacketizer for Vp8Depacketizer {
             discardable: self.n == 1,
             sync: self.y == 1,
             layer_index: self.tid,
-            picture_id: if self.i == 1 {
-                Some(self.extended_pid)
+            picture_id: if self.i == 1 { self.extended_pid } else { None },
             } else {
                 None
             },

--- a/src/packet/vp8.rs
+++ b/src/packet/vp8.rs
@@ -8,17 +8,15 @@ pub const VP8_HEADER_SIZE: usize = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Vp8CodecExtra {
     /// True if the frame can be discarded safely, without causing decoding problems
-    /// No other frames are encoded depending on this frame
+    /// No other frames are encoded depending on this frame (non-reference frame)
     pub discardable: bool,
-    /// True if the frame is encoded only depending on a frame on layer 0.
-    /// This attribute can only be true for frames on layer 1
+    /// True if this frame and subsequent ones on this layer depend only on tl0_pic_idx
     pub sync: bool,
     /// Index of the vp8 temporal layer.
-    /// Only 2 layers are possible in WebRTC
     pub layer_index: u8,
-    /// extended picture id, if present
+    /// Extended picture id, if present
     pub picture_id: Option<u64>,
-    /// extended picture id of layer 0 frames, if present
+    /// Extended picture id of layer 0 frames, if present
     pub tl0_picture_id: Option<u64>,
 }
 

--- a/src/streams/register_nack.rs
+++ b/src/streams/register_nack.rs
@@ -120,8 +120,8 @@ impl NackRegister {
         // reset packets that are rolling our of the nack window
         for s in *active.start..*start {
             let p = self.packet(s.into());
-            if !p.received {
-                debug!("Seq no {} missing after {} attempts", seq, p.nack_count);
+            if !p.received && s != *seq {
+                debug!("Seq no {} missing after {} attempts", s, p.nack_count);
             }
             self.packet(s.into()).reset();
         }

--- a/tests/contiguous.rs
+++ b/tests/contiguous.rs
@@ -191,13 +191,16 @@ pub fn not_contiguous() -> Result<(), RtcError> {
     // Contiguous all the way through.
     for data in iter {
         count += 1;
-        // We dropped packet 14337, which means 14338 should not be contiguous.
-        let assume_contiguous = !data.seq_range.contains(&14338.into());
-        assert!(assume_contiguous == data.contiguous);
+        // We dropped packet 14337, which means its dependendant 14338 is not
+        // emitted, and 14339 is emitted and marked as discontinuous.
+        let assume_contiguous = !data.seq_range.contains(&14339.into());
+        assert_eq!(assume_contiguous, data.contiguous);
     }
 
-    // We have 3 continuations, one missing packet, and one last packet missing: 104 - 3 - 1 - 1 == 99
-    assert_eq!(count, 99);
+    // assert!(false);
+    // We have 3 continuations, 2 missing packet (14337 14338), and one last
+    // packet missing: 104 - 3 - 1 - 1 == 99
+    assert_eq!(count, 98);
 
     Ok(())
 }


### PR DESCRIPTION
This PR improves how we wait for retransmissions and detect discontinuities in our sample-based api (MediaData). This is relevant for VP8 when temporal layers are enabled (simulcast) in case of network loss.

 Fixes issue with minor corruption on Chrome improves major corruption on Safari (it’s less frequent and when it happens the discontinuity is reported).