### PR TITLE
Enhance SDP Generation Flexibility

### DIFF
--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -1,14 +1,14 @@
-use crate::change::sdp::{accept_answer, Changes, create_offer};
+use crate::change::sdp::{accept_answer, create_offer, Changes};
 use crate::channel::ChannelId;
 use crate::dtls::Fingerprint;
 use crate::ice::IceCreds;
 use crate::media::{Media, MediaKind};
 use crate::rtp_::{Mid, Rid, Ssrc};
 use crate::sctp::ChannelConfig;
+use crate::sdp::{SdpAnswer, SdpOffer};
 use crate::streams::{StreamRx, StreamTx, DEFAULT_RTX_CACHE_DURATION};
 use crate::Rtc;
 use crate::RtcError;
-use crate::sdp::{SdpAnswer, SdpOffer};
 
 /// Direct change strategy.
 ///
@@ -149,7 +149,13 @@ impl<'a> DirectApi<'a> {
         };
 
         let exts = self.rtc.session.exts.cloned_with_type(kind.is_audio());
-        let pts = self.rtc.session.codec_config.all_for_kind(kind).map(|p| p.pt()).collect();
+        let pts = self
+            .rtc
+            .session
+            .codec_config
+            .all_for_kind(kind)
+            .map(|p| p.pt())
+            .collect();
         let m = Media::from_direct_api(mid, next_index, kind, exts, pts);
 
         self.rtc.session.medias.push(m);

--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -244,10 +244,12 @@ impl<'a> DirectApi<'a> {
         stream
     }
 
+    /// Creates new [`SdpOffer`] from the `str0m`'s state.
     pub fn create_offer(&mut self) -> SdpOffer {
         create_offer(self.rtc, &Changes(Vec::new()))
     }
 
+    /// Accept an answer to a previously created [`SdpOffer`].
     pub fn accept_answer(&mut self, answer: SdpAnswer) -> Result<(), RtcError> {
         accept_answer(self.rtc, answer)
     }

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -519,10 +519,7 @@ pub(crate) fn create_offer(rtc: &mut Rtc, changes: &Changes) -> SdpOffer {
     sdp.into()
 }
 
-pub(crate) fn accept_answer(
-    rtc: &mut Rtc,
-    answer: SdpAnswer,
-) -> Result<(), RtcError> {
+pub(crate) fn accept_answer(rtc: &mut Rtc, answer: SdpAnswer) -> Result<(), RtcError> {
     add_ice_details(rtc, &answer, None)?;
 
     // Ensure setup=active/passive is corresponding remote and init dtls.

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -523,8 +523,6 @@ pub(crate) fn accept_answer(
     rtc: &mut Rtc,
     answer: SdpAnswer,
 ) -> Result<(), RtcError> {
-    debug!("Accept answer");
-
     add_ice_details(rtc, &answer, None)?;
 
     // Ensure setup=active/passive is corresponding remote and init dtls.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -496,7 +496,7 @@
 #![allow(clippy::bool_to_int_with_if)]
 #![allow(clippy::assertions_on_constants)]
 #![allow(clippy::manual_range_contains)]
-#![deny(missing_docs)]
+// #![deny(missing_docs)]
 
 #[macro_use]
 extern crate tracing;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -496,7 +496,7 @@
 #![allow(clippy::bool_to_int_with_if)]
 #![allow(clippy::assertions_on_constants)]
 #![allow(clippy::manual_range_contains)]
-// #![deny(missing_docs)]
+#![deny(missing_docs)]
 
 #[macro_use]
 extern crate tracing;

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -528,11 +528,13 @@ impl Media {
         index: usize,
         kind: MediaKind,
         exts: ExtensionMap,
+        pts: Vec<Pt>,
     ) -> Media {
         Media {
             mid,
             index,
             kind,
+            remote_pts: pts,
             dir: Direction::SendRecv,
             remote_exts: exts,
             ..Default::default()


### PR DESCRIPTION
This pull request addresses limitations in the current SDP API. While it's secure, it lacks flexibility in certain cases. `str0m` also have a Direct API for media source creation and etc, but it doesn't support manual SDP generation. To improve this, we propose adding raw APIs for SDP generation and applying.

While Direct API may not be the ideal place for SDP offers, I'm open to alternative suggestions for implementation. Your input is welcome!