### PR TITLE
Re-work `IceAgent::accepts_message` and `IceAgent::handle_receive`

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1537,6 +1537,8 @@ impl IceAgent {
 
 #[cfg(test)]
 mod test {
+    use crate::net;
+
     use super::*;
     use std::net::SocketAddr;
     use std::sync::Once;
@@ -1818,8 +1820,12 @@ mod test {
         let fake_reply =
             make_authenticated_stun_reply(TransId::new(), ipv4_4(), &remote_creds.pass);
 
-        assert!(!agent.accepts_message(&StunMessage::parse(&fake_reply).unwrap()));
-        assert!(agent.accepts_message(&StunMessage::parse(&valid_reply).unwrap()));
+        assert!(!agent.accepts_message(
+            &net::Receive::new(Protocol::Udp, ipv4_1(), ipv4_1(), &fake_reply).unwrap()
+        ));
+        assert!(agent.accepts_message(
+            &net::Receive::new(Protocol::Udp, ipv4_1(), ipv4_1(), &valid_reply).unwrap()
+        ));
     }
 
     fn make_authenticated_stun_reply(tx_id: TransId, addr: SocketAddr, password: &str) -> Vec<u8> {

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -804,19 +804,19 @@ impl IceAgent {
     /// Handles an incoming STUN message.
     ///
     /// Will not be used if [`IceAgent::accepts_message`] returns false.
-    pub fn handle_receive(&mut self, now: Instant, r: Receive) {
+    pub fn handle_receive(&mut self, now: Instant, r: Receive) -> bool {
         trace!("Handle receive: {:?}", r);
 
         if !self.accepts_message(&r) {
             debug!("Message not accepted");
-            return;
+            return false;
         }
 
         let message = match r.contents {
             DatagramRecv::Stun(v) => v,
             _ => {
                 trace!("Receive rejected, not STUN");
-                return;
+                return false;
             }
         };
 
@@ -832,6 +832,8 @@ impl IceAgent {
         });
 
         // TODO handle unsuccessful responses.
+
+        true
     }
 
     pub fn handle_timeout(&mut self, now: Instant) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1492,7 +1492,7 @@ impl Rtc {
 
         // STUN can use the ufrag/password to identify that a message belongs
         // to this Rtc instance.
-        self.ice.accepts_message(&r)
+        self.ice.accepts_message(r)
     }
 
     /// Provide input to this `Rtc` instance. Input is either a [`Input::Timeout`] for some

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1578,7 +1578,9 @@ impl Rtc {
         self.peer_bytes_rx += bytes_rx as u64;
 
         match r.contents {
-            Stun(_) => self.ice.handle_receive(now, r),
+            Stun(_) => {
+                self.ice.handle_receive(now, r);
+            }
             Dtls(_) => self.dtls.handle_receive(r)?,
             Rtp(_) | Rtcp(_) => self.session.handle_receive(now, r),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -603,7 +603,6 @@ use ice::IceCreds;
 pub use ice::{Candidate, CandidateKind};
 
 mod io;
-use io::DatagramRecv;
 
 mod packet;
 
@@ -1493,11 +1492,7 @@ impl Rtc {
 
         // STUN can use the ufrag/password to identify that a message belongs
         // to this Rtc instance.
-        if let DatagramRecv::Stun(v) = &r.contents {
-            return self.ice.accepts_message(v);
-        }
-
-        false
+        self.ice.accepts_message(&r)
     }
 
     /// Provide input to this `Rtc` instance. Input is either a [`Input::Timeout`] for some


### PR DESCRIPTION
In preparation for making `IceAgent` public, we re-work parts of its public API to make the process easier. In particular, we remove `StunMessage` from the public API by changing the signature of `accepts_message` to take a `net::Receive` instead. `net::Receive` is already part of str0m's public API and can be easily constructed by end-users.

To align the two APIs further, we also return a `bool` from `handle_receive`, indicating whether or not the message was actually handled. 