### PR TITLE
Send unpaced media as padding.

### DIFF
--- a/src/packet/pacer.rs
+++ b/src/packet/pacer.rs
@@ -431,7 +431,7 @@ impl LeakyBucketPacer {
             .filter_map(|qs| (qs.snapshot.first_unsent.map(|t| (t, qs))))
             .min_by_key(|(t, _)| *t);
 
-        // Unpaced packets (such as audio buy default) are sent immediately.
+        // Unpaced packets (such as audio by default) are sent immediately.
         if let Some((queued_at, qs)) = unpaced {
             return Some((queued_at, Some(qs)));
         }

--- a/src/packet/pacer.rs
+++ b/src/packet/pacer.rs
@@ -436,18 +436,11 @@ impl LeakyBucketPacer {
             return Some((queued_at, Some(qs)));
         }
 
-        // "Media queue" as opposed to a "padding queue".
         let non_empty_queue = {
-            let non_empty_queues = self.queue_states.iter().filter(|q| {
-                let is_none_empty_queue = match q.snapshot.priority {
-                    QueuePriority::Media => true,
-                    // TODO: Try changing this to false.  Currently, if it's false, the test_realistic test fails.
-                    QueuePriority::Padding => true,
-                    // TODO: Try removing "q.snapshot.packet_count > 0" and using "QueuePriority::Empty => false" instead
-                    QueuePriority::Empty => true,
-                };
-                q.snapshot.packet_count > 0 && is_none_empty_queue
-            });
+            let non_empty_queues = self
+                .queue_states
+                .iter()
+                .filter(|q| q.snapshot.packet_count > 0);
 
             // Send on the non-empty queue with the lowest priority that, was least recently
             // sent on.


### PR DESCRIPTION
This prevents a hot loop when you enable RTX for audio and BWE/pacing at the same time without having to know to call .set_unpaced(false) for the audio.