### PR TITLE
Implement REMB (Receiver Estimated Maximum Bitrate)

### DIFF
--- a/src/bwe.rs
+++ b/src/bwe.rs
@@ -1,8 +1,17 @@
 //! Bandwidth estimation.
 
-use crate::Rtc;
+use crate::{rtp_::Mid, Rtc};
 
 pub use crate::rtp_::Bitrate;
+
+#[derive(Debug)]
+/// Bandwidth estimation kind.
+pub enum BweKind {
+    /// Transport wide congestion control.
+    Twcc(Bitrate),
+    /// REMB (Receiver Estimated Maximum Bitrate)
+    Remb(Mid, Bitrate),
+}
 
 /// Access to the Bandwidth Estimate subsystem.
 pub struct Bwe<'a>(pub(crate) &'a mut Rtc);

--- a/src/bwe.rs
+++ b/src/bwe.rs
@@ -4,7 +4,7 @@ use crate::{rtp_::Mid, Rtc};
 
 pub use crate::rtp_::Bitrate;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 /// Bandwidth estimation kind.
 pub enum BweKind {
     /// Transport wide congestion control.

--- a/src/format.rs
+++ b/src/format.rs
@@ -56,6 +56,9 @@ pub struct PayloadParams {
     /// Whether the payload uses the FIR (Full Intra Request) mechanic.
     pub(crate) fb_fir: bool,
 
+    /// Whether the payload uses the REMB (Receiver Estimated Maximum Bitrate) mechanic.
+    pub(crate) fb_remb: bool,
+
     /// Whether the payload is locked by negotiation or can still be debated.
     ///
     /// If we make an OFFER or ANSWER and the direction is sendrecv/recvonly, the parameters are locked
@@ -179,6 +182,7 @@ impl PayloadParams {
             fb_fir: is_video,
             fb_nack: is_video,
             fb_pli: is_video,
+            fb_remb: is_video,
 
             locked: false,
         }
@@ -238,6 +242,16 @@ impl PayloadParams {
     /// Whether the payload uses the FIR (Full Intra Request) mechanic.
     pub fn fb_fir(&self) -> bool {
         self.fb_fir
+    }
+
+    /// Set whether the payload uses the REMB (Receiver Estimated Maximum Bitrate) mechanic.
+    pub fn set_fb_remb(&mut self, fb_remb: bool) {
+        self.fb_remb = fb_remb
+    }
+
+    /// Whether the payload uses the REMB (Receiver Estimated Maximum Bitrate) mechanic.
+    pub fn fb_remb(&self) -> bool {
+        self.fb_remb
     }
 
     pub(crate) fn match_score(&self, o: &PayloadParams) -> Option<usize> {
@@ -430,10 +444,10 @@ impl CodecConfig {
         channels: Option<u8>,
         format: FormatParams,
     ) {
-        let (fb_transport_cc, fb_fir, fb_nack, fb_pli) = if codec.is_video() {
-            (true, true, true, true)
+        let (fb_transport_cc, fb_fir, fb_nack, fb_pli, fb_remb) = if codec.is_video() {
+            (true, true, true, true, true)
         } else {
-            (true, false, false, false)
+            (true, false, false, false, false)
         };
 
         let p = PayloadParams {
@@ -449,6 +463,7 @@ impl CodecConfig {
             fb_fir,
             fb_nack,
             fb_pli,
+            fb_remb,
             locked: false,
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -580,7 +580,7 @@
 #[macro_use]
 extern crate tracing;
 
-use bwe::Bwe;
+use bwe::{Bwe, BweKind};
 use change::{DirectApi, SdpApi};
 use rtp::RawPacket;
 use std::fmt;
@@ -906,7 +906,7 @@ pub enum Event {
     MediaEgressStats(MediaEgressStats),
 
     /// A new estimate from the bandwidth estimation subsystem.
-    EgressBitrateEstimate(Bitrate),
+    EgressBitrateEstimate(BweKind),
 
     // =================== RTP related events ===================
 

--- a/src/rtp/rtcp/mod.rs
+++ b/src/rtp/rtcp/mod.rs
@@ -42,6 +42,9 @@ pub use twcc::{Twcc, TwccRecvRegister, TwccSendRecord, TwccSendRegister};
 mod rtcpfb;
 pub use rtcpfb::RtcpFb;
 
+mod remb;
+pub use remb::Remb;
+
 use super::extend_u16;
 use super::SeqNo;
 use super::Ssrc;
@@ -83,6 +86,8 @@ pub enum Rtcp {
     Fir(Fir),
     /// Transport Wide Congestion Control. Feedback for every received RTP packet.
     Twcc(Twcc),
+    /// Receiver Estimated Maximum Bitrate. Feedback to the sender about the maximum bitrate.
+    Remb(Remb),
 }
 
 impl Rtcp {
@@ -230,6 +235,7 @@ impl Rtcp {
             Rtcp::Pli(_) => true,
             Rtcp::Fir(v) => v.reports.is_full(),
             Rtcp::Twcc(_) => true,
+            Rtcp::Remb(_) => true,
         }
     }
 
@@ -255,6 +261,8 @@ impl Rtcp {
             Rtcp::Fir(v) => v.reports.is_empty(),
             // A twcc report is never empty.
             Rtcp::Twcc(_) => false,
+            // A REMB report is never empty.
+            Rtcp::Remb(_) => false,
         }
     }
 
@@ -331,6 +339,7 @@ impl Rtcp {
             Pli(_) => 4,
             Fir(_) => 5,
             Twcc(_) => 6,
+            Remb(_) => 7,
             ExtendedReport(_) => 10,
 
             // Goodbye last since they remove stuff.
@@ -351,6 +360,7 @@ impl RtcpPacket for Rtcp {
             Rtcp::Pli(v) => v.header(),
             Rtcp::Fir(v) => v.header(),
             Rtcp::Twcc(v) => v.header(),
+            Rtcp::Remb(v) => v.header(),
         }
     }
 
@@ -365,6 +375,7 @@ impl RtcpPacket for Rtcp {
             Rtcp::Pli(v) => v.length_words(),
             Rtcp::Fir(v) => v.length_words(),
             Rtcp::Twcc(v) => v.length_words(),
+            Rtcp::Remb(v) => v.length_words(),
         }
     }
 
@@ -379,6 +390,7 @@ impl RtcpPacket for Rtcp {
             Rtcp::Pli(v) => v.write_to(buf),
             Rtcp::Fir(v) => v.write_to(buf),
             Rtcp::Twcc(v) => v.write_to(buf),
+            Rtcp::Remb(v) => v.write_to(buf),
         }
     }
 }

--- a/src/rtp/rtcp/mod.rs
+++ b/src/rtp/rtcp/mod.rs
@@ -437,13 +437,10 @@ impl<'a> TryFrom<&'a [u8]> for Rtcp {
                     }
                     PayloadType::FullIntraRequest => Rtcp::Fir(buf.try_into()?),
                     PayloadType::ApplicationLayer => {
-                        match header.rtcp_type() {
-                            RtcpType::PayloadSpecificFeedback => {
-                                if let Ok(remb) = Remb::try_from(buf) {
-                                    return Ok(Rtcp::Remb(remb));
-                                }
+                        if header.rtcp_type() == RtcpType::PayloadSpecificFeedback {
+                            if let Ok(remb) = Remb::try_from(buf) {
+                                return Ok(Rtcp::Remb(remb));
                             }
-                            _ => {}
                         }
                         return Err("Ignore PayloadType: ApplicationLayer");
                     }

--- a/src/rtp/rtcp/mod.rs
+++ b/src/rtp/rtcp/mod.rs
@@ -437,7 +437,15 @@ impl<'a> TryFrom<&'a [u8]> for Rtcp {
                     }
                     PayloadType::FullIntraRequest => Rtcp::Fir(buf.try_into()?),
                     PayloadType::ApplicationLayer => {
-                        return Err("Ignore PayloadType: ApplicationLayer")
+                        match header.rtcp_type() {
+                            RtcpType::PayloadSpecificFeedback => {
+                                if let Ok(remb) = Remb::try_from(buf) {
+                                    return Ok(Rtcp::Remb(remb));
+                                }
+                            }
+                            _ => {}
+                        }
+                        return Err("Ignore PayloadType: ApplicationLayer");
                     }
                 }
             }

--- a/src/rtp/rtcp/remb.rs
+++ b/src/rtp/rtcp/remb.rs
@@ -1,0 +1,311 @@
+use crate::rtp::Ssrc;
+
+use super::RtcpType;
+use super::{FeedbackMessageType, PayloadType, RtcpHeader, RtcpPacket};
+
+const BITRATE_MAX: f32 = 2.417_842_4e24; //0x3FFFFp+63;
+const MANTISSA_MAX: u32 = 0x7FFFFF;
+const REMB_OFFSET: usize = 16;
+
+const UNIQUE_IDENTIFIER: [u8; 4] = [b'R', b'E', b'M', b'B'];
+
+/*
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |V=2|P| FMT=15  |   PT=206      |             length            |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                  SSRC of packet sender                        |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                  SSRC of media source                         |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |  Unique identifier 'R' 'E' 'M' 'B'                            |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |  Num SSRC     | BR Exp    |  BR Mantissa                      |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |   SSRC feedback                                               |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |  ...                                                          |
+*/
+
+#[derive(Debug, Clone)]
+pub struct Remb {
+    /// SSRC of sender
+    pub sender_ssrc: Ssrc,
+
+    /// SSRC of source, in Remb is default 0
+    pub ssrc: Ssrc,
+
+    /// Estimated maximum bitrate
+    pub bitrate: f32,
+
+    /// SSRC entries which this packet applies to
+    pub ssrcs: Vec<u32>,
+}
+
+impl Eq for Remb {}
+impl PartialEq for Remb {
+    fn eq(&self, other: &Self) -> bool {
+        self.sender_ssrc == other.sender_ssrc
+            && (self.bitrate as u64) == (other.bitrate as u64)
+            && self.ssrcs == other.ssrcs
+    }
+}
+
+impl RtcpPacket for Remb {
+    fn header(&self) -> RtcpHeader {
+        RtcpHeader {
+            rtcp_type: RtcpType::PayloadSpecificFeedback,
+            feedback_message_type: FeedbackMessageType::PayloadFeedback(
+                PayloadType::ApplicationLayer,
+            ),
+            words_less_one: (self.length_words() - 1) as u16,
+        }
+    }
+
+    fn length_words(&self) -> usize {
+        // header
+        // remb
+        // ssrcs
+        1 + REMB_OFFSET / 4 + self.ssrcs.len()
+    }
+
+    fn write_to(&self, buf: &mut [u8]) -> usize {
+        let mut exp = 0;
+        let mut bitrate = self.bitrate;
+        if bitrate >= BITRATE_MAX {
+            bitrate = BITRATE_MAX
+        }
+
+        if bitrate < 0.0 {
+            bitrate = 0.0;
+        }
+
+        while bitrate >= (1 << 18) as f32 {
+            bitrate /= 2.0;
+            exp += 1;
+        }
+
+        let mantissa = bitrate.floor() as u32;
+
+        self.header().write_to(&mut buf[..4]);
+        buf[4..8].copy_from_slice(&self.sender_ssrc.to_be_bytes());
+        buf[8..12].copy_from_slice(&[0; 4]);
+        buf[12..16].copy_from_slice(&UNIQUE_IDENTIFIER);
+        buf[16] = self.ssrcs.len() as u8;
+        // We can't quite use the binary package because
+        // a) it's a uint24 and b) the exponent is only 6-bits
+        // Just trust me; this is big-endian encoding.
+        buf[17] = (exp << 2) as u8 | (mantissa >> 16) as u8;
+        buf[18] = (mantissa >> 8) as u8;
+        buf[19] = mantissa as u8;
+
+        // Write the SSRCs at the very end.
+        for (index, ssrc) in self.ssrcs.iter().enumerate() {
+            let begin = 4 + REMB_OFFSET + index * 4;
+            let end = begin + 4;
+            buf[begin..end].copy_from_slice(&ssrc.to_be_bytes());
+        }
+
+        4 + REMB_OFFSET + self.ssrcs.len() * 4
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for Remb {
+    type Error = &'static str;
+
+    fn try_from(buf: &'a [u8]) -> Result<Self, Self::Error> {
+        if buf.len() < 16 {
+            return Err("Remb less than 16 bytes");
+        }
+
+        let sender_ssrc = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]).into();
+        let media_ssrc = u32::from_be_bytes([buf[4], buf[5], buf[6], buf[7]]);
+        if media_ssrc != 0 {
+            return Err("Ssrc must be zero");
+        }
+
+        if buf[8] != UNIQUE_IDENTIFIER[0]
+            || buf[9] != UNIQUE_IDENTIFIER[1]
+            || buf[10] != UNIQUE_IDENTIFIER[2]
+            || buf[11] != UNIQUE_IDENTIFIER[3]
+        {
+            return Err("Missing remb identifier");
+        }
+
+        // The next byte is the number of SSRC entries at the end.
+        let ssrcs_len = buf[12] as usize;
+
+        // Get the 6-bit exponent value.
+        let b17 = buf[13];
+        let mut exp = (b17 as u64) >> 2;
+        exp += 127; // bias for IEEE754
+        exp += 23; // IEEE754 biases the decimal to the left, abs-send-time biases it to the right
+
+        // The remaining 2-bits plus the next 16-bits are the mantissa.
+        let b18 = buf[14];
+        let b19 = buf[15];
+        let mut mantissa = ((b17 & 3) as u32) << 16 | (b18 as u32) << 8 | b19 as u32;
+
+        if mantissa != 0 {
+            // ieee754 requires an implicit leading bit
+            while (mantissa & (MANTISSA_MAX + 1)) == 0 {
+                exp -= 1;
+                mantissa *= 2;
+            }
+        }
+
+        // bitrate = mantissa * 2^exp
+        let bitrate = f32::from_bits(((exp as u32) << 23) | (mantissa & MANTISSA_MAX));
+
+        let mut ssrcs = vec![];
+        for i in 0..ssrcs_len {
+            let b_index = 16 + i * 4;
+            ssrcs.push(u32::from_be_bytes([
+                buf[b_index],
+                buf[b_index + 1],
+                buf[b_index + 2],
+                buf[b_index + 3],
+            ]));
+        }
+
+        Ok(Remb {
+            sender_ssrc,
+            ssrc: 0.into(),
+            ssrcs,
+            bitrate,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_receiver_estimated_maximum_bitrate_marshal() {
+        let input = Remb {
+            sender_ssrc: 1.into(),
+            ssrc: 0.into(),
+            bitrate: 8927168.0,
+            ssrcs: vec![1215622422],
+        };
+
+        let expected = vec![
+            143, 206, 0, 5, 0, 0, 0, 1, 0, 0, 0, 0, 82, 69, 77, 66, 1, 26, 32, 223, 72, 116, 237,
+            22,
+        ];
+
+        let mut output = [0; 1500];
+        let len = input.write_to(&mut output);
+        assert_eq!(expected, output[0..len]);
+    }
+
+    #[test]
+    fn test_receiver_estimated_maximum_bitrate_unmarshal() {
+        // Real data sent by Chrome while watching a 6Mb/s stream
+        let input: Vec<u8> = vec![
+            143, 206, 0, 5, 0, 0, 0, 1, 0, 0, 0, 0, 82, 69, 77, 66, 1, 26, 32, 223, 72, 116, 237,
+            22,
+        ];
+
+        // mantissa = []byte{26 & 3, 32, 223} = []byte{2, 32, 223} = 139487
+        // exp = 26 >> 2 = 6
+        // bitrate = 139487 * 2^6 = 139487 * 64 = 8927168 = 8.9 Mb/s
+        let expected = Remb {
+            sender_ssrc: 1.into(),
+            ssrc: 0.into(),
+            bitrate: 8927168.0,
+            ssrcs: vec![1215622422],
+        };
+
+        let packet = Remb::try_from(&input[4..]).unwrap();
+        assert_eq!(expected, packet);
+    }
+
+    #[test]
+    fn test_receiver_estimated_maximum_bitrate_truncate() {
+        let input: Vec<u8> = vec![
+            143, 206, 0, 5, 0, 0, 0, 1, 0, 0, 0, 0, 82, 69, 77, 66, 1, 26, 32, 223, 72, 116, 237,
+            22,
+        ];
+
+        // Make sure that we're interpreting the bitrate correctly.
+        // For the above example, we have:
+
+        // mantissa = 139487
+        // exp = 6
+        // bitrate = 8927168
+
+        let mut packet = Remb::try_from(&input[4..]).unwrap();
+        assert_eq!(8927168.0, packet.bitrate);
+
+        // Just verify marshal produces the same input.
+        let mut output = vec![0; 1500];
+        let output_len = packet.write_to(&mut output);
+        assert_eq!(input, output[0..output_len]);
+
+        // If we subtract the bitrate by 1, we'll round down a lower mantissa
+        packet.bitrate -= 1.0;
+
+        // bitrate = 8927167
+        // mantissa = 139486
+        // exp = 6
+
+        let output_len = packet.write_to(&mut output);
+        assert_ne!(input, output);
+        let expected = vec![
+            143, 206, 0, 5, 0, 0, 0, 1, 0, 0, 0, 0, 82, 69, 77, 66, 1, 26, 32, 222, 72, 116, 237,
+            22,
+        ];
+        assert_eq!(expected, output[0..output_len]);
+
+        // Which if we actually unmarshal again, we'll find that it's actually decreased by 63 (which is exp)
+        // mantissa = 139486
+        // exp = 6
+        // bitrate = 8927104
+
+        let packet = Remb::try_from(&output[4..]).unwrap();
+        assert_eq!(8927104.0, packet.bitrate);
+    }
+
+    #[test]
+    fn test_receiver_estimated_maximum_bitrate_overflow() {
+        // Marshal a packet with the maximum possible bitrate.
+        let packet = Remb {
+            sender_ssrc: 0.into(),
+            ssrc: 0.into(),
+            bitrate: f32::MAX,
+            ssrcs: vec![],
+        };
+
+        // mantissa = 262143 = 0x3FFFF
+        // exp = 63
+
+        let expected = vec![
+            143, 206, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 82, 69, 77, 66, 0, 255, 255, 255,
+        ];
+
+        let mut output = vec![0; 1500];
+        let output_len = packet.write_to(&mut output);
+        assert_eq!(expected, output[0..output_len]);
+
+        // mantissa = 262143
+        // exp = 63
+        // bitrate = 0xFFFFC00000000000
+
+        let packet = Remb::try_from(&output[4..output_len]).unwrap();
+        assert_eq!(f32::from_bits(0x67FFFFC0), packet.bitrate);
+
+        // Make sure we marshal to the same result again.
+        let output_len = packet.write_to(&mut output);
+        assert_eq!(expected, output[0..output_len]);
+
+        // Finally, try unmarshalling one number higher than we used to be able to handle.
+        let input = vec![
+            143, 206, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 82, 69, 77, 66, 0, 188, 0, 0,
+        ];
+        let packet = Remb::try_from(&input[4..]).unwrap();
+        assert_eq!(f32::from_bits(0x62800000), packet.bitrate);
+    }
+}

--- a/src/rtp/rtcp/remb.rs
+++ b/src/rtp/rtcp/remb.rs
@@ -191,7 +191,7 @@ mod tests {
             ssrcs: vec![1215622422],
         };
 
-        let expected = vec![
+        let expected = [
             143, 206, 0, 5, 0, 0, 0, 1, 0, 0, 0, 0, 82, 69, 77, 66, 1, 26, 32, 223, 72, 116, 237,
             22,
         ];
@@ -204,7 +204,7 @@ mod tests {
     #[test]
     fn test_receiver_estimated_maximum_bitrate_unmarshal() {
         // Real data sent by Chrome while watching a 6Mb/s stream
-        let input: Vec<u8> = vec![
+        let input = [
             143, 206, 0, 5, 0, 0, 0, 1, 0, 0, 0, 0, 82, 69, 77, 66, 1, 26, 32, 223, 72, 116, 237,
             22,
         ];
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn test_receiver_estimated_maximum_bitrate_truncate() {
-        let input: Vec<u8> = vec![
+        let input = [
             143, 206, 0, 5, 0, 0, 0, 1, 0, 0, 0, 0, 82, 69, 77, 66, 1, 26, 32, 223, 72, 116, 237,
             22,
         ];
@@ -241,7 +241,7 @@ mod tests {
         assert_eq!(8927168.0, packet.bitrate);
 
         // Just verify marshal produces the same input.
-        let mut output = vec![0; 1500];
+        let mut output = [0; 1500];
         let output_len = packet.write_to(&mut output);
         assert_eq!(input, output[0..output_len]);
 
@@ -253,8 +253,8 @@ mod tests {
         // exp = 6
 
         let output_len = packet.write_to(&mut output);
-        assert_ne!(input, output);
-        let expected = vec![
+        assert_ne!(input, output[0..output_len]);
+        let expected = [
             143, 206, 0, 5, 0, 0, 0, 1, 0, 0, 0, 0, 82, 69, 77, 66, 1, 26, 32, 222, 72, 116, 237,
             22,
         ];
@@ -282,11 +282,11 @@ mod tests {
         // mantissa = 262143 = 0x3FFFF
         // exp = 63
 
-        let expected = vec![
+        let expected = [
             143, 206, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 82, 69, 77, 66, 0, 255, 255, 255,
         ];
 
-        let mut output = vec![0; 1500];
+        let mut output = [0; 1500];
         let output_len = packet.write_to(&mut output);
         assert_eq!(expected, output[0..output_len]);
 
@@ -302,7 +302,7 @@ mod tests {
         assert_eq!(expected, output[0..output_len]);
 
         // Finally, try unmarshalling one number higher than we used to be able to handle.
-        let input = vec![
+        let input = [
             143, 206, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 82, 69, 77, 66, 0, 188, 0, 0,
         ];
         let packet = Remb::try_from(&input[4..]).unwrap();

--- a/src/rtp/rtcp/rtcpfb.rs
+++ b/src/rtp/rtcp/rtcpfb.rs
@@ -1,4 +1,4 @@
-use super::{DlrrItem, FirEntry, NackEntry, ReceptionReport, ReportBlock, ReportList};
+use super::{DlrrItem, FirEntry, NackEntry, ReceptionReport, Remb, ReportBlock, ReportList};
 use super::{Rrtr, Rtcp, Sdes, SenderInfo, Ssrc, Twcc};
 
 /// Normalization of [`Rtcp`] so we can deal with one SSRC at a time.
@@ -15,6 +15,7 @@ pub enum RtcpFb {
     Pli(Ssrc),                         // rx -> tx
     Fir(FirEntry),                     // rx -> tx
     Twcc(Twcc),                        // rx -> tx
+    Remb(Remb),                        // rx -> tx
 }
 
 impl RtcpFb {
@@ -68,6 +69,9 @@ impl RtcpFb {
                 Rtcp::Twcc(v) => {
                     q.push(RtcpFb::Twcc(v));
                 }
+                Rtcp::Remb(v) => {
+                    q.push(RtcpFb::Remb(v));
+                }
             }
         }
         q.into_iter()
@@ -85,6 +89,7 @@ impl RtcpFb {
             RtcpFb::Pli(v) => *v,
             RtcpFb::Fir(v) => v.ssrc,
             RtcpFb::Twcc(v) => v.ssrc,
+            RtcpFb::Remb(v) => v.ssrc,
         }
     }
 }

--- a/src/rtp/rtcp/rtcpfb.rs
+++ b/src/rtp/rtcp/rtcpfb.rs
@@ -89,7 +89,7 @@ impl RtcpFb {
             RtcpFb::Pli(v) => *v,
             RtcpFb::Fir(v) => v.ssrc,
             RtcpFb::Twcc(v) => v.ssrc,
-            RtcpFb::Remb(v) => v.ssrc,
+            RtcpFb::Remb(v) => v.ssrcs.first().map(|ssrc| (*ssrc).into()).unwrap_or(v.ssrc),
         }
     }
 }

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -346,7 +346,7 @@ impl MediaLine {
                 if **pt == p.pt {
                     match &value[..] {
                         "goog-remb" => {
-                            //
+                            p.fb_remb = true;
                         }
                         "transport-cc" => {
                             p.fb_transport_cc = true;
@@ -995,6 +995,12 @@ impl PayloadParams {
             attrs.push(MediaAttribute::RtcpFb {
                 pt: self.pt,
                 value: "transport-cc".into(),
+            });
+        }
+        if self.fb_remb {
+            attrs.push(MediaAttribute::RtcpFb {
+                pt: self.pt,
+                value: "goog-remb".into(),
             });
         }
         if self.fb_fir {

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
+use crate::bwe::BweKind;
 use crate::dtls::{KeyingMaterial, SrtpProfile};
 use crate::format::CodecConfig;
 use crate::format::PayloadParams;
@@ -520,7 +521,9 @@ impl Session {
 
     pub fn poll_event(&mut self) -> Option<Event> {
         if let Some(bitrate_estimate) = self.bwe.as_mut().and_then(|bwe| bwe.poll_estimate()) {
-            return Some(Event::EgressBitrateEstimate(bitrate_estimate));
+            return Some(Event::EgressBitrateEstimate(BweKind::Twcc(
+                bitrate_estimate,
+            )));
         }
 
         // If we're not ready to flow media, don't send any events.
@@ -546,6 +549,10 @@ impl Session {
 
         if let Some(req) = self.streams.poll_keyframe_request() {
             return Some(Event::KeyframeRequest(req));
+        }
+
+        if let Some((mid, bitrate)) = self.streams.poll_remb_request() {
+            return Some(Event::EgressBitrateEstimate(BweKind::Remb(mid, bitrate)));
         }
 
         for media in &mut self.medias {

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -400,6 +400,7 @@ impl Streams {
 
         for stream in self.streams_rx.values_mut() {
             stream.maybe_create_keyframe_request(sender_ssrc, feedback);
+            stream.maybe_create_remb_request(sender_ssrc, feedback);
 
             // All StreamRx belonging to the same Mid are reported together.
             if self.mids_to_report.contains(&stream.mid()) {

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -6,8 +6,8 @@ use std::time::Instant;
 use crate::format::CodecConfig;
 use crate::format::PayloadParams;
 use crate::media::{KeyframeRequest, Media};
-use crate::rtp_::Pt;
 use crate::rtp_::Ssrc;
+use crate::rtp_::{Bitrate, Pt};
 use crate::rtp_::{MediaTime, SenderInfo};
 use crate::rtp_::{Mid, Rid, SeqNo};
 use crate::rtp_::{Rtcp, RtpHeader};
@@ -459,6 +459,12 @@ impl Streams {
                 kind,
             })
         })
+    }
+
+    pub(crate) fn poll_remb_request(&mut self) -> Option<(Mid, Bitrate)> {
+        self.streams_tx
+            .values_mut()
+            .find_map(|s| s.poll_remb_request().map(|b| (s.mid(), b)))
     }
 
     pub(crate) fn poll_stream_paused(&mut self) -> Option<StreamPaused> {

--- a/tests/remb.rs
+++ b/tests/remb.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use str0m::bwe::{Bitrate, BweKind};
 use str0m::media::{Direction, MediaKind};
 use str0m::{Candidate, Event, Rtc, RtcError};
-use tracing::{info, info_span};
+use tracing::info_span;
 
 mod common;
 use common::{init_log, negotiate, progress, TestRtc};

--- a/tests/remb.rs
+++ b/tests/remb.rs
@@ -1,0 +1,76 @@
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+use str0m::bwe::{Bitrate, BweKind};
+use str0m::media::{Direction, MediaKind};
+use str0m::{Candidate, Event, Rtc, RtcError};
+use tracing::{info, info_span};
+
+mod common;
+use common::{init_log, negotiate, progress, TestRtc};
+
+#[test]
+pub fn remb() -> Result<(), RtcError> {
+    init_log();
+    let l_rtc = Rtc::builder().build();
+    let r_rtc = Rtc::builder().build();
+
+    let mut l = TestRtc::new_with_rtc(info_span!("L"), l_rtc);
+    let mut r = TestRtc::new_with_rtc(info_span!("R"), r_rtc);
+
+    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
+    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
+    l.add_local_candidate(host1);
+    r.add_local_candidate(host2);
+
+    let mid = negotiate(&mut l, &mut r, |change| {
+        change.add_media(MediaKind::Video, Direction::SendOnly, None, None)
+    });
+
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r)?;
+    }
+
+    //wait for srtp success
+    let settle_time = l.duration() + Duration::from_millis(20);
+    loop {
+        progress(&mut l, &mut r)?;
+
+        if l.duration() > settle_time {
+            break;
+        }
+    }
+
+    r.direct_api()
+        .stream_rx_by_mid(mid, None)
+        .expect("Should has rx")
+        .request_remb(Bitrate::bps(123456));
+
+    let settle_time = l.duration() + Duration::from_millis(20);
+    loop {
+        progress(&mut l, &mut r)?;
+
+        if l.duration() > settle_time {
+            break;
+        }
+    }
+
+    let l_remb: Vec<_> = l
+        .events
+        .iter()
+        .filter_map(|(_, e)| {
+            if let Event::EgressBitrateEstimate(event) = e {
+                Some(event)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert_eq!(l_remb, vec![&BweKind::Remb(mid, Bitrate::bps(123456))]);
+
+    Ok(())
+}


### PR DESCRIPTION
I am currently developing a decentralized media server. In some cases, we need a way to limit the sending bitrate from the sender. For example, in a conference room, we need to adapt the sending bitrate to accommodate viewers with slow internet connections.

The current implementation of str0m only supports TWCC, meaning only the sender can control the sending bitrate. To address this, I have added the REMB mechanism, which works on the receiver side, similar to FIR or PLI.

For more details on usage, please refer to my media server implementation:

https://github.com/8xFF/decentralized-media-server/blob/0102e4cda023efa5671f4ac440659a25ae5d0c66/transports/webrtc/src/transport.rs#L178-L185