### PR TITLE
SdpPendingOffer merging

### DIFF
--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -411,10 +411,8 @@ impl<'a> SdpApi<'a> {
     /// ## Example
     ///
     /// ```no_run
-    ///
     /// # use str0m::media::{Direction, MediaKind};
     /// # use str0m::Rtc;
-    ///
     /// let mut rtc = Rtc::new();
     /// let mut changes = rtc.sdp_api();
     /// changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None);

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -475,7 +475,7 @@ impl<'a> SdpApi<'a> {
         mut self,
         pending_offer: &mut SdpPendingOffer,
     ) -> Option<(SdpOffer, SdpPendingOffer)> {
-        pending_offer.retain_relevant(&self.rtc);
+        pending_offer.retain_relevant(self.rtc);
 
         pending_offer.changes.extend(self.changes.drain(..));
         swap(&mut self.changes, &mut pending_offer.changes);

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -1,6 +1,7 @@
 //! Strategy that amends the [`Rtc`] via SDP OFFER/ANSWER negotiation.
 
 use std::fmt;
+use std::mem::swap;
 use std::ops::{Deref, DerefMut};
 
 use crate::channel::ChannelId;
@@ -401,6 +402,86 @@ impl<'a> SdpApi<'a> {
             None
         }
     }
+
+    /// Combines the modifications made in [`SdpApi`] with those in [`SdpPendingOffer`], generating
+    /// a new [`SdpOffer`] and [`SdpPendingOffer`].
+    ///
+    /// This function merges the changes present in [`SdpApi`] with the changes
+    /// in [`SdpPendingOffer`]. The resulting [`SdpOffer`] incorporates modifications
+    /// from both the previous [`SdpPendingOffer`] and any newly added changes.
+    ///
+    /// The original [`SdpPendingOffer`] is intentionally not consumed by this function to
+    /// allow users the flexibility to retain it for case when [`SdpAnswer`] for the
+    /// old [`SdpPendingOffer`] is received. It will not affect any state, but it can be used
+    /// to discard outdated [`SdpAnswer`]s.
+    ///
+    /// ## Example
+    ///
+    /// ```no_run
+    /// # use std::collections::VecDeque;
+    /// # use str0m::{Rtc, RtcError};
+    /// # use str0m::media::{MediaKind, Direction};
+    /// # use str0m::change::{SdpAnswer, SdpOffer, SdpPendingOffer};
+    ///
+    ///
+    /// struct MediaController {
+    ///     rtc: Rtc,
+    ///     pending_offers: VecDeque<SdpPendingOffer>,
+    /// }
+    ///
+    /// impl MediaController {
+    ///     pub fn new() -> Self {
+    ///         Self {
+    ///             rtc: Rtc::new(),
+    ///             pending_offers: VecDeque::new(),
+    ///         }
+    ///     }
+    ///
+    ///     pub fn add_media(&mut self) -> SdpOffer {
+    ///         let mut changes = self.rtc.sdp_api();
+    ///         changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None);
+    ///         if self.pending_offers.is_empty() {
+    ///             let (offer, pending) = changes.apply().unwrap();
+    ///             self.pending_offers.push_front(pending);
+    ///             offer
+    ///         } else {
+    ///             let last_pending_offer = self.pending_offers.back_mut().unwrap();
+    ///             let (offer, pending) = changes.merge_and_apply(last_pending_offer).unwrap();
+    ///             self.pending_offers.push_back(pending);
+    ///             offer
+    ///         }
+    ///     }
+    ///
+    ///     pub fn accept_answer(&mut self, answer: SdpAnswer) -> Result<(), RtcError> {
+    ///         let pending = self.pending_offers.pop_front().unwrap();
+    ///         self.rtc.sdp_api().accept_answer(pending, answer)
+    ///     }
+    /// }
+    ///
+    /// let mut media_controller = MediaController::new();
+    ///
+    /// let first_offer = media_controller.add_media();
+    /// let first_answer: SdpAnswer = todo!();
+    /// let second_offer = media_controller.add_media();
+    /// let second_answer: SdpAnswer = todo!();
+    /// let third_offer = media_controller.add_media();
+    /// let third_answer: SdpAnswer = todo!();
+    ///
+    /// media_controller.accept_answer(first_answer).unwrap_err();
+    /// media_controller.accept_answer(second_answer).unwrap_err();
+    /// media_controller.accept_answer(third_answer).unwrap();
+    /// ```
+    pub fn merge_and_apply(
+        mut self,
+        pending_offer: &mut SdpPendingOffer,
+    ) -> Option<(SdpOffer, SdpPendingOffer)> {
+        pending_offer.retain_relevant(&self.rtc);
+
+        pending_offer.changes.extend(self.changes.drain(..));
+        swap(&mut self.changes, &mut pending_offer.changes);
+
+        self.apply()
+    }
 }
 
 /// Pending offer from a previous [`Rtc::sdp_api()`] call.
@@ -427,6 +508,29 @@ impl<'a> SdpApi<'a> {
 pub struct SdpPendingOffer {
     change_id: usize,
     changes: Changes,
+}
+
+impl SdpPendingOffer {
+    /// Retains only the relevant changes in the `changes` vector based on the provided `Rtc` instance.
+    ///
+    /// This function filters the vector of `Change` instances stored in the current object and retains
+    /// only those changes that are considered relevant with respect to the provided `Rtc` instance.
+    fn retain_relevant(&mut self, rtc: &Rtc) {
+        fn is_relevant(rtc: &Rtc, c: &Change) -> bool {
+            match c {
+                Change::AddMedia(v) => rtc.media(v.mid).is_none(),
+                Change::AddApp(_) => rtc.session.app().is_none(),
+                Change::AddChannel(v) => rtc.chan.stream_id_by_channel_id(v.0).is_none(),
+                Change::Direction(m, d) => {
+                    // If mid is missing, this is not relevant.
+                    rtc.media(*m).map(|m| m.direction() != *d).unwrap_or(false)
+                }
+                Change::IceRestart(v, _) => rtc.ice.local_credentials() != v,
+            }
+        }
+
+        self.changes.retain(|c| is_relevant(rtc, c));
+    }
 }
 
 #[derive(Default)]
@@ -1520,6 +1624,68 @@ mod test {
         let r = rtc1.sdp_api().accept_answer(pending1, answer2);
 
         assert!(matches!(r, Err(RtcError::ChangesOutOfOrder)));
+    }
+
+    mod merge_and_apply {
+        use super::*;
+
+        fn add_media_with_apply(rtc: &mut Rtc) -> (SdpOffer, SdpPendingOffer) {
+            let mut changes = rtc.sdp_api();
+            changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None);
+            changes.apply().unwrap()
+        }
+
+        fn add_media_with_merge_and_apply(
+            rtc: &mut Rtc,
+            prev_pending: &mut SdpPendingOffer,
+        ) -> (SdpOffer, SdpPendingOffer) {
+            let mut changes = rtc.sdp_api();
+            changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None);
+            changes.merge_and_apply(prev_pending).unwrap()
+        }
+
+        #[test]
+        fn pending_offer_cancelling_works() {
+            let mut rtc = Rtc::new();
+            let (first_offer, mut first_pending) = add_media_with_apply(&mut rtc);
+            let first_answer = SdpAnswer::from((*first_offer).clone());
+
+            let (_, _) = add_media_with_merge_and_apply(&mut rtc, &mut first_pending);
+
+            assert!(matches!(
+                rtc.sdp_api()
+                    .accept_answer(first_pending, first_answer)
+                    .unwrap_err(),
+                RtcError::ChangesOutOfOrder
+            ));
+        }
+
+        #[test]
+        fn media_lines_ordering_is_correct() {
+            let mut rtc = Rtc::new();
+            let (first_offer, mut first_pending) = add_media_with_apply(&mut rtc);
+            let (second_offer, mut second_pending) =
+                add_media_with_merge_and_apply(&mut rtc, &mut first_pending);
+            let (third_offer, _) = add_media_with_merge_and_apply(&mut rtc, &mut second_pending);
+
+            assert_eq!(second_offer.media_lines[0], first_offer.media_lines[0]);
+            assert!(second_offer.media_lines.get(1).is_some());
+
+            assert_eq!(third_offer.media_lines[0], second_offer.media_lines[0]);
+            assert_eq!(third_offer.media_lines[1], second_offer.media_lines[1]);
+            assert!(third_offer.media_lines.get(2).is_some());
+        }
+
+        #[test]
+        fn applying_of_last_merged_pending_offer_works() {
+            let mut rtc = Rtc::new();
+            let (_, mut pending) = add_media_with_apply(&mut rtc);
+            let (_, mut pending) = add_media_with_merge_and_apply(&mut rtc, &mut pending);
+            let (offer, pending) = add_media_with_merge_and_apply(&mut rtc, &mut pending);
+
+            let answer = SdpAnswer::from((*offer).clone());
+            rtc.sdp_api().accept_answer(pending, answer).unwrap();
+        }
     }
 
     #[test]

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -1,7 +1,6 @@
 //! Strategy that amends the [`Rtc`] via SDP OFFER/ANSWER negotiation.
 
 use std::fmt;
-use std::mem::swap;
 use std::ops::{Deref, DerefMut};
 
 use crate::channel::ChannelId;
@@ -403,84 +402,35 @@ impl<'a> SdpApi<'a> {
         }
     }
 
-    /// Combines the modifications made in [`SdpApi`] with those in [`SdpPendingOffer`], generating
-    /// a new [`SdpOffer`] and [`SdpPendingOffer`].
+    /// Combines the modifications made in [`SdpApi`] with those in [`SdpPendingOffer`].
     ///
     /// This function merges the changes present in [`SdpApi`] with the changes
-    /// in [`SdpPendingOffer`]. The resulting [`SdpOffer`] incorporates modifications
+    /// in [`SdpPendingOffer`]. In result this [`SdpApi`] will incorporate modifications
     /// from both the previous [`SdpPendingOffer`] and any newly added changes.
-    ///
-    /// The original [`SdpPendingOffer`] is intentionally not consumed by this function to
-    /// allow users the flexibility to retain it for case when [`SdpAnswer`] for the
-    /// old [`SdpPendingOffer`] is received. It will not affect any state, but it can be used
-    /// to discard outdated [`SdpAnswer`]s.
     ///
     /// ## Example
     ///
     /// ```no_run
-    /// # use std::collections::VecDeque;
-    /// # use str0m::{Rtc, RtcError};
-    /// # use str0m::media::{MediaKind, Direction};
-    /// # use str0m::change::{SdpAnswer, SdpOffer, SdpPendingOffer};
     ///
+    /// # use str0m::media::{Direction, MediaKind};
+    /// # use str0m::Rtc;
     ///
-    /// struct MediaController {
-    ///     rtc: Rtc,
-    ///     pending_offers: VecDeque<SdpPendingOffer>,
-    /// }
+    /// let mut rtc = Rtc::new();
+    /// let mut changes = rtc.sdp_api();
+    /// changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None);
+    /// let (_offer, pending) = changes.apply().unwrap();
     ///
-    /// impl MediaController {
-    ///     pub fn new() -> Self {
-    ///         Self {
-    ///             rtc: Rtc::new(),
-    ///             pending_offers: VecDeque::new(),
-    ///         }
-    ///     }
+    /// let mut changes = rtc.sdp_api();
+    /// changes.add_media(MediaKind::Video, Direction::SendOnly, None, None);
+    /// changes.merge(pending);
     ///
-    ///     pub fn add_media(&mut self) -> SdpOffer {
-    ///         let mut changes = self.rtc.sdp_api();
-    ///         changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None);
-    ///         if self.pending_offers.is_empty() {
-    ///             let (offer, pending) = changes.apply().unwrap();
-    ///             self.pending_offers.push_front(pending);
-    ///             offer
-    ///         } else {
-    ///             let last_pending_offer = self.pending_offers.back_mut().unwrap();
-    ///             let (offer, pending) = changes.merge_and_apply(last_pending_offer).unwrap();
-    ///             self.pending_offers.push_back(pending);
-    ///             offer
-    ///         }
-    ///     }
-    ///
-    ///     pub fn accept_answer(&mut self, answer: SdpAnswer) -> Result<(), RtcError> {
-    ///         let pending = self.pending_offers.pop_front().unwrap();
-    ///         self.rtc.sdp_api().accept_answer(pending, answer)
-    ///     }
-    /// }
-    ///
-    /// let mut media_controller = MediaController::new();
-    ///
-    /// let first_offer = media_controller.add_media();
-    /// let first_answer: SdpAnswer = todo!();
-    /// let second_offer = media_controller.add_media();
-    /// let second_answer: SdpAnswer = todo!();
-    /// let third_offer = media_controller.add_media();
-    /// let third_answer: SdpAnswer = todo!();
-    ///
-    /// media_controller.accept_answer(first_answer).unwrap_err();
-    /// media_controller.accept_answer(second_answer).unwrap_err();
-    /// media_controller.accept_answer(third_answer).unwrap();
+    /// // This `SdpOffer` will have changes from the first `SdpPendingChanges`
+    /// // and new changes from `SdpApi`
+    /// let (_offer, pending) = changes.apply().unwrap();
     /// ```
-    pub fn merge_and_apply(
-        mut self,
-        pending_offer: &mut SdpPendingOffer,
-    ) -> Option<(SdpOffer, SdpPendingOffer)> {
+    pub fn merge(&mut self, mut pending_offer: SdpPendingOffer) {
         pending_offer.retain_relevant(self.rtc);
-
-        pending_offer.changes.extend(self.changes.drain(..));
-        swap(&mut self.changes, &mut pending_offer.changes);
-
-        self.apply()
+        self.changes.extend(pending_offer.changes.drain(..));
     }
 }
 
@@ -1626,66 +1576,20 @@ mod test {
         assert!(matches!(r, Err(RtcError::ChangesOutOfOrder)));
     }
 
-    mod merge_and_apply {
-        use super::*;
+    #[test]
+    fn sdp_api_merge_works() {
+        let mut rtc = Rtc::new();
+        let mut changes = rtc.sdp_api();
+        changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None);
+        let (offer, pending) = changes.apply().unwrap();
 
-        fn add_media_with_apply(rtc: &mut Rtc) -> (SdpOffer, SdpPendingOffer) {
-            let mut changes = rtc.sdp_api();
-            changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None);
-            changes.apply().unwrap()
-        }
+        let mut changes = rtc.sdp_api();
+        changes.add_media(MediaKind::Video, Direction::SendOnly, None, None);
+        changes.merge(pending);
+        let (new_offer, _) = changes.apply().unwrap();
 
-        fn add_media_with_merge_and_apply(
-            rtc: &mut Rtc,
-            prev_pending: &mut SdpPendingOffer,
-        ) -> (SdpOffer, SdpPendingOffer) {
-            let mut changes = rtc.sdp_api();
-            changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None);
-            changes.merge_and_apply(prev_pending).unwrap()
-        }
-
-        #[test]
-        fn pending_offer_cancelling_works() {
-            let mut rtc = Rtc::new();
-            let (first_offer, mut first_pending) = add_media_with_apply(&mut rtc);
-            let first_answer = SdpAnswer::from((*first_offer).clone());
-
-            let (_, _) = add_media_with_merge_and_apply(&mut rtc, &mut first_pending);
-
-            assert!(matches!(
-                rtc.sdp_api()
-                    .accept_answer(first_pending, first_answer)
-                    .unwrap_err(),
-                RtcError::ChangesOutOfOrder
-            ));
-        }
-
-        #[test]
-        fn media_lines_ordering_is_correct() {
-            let mut rtc = Rtc::new();
-            let (first_offer, mut first_pending) = add_media_with_apply(&mut rtc);
-            let (second_offer, mut second_pending) =
-                add_media_with_merge_and_apply(&mut rtc, &mut first_pending);
-            let (third_offer, _) = add_media_with_merge_and_apply(&mut rtc, &mut second_pending);
-
-            assert_eq!(second_offer.media_lines[0], first_offer.media_lines[0]);
-            assert!(second_offer.media_lines.get(1).is_some());
-
-            assert_eq!(third_offer.media_lines[0], second_offer.media_lines[0]);
-            assert_eq!(third_offer.media_lines[1], second_offer.media_lines[1]);
-            assert!(third_offer.media_lines.get(2).is_some());
-        }
-
-        #[test]
-        fn applying_of_last_merged_pending_offer_works() {
-            let mut rtc = Rtc::new();
-            let (_, mut pending) = add_media_with_apply(&mut rtc);
-            let (_, mut pending) = add_media_with_merge_and_apply(&mut rtc, &mut pending);
-            let (offer, pending) = add_media_with_merge_and_apply(&mut rtc, &mut pending);
-
-            let answer = SdpAnswer::from((*offer).clone());
-            rtc.sdp_api().accept_answer(pending, answer).unwrap();
-        }
+        assert_eq!(offer.media_lines[0], new_offer.media_lines[1]);
+        assert_eq!(new_offer.media_lines.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
Related to #364

## Synopsis

Sometimes, when using `str0m`, users may need to run a a second negotiation while first one is still in progress. 


## Implementation

To make this possible, I suggest adding an API that lets us combine a `SdpPendingOffer` with new changes from `SdpApi`. This combination will produce a new `SdpOffer` and a fresh `SdpPendingOffer`. These new offer will include changes from the previous `SdpPendingOffer` as well as new changes from `SdpApi`. The original `SdpPendingOffer` will still be available for users, allowing them to cancel any `SdpAnswer` related to the previous `SdpOffers`. This can be done using the `ChangeId` stored in the original `SdpPendingOffer`.

It's important to note that these older `SdpPendingOffers` will be empty and won't make any changes. Only the latest `SdpPendingOffer` generated by the `SdpApi::merge_and_apply` method can be used to update the `str0m` state and will be accepted in the `SdpApi::accept_answer` process.

The ordering of `m-lines` in the SDP offer will also be accurate.

Example of usage of this new API can be found in the `SdpApi::merge_and_apply` doc. 