### PR TITLE
Serialize/Deserialize Candidate

### DIFF
--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -503,13 +503,13 @@ impl fmt::Display for Candidate {
 
 /// Serialize [Candidate] into trickle ICE candidate format.
 ///
-/// Always set `sdpMid` to "" and `sdpMLineIndex` to 0, as we only support one media line.
+/// Always set `sdpMid` to null and `sdpMLineIndex` to 0, as we only support one media line.
 ///
 /// e.g. serde_json would produce:
 /// ```json
 /// {
 ///  "candidate": "candidate:12044049749558888150 1 udp 2130706175 1.2.3.4 1234 typ host",
-///  "sdpMid": "",
+///  "sdpMid": null,
 ///  "sdpMLineIndex": 0
 ///  "usernameFragment": "ufrag"
 /// }
@@ -521,7 +521,7 @@ impl Serialize for Candidate {
     {
         let mut o = serializer.serialize_struct("Candidate", 4)?;
         o.serialize_field("candidate", &self.to_sdp_string(false))?;
-        o.serialize_field("sdpMid", "")?;
+        o.serialize_field("sdpMid", &None::<()>)?;
         o.serialize_field("sdpMLineIndex", &0)?;
         o.serialize_field("usernameFragment", &self.ufrag())?;
         o.end()
@@ -665,14 +665,14 @@ mod tests {
         let mut candidate = Candidate::host(socket_addr, Protocol::Udp).unwrap();
         assert_eq!(
             serde_json::to_string(&candidate).unwrap(),
-            r#"{"candidate":"candidate:12044049749558888150 1 udp 2130706175 1.2.3.4 9876 typ host","sdpMid":"","sdpMLineIndex":0,"usernameFragment":null}"#
+            r#"{"candidate":"candidate:12044049749558888150 1 udp 2130706175 1.2.3.4 9876 typ host","sdpMid":null,"sdpMLineIndex":0,"usernameFragment":null}"#
         );
 
         // Add a username fragment
         candidate.ufrag = Some("ufrag".to_string());
         assert_eq!(
             serde_json::to_string(&candidate).unwrap(),
-            r#"{"candidate":"candidate:12044049749558888150 1 udp 2130706175 1.2.3.4 9876 typ host ufrag ufrag","sdpMid":"","sdpMLineIndex":0,"usernameFragment":"ufrag"}"#
+            r#"{"candidate":"candidate:12044049749558888150 1 udp 2130706175 1.2.3.4 9876 typ host ufrag ufrag","sdpMid":null,"sdpMLineIndex":0,"usernameFragment":"ufrag"}"#
         );
     }
 

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -1,6 +1,6 @@
 use super::IceError;
 use crate::io::Protocol;
-use crate::sdp::parse_candidate_attribute;
+use crate::sdp::parse_candidate;
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize, Serializer};
 use std::collections::hash_map::DefaultHasher;
@@ -222,7 +222,7 @@ impl Candidate {
 
     /// Creates a new ICE candidate from a string.
     pub fn from_sdp_string(s: &str) -> Result<Self, IceError> {
-        parse_candidate_attribute(s).map_err(|e| IceError::BadCandidate(format!("{}: {}", s, e)))
+        parse_candidate(s).map_err(|e| IceError::BadCandidate(format!("{}: {}", s, e)))
     }
 
     /// Creates a peer reflexive ICE candidate.
@@ -419,7 +419,7 @@ impl Candidate {
         self.ufrag = None;
     }
 
-    /// Generates a String representation of the candidate attribute.
+    /// Generates a candidate attribute string.
     pub fn to_sdp_string(&self) -> String {
         let mut s = format!(
             "candidate:{} {} {} {} {} {} typ {}",
@@ -438,6 +438,12 @@ impl Candidate {
             s.push_str(&format!(" ufrag {}", ufrag));
         }
         s
+    }
+}
+
+impl fmt::Display for Candidate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_sdp_string())
     }
 }
 
@@ -478,13 +484,6 @@ fn is_valid_ip(ip: IpAddr) -> bool {
             !v.is_link_local() && !v.is_broadcast() && !v.is_multicast() && !v.is_unspecified()
         }
         IpAddr::V6(v) => !v.is_multicast() && !v.is_unspecified(),
-    }
-}
-
-// TODO: maybe a bit strange this is used for SDP serializing?
-impl fmt::Display for Candidate {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.to_sdp_string())
     }
 }
 

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -429,7 +429,7 @@ impl Candidate {
     /// Generates a String representation of the candidate.
     ///
     /// Specifying m_line will prefix the candidate with "a=" and add a trailing "\r\n".
-    pub(crate) fn to_ice_string(&self, m_line: bool) -> String {
+    pub fn to_ice_string(&self, m_line: bool) -> String {
         let attribute = if m_line { "a=" } else { "" };
         let mut s = format!(
             "{attribute}candidate:{} {} {} {} {} {} typ {}",

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -223,6 +223,7 @@ impl Candidate {
         ))
     }
 
+    /// Creates a new ICE candidate from a string.
     pub fn new_from_ice_string(s: &str) -> Result<Self, IceError> {
         let (c, _) = trickle_candidate_parser()
             .parse(s)

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -223,6 +223,14 @@ impl Candidate {
         ))
     }
 
+    pub fn new_from_ice_string(s: &str) -> Result<Self, IceError> {
+        let (c, _) = trickle_candidate_parser()
+            .parse(s)
+            .map_err(|e| IceError::BadCandidate(format!("{}: {}", s, e)))?;
+
+        Ok(c)
+    }
+
     /// Creates a peer reflexive ICE candidate.
     ///
     /// Peer reflexive candidates are NAT:ed addresses discovered via STUN

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -451,14 +451,6 @@ impl Candidate {
         }
         s
     }
-
-    pub fn new_from_ice_string(s: &str) -> Result<Self, IceError> {
-        let (c, _) = trickle_candidate_parser()
-            .parse(s)
-            .map_err(|e| IceError::BadCandidate(format!("{}: {}", s, e)))?;
-
-        Ok(c)
-    }
 }
 
 fn parse_proto(proto: impl TryInto<Protocol>) -> Result<Protocol, IceError> {

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -691,23 +691,24 @@ mod tests {
         let mut candidate = Candidate::host(socket_addr, Protocol::Udp).unwrap();
         assert_eq!(
             candidate.to_string(),
-            "a=candidate:12044049749558888150 1 udp 2130706175 1.2.3.4 9876 typ host\r\n"
+            "candidate:12044049749558888150 1 udp 2130706175 1.2.3.4 9876 typ host"
         );
 
         candidate.ufrag = Some("ufrag".into());
         assert_eq!(
             candidate.to_string(),
-            "a=candidate:12044049749558888150 1 udp 2130706175 1.2.3.4 9876 typ host ufrag ufrag\r\n");
+            "candidate:12044049749558888150 1 udp 2130706175 1.2.3.4 9876 typ host ufrag ufrag"
+        );
 
         candidate.raddr = Some("5.5.5.5:5555".parse().unwrap());
         assert_eq!(
             candidate.to_string(),
-            "a=candidate:6812072969737413130 1 udp 2130706175 1.2.3.4 9876 typ host raddr 5.5.5.5 rport 5555 ufrag ufrag\r\n");
+            "candidate:6812072969737413130 1 udp 2130706175 1.2.3.4 9876 typ host raddr 5.5.5.5 rport 5555 ufrag ufrag");
 
         let candidate = Candidate::relayed(socket_addr, Protocol::SslTcp).unwrap();
         assert_eq!(
             candidate.to_string(),
-            "a=candidate:432709134138909083 1 ssltcp 16776959 1.2.3.4 9876 typ relay\r\n"
+            "candidate:432709134138909083 1 ssltcp 16776959 1.2.3.4 9876 typ relay"
         );
     }
 

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -549,7 +549,7 @@ impl<'de> Deserialize<'de> for Candidate {
         } = CandidateDeserialized::deserialize(deserializer)?;
 
         let mut candidate =
-            Candidate::from_sdp_string(&candidate).map_err(|e| serde::de::Error::custom(e))?;
+            Candidate::from_sdp_string(&candidate).map_err(serde::de::Error::custom)?;
 
         if let Some(ufrag) = username_fragment {
             candidate.set_ufrag(&ufrag);

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -224,7 +224,7 @@ impl Candidate {
     }
 
     /// Creates a new ICE candidate from a string.
-    pub fn new_from_ice_string(s: &str) -> Result<Self, IceError> {
+    pub fn new_from_ice_str(s: &str) -> Result<Self, IceError> {
         let (c, _) = trickle_candidate_parser()
             .parse(s)
             .map_err(|e| IceError::BadCandidate(format!("{}: {}", s, e)))?;
@@ -549,7 +549,7 @@ impl<'de> Deserialize<'de> for Candidate {
         } = CandidateDeserialized::deserialize(deserializer)?;
 
         let mut candidate =
-            Candidate::new_from_ice_string(&candidate).map_err(|e| serde::de::Error::custom(e))?;
+            Candidate::new_from_ice_str(&candidate).map_err(|e| serde::de::Error::custom(e))?;
 
         if let Some(ufrag) = username_fragment {
             candidate.set_ufrag(&ufrag);
@@ -719,7 +719,7 @@ mod tests {
 
     #[test]
     fn new_from_ice_string() {
-        let candidate = Candidate::new_from_ice_string(
+        let candidate = Candidate::new_from_ice_str(
             "candidate:6812072969737413130 1 udp 2130706175 1.2.3.4 9876 typ host ufrag myuserfrag",
         )
         .unwrap();

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -1174,7 +1174,7 @@ impl fmt::Display for SessionAttribute {
                 )?;
             }
             Setup(v) => write!(f, "a=setup:{}\r\n", v.setup_line())?,
-            Candidate(c) => write!(f, "{c}")?,
+            Candidate(c) => write!(f, "a={}\r\n", c.to_sdp_string())?,
             EndOfCandidates => write!(f, "a=end-of-candidates\r\n")?,
             Unused(v) => write!(f, "a={v}\r\n")?,
         }
@@ -1270,7 +1270,7 @@ impl fmt::Display for MediaAttribute {
             RtcpMux => write!(f, "a=rtcp-mux\r\n")?,
             RtcpMuxOnly => write!(f, "a=rtcp-mux-only\r\n")?,
             RtcpRsize => write!(f, "a=rtcp-rsize\r\n")?,
-            Candidate(c) => write!(f, "{c}")?,
+            Candidate(c) => write!(f, "a={}\r\n", c.to_sdp_string())?,
             EndOfCandidates => write!(f, "a=end-of-candidates\r\n")?,
             RtpMap { pt, value: c } => {
                 write!(f, "a=rtpmap:{} {}/{}", pt, c.codec, c.clock_rate)?;

--- a/src/sdp/mod.rs
+++ b/src/sdp/mod.rs
@@ -9,6 +9,7 @@ mod data;
 pub(crate) use data::{FormatParam, Sdp, Session, SessionAttribute, Setup};
 pub(crate) use data::{MediaAttribute, MediaLine, MediaType, Msid, Proto};
 pub(crate) use data::{Simulcast, SimulcastGroups};
+pub(crate) use parser::parse_candidate_attribute;
 
 #[cfg(test)]
 pub(crate) use data::RtpMap;

--- a/src/sdp/mod.rs
+++ b/src/sdp/mod.rs
@@ -9,7 +9,7 @@ mod data;
 pub(crate) use data::{FormatParam, Sdp, Session, SessionAttribute, Setup};
 pub(crate) use data::{MediaAttribute, MediaLine, MediaType, Msid, Proto};
 pub(crate) use data::{Simulcast, SimulcastGroups};
-pub(crate) use parser::parse_candidate_attribute;
+pub(crate) use parser::parse_candidate;
 
 #[cfg(test)]
 pub(crate) use data::RtpMap;


### PR DESCRIPTION
* When used with serde_json, it will generate:
```json
{
  "candidate": "candidate:12044049749558888150 1 udp 2130706175 1.2.3.4 9876 typ host ufrag ufrag",
  "sdpMid": null,
  "sdpMLineIndex": 0,
  "usernameFragment": "ufrag"
}
```
* It will ignore `sdpMid` and `sdpMLineIndex` and set them to null and 0 respectively, because 1) `Candidate` does not store these values, and 2) ICE candidates require them to [not be null](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate/sdpMLineIndex#value)).
* Also add `pub fn from_sdp_string(s: &str)` and `pub fn to_sdp_string(&self) -> String`
* Display/from_str now doesn't return an sdp m-line.