### PR TITLE
send stats performances

### DIFF
--- a/src/util/value_history.rs
+++ b/src/util/value_history.rs
@@ -14,7 +14,7 @@ pub(crate) struct ValueHistory<T> {
     max_time: Duration,
 }
 
-const DEFAULT_VALUE_HISTORY_DURATION: Duration = Duration::from_secs(2);
+const DEFAULT_VALUE_HISTORY_DURATION: Duration = Duration::from_secs(1);
 
 impl<T: Default> Default for ValueHistory<T> {
     fn default() -> Self {


### PR DESCRIPTION
Based on this capture ValueHistory contributes to the heaviness of str0m::session::Session::poll_packet

<img width="580" alt="Screenshot 2023-10-04 at 19 12 55" src="https://github.com/algesten/str0m/assets/123929/6cd93916-37d7-4ced-af53-4fab0d7ea8bf">


Tested locally these 2 alternatives

```
+        for _ in 0..1_000_000 {
+            h.push(now, 22);
+
+            // 1
+            h.sum_since(now - Duration::from_secs(1));
+            // 2
+            h.sum();
+
+            now += inc;
+        }
```

This goes from 2s to 0.05s