### PR TITLE
De-multiplex STUN replies based on transaction ID

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1781,4 +1781,41 @@ mod test {
             }
         }
     }
+
+    #[test]
+    fn does_not_accept_response_with_unknown_transaction_id() {
+        let mut agent = IceAgent::new();
+        let remote_creds = IceCreds::new();
+        let mut remote_candidate = Candidate::host(ipv4_3(), "udp").unwrap();
+        remote_candidate.set_ufrag(&remote_creds.ufrag);
+
+        agent.set_remote_credentials(remote_creds.clone());
+        agent.add_local_candidate(Candidate::host(ipv4_1(), "udp").unwrap());
+        agent.add_remote_candidate(remote_candidate);
+        agent.handle_timeout(Instant::now());
+
+        let payload = Vec::from(agent.poll_transmit().unwrap().contents);
+        let stun_message = StunMessage::parse(&payload).unwrap();
+
+        let valid_reply =
+            make_authenticated_stun_reply(stun_message.trans_id(), ipv4_4(), &remote_creds.pass);
+        let fake_reply =
+            make_authenticated_stun_reply(TransId::new(), ipv4_4(), &remote_creds.pass);
+
+        assert!(!agent.accepts_message(&StunMessage::parse(&fake_reply).unwrap()));
+        assert!(agent.accepts_message(&StunMessage::parse(&valid_reply).unwrap()));
+    }
+
+    fn make_authenticated_stun_reply(tx_id: TransId, addr: SocketAddr, password: &str) -> Vec<u8> {
+        let reply = StunMessage::reply(tx_id, addr);
+
+        let mut buf = vec![0_u8; DATAGRAM_MTU];
+
+        let n = reply
+            .to_bytes(password, &mut buf)
+            .expect("IO error writing STUN reply");
+        buf.truncate(n);
+
+        buf
+    }
 }

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -775,16 +775,16 @@ impl IceAgent {
             }
         }
 
-        if message.is_successful_binding_response()
-            && !self
+        if message.is_successful_binding_response() {
+            let belongs_to_a_candidate_pair = self
                 .candidate_pairs
                 .iter()
-                .any(|p| p.has_binding_attempt(message.trans_id()))
-        {
-            trace!(
-                "Message rejected, transaction ID does not belong to any of our candidate pairs"
-            );
-            return false;
+                .any(|pair| pair.has_binding_attempt(message.trans_id()));
+
+            if !belongs_to_a_candidate_pair {
+                trace!("Message rejected, transaction ID does not belong to any of our candidate pairs");
+                return false;
+            }
         }
 
         let (_, password) = self.stun_credentials(!message.is_response());

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -775,6 +775,18 @@ impl IceAgent {
             }
         }
 
+        if message.is_successful_binding_response()
+            && !self
+                .candidate_pairs
+                .iter()
+                .any(|p| p.has_binding_attempt(message.trans_id()))
+        {
+            trace!(
+                "Message rejected, transaction ID does not belong to any of our candidate pairs"
+            );
+            return false;
+        }
+
         let (_, password) = self.stun_credentials(!message.is_response());
         if !message.check_integrity(&password) {
             trace!("Message rejected, integrity check failed");


### PR DESCRIPTION
Previously, `accept_message` would validate that incoming STUN requests match the credentials we have locally. This allows a server to de-multiplex, which agent should handle an particular STUN request.

In a peer-to-peer setting, both parties will make STUN requests and thus, we also need to de-multiplexing incoming STUN replies. Luckily this is quite easy because the candidate pairs that we have formed locally keep track of the transaction IDs that we've used so far. If an inbound message is a STUN reply but we don't recognise the transaction ID, we now return `false` from `accepts_message`.