### PR TITLE
filter out unexpected rtx packets

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -494,7 +494,10 @@ impl Session {
             }
 
             // Rewrite the header, and removes the resent seq_no from the body.
-            stream.un_rtx(&mut header, &mut data, pt);
+            if !stream.un_rtx(&mut header, &mut data, pt) {
+                // Discard the packet if we did not ask for it
+                return;
+            }
 
             // Now update the "main" register with the repaired packet info.
             // This gives us the extended sequence number of the main stream.

--- a/src/streams/register.rs
+++ b/src/streams/register.rs
@@ -89,6 +89,10 @@ impl ReceiverRegister {
         new
     }
 
+    pub fn accept_resend(&self, seq: SeqNo) -> bool {
+        self.nack.accept_resend(seq)
+    }
+
     /// Generates a NACK report
     pub fn nack_report(&mut self) -> Option<impl Iterator<Item = Nack>> {
         self.nack.nack_reports()

--- a/src/streams/register_nack.rs
+++ b/src/streams/register_nack.rs
@@ -139,6 +139,14 @@ impl NackRegister {
         self.active.as_ref().map(|a| a.end)
     }
 
+    pub fn accept_resend(&self, seq: SeqNo) -> bool {
+        let Some(active) = self.active.clone() else {
+            return false;
+        };
+        let packet = self.packets[self.as_index(seq)];
+        active.contains(&seq) && !packet.received
+    }
+
     /// Create a new nack report
     ///
     /// This modifies the state as it counts how many times packets have been nacked


### PR DESCRIPTION
Firefox is sending spurious padding on the "wrong" rtx. This can cause wrong receiver report and stream corruption.
