### PR TITLE
Add proto to Transmit debug

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -217,6 +217,7 @@ impl<'a> TryFrom<&'a Transmit> for Receive<'a> {
 impl fmt::Debug for Transmit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Transmit")
+            .field("proto", &self.proto)
             .field("source", &self.source)
             .field("destination", &self.destination)
             .field("len", &self.contents.len())


### PR DESCRIPTION
when debugging ice connectivity check when running str0m as a client I noticed proto was missing from debug of transmit.