### PR TITLE
Pass Candidate Protocol arounds along with Address(es) so that routing to the correct ICE route can be done cleanly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ let mut rtc = Rtc::new();
 
 //  Add some ICE candidate such as a locally bound UDP port.
 let addr = "1.2.3.4:5000".parse().unwrap();
-let candidate = Candidate::host(addr).unwrap();
+let candidate = Candidate::host(addr, CandidateProtocol::Udp).unwrap();
 rtc.add_local_candidate(candidate);
 
 // Accept an incoming offer from the remote peer
@@ -83,7 +83,7 @@ let mut rtc = Rtc::new();
 
 // Add some ICE candidate such as a locally bound UDP port.
 let addr = "1.2.3.4:5000".parse().unwrap();
-let candidate = Candidate::host(addr).unwrap();
+let candidate = Candidate::host(addr, CandidateProtocol::Udp).unwrap();
 rtc.add_local_candidate(candidate);
 
 // Create a `SdpApi`. The change lets us make multiple changes

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -17,8 +17,10 @@ use str0m::change::{SdpAnswer, SdpOffer, SdpPendingOffer};
 use str0m::channel::{ChannelData, ChannelId};
 use str0m::media::MediaKind;
 use str0m::media::{Direction, KeyframeRequest, MediaData, Mid, Rid};
-use str0m::Event;
-use str0m::{net::Receive, Candidate, IceConnectionState, Input, Output, Rtc, RtcError};
+use str0m::{
+    net::Receive, Candidate, CandidateProtocol, Event, IceConnectionState, Input, Output, Rtc,
+    RtcError,
+};
 
 mod util;
 
@@ -87,7 +89,7 @@ fn web_request(request: &Request, addr: SocketAddr, tx: SyncSender<Rtc>) -> Resp
         .build();
 
     // Add the shared UDP socket as a host candidate
-    let candidate = Candidate::host(addr).expect("a host candidate");
+    let candidate = Candidate::host(addr, CandidateProtocol::Udp).expect("a host candidate");
     rtc.add_local_candidate(candidate);
 
     // Create an SDP Answer.
@@ -240,6 +242,7 @@ fn read_socket_input<'a>(socket: &UdpSocket, buf: &'a mut Vec<u8>) -> Option<Inp
             return Some(Input::Receive(
                 Instant::now(),
                 Receive {
+                    proto: CandidateProtocol::Udp,
                     source,
                     destination: socket.local_addr().unwrap(),
                     contents,

--- a/examples/http-post.rs
+++ b/examples/http-post.rs
@@ -12,8 +12,9 @@ use rouille::{Request, Response};
 
 use str0m::change::SdpOffer;
 use str0m::net::Receive;
-use str0m::IceConnectionState;
-use str0m::{Candidate, Event, Input, Output, Rtc, RtcError};
+use str0m::{
+    Candidate, CandidateProtocol, Event, IceConnectionState, Input, Output, Rtc, RtcError,
+};
 
 mod util;
 
@@ -62,7 +63,7 @@ fn web_request(request: &Request) -> Response {
     // Spin up a UDP socket for the RTC
     let socket = UdpSocket::bind(format!("{addr}:0")).expect("binding a random UDP port");
     let addr = socket.local_addr().expect("a local socket adddress");
-    let candidate = Candidate::host(addr).expect("a host candidate");
+    let candidate = Candidate::host(addr, CandidateProtocol::Udp).expect("a host candidate");
     rtc.add_local_candidate(candidate);
 
     // Create an SDP Answer.
@@ -124,6 +125,7 @@ fn run(mut rtc: Rtc, socket: UdpSocket) -> Result<(), RtcError> {
                 Input::Receive(
                     Instant::now(),
                     Receive {
+                        proto: CandidateProtocol::Udp,
                         source,
                         destination: socket.local_addr().unwrap(),
                         contents: buf.as_slice().try_into()?,

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -32,7 +32,7 @@ pub struct Candidate {
     component_id: u16, // 1 for RTP, 2 for RTCP
 
     /// Protocol for the candidate.
-    proto: String, // "udp" or "tcp"
+    proto: CandidateProtocol,
 
     /// Priority.
     ///
@@ -80,7 +80,7 @@ pub struct Candidate {
 
 impl fmt::Debug for Candidate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Candidate({}={}", self.kind, self.addr)?;
+        write!(f, "Candidate({}={}/{}", self.kind, self.addr, self.proto)?;
         if let Some(base) = self.base {
             if base != self.addr {
                 write!(f, " base={base}")?;
@@ -102,7 +102,7 @@ impl Candidate {
     fn new(
         foundation: Option<String>,
         component_id: u16,
-        proto: String,
+        proto: CandidateProtocol,
         prio: Option<u32>,
         addr: SocketAddr,
         base: Option<SocketAddr>,
@@ -130,7 +130,7 @@ impl Candidate {
     pub fn parsed(
         foundation: String,
         component_id: u16,
-        proto: String,
+        proto: CandidateProtocol,
         prio: u32,
         addr: SocketAddr,
         kind: CandidateKind,
@@ -153,7 +153,7 @@ impl Candidate {
     /// Creates a host ICE candidate.
     ///
     /// Host candidates are local sockets directly on the host.
-    pub fn host(addr: SocketAddr) -> Result<Self, IceError> {
+    pub fn host(addr: SocketAddr, proto: CandidateProtocol) -> Result<Self, IceError> {
         if !is_valid_ip(addr.ip()) {
             return Err(IceError::BadCandidate(format!("invalid ip {}", addr.ip())));
         }
@@ -161,7 +161,7 @@ impl Candidate {
         Ok(Candidate::new(
             None,
             1, // only RTP
-            "udp".into(),
+            proto,
             None,
             addr,
             Some(addr),
@@ -175,7 +175,7 @@ impl Candidate {
     ///
     /// Server reflexive candidates are local sockets mapped to external ip discovered
     /// via a STUN binding request.
-    pub fn server_reflexive(addr: SocketAddr) -> Result<Self, IceError> {
+    pub fn server_reflexive(addr: SocketAddr, proto: CandidateProtocol) -> Result<Self, IceError> {
         if !is_valid_ip(addr.ip()) {
             return Err(IceError::BadCandidate(format!("invalid ip {}", addr.ip())));
         }
@@ -183,7 +183,7 @@ impl Candidate {
         Ok(Candidate::new(
             None,
             1, // only RTP
-            "udp".into(),
+            proto,
             None,
             addr,
             Some(addr),
@@ -205,7 +205,7 @@ impl Candidate {
         Ok(Candidate::new(
             None,
             1, // only RTP
-            network_type.into(),
+            network_type.try_into()?,
             None,
             addr,
             Some(addr),
@@ -221,6 +221,7 @@ impl Candidate {
     /// binding responses. `addr` is the discovered address. `base` is the local
     /// (host) address inside the NAT we used to get this response.
     pub(crate) fn peer_reflexive(
+        proto: CandidateProtocol,
         addr: SocketAddr,
         base: SocketAddr,
         prio: u32,
@@ -230,7 +231,7 @@ impl Candidate {
         Candidate::new(
             found,
             1, // only RTP
-            "udp".into(),
+            proto,
             Some(prio),
             addr,
             Some(base),
@@ -241,11 +242,15 @@ impl Candidate {
     }
 
     #[cfg(test)]
-    pub(crate) fn test_peer_rflx(addr: SocketAddr, base: SocketAddr) -> Self {
+    pub(crate) fn test_peer_rflx(
+        addr: SocketAddr,
+        base: SocketAddr,
+        proto: CandidateProtocol,
+    ) -> Self {
         Candidate::new(
             None,
             1, // only RTP
-            "udp".into(),
+            proto,
             None,
             addr,
             Some(base),
@@ -307,18 +312,26 @@ impl Candidate {
             return *prio;
         }
 
-        // The RECOMMENDED values for type preferences are 126 for host
-        // candidates, 110 for peer-reflexive candidates, 100 for server-
-        // reflexive candidates, and 0 for relayed candidates.
-        let type_preference = if as_prflx {
-            110
+        let kind = if as_prflx {
+            CandidateKind::PeerReflexive
         } else {
-            match self.kind {
-                CandidateKind::Host => 126,
-                CandidateKind::PeerReflexive => 110,
-                CandidateKind::ServerReflexive => 100,
-                CandidateKind::Relayed => 0,
-            }
+            self.kind
+        };
+
+        // Per RFC5245 Sec. 4.1.2.1, the RECOMMENDED values for type preferences are
+        // 126 for host candidates, 110 for peer-reflexive candidates, 100 for
+        // server-reflexive candidates, and 0 for relayed candidates. The variations
+        // for non-UDP protocols are taken from libwebrtc:
+        // <https://webrtc.googlesource.com/src/+/refs/heads/main/p2p/base/port.h#68>
+        let type_preference = match (kind, self.proto) {
+            (CandidateKind::Host, CandidateProtocol::Udp) => 126,
+            (CandidateKind::PeerReflexive, CandidateProtocol::Udp) => 110,
+            (CandidateKind::ServerReflexive, _) => 100,
+            (CandidateKind::Host, _) => 90,
+            (CandidateKind::PeerReflexive, _) => 80,
+            (CandidateKind::Relayed, CandidateProtocol::Udp) => 2,
+            (CandidateKind::Relayed, CandidateProtocol::Tcp) => 1,
+            (CandidateKind::Relayed, _) => 0,
         };
 
         // The recommended formula combines a preference for the candidate type
@@ -355,8 +368,8 @@ impl Candidate {
 
     /// Returns a reference to the String containing the transport protocol of
     /// the ICE candidate. For example tcp/udp/..
-    pub fn proto(&self) -> &String {
-        &self.proto
+    pub fn proto(&self) -> CandidateProtocol {
+        self.proto
     }
 
     pub(crate) fn base(&self) -> SocketAddr {
@@ -418,6 +431,57 @@ impl fmt::Display for CandidateKind {
             CandidateKind::ServerReflexive => "srflx",
             CandidateKind::Relayed => "relay",
         };
+        write!(f, "{x}")
+    }
+}
+
+/// Type of candidate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CandidateProtocol {
+    /// UDP
+    Udp,
+    /// TCP (See RFC 4571 for framing)
+    Tcp,
+    /// TCP with fixed SSL Hello Exchange
+    /// See AsyncSSLServerSocket implementation for exchange details:
+    /// <https://webrtc.googlesource.com/src/+/refs/heads/main/rtc_base/server_socket_adapters.cc#19>
+    SslTcp,
+    /// TLS (only used via relay)
+    Tls,
+}
+
+impl TryFrom<&str> for CandidateProtocol {
+    type Error = IceError;
+
+    fn try_from(proto: &str) -> Result<Self, Self::Error> {
+        let proto = proto.to_lowercase();
+        match proto.as_str() {
+            "udp" => Ok(CandidateProtocol::Udp),
+            "tcp" => Ok(CandidateProtocol::Tcp),
+            "ssltcp" => Ok(CandidateProtocol::SslTcp),
+            "tls" => Ok(CandidateProtocol::Tls),
+            _ => Err(IceError::BadCandidate(format!(
+                "invalid protocol {}",
+                proto
+            ))),
+        }
+    }
+}
+
+impl From<CandidateProtocol> for &str {
+    fn from(proto: CandidateProtocol) -> Self {
+        match proto {
+            CandidateProtocol::Udp => "udp",
+            CandidateProtocol::Tcp => "tcp",
+            CandidateProtocol::SslTcp => "ssltcp",
+            CandidateProtocol::Tls => "tls",
+        }
+    }
+}
+
+impl fmt::Display for CandidateProtocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let x: &str = (*self).into();
         write!(f, "{x}")
     }
 }

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -8,7 +8,7 @@ pub(crate) use agent::{IceAgent, IceAgentEvent};
 pub use agent::{IceConnectionState, IceCreds};
 
 mod candidate;
-pub use candidate::{Candidate, CandidateKind};
+pub use candidate::{Candidate, CandidateKind, CandidateProtocol};
 
 mod pair;
 
@@ -30,10 +30,10 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = host("1.1.1.1:9999"); // 9999 is just dropped by propagate
+        let c1 = host("1.1.1.1:9999", CandidateProtocol::Udp); // 9999 is just dropped by propagate
         a1.add_local_candidate(c1.clone());
         a2.add_remote_candidate(c1);
-        let c2 = host("2.2.2.2:1000");
+        let c2 = host("2.2.2.2:1000", CandidateProtocol::Udp);
         a2.add_local_candidate(c2.clone());
         a1.add_remote_candidate(c2);
         a1.set_controlling(true);
@@ -82,8 +82,8 @@ mod test {
         s.parse().unwrap()
     }
 
-    pub fn host(s: impl Into<String>) -> Candidate {
-        Candidate::host(sock(s)).unwrap()
+    pub fn host(s: impl Into<String>, proto: CandidateProtocol) -> Candidate {
+        Candidate::host(sock(s), proto).unwrap()
     }
 
     /// Transform the socket to rig different test scenarios.
@@ -139,10 +139,10 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = host("1.1.1.1:1000");
+        let c1 = host("1.1.1.1:1000", CandidateProtocol::Udp);
         a1.add_local_candidate(c1.clone());
         a2.add_remote_candidate(c1);
-        let c2 = host("2.2.2.2:1000");
+        let c2 = host("2.2.2.2:1000", CandidateProtocol::Udp);
         a2.add_local_candidate(c2.clone());
         a1.add_remote_candidate(c2);
 
@@ -210,10 +210,10 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = host("1.1.1.1:1000");
+        let c1 = host("1.1.1.1:1000", CandidateProtocol::Udp);
         a1.add_local_candidate(c1.clone());
         a2.add_remote_candidate(c1);
-        let c2 = host("2.2.2.2:1000");
+        let c2 = host("2.2.2.2:1000", CandidateProtocol::Udp);
         a2.add_local_candidate(c2.clone());
         a1.add_remote_candidate(c2);
         a1.set_controlling(true);
@@ -257,10 +257,10 @@ mod test {
         // a1 acts as "server"
         a1.agent.set_ice_lite(true);
 
-        let c1 = host("1.1.1.1:9999"); // 9999 is just dropped by propagate
+        let c1 = host("1.1.1.1:9999", CandidateProtocol::Udp); // 9999 is just dropped by propagate
         a1.add_local_candidate(c1.clone());
         a2.add_remote_candidate(c1);
-        let c2 = host("2.2.2.2:1000");
+        let c2 = host("2.2.2.2:1000", CandidateProtocol::Udp);
         a2.add_local_candidate(c2.clone());
         a1.add_remote_candidate(c2);
         a1.set_controlling(true);
@@ -305,10 +305,10 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = host("3.3.3.3:1000"); // will be rewritten to 4.4.4.4
+        let c1 = host("3.3.3.3:1000", CandidateProtocol::Udp); // will be rewritten to 4.4.4.4
         a1.add_local_candidate(c1.clone());
         a2.add_remote_candidate(c1);
-        let c2 = host("2.2.2.2:1000");
+        let c2 = host("2.2.2.2:1000", CandidateProtocol::Udp);
         a2.add_local_candidate(c2.clone());
         a1.add_remote_candidate(c2);
 
@@ -366,10 +366,10 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = host("1.1.1.1:1000");
+        let c1 = host("1.1.1.1:1000", CandidateProtocol::Udp);
         a1.add_local_candidate(c1.clone());
         a2.add_remote_candidate(c1.clone());
-        let c2 = host("2.2.2.2:1000");
+        let c2 = host("2.2.2.2:1000", CandidateProtocol::Udp);
         a2.add_local_candidate(c2.clone());
         a1.add_remote_candidate(c2.clone());
 
@@ -417,10 +417,10 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = host("3.3.3.3:9999"); // no traffic possible
+        let c1 = host("3.3.3.3:9999", CandidateProtocol::Udp); // no traffic possible
         a1.add_local_candidate(c1.clone());
         a2.add_remote_candidate(c1);
-        let c2 = host("2.2.2.2:1000");
+        let c2 = host("2.2.2.2:1000", CandidateProtocol::Udp);
         a2.add_local_candidate(c2.clone());
         a1.add_remote_candidate(c2);
 
@@ -433,7 +433,7 @@ mod test {
         }
 
         // "trickle" a possible candidate
-        a1.add_local_candidate(host("1.1.1.1:1000")); // possible
+        a1.add_local_candidate(host("1.1.1.1:1000", CandidateProtocol::Udp)); // possible
 
         // loop until we're connected.
         loop {

--- a/src/sdp/parser.rs
+++ b/src/sdp/parser.rs
@@ -242,7 +242,11 @@ where
                     .map_err(StreamErrorFor::<Input>::message_format)
             }),
             token(' '),
-            not_sp(),
+            not_sp().and_then(|s| {
+                s.as_str()
+                    .try_into()
+                    .map_err(StreamErrorFor::<Input>::message_format)
+            }),
             token(' '),
             not_sp().and_then(|s| {
                 s.parse::<u32>()

--- a/tests/bidirectional.rs
+++ b/tests/bidirectional.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use str0m::format::Codec;
 use str0m::media::{Direction, MediaKind};
-use str0m::{Candidate, Event, RtcError};
+use str0m::{Candidate, CandidateProtocol, Event, RtcError};
 use tracing::info_span;
 
 mod common;
@@ -16,8 +16,14 @@ pub fn bidirectional_same_m_line() -> Result<(), RtcError> {
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into())?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into())?;
+    let host1 = Candidate::host(
+        (Ipv4Addr::new(1, 1, 1, 1), 1000).into(),
+        CandidateProtocol::Udp,
+    )?;
+    let host2 = Candidate::host(
+        (Ipv4Addr::new(2, 2, 2, 2), 2000).into(),
+        CandidateProtocol::Udp,
+    )?;
     l.add_local_candidate(host1);
     r.add_local_candidate(host2);
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -13,7 +13,7 @@ use str0m::format::PayloadParams;
 use str0m::net::Receive;
 use str0m::rtp::ExtensionMap;
 use str0m::rtp::RtpHeader;
-use str0m::Candidate;
+use str0m::{Candidate, CandidateProtocol};
 use str0m::{Event, Input, Output, Rtc, RtcError};
 use tracing::info_span;
 use tracing::Span;
@@ -81,6 +81,7 @@ pub fn progress(l: &mut TestRtc, r: &mut TestRtc) -> Result<(), RtcError> {
                 let input = Input::Receive(
                     f.last,
                     Receive {
+                        proto: v.proto,
                         source: v.source,
                         destination: v.destination,
                         contents: (&*data).try_into()?,
@@ -121,6 +122,7 @@ pub fn progress_with_loss(l: &mut TestRtc, r: &mut TestRtc, loss: f32) -> Result
                 let input = Input::Receive(
                     f.last,
                     Receive {
+                        proto: v.proto,
                         source: v.source,
                         destination: v.destination,
                         contents: (&*data).try_into()?,
@@ -217,8 +219,16 @@ pub fn connect_l_r() -> (TestRtc, TestRtc) {
     let mut l = TestRtc::new_with_rtc(info_span!("L"), rtc1);
     let mut r = TestRtc::new_with_rtc(info_span!("R"), rtc2);
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into()).unwrap();
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into()).unwrap();
+    let host1 = Candidate::host(
+        (Ipv4Addr::new(1, 1, 1, 1), 1000).into(),
+        CandidateProtocol::Udp,
+    )
+    .unwrap();
+    let host2 = Candidate::host(
+        (Ipv4Addr::new(2, 2, 2, 2), 2000).into(),
+        CandidateProtocol::Udp,
+    )
+    .unwrap();
     l.add_local_candidate(host1.clone());
     l.add_remote_candidate(host2.clone());
     r.add_local_candidate(host2);

--- a/tests/contiguous.rs
+++ b/tests/contiguous.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use str0m::format::Codec;
 use str0m::media::{Direction, MediaKind};
-use str0m::Rtc;
 use str0m::{Candidate, Event, RtcError};
+use str0m::{CandidateProtocol, Rtc};
 use tracing::info_span;
 
 mod common;
@@ -18,8 +18,14 @@ pub fn contiguous_all_the_way() -> Result<(), RtcError> {
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into())?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into())?;
+    let host1 = Candidate::host(
+        (Ipv4Addr::new(1, 1, 1, 1), 1000).into(),
+        CandidateProtocol::Udp,
+    )?;
+    let host2 = Candidate::host(
+        (Ipv4Addr::new(2, 2, 2, 2), 2000).into(),
+        CandidateProtocol::Udp,
+    )?;
     l.add_local_candidate(host1);
     r.add_local_candidate(host2);
 
@@ -114,8 +120,14 @@ pub fn not_contiguous() -> Result<(), RtcError> {
 
     let mut r = TestRtc::new_with_rtc(info_span!("R"), rtc_r);
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into())?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into())?;
+    let host1 = Candidate::host(
+        (Ipv4Addr::new(1, 1, 1, 1), 1000).into(),
+        CandidateProtocol::Udp,
+    )?;
+    let host2 = Candidate::host(
+        (Ipv4Addr::new(2, 2, 2, 2), 2000).into(),
+        CandidateProtocol::Udp,
+    )?;
     l.add_local_candidate(host1);
     r.add_local_candidate(host2);
 

--- a/tests/data-channel-direct.rs
+++ b/tests/data-channel-direct.rs
@@ -2,7 +2,7 @@ use std::net::Ipv4Addr;
 use std::time::Duration;
 
 use str0m::channel::ChannelConfig;
-use str0m::{Candidate, Event, RtcConfig, RtcError};
+use str0m::{Candidate, CandidateProtocol, Event, RtcConfig, RtcError};
 use tracing::info_span;
 
 mod common;
@@ -17,8 +17,14 @@ pub fn data_channel_direct() -> Result<(), RtcError> {
     let rtc_r = RtcConfig::new().set_ice_lite(true).build();
     let mut r = TestRtc::new_with_rtc(info_span!("R"), rtc_r);
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into())?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into())?;
+    let host1 = Candidate::host(
+        (Ipv4Addr::new(1, 1, 1, 1), 1000).into(),
+        CandidateProtocol::Udp,
+    )?;
+    let host2 = Candidate::host(
+        (Ipv4Addr::new(2, 2, 2, 2), 2000).into(),
+        CandidateProtocol::Udp,
+    )?;
     l.add_local_candidate(host1.clone());
     l.add_remote_candidate(host2.clone());
     r.add_local_candidate(host2);

--- a/tests/data-channel.rs
+++ b/tests/data-channel.rs
@@ -1,7 +1,7 @@
 use std::net::Ipv4Addr;
 use std::time::Duration;
 
-use str0m::{Candidate, RtcError};
+use str0m::{Candidate, CandidateProtocol, RtcError};
 use tracing::info_span;
 
 mod common;
@@ -14,8 +14,14 @@ pub fn data_channel() -> Result<(), RtcError> {
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into())?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into())?;
+    let host1 = Candidate::host(
+        (Ipv4Addr::new(1, 1, 1, 1), 1000).into(),
+        CandidateProtocol::Udp,
+    )?;
+    let host2 = Candidate::host(
+        (Ipv4Addr::new(2, 2, 2, 2), 2000).into(),
+        CandidateProtocol::Udp,
+    )?;
     l.add_local_candidate(host1);
     r.add_local_candidate(host2);
 

--- a/tests/flappy-ice-state.rs
+++ b/tests/flappy-ice-state.rs
@@ -1,8 +1,8 @@
 use std::net::Ipv4Addr;
 use std::time::Duration;
 
-use str0m::RtcConfig;
 use str0m::{Candidate, Event, RtcError};
+use str0m::{CandidateProtocol, RtcConfig};
 use tracing::info_span;
 
 mod common;
@@ -17,8 +17,14 @@ pub fn flappy_ice_lite_state() -> Result<(), RtcError> {
     let rtc = RtcConfig::new().set_ice_lite(true).build();
     let mut r = TestRtc::new_with_rtc(info_span!("R"), rtc);
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into())?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into())?;
+    let host1 = Candidate::host(
+        (Ipv4Addr::new(1, 1, 1, 1), 1000).into(),
+        CandidateProtocol::Udp,
+    )?;
+    let host2 = Candidate::host(
+        (Ipv4Addr::new(2, 2, 2, 2), 2000).into(),
+        CandidateProtocol::Udp,
+    )?;
     l.add_local_candidate(host1);
     r.add_local_candidate(host2);
 

--- a/tests/ice-restart.rs
+++ b/tests/ice-restart.rs
@@ -1,8 +1,8 @@
 use std::net::Ipv4Addr;
 use std::time::Duration;
 
-use str0m::RtcConfig;
 use str0m::{Candidate, RtcError};
+use str0m::{CandidateProtocol, RtcConfig};
 use tracing::info_span;
 
 mod common;
@@ -17,8 +17,14 @@ pub fn ice_restart() -> Result<(), RtcError> {
     let rtc = RtcConfig::new().set_ice_lite(true).build();
     let mut r = TestRtc::new_with_rtc(info_span!("R"), rtc);
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into())?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into())?;
+    let host1 = Candidate::host(
+        (Ipv4Addr::new(1, 1, 1, 1), 1000).into(),
+        CandidateProtocol::Udp,
+    )?;
+    let host2 = Candidate::host(
+        (Ipv4Addr::new(2, 2, 2, 2), 2000).into(),
+        CandidateProtocol::Udp,
+    )?;
     l.add_local_candidate(host1);
     r.add_local_candidate(host2);
 

--- a/tests/stats.rs
+++ b/tests/stats.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use str0m::format::Codec;
 use str0m::media::{Direction, MediaKind};
 use str0m::stats::MediaEgressStats;
-use str0m::{Candidate, Event, RtcConfig, RtcError};
+use str0m::{Candidate, CandidateProtocol, Event, RtcConfig, RtcError};
 use tracing::info_span;
 
 mod common;
@@ -20,8 +20,14 @@ pub fn stats() -> Result<(), RtcError> {
     let mut l = TestRtc::new_with_rtc(info_span!("L"), l_config.build());
     let mut r = TestRtc::new_with_rtc(info_span!("R"), r_config.build());
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into())?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into())?;
+    let host1 = Candidate::host(
+        (Ipv4Addr::new(1, 1, 1, 1), 1000).into(),
+        CandidateProtocol::Udp,
+    )?;
+    let host2 = Candidate::host(
+        (Ipv4Addr::new(2, 2, 2, 2), 2000).into(),
+        CandidateProtocol::Udp,
+    )?;
     l.add_local_candidate(host1);
     r.add_local_candidate(host2);
 

--- a/tests/twcc.rs
+++ b/tests/twcc.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use str0m::format::Codec;
 use str0m::media::{Direction, MediaKind};
 use str0m::rtp::rtcp::Twcc;
-use str0m::{Candidate, Rtc, RtcError};
+use str0m::{Candidate, CandidateProtocol, Rtc, RtcError};
 use tracing::info_span;
 
 mod common;
@@ -19,8 +19,14 @@ pub fn twcc() -> Result<(), RtcError> {
     let mut l = TestRtc::new_with_rtc(info_span!("L"), l_rtc);
     let mut r = TestRtc::new_with_rtc(info_span!("R"), r_rtc);
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into())?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into())?;
+    let host1 = Candidate::host(
+        (Ipv4Addr::new(1, 1, 1, 1), 1000).into(),
+        CandidateProtocol::Udp,
+    )?;
+    let host2 = Candidate::host(
+        (Ipv4Addr::new(2, 2, 2, 2), 2000).into(),
+        CandidateProtocol::Udp,
+    )?;
     l.add_local_candidate(host1);
     r.add_local_candidate(host2);
 

--- a/tests/unidirectional-r-create-media.rs
+++ b/tests/unidirectional-r-create-media.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use str0m::change::SdpOffer;
 use str0m::format::Codec;
 use str0m::media::{Direction, MediaKind};
-use str0m::{Candidate, Event, RtcError};
+use str0m::{Candidate, CandidateProtocol, Event, RtcError};
 use tracing::info_span;
 
 mod common;
@@ -17,8 +17,14 @@ pub fn unidirectional_r_create_media() -> Result<(), RtcError> {
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into())?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into())?;
+    let host1 = Candidate::host(
+        (Ipv4Addr::new(1, 1, 1, 1), 1000).into(),
+        CandidateProtocol::Udp,
+    )?;
+    let host2 = Candidate::host(
+        (Ipv4Addr::new(2, 2, 2, 2), 2000).into(),
+        CandidateProtocol::Udp,
+    )?;
     l.add_local_candidate(host1);
     r.add_local_candidate(host2);
 

--- a/tests/unidirectional.rs
+++ b/tests/unidirectional.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use str0m::format::Codec;
 use str0m::media::{Direction, MediaKind};
-use str0m::{Candidate, Event, RtcError};
+use str0m::{Candidate, CandidateProtocol, Event, RtcError};
 use tracing::info_span;
 
 mod common;
@@ -16,8 +16,14 @@ pub fn unidirectional() -> Result<(), RtcError> {
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into())?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into())?;
+    let host1 = Candidate::host(
+        (Ipv4Addr::new(1, 1, 1, 1), 1000).into(),
+        CandidateProtocol::Udp,
+    )?;
+    let host2 = Candidate::host(
+        (Ipv4Addr::new(2, 2, 2, 2), 2000).into(),
+        CandidateProtocol::Udp,
+    )?;
     l.add_local_candidate(host1);
     r.add_local_candidate(host2);
 

--- a/tests/user-rtp-header-extension.rs
+++ b/tests/user-rtp-header-extension.rs
@@ -6,8 +6,8 @@ use str0m::media::{Direction, MediaKind};
 use str0m::rtp::Extension;
 use str0m::rtp::ExtensionSerializer;
 use str0m::rtp::ExtensionValues;
-use str0m::Rtc;
 use str0m::{Candidate, Event, RtcError};
+use str0m::{CandidateProtocol, Rtc};
 use tracing::info_span;
 
 mod common;
@@ -80,8 +80,14 @@ pub fn user_rtp_header_extension() -> Result<(), RtcError> {
     let mut l = TestRtc::new_with_rtc(info_span!("L"), rtc_l);
     let mut r = TestRtc::new_with_rtc(info_span!("R"), rtc_r);
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into())?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into())?;
+    let host1 = Candidate::host(
+        (Ipv4Addr::new(1, 1, 1, 1), 1000).into(),
+        CandidateProtocol::Udp,
+    )?;
+    let host2 = Candidate::host(
+        (Ipv4Addr::new(2, 2, 2, 2), 2000).into(),
+        CandidateProtocol::Udp,
+    )?;
     l.add_local_candidate(host1);
     r.add_local_candidate(host2);
 


### PR DESCRIPTION
With this change it is possible to have UDP and TCP candidates that use the same port number, as well as, the ability to create non-UDP host candidates manually (via the Candidate::host function.

Synopsis of the changes:
- proto on Candidate has been change from a String to an enum CandidateProtocol
- Functions that create Candidates now take the CandidateProtocol, rather than sometimes simply using "udp"
- do_prio() in Candidate now takes into account protocol as well as candidate type. This matches libwebtc values.
- Candidates are now considered redundant only if the old rules that were applied are still true, and the protos match
- Candidates being placed in pairs, must have the same protocol
- StunRequest, NominatedSend, DiscoveredRecv, Receive, Transmit all now includes protocol the Candidate used in addition to the address(es).
