### PR TITLE
Rework Firefox SSRC workaround

### DIFF
--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -446,6 +446,11 @@ impl Media {
             .find(|p| p.resend().is_some() && self.remote_pts.contains(&p.pt))
             .map(|p| p.pt())
     }
+
+    pub(crate) fn reset_depayloader(&mut self, payload_type: Pt, rid: Option<Rid>) {
+        // Simply remove the depayloader, it will be re-created on the next RTP packet.
+        self.depayloaders.remove(&(payload_type, rid));
+    }
 }
 
 impl Default for Media {

--- a/src/rtp/ext.rs
+++ b/src/rtp/ext.rs
@@ -438,22 +438,6 @@ impl ExtensionMap {
         }
     }
 
-    pub(crate) fn remove(&mut self, ext: Extension) {
-        let maybe_entry = self.0.iter_mut().find_map(|e| {
-            if e.as_mut().map(|e| e.ext == ext).unwrap_or(false) {
-                Some(e)
-            } else {
-                None
-            }
-        });
-
-        let Some(entry) = maybe_entry else {
-            return;
-        };
-
-        let _ = entry.take();
-    }
-
     fn swap(&mut self, id: u8, ext: &Extension) {
         if id < 1 || id > 14 {
             return;

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -2,7 +2,7 @@
 
 use combine::EasyParser;
 use std::collections::HashSet;
-use std::fmt;
+use std::fmt::{self};
 use std::num::ParseFloatError;
 use std::ops::Deref;
 use std::str::FromStr;
@@ -602,7 +602,6 @@ impl MediaLine {
                 _ => {}
             }
         }
-
         // Match this second to ensure we preserve order of a=ssrc.
         for a in &self.attrs {
             match a {
@@ -617,33 +616,10 @@ impl MediaLine {
                         continue;
                     }
 
-                    let repair_info = by_ssrc(&mut v, ssrcs[1]);
-                    repair_info.repairs = Some(ssrcs[0]);
+                    let info = by_ssrc(&mut v, ssrcs[1]);
+                    info.repairs = Some(ssrcs[0]);
                 }
                 _ => {}
-            }
-        }
-
-        // The order of the `a=ssrc-group:FID` lines map to the declared order of the `a=simulcast`
-        // line. For example
-        // a=simulcast:recv l;m;h
-        // a=ssrc-group:FID 1 2
-        // a=ssrc-group:FID 3 4
-        // a=ssrc-group:FID 5 6
-        //
-        // maps 1 as the SSRC for rid l, 2 as the RTX SSRC for rid l, 3 as the SSRC for rid m, 4 as
-        // the RTX SSRC for rid m and so on.
-        if let Some(simulcast_group) = self.simulcast().map(|s| s.send) {
-            if simulcast_group.len() * 2 == v.len() {
-                for (i, id) in simulcast_group.iter().enumerate() {
-                    let rid = id.0.as_str().into();
-
-                    v[i * 2].rid = Some(rid);
-                    v[i * 2 + 1].rid = Some(rid);
-                }
-            } else if !v.is_empty() {
-                // if v.len() == 0 we are not using signalled SSRCs at all.
-                warn!("a=ssrc-group count doesnt match a=rid count");
             }
         }
 
@@ -659,7 +635,6 @@ pub struct SsrcInfo {
     pub cname: Option<String>,
     pub stream_id: Option<String>,
     pub track_id: Option<String>,
-    pub rid: Option<Rid>,
 }
 
 impl Default for SsrcInfo {
@@ -670,7 +645,6 @@ impl Default for SsrcInfo {
             cname: None,
             stream_id: None,
             track_id: None,
-            rid: None,
         }
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -337,6 +337,10 @@ impl Session {
                             // We got a change in main SSRC for this stream.
                             let ssrc_from = stream.ssrc();
                             self.streams.change_stream_rx_ssrc(ssrc_from, ssrc);
+                            // When the SSRCs changes the sequence number typically also does, the
+                            // depayloader(if in use) relies on sequence numbers and will not handle a
+                            // large jump corretly, reset it.
+                            media.reset_depayloader(header.payload_type, None);
                         }
                     }
 
@@ -381,6 +385,10 @@ impl Session {
                         // We got a change in main SSRC for this stream.
                         let ssrc_from = stream.ssrc();
                         self.streams.change_stream_rx_ssrc(ssrc_from, ssrc);
+                        // When the SSRCs changes the sequence number typically also does, the
+                        // depayloader(if in use) relies on sequence numbers and will not handle a
+                        // large jump corretly, reset it.
+                        media.reset_depayloader(header.payload_type, Some(rid));
                     }
                 }
                 ssrc

--- a/src/session.rs
+++ b/src/session.rs
@@ -378,7 +378,15 @@ impl Session {
             let stream_mid_rid = self.streams.stream_rx_by_mid_rid(mid, Some(rid));
 
             let ssrc_main = if is_repair {
-                stream_mid_rid?.ssrc()
+                let stream = stream_mid_rid?;
+                let main = stream.ssrc();
+
+                if let Some(rtx) = stream.rtx().and_then(|rtx| (rtx != ssrc).then_some(rtx)) {
+                    // We got a change in the RTX SSRC
+                    self.streams.change_stream_rx_rtx(rtx, ssrc);
+                }
+
+                main
             } else {
                 if let Some(stream) = stream_mid_rid {
                     if stream.ssrc() != ssrc {

--- a/tests/sdp-negotiation.rs
+++ b/tests/sdp-negotiation.rs
@@ -230,9 +230,6 @@ fn answer_remaps() {
     let a_l: Vec<_> = l.exts().iter(true).collect();
     let a_r: Vec<_> = r.exts().iter(true).collect();
 
-    // NB: `RtpStreamId` and `RepairedStreamId` are not negotiated because str0m disables them if
-    // the offering side uses `a=ssrc-group:FID {main} {rtx}`, which str0m does.
-
     // L locks 3 and changes it from 14
     // R keeps 3 and changes it from 14.
     assert_eq!(
@@ -241,6 +238,8 @@ fn answer_remaps() {
             (2, &AbsoluteSendTime),
             (3, &TransportSequenceNumber),
             (4, &RtpMid),
+            (10, &RtpStreamId),
+            (11, &RepairedRtpStreamId),
             (13, &VideoOrientation)
         ]
     );
@@ -255,6 +254,8 @@ fn answer_remaps() {
             (2, &AbsoluteSendTime),
             (3, &TransportSequenceNumber),
             (4, &RtpMid),
+            (10, &RtpStreamId),
+            (11, &RepairedRtpStreamId)
         ]
     );
     assert_eq!(a_r, vec![(3, &TransportSequenceNumber), (12, &AudioLevel)]);


### PR DESCRIPTION
In #346 we attempted to workaround some bugs in Firefox to do with establishing the SSRC mappings for simulcast media. 
We took the approach of always relying on the information communicated via SDP i.e. `a=ssrc-group`, however it turns out 
this information is not reliable and what we should have relied on is the information communicated via the `rid` and `repaired-rid`
RTP headers exclusively.

This PR also fixes an issue where hangover state in `DepacketizingBuffer` would cause it to not emit samples when the SSRC for a given 
(Rid, Mid) pair, or just Mid in the case of non-simulcast, changes.
