### PR TITLE
Fix SDP for inactive `rid`s

### DIFF
--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -667,14 +667,16 @@ impl From<Direction> for MediaAttribute {
 pub struct RestrictionId(pub String, pub bool);
 
 impl RestrictionId {
-    pub fn new(v: String) -> Self {
-        let rid = v.trim_start_matches("~");  
-        
-        RestrictionId(rid.to_string(), v == rid)
+    pub fn new(rid: String, active: bool) -> Self {
+        RestrictionId(rid, active)
+    }
+
+    pub fn new_active(rid: String) -> Self {
+        RestrictionId(rid, true)
     }
 
     pub fn to_sdp(&self) -> String {
-        format!("{}{}", if self.1 {""} else {"~"}, self.0)
+        format!("{}{}", if self.1 { "" } else { "~" }, self.0)
     }
 }
 

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -664,17 +664,23 @@ impl From<Direction> for MediaAttribute {
 ///
 /// Defined in https://tools.ietf.org/html/draft-ietf-avtext-rid-09
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RestrictionId(pub String);
+pub struct RestrictionId(pub String, pub bool);
 
 impl RestrictionId {
     pub fn new(v: String) -> Self {
-        RestrictionId(v)
+        let rid = v.trim_start_matches("~");  
+        
+        RestrictionId(rid.to_string(), v == rid)
+    }
+
+    pub fn to_sdp(&self) -> String {
+        format!("{}{}", if self.1 {""} else {"~"}, self.0)
     }
 }
 
 impl Default for RestrictionId {
     fn default() -> Self {
-        RestrictionId("".to_string())
+        RestrictionId("".to_string(), true)
     }
 }
 
@@ -1107,9 +1113,9 @@ impl fmt::Display for SimulcastGroups {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (idx, a) in self.0.iter().enumerate() {
             if idx + 1 == self.0.len() {
-                write!(f, "{}", a.0)?;
+                write!(f, "{}", a.to_sdp())?;
             } else {
-                write!(f, "{};", a.0)?;
+                write!(f, "{};", a.to_sdp())?;
             }
         }
         Ok(())

--- a/src/sdp/parser.rs
+++ b/src/sdp/parser.rs
@@ -632,7 +632,13 @@ where
         (
             string(direction),
             token(' '),
-            sep_by1::<Vec<Vec<String>>, _, _, _>(sep_by1(many1(satisfy(|c: char| c == '~' || c.is_alphanumeric())), token(',')), token(';')),
+            sep_by1::<Vec<Vec<String>>, _, _, _>(
+                sep_by1(
+                    many1(satisfy(|c: char| c == '~' || c.is_alphanumeric())),
+                    token(','),
+                ),
+                token(';'),
+            ),
         )
     };
 
@@ -646,8 +652,6 @@ where
     let simulcast = attribute_line("simulcast", simul2).map(|(s1, maybe_s2)| {
         let mut send = SimulcastGroups(vec![]);
         let mut recv = SimulcastGroups(vec![]);
-        error!("s1: {s1:?}");
-        error!("maybe_s2: {maybe_s2:?}");
 
         fn to_simul(to: &mut SimulcastGroups, groups: Vec<Vec<String>>) {
             for group in groups {

--- a/src/sdp/parser.rs
+++ b/src/sdp/parser.rs
@@ -632,7 +632,7 @@ where
         (
             string(direction),
             token(' '),
-            sep_by1::<Vec<Vec<String>>, _, _, _>(sep_by1(name(), token(',')), token(';')),
+            sep_by1::<Vec<Vec<String>>, _, _, _>(sep_by1(many1(satisfy(|c: char| c == '~' || c.is_alphanumeric())), token(',')), token(';')),
         )
     };
 
@@ -646,6 +646,8 @@ where
     let simulcast = attribute_line("simulcast", simul2).map(|(s1, maybe_s2)| {
         let mut send = SimulcastGroups(vec![]);
         let mut recv = SimulcastGroups(vec![]);
+        error!("s1: {s1:?}");
+        error!("maybe_s2: {maybe_s2:?}");
 
         fn to_simul(to: &mut SimulcastGroups, groups: Vec<Vec<String>>) {
             for group in groups {
@@ -653,7 +655,7 @@ where
                 // provided and use the first rid.
                 let first = group.into_iter().next();
 
-                if let Some(rid) = first.map(RestrictionId) {
+                if let Some(rid) = first.map(RestrictionId::new) {
                     to.0.push(rid);
                 }
             }


### PR DESCRIPTION
This PR adds ability to receive offer with simulcast including some inactive `rid`s ([marked with "~" prefix](https://datatracker.ietf.org/doc/html/rfc8853#name-simulcast-attribute)) and to generate correct answer.  