### PR TITLE
MediaTime: fix negative value into Duration bug

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -5,8 +5,8 @@ use std::fmt;
 use std::ops::RangeInclusive;
 
 use crate::packet::{H264ProfileLevel, MediaKind};
-use crate::rtp_::Direction;
 use crate::rtp_::Pt;
+use crate::rtp_::{Direction, Frequency};
 use crate::sdp::FormatParam;
 
 // These really don't belong anywhere, but I guess they're kind of related
@@ -89,7 +89,7 @@ pub struct CodecSpec {
     pub codec: Codec,
 
     /// Clock rate of the codec.
-    pub clock_rate: u32,
+    pub clock_rate: Frequency,
 
     /// Number of audio channels (if any).
     pub channels: Option<u8>,
@@ -440,7 +440,7 @@ impl CodecConfig {
         pt: Pt,
         resend: Option<Pt>,
         codec: Codec,
-        clock_rate: u32,
+        clock_rate: Frequency,
         channels: Option<u8>,
         format: FormatParams,
     ) {
@@ -482,7 +482,7 @@ impl CodecConfig {
             pt,
             resend,
             Codec::H264,
-            90_000,
+            Frequency::NINETY_KHZ,
             None,
             FormatParams {
                 level_asymmetry_allowed: Some(true),
@@ -503,7 +503,7 @@ impl CodecConfig {
             111.into(),
             None,
             Codec::Opus,
-            48_000,
+            Frequency::FORTY_EIGHT_KHZ,
             Some(2),
             FormatParams {
                 min_p_time: Some(10),
@@ -523,7 +523,7 @@ impl CodecConfig {
             96.into(),
             Some(97.into()),
             Codec::Vp8,
-            90_000,
+            Frequency::NINETY_KHZ,
             None,
             FormatParams::default(),
         )
@@ -574,7 +574,7 @@ impl CodecConfig {
             98.into(),
             Some(99.into()),
             Codec::Vp9,
-            90_000,
+            Frequency::NINETY_KHZ,
             None,
             FormatParams {
                 profile_id: Some(0),
@@ -585,7 +585,7 @@ impl CodecConfig {
             100.into(),
             Some(101.into()),
             Codec::Vp9,
-            90_000,
+            Frequency::NINETY_KHZ,
             None,
             FormatParams {
                 profile_id: Some(2),
@@ -903,6 +903,8 @@ impl std::ops::DerefMut for CodecConfig {
 
 #[cfg(test)]
 mod test {
+    use crate::rtp_::Frequency;
+
     use super::*;
 
     fn h264_codec_spec(
@@ -912,7 +914,7 @@ mod test {
     ) -> CodecSpec {
         CodecSpec {
             codec: Codec::H264,
-            clock_rate: 90000,
+            clock_rate: Frequency::NINETY_KHZ,
             channels: None,
             format: FormatParams {
                 min_p_time: None,

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -25,7 +25,7 @@ mod writer;
 pub use writer::Writer;
 
 pub use crate::packet::MediaKind;
-pub use crate::rtp_::{Direction, ExtensionValues, MediaTime, Mid, Pt, Rid};
+pub use crate::rtp_::{Direction, ExtensionValues, Frequency, MediaTime, Mid, Pt, Rid};
 
 #[derive(Debug)]
 /// Information about some configured media.

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -518,7 +518,7 @@ mod test {
             let meta = RtpMeta {
                 received: Instant::now(),
                 seq_no: (*seq).into(),
-                time: MediaTime::new(*time, 90_000),
+                time: MediaTime::from_90khz(*time),
                 last_sender_info: None,
                 header: RtpHeader {
                     sequence_number: *seq as u16,

--- a/src/packet/payload.rs
+++ b/src/packet/payload.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use crate::format::CodecSpec;
 use crate::media::ToPayload;
-use crate::rtp_::{ExtensionValues, MediaTime, Rid, RtpHeader, SeqNo, Ssrc};
+use crate::rtp_::{ExtensionValues, Frequency, MediaTime, Rid, RtpHeader, SeqNo, Ssrc};
 use crate::streams::StreamTx;
 
 use super::{CodecPacketizer, PacketError, Packetizer, QueueSnapshot};
@@ -15,7 +15,7 @@ use super::{MediaKind, QueuePriority};
 #[derive(Debug)]
 pub struct Payloader {
     pack: CodecPacketizer,
-    clock_rate: u32,
+    clock_rate: Frequency,
 }
 
 impl Payloader {
@@ -67,7 +67,7 @@ impl Payloader {
             stream.write_rtp(
                 pt,
                 seq_no,
-                rtp_time.rebase(self.clock_rate.into()).numer() as u32,
+                rtp_time.rebase(self.clock_rate).numer() as u32,
                 wallclock,
                 marker,
                 ext_vals.clone(),

--- a/src/rtp/mod.rs
+++ b/src/rtp/mod.rs
@@ -14,6 +14,7 @@ mod dir;
 pub use dir::Direction;
 
 mod mtime;
+pub use mtime::Frequency;
 pub use mtime::MediaTime;
 
 mod header;

--- a/src/rtp/mtime.rs
+++ b/src/rtp/mtime.rs
@@ -3,7 +3,7 @@
 use std::cmp::Ordering;
 use std::fmt::Display;
 use std::num::{NonZeroU32, TryFromIntError};
-use std::ops::{Add, Sub};
+use std::ops::{Add, AddAssign, Sub, SubAssign};
 use std::str::FromStr;
 use std::time::Duration;
 use std::time::Instant;
@@ -255,6 +255,18 @@ impl Add for MediaTime {
     fn add(self, rhs: Self) -> Self::Output {
         let (t0, t1) = MediaTime::same_base(self, rhs);
         MediaTime::new(t0.0 + t1.0, t0.1)
+    }
+}
+
+impl AddAssign for MediaTime {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl SubAssign for MediaTime {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
     }
 }
 

--- a/src/rtp/mtime.rs
+++ b/src/rtp/mtime.rs
@@ -248,6 +248,32 @@ impl Sub for MediaTime {
     }
 }
 
+impl SubAssign for MediaTime {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl Sub<MediaTime> for Instant {
+    type Output = Instant;
+
+    fn sub(self, rhs: MediaTime) -> Self::Output {
+        if rhs.numer() < 0 {
+            // abs(numer < 0) => positive i64 which can always fit in u64
+            self + Duration::try_from(rhs.abs()).unwrap()
+        } else {
+            // numer >= 0 => positive i64 which can always fit in u64
+            self - Duration::try_from(rhs).unwrap()
+        }
+    }
+}
+
+impl SubAssign<MediaTime> for Instant {
+    fn sub_assign(&mut self, rhs: MediaTime) {
+        *self = *self - rhs;
+    }
+}
+
 impl Add for MediaTime {
     type Output = MediaTime;
 
@@ -264,9 +290,23 @@ impl AddAssign for MediaTime {
     }
 }
 
-impl SubAssign for MediaTime {
-    fn sub_assign(&mut self, rhs: Self) {
-        *self = *self - rhs;
+impl Add<MediaTime> for Instant {
+    type Output = Instant;
+
+    fn add(self, rhs: MediaTime) -> Self::Output {
+        if rhs.numer() < 0 {
+            // abs(numer < 0) => positive i64 which can always fit in u64
+            self - Duration::try_from(rhs.abs()).unwrap()
+        } else {
+            // numer >= 0 => positive i64 which can always fit in u64
+            self + Duration::try_from(rhs).unwrap()
+        }
+    }
+}
+
+impl AddAssign<MediaTime> for Instant {
+    fn add_assign(&mut self, rhs: MediaTime) {
+        *self = *self + rhs;
     }
 }
 

--- a/src/rtp/mtime.rs
+++ b/src/rtp/mtime.rs
@@ -164,4 +164,31 @@ mod test {
 
         println!("{}", (10.0234_f64).fract());
     }
+
+    #[test]
+    fn ts_negative_duration() {
+        let t = MediaTime::new(-1, 1);
+        let t_dur: Duration = t.into();
+        assert_eq!(t_dur.as_secs(), 1);
+    }
+
+    #[test]
+    fn ts_eq_negative_denom() {
+        let t1 = MediaTime::new(-1, -2);
+        let t2 = MediaTime::new(0, 1);
+        assert_ne!(t1, t2)
+    }
+
+    #[test]
+    fn ts_abs_negative_denom() {
+        let t1 = MediaTime::new(-1, -1);
+        assert!(t1.abs() >= MediaTime::ZERO)
+    }
+
+    #[test]
+    fn ts_zero_denom() {
+        let t1 = MediaTime::new(1, 1);
+        let t2 = MediaTime::new(0, 0);
+        assert_ne!(t1, t2)
+    }
 }

--- a/src/rtp/mtime.rs
+++ b/src/rtp/mtime.rs
@@ -5,23 +5,23 @@ use std::ops::{Add, Sub};
 use std::time::Duration;
 
 /// Microseconds in a second.
-const MICROS: i64 = 1_000_000;
+const MICROS: u64 = 1_000_000;
 
 /// Milliseconds in a second.
-const MILLIS: i64 = 1_000;
+const MILLIS: u64 = 1_000;
 
 /// Media time represented by a numerator / denominator.
 ///
 /// The numerator is typically the packet time of an Rtp header. The denominator is the
 /// clock frequency of the media source (typically 90kHz for video and 48kHz for audio).
 #[derive(Debug, Clone, Copy)]
-pub struct MediaTime(i64, i64);
+pub struct MediaTime(i64, u64);
 
 impl MediaTime {
     pub const ZERO: MediaTime = MediaTime(0, 1);
 
-    pub const fn new(numer: i64, denom: i64) -> MediaTime {
-        MediaTime(numer, denom)
+    pub const fn new(numer: i64, denom: u64) -> Self {
+        Self(numer, denom)
     }
 
     #[inline(always)]
@@ -30,7 +30,7 @@ impl MediaTime {
     }
 
     #[inline(always)]
-    pub const fn denom(&self) -> i64 {
+    pub const fn denom(&self) -> u64 {
         self.1
     }
 
@@ -72,7 +72,7 @@ impl MediaTime {
     }
 
     #[inline(always)]
-    pub const fn rebase(self, denom: i64) -> MediaTime {
+    pub const fn rebase(self, denom: u64) -> MediaTime {
         if denom == self.1 {
             self
         } else {
@@ -170,19 +170,6 @@ mod test {
         let t = MediaTime::new(-1, 1);
         let t_dur: Duration = t.into();
         assert_eq!(t_dur.as_secs(), 1);
-    }
-
-    #[test]
-    fn ts_eq_negative_denom() {
-        let t1 = MediaTime::new(-1, -2);
-        let t2 = MediaTime::new(0, 1);
-        assert_ne!(t1, t2)
-    }
-
-    #[test]
-    fn ts_abs_negative_denom() {
-        let t1 = MediaTime::new(-1, -1);
-        assert!(t1.abs() >= MediaTime::ZERO)
     }
 
     #[test]

--- a/src/rtp/rtcp/mod.rs
+++ b/src/rtp/rtcp/mod.rs
@@ -608,7 +608,7 @@ mod test {
             sender_info: SenderInfo {
                 ssrc: ssrc.into(),
                 ntp_time,
-                rtp_time: MediaTime::new(4, 1),
+                rtp_time: MediaTime::from_secs(4),
                 sender_packet_count: 5,
                 sender_octet_count: 6,
             },

--- a/src/rtp/rtcp/sr.rs
+++ b/src/rtp/rtcp/sr.rs
@@ -134,7 +134,7 @@ impl<'a> TryFrom<&'a [u8]> for SenderInfo {
         // frame, for a 25 f/s video by 3,600 for each frame.
         let rtp_time = u32::from_be_bytes([buf[12], buf[13], buf[14], buf[15]]);
         // The base (90kHz etc) is set higher up the stack (in StreamRx to be precise).
-        let rtp_time = MediaTime::new(rtp_time as i64, 1);
+        let rtp_time = MediaTime::from_secs(rtp_time as i64);
 
         let sender_packet_count = u32::from_be_bytes([buf[16], buf[17], buf[18], buf[19]]);
         let sender_octet_count = u32::from_be_bytes([buf[20], buf[21], buf[22], buf[23]]);

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -13,7 +13,7 @@ use crate::format::CodecSpec;
 use crate::format::FormatParams;
 use crate::format::PayloadParams;
 use crate::ice::{Candidate, IceCreds};
-use crate::rtp_::{Direction, Extension, Mid, Pt, Rid, SessionId, Ssrc};
+use crate::rtp_::{Direction, Extension, Frequency, Mid, Pt, Rid, SessionId, Ssrc};
 use crate::VERSION;
 
 use super::parser::sdp_parser;
@@ -1050,7 +1050,7 @@ impl PayloadParams {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RtpMap {
     pub codec: Codec,
-    pub clock_rate: u32,
+    pub clock_rate: Frequency,
     pub channels: Option<u8>,
 }
 
@@ -1402,7 +1402,7 @@ impl<'a> std::fmt::Display for FingerprintFmt<'a> {
 
 #[cfg(test)]
 mod test {
-    use crate::rtp_::Extension;
+    use crate::rtp_::{Extension, Frequency};
     use crate::VERSION;
 
     use super::*;
@@ -1498,7 +1498,7 @@ mod test {
                         MediaAttribute::SendRecv,
                         MediaAttribute::Msid(Msid { stream_id: "5UUdwiuY7OML2EkQtF38pJtNP5v7In1LhjEK".into(), track_id: "f78dde68-7055-4e20-bb37-433803dd1ed1".into() }),
                         MediaAttribute::RtcpMux,
-                        MediaAttribute::RtpMap { pt: 111.into(), value: RtpMap {  codec: "opus".into(), clock_rate: 48_000, channels: Some(2) }},
+                        MediaAttribute::RtpMap { pt: 111.into(), value: RtpMap {  codec: "opus".into(), clock_rate: Frequency::FORTY_EIGHT_KHZ, channels: Some(2) }},
                         MediaAttribute::RtcpFb { pt: 111.into(), value: "transport-cc".into() },
                         MediaAttribute::Fmtp { pt: 111.into(), values: vec![FormatParam::MinPTime(10), FormatParam::UseInbandFec(true)] },
                         MediaAttribute::Ssrc { ssrc: 3_948_621_874.into(), attr: "cname".into(), value: "xeXs3aE9AOBn00yJ".into() },

--- a/src/sdp/parser.rs
+++ b/src/sdp/parser.rs
@@ -10,7 +10,7 @@ use {
 
 use crate::dtls::Fingerprint;
 use crate::ice::{Candidate, CandidateKind};
-use crate::rtp_::{Direction, Extension, Mid, Pt, SessionId, Ssrc};
+use crate::rtp_::{Direction, Extension, Frequency, Mid, Pt, SessionId, Ssrc};
 use crate::sdp::SdpError;
 
 use super::data::*;
@@ -567,7 +567,7 @@ where
             many1::<String, _, _>(satisfy(|c| c != '/' && c != '\r' && c != '\n')),
             token('/'),
             many1::<String, _, _>(satisfy(|c| c != '/' && c != '\r' && c != '\n')).and_then(|s| {
-                s.parse::<u32>()
+                s.parse::<Frequency>()
                     .map_err(StreamErrorFor::<Input>::message_format)
             }),
             optional((

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -105,7 +105,7 @@ impl RtpPacket {
     fn blank() -> RtpPacket {
         RtpPacket {
             seq_no: 0.into(),
-            time: MediaTime::new(0, 90_000),
+            time: MediaTime::from_90khz(0),
             header: RtpHeader {
                 payload_type: BLANK_PACKET_DEFAULT_PT,
                 ..Default::default()

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -54,7 +54,7 @@ pub struct StreamRx {
     last_used: Instant,
 
     /// Last seen pt and clock_rate in
-    last_clock_rate: Option<(Pt, i64)>,
+    last_clock_rate: Option<(Pt, u64)>,
 
     /// Last received sender info.
     sender_info: Option<(Instant, SenderInfo)>,
@@ -352,7 +352,7 @@ impl StreamRx {
 
         let previous_time = self.last_time.map(|t| t.numer() as u64);
         let time_u32 = extend_u32(previous_time, header.timestamp);
-        let time = MediaTime::new(time_u32 as i64, clock_rate as i64);
+        let time = MediaTime::new(time_u32 as i64, clock_rate as u64);
 
         if !is_repair {
             self.last_time = Some(time);

--- a/src/streams/rtx_cache.rs
+++ b/src/streams/rtx_cache.rs
@@ -87,7 +87,7 @@ mod test {
         RtpPacket {
             header: RtpHeader::default(),
             seq_no: seq_no.into(),
-            time: MediaTime::new(0, 90_000),
+            time: MediaTime::from_90khz(0),
             payload: millis.to_be_bytes().to_vec(),
             timestamp: after(now, millis),
             last_sender_info: None,

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -16,7 +16,7 @@ use crate::packet::QueueState;
 use crate::rtp_::Bitrate;
 use crate::rtp_::{extend_u16, Descriptions, ReportList, Rtcp};
 use crate::rtp_::{ExtensionMap, ReceptionReport, RtpHeader};
-use crate::rtp_::{ExtensionValues, MediaTime, Mid, NackEntry};
+use crate::rtp_::{ExtensionValues, Frequency, MediaTime, Mid, NackEntry};
 use crate::rtp_::{Pt, Rid, RtcpFb, SenderInfo, SenderReport, Ssrc};
 use crate::rtp_::{Sdes, SdesType, MAX_BLANK_PADDING_PAYLOAD_SIZE};
 use crate::rtp_::{SeqNo, SRTP_BLOCK_SIZE};
@@ -64,7 +64,7 @@ pub struct StreamTx {
     cname: Option<String>,
 
     /// The last main payload clock rate that was sent.
-    clock_rate: Option<u64>,
+    clock_rate: Option<Frequency>,
 
     /// If we are doing seq_no ourselves (when writing sample mode).
     seq_no: SeqNo,
@@ -268,7 +268,7 @@ impl StreamTx {
         }
 
         // This 1 in clock frequency will be fixed in poll_output.
-        let media_time = MediaTime::new(time as i64, 1);
+        let media_time = MediaTime::from_secs(time as i64);
         self.rtp_and_wallclock = Some((time, wallclock));
 
         let header = RtpHeader {
@@ -364,7 +364,7 @@ impl StreamTx {
                 // because we already have a mutable borrow.
                 set_pt = Some(param.pt());
 
-                let clock_rate = param.spec().clock_rate as u64;
+                let clock_rate = param.spec().clock_rate;
                 set_cr = Some(clock_rate);
 
                 // Modify the cached packet time. This is so write_rtp can use u32 media time without

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -64,7 +64,7 @@ pub struct StreamTx {
     cname: Option<String>,
 
     /// The last main payload clock rate that was sent.
-    clock_rate: Option<i64>,
+    clock_rate: Option<u64>,
 
     /// If we are doing seq_no ourselves (when writing sample mode).
     seq_no: SeqNo,
@@ -364,7 +364,7 @@ impl StreamTx {
                 // because we already have a mutable borrow.
                 set_pt = Some(param.pt());
 
-                let clock_rate = param.spec().clock_rate as i64;
+                let clock_rate = param.spec().clock_rate as u64;
                 set_cr = Some(clock_rate);
 
                 // Modify the cached packet time. This is so write_rtp can use u32 media time without

--- a/src/streams/send_queue.rs
+++ b/src/streams/send_queue.rs
@@ -209,7 +209,7 @@ mod test {
 
         queue.push(RtpPacket {
             seq_no: 0.into(),
-            time: MediaTime::new(10, 90_000),
+            time: MediaTime::from_90khz(10),
             header: RtpHeader::default(),
             payload: vec![],
             timestamp: Instant::now(),
@@ -244,7 +244,7 @@ mod test {
 
         queue.push(RtpPacket {
             seq_no: 0.into(),
-            time: MediaTime::new(10, 90_000),
+            time: MediaTime::from_90khz(10),
             header: RtpHeader::default(),
             payload: vec![42, 42],
             timestamp: start,

--- a/tests/sdp-negotiation.rs
+++ b/tests/sdp-negotiation.rs
@@ -8,6 +8,7 @@ use str0m::format::CodecSpec;
 use str0m::format::FormatParams;
 use str0m::format::PayloadParams;
 use str0m::media::Direction;
+use str0m::media::Frequency;
 use str0m::media::MediaKind;
 use str0m::rtp::{Extension, ExtensionMap};
 use str0m::Rtc;
@@ -439,7 +440,7 @@ fn opus(pt: u8) -> PayloadParams {
         CodecSpec {
             codec: Codec::Opus,
             channels: Some(2),
-            clock_rate: 48_000,
+            clock_rate: Frequency::FORTY_EIGHT_KHZ,
             format: FormatParams::default(),
         },
     )
@@ -452,7 +453,7 @@ fn vp8(pt: u8) -> PayloadParams {
         CodecSpec {
             codec: Codec::Vp8,
             channels: None,
-            clock_rate: 90_000,
+            clock_rate: Frequency::NINETY_KHZ,
             format: FormatParams::default(),
         },
     )
@@ -465,7 +466,7 @@ fn h264(pt: u8) -> PayloadParams {
         CodecSpec {
             codec: Codec::H264,
             channels: None,
-            clock_rate: 90_000,
+            clock_rate: Frequency::NINETY_KHZ,
             format: FormatParams::default(),
         },
     )


### PR DESCRIPTION
`as u64` of `i64` is dangerous. `Duration` is non-negative but `MediaTime` is not necessarily. This fixes what is effectively an integer underflow.