### PR TITLE
sdp: expose MediaType and MediaLine to crate users

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -575,6 +575,12 @@ use sctp::{RtcSctp, SctpEvent};
 
 mod sdp;
 
+/// type of media
+pub type MediaType = crate::sdp::MediaType;
+
+/// SDP media line
+pub type MediaLine = crate::sdp::MediaLine;
+
 pub mod format;
 use format::CodecConfig;
 

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -699,11 +699,15 @@ impl FromStr for F32Eq {
 /// "audio", "video", "application"
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub enum MediaType {
+    /// audio
     #[default]
     Audio,
+    /// video
     Video,
+    /// application
     Application,
     #[doc(hidden)]
+    /// unknown
     Unknown(String),
 }
 


### PR DESCRIPTION
This enables users to easily inspect str0m's SDP negotiation outcome for, e.g., codec preferences.

I appreciate this is probably not currently to your standards for merging e.g. regarding docs or policies about type aliases or something but I thought I'd get the conversation going.

The use case is basically one where a client makes an SDP offer, str0m generates an SDP answer, and the application would like to know what str0m is negotiating and which codecs are expected in what preferred order.