### PR TITLE
Remove `StunError::Other`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * Header extension abs_send_time is now an Instant
   * Handle more optional a=candidate parameters
   * Support REMB (receiver estimated maximum bitrate) feedback packets (breaking)
+  * Remove `StunError::Other` because it was unused
 
 # 0.4.1
   * Generated DTLS certificates set issuer/subject for compat with OBS/libdatachannel

--- a/src/io/stun.rs
+++ b/src/io/stun.rs
@@ -39,9 +39,6 @@ pub enum StunError {
 
     #[error("STUN io: {0}")]
     Io(#[from] io::Error),
-
-    #[error("STUN error: {0}")]
-    Other(String),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -232,11 +229,6 @@ impl<'a> StunMessage<'a> {
     }
 
     pub fn to_bytes(&self, password: &str, buf: &mut [u8]) -> Result<usize, StunError> {
-        self.do_to_bytes(password, buf)
-            .map_err(|e| StunError::Other(format!("io write: {e:?}")))
-    }
-
-    fn do_to_bytes(&self, password: &str, buf: &mut [u8]) -> Result<usize, io::Error> {
         let attr_len = self.attrs.iter().fold(0, |p, a| p + a.padded_len());
         let msg_len = 20 + attr_len;
 


### PR DESCRIPTION
The only usage site of `StunError::Other` is an `io::Error` which we already have a variant for.