### PR TITLE
Allow low-level access to `IceAgent`, `IceAgentEvent` & `StunMessage` via `ice` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Handle more optional a=candidate parameters
   * Support REMB (receiver estimated maximum bitrate) feedback packets (breaking)
   * Remove `StunError::Other` because it was unused
+  * Introduce top-level `ice` module, providing access to the `ice::Agent` for standalone usage
 
 # 0.4.1
   * Generated DTLS certificates set issuer/subject for compat with OBS/libdatachannel

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 
 [features]
 _internal_dont_use_log_stats = []
+ice-agent = []
 
 [dependencies]
 thiserror = "1.0.38"

--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -1,10 +1,10 @@
 use crate::channel::ChannelId;
 use crate::dtls::Fingerprint;
-use crate::ice::IceCreds;
 use crate::media::{Media, MediaKind};
 use crate::rtp_::{Mid, Rid, Ssrc};
 use crate::sctp::ChannelConfig;
 use crate::streams::{StreamRx, StreamTx, DEFAULT_RTX_CACHE_DURATION};
+use crate::IceCreds;
 use crate::Rtc;
 use crate::RtcError;
 

--- a/src/change/mod.rs
+++ b/src/change/mod.rs
@@ -20,4 +20,3 @@ mod direct;
 pub use direct::DirectApi;
 
 pub use crate::dtls::{DtlsCert, Fingerprint};
-pub use crate::ice_::IceCreds;

--- a/src/change/mod.rs
+++ b/src/change/mod.rs
@@ -20,4 +20,4 @@ mod direct;
 pub use direct::DirectApi;
 
 pub use crate::dtls::{DtlsCert, Fingerprint};
-pub use crate::ice::IceCreds;
+pub use crate::ice_::IceCreds;

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -7,7 +7,6 @@ use crate::channel::ChannelId;
 use crate::dtls::Fingerprint;
 use crate::format::CodecConfig;
 use crate::format::PayloadParams;
-use crate::ice::{Candidate, IceCreds};
 use crate::io::Id;
 use crate::media::Media;
 use crate::packet::MediaKind;
@@ -20,6 +19,7 @@ use crate::sdp::{Proto, SessionAttribute, Setup};
 use crate::session::Session;
 use crate::Rtc;
 use crate::RtcError;
+use crate::{Candidate, IceCreds};
 
 pub use crate::sdp::{SdpAnswer, SdpOffer};
 use crate::streams::Streams;

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -296,6 +296,11 @@ impl IceAgent {
         &self.local_candidates
     }
 
+    /// Remote ice candidates.
+    pub fn remote_candidates(&self) -> &[Candidate] {
+        &self.remote_candidates
+    }
+
     /// Sets the remote ice credentials.
     pub fn set_remote_credentials(&mut self, r: IceCreds) {
         if self.remote_credentials.as_ref() != Some(&r) {

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -4,8 +4,7 @@
 use thiserror::Error;
 
 mod agent;
-pub(crate) use agent::{IceAgent, IceAgentEvent};
-pub use agent::{IceConnectionState, IceCreds};
+pub use agent::{IceAgent, IceAgentEvent, IceConnectionState, IceCreds};
 
 mod candidate;
 pub use candidate::{Candidate, CandidateKind};

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -11,9 +11,8 @@ use thiserror::Error;
 
 mod stun;
 pub(crate) use stun::stun_resend_delay;
-pub(crate) use stun::{
-    StunError, StunMessage, TransId, STUN_MAX_RETRANS, STUN_MAX_RTO_MILLIS, STUN_TIMEOUT,
-};
+pub use stun::StunMessage;
+pub(crate) use stun::{StunError, TransId, STUN_MAX_RETRANS, STUN_MAX_RTO_MILLIS, STUN_TIMEOUT};
 
 mod sha1;
 pub(crate) use self::sha1::Sha1;

--- a/src/io/stun.rs
+++ b/src/io/stun.rs
@@ -141,12 +141,12 @@ impl<'a> StunMessage<'a> {
     }
 
     /// Whether this STUN message is a BINDING request.
-    pub fn is_binding_request(&self) -> bool {
+    pub(crate) fn is_binding_request(&self) -> bool {
         self.method == Method::Binding && self.class == Class::Request
     }
 
     /// Whether this STUN message is a response.
-    pub fn is_response(&self) -> bool {
+    pub(crate) fn is_response(&self) -> bool {
         matches!(self.class, Class::Success | Class::Failure)
     }
 
@@ -154,17 +154,17 @@ impl<'a> StunMessage<'a> {
     ///
     /// STUN binding requests are very simple, they just return the observed address.
     /// As such, they cannot actually fail which is why we don't have `is_failed_binding_response`.
-    pub fn is_successful_binding_response(&self) -> bool {
+    pub(crate) fn is_successful_binding_response(&self) -> bool {
         self.method == Method::Binding && self.class == Class::Success
     }
 
     /// The transaction ID of this STUN message.
-    pub fn trans_id(&self) -> TransId {
+    pub(crate) fn trans_id(&self) -> TransId {
         self.trans_id
     }
 
     /// Constructs a new BINDING request from the provided data.
-    pub fn binding_request(
+    pub(crate) fn binding_request(
         username: &'a str,
         trans_id: TransId,
         controlling: bool,
@@ -200,7 +200,7 @@ impl<'a> StunMessage<'a> {
     }
 
     /// Constructs a new STUN BINDING reply.
-    pub fn reply(trans_id: TransId, mapped_address: SocketAddr) -> StunMessage<'a> {
+    pub(crate) fn reply(trans_id: TransId, mapped_address: SocketAddr) -> StunMessage<'a> {
         StunMessage {
             class: Class::Success,
             method: Method::Binding,
@@ -216,28 +216,28 @@ impl<'a> StunMessage<'a> {
     }
 
     /// If present, splits the value of the USERNAME attribute into local and remote (separated by `:`).
-    pub fn split_username(&self) -> Option<(&str, &str)> {
+    pub(crate) fn split_username(&self) -> Option<(&str, &str)> {
         self.attrs.split_username()
     }
 
     /// If present, returns the value of XOR-MAPPED-ADDRESS attribute.
-    pub fn mapped_address(&self) -> Option<SocketAddr> {
+    pub(crate) fn mapped_address(&self) -> Option<SocketAddr> {
         self.attrs.mapped_address()
     }
 
     /// If present, returns the value of the PRIORITY attribute.
-    pub fn prio(&self) -> Option<u32> {
+    pub(crate) fn prio(&self) -> Option<u32> {
         self.attrs.prio()
     }
 
     /// Whether this message has the USE-CANDIDATE attribute.
-    pub fn use_candidate(&self) -> bool {
+    pub(crate) fn use_candidate(&self) -> bool {
         self.attrs.use_candidate()
     }
 
     /// Verify the integrity of this message against the provided password.
     #[must_use]
-    pub fn check_integrity(&self, password: &str) -> bool {
+    pub(crate) fn check_integrity(&self, password: &str) -> bool {
         if let Some(integ) = self.attrs.message_integrity() {
             let sha1: Sha1 = password.as_bytes().into();
             let comp = sha1.hmac(&[
@@ -254,7 +254,7 @@ impl<'a> StunMessage<'a> {
     /// Serialize this message into the provided buffer, returning the final length of the message.
     ///
     /// The provided password is used to authenticate the message.
-    pub fn to_bytes(&self, password: &str, buf: &mut [u8]) -> Result<usize, StunError> {
+    pub(crate) fn to_bytes(&self, password: &str, buf: &mut [u8]) -> Result<usize, StunError> {
         let attr_len = self.attrs.iter().fold(0, |p, a| p + a.padded_len());
         let msg_len = 20 + attr_len;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -604,6 +604,7 @@ use ice_::IceAgentEvent;
 pub use ice_::{Candidate, CandidateKind, IceConnectionState};
 
 /// Low level ICE access.
+#[cfg_attr(not(feature = "ice-agent"), doc(hidden))]
 pub mod ice {
     pub use crate::ice_::IceCreds;
     pub use crate::ice_::{IceAgent as Agent, IceAgentEvent as AgentEvent};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,7 +607,7 @@ pub use ice_::{Candidate, CandidateKind, IceConnectionState};
 #[cfg_attr(not(feature = "ice-agent"), doc(hidden))]
 pub mod ice {
     pub use crate::ice_::IceCreds;
-    pub use crate::ice_::{IceAgent as Agent, IceAgentEvent as AgentEvent};
+    pub use crate::ice_::{IceAgent, IceAgentEvent};
     pub use crate::io::StunMessage;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -582,6 +582,7 @@ extern crate tracing;
 
 use bwe::{Bwe, BweKind};
 use change::{DirectApi, SdpApi};
+use ice::IceCreds;
 use rtp::RawPacket;
 use std::fmt;
 use std::net::SocketAddr;
@@ -600,11 +601,11 @@ use dtls::{Dtls, DtlsEvent};
 mod ice_;
 use ice_::IceAgent;
 use ice_::IceAgentEvent;
-use ice_::IceCreds;
 pub use ice_::{Candidate, CandidateKind, IceConnectionState};
 
 /// Low level ICE access.
 pub mod ice {
+    pub use crate::ice_::IceCreds;
     pub use crate::ice_::{IceAgent as Agent, IceAgentEvent as AgentEvent};
     pub use crate::io::StunMessage;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -596,11 +596,17 @@ use dtls::DtlsCert;
 use dtls::Fingerprint;
 use dtls::{Dtls, DtlsEvent};
 
-mod ice;
-use ice::IceAgent;
-use ice::IceAgentEvent;
-use ice::IceCreds;
-pub use ice::{Candidate, CandidateKind};
+#[path = "ice/mod.rs"]
+mod ice_;
+use ice_::IceAgent;
+use ice_::IceAgentEvent;
+use ice_::IceCreds;
+pub use ice_::{Candidate, CandidateKind, IceConnectionState};
+
+/// Low level ICE access.
+pub mod ice {
+    pub use crate::ice_::{IceAgent as Agent, IceAgentEvent as AgentEvent};
+}
 
 mod io;
 use io::DatagramRecv;
@@ -659,8 +665,6 @@ mod sdp;
 pub mod format;
 use format::CodecConfig;
 
-pub use ice::IceConnectionState;
-
 pub mod channel;
 use channel::{Channel, ChannelData, ChannelHandler, ChannelId};
 
@@ -690,7 +694,7 @@ pub mod net {
 /// Various error types.
 pub mod error {
     pub use crate::dtls::DtlsError;
-    pub use crate::ice::IceError;
+    pub use crate::ice_::IceError;
     pub use crate::io::NetError;
     pub use crate::packet::PacketError;
     pub use crate::rtp_::RtpError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -606,6 +606,7 @@ pub use ice_::{Candidate, CandidateKind, IceConnectionState};
 /// Low level ICE access.
 pub mod ice {
     pub use crate::ice_::{IceAgent as Agent, IceAgentEvent as AgentEvent};
+    pub use crate::io::StunMessage;
 }
 
 mod io;

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -12,9 +12,8 @@ use crate::format::Codec;
 use crate::format::CodecSpec;
 use crate::format::FormatParams;
 use crate::format::PayloadParams;
-use crate::ice::{Candidate, IceCreds};
 use crate::rtp_::{Direction, Extension, Frequency, Mid, Pt, Rid, SessionId, Ssrc};
-use crate::VERSION;
+use crate::{Candidate, IceCreds, VERSION};
 
 use super::parser::sdp_parser;
 use super::SdpError;

--- a/src/sdp/parser.rs
+++ b/src/sdp/parser.rs
@@ -9,9 +9,9 @@ use {
 };
 
 use crate::dtls::Fingerprint;
-use crate::ice::{Candidate, CandidateKind};
 use crate::rtp_::{Direction, Extension, Frequency, Mid, Pt, SessionId, Ssrc};
 use crate::sdp::SdpError;
+use crate::{Candidate, CandidateKind};
 
 use super::data::*;
 


### PR DESCRIPTION
In order to allow low level access to `ice` in a similar way as `rtp`, we introduce a public `ice` module that rexports `IceAgent` and `IceAgentEvent`. In addition, we also export `StunMessage` publicly from the `ice` module. To keep the public API small, all functions apart from `StunMessage::parse` are marked as `pub(crate)`. For standalone usage of `IceAgent`, we only need to be able to parse `StunMessage`s but not expose any other details.