### PR TITLE
Decouple low-level components from `net::Receice`

### DIFF
--- a/src/dtls/mod.rs
+++ b/src/dtls/mod.rs
@@ -6,7 +6,7 @@ use std::io::{self, ErrorKind, Read, Write};
 use std::net::SocketAddr;
 use thiserror::Error;
 
-use crate::io::{DatagramRecv, DatagramSend, Receive, DATAGRAM_MTU_WARN};
+use crate::io::{DatagramSend, DATAGRAM_MTU_WARN};
 
 mod ossl;
 use ossl::{dtls_create_ctx, dtls_ssl_create, TlsStream};
@@ -251,15 +251,7 @@ impl Dtls {
     }
 
     /// Handles an incoming DTLS datagrams.
-    pub fn handle_receive(&mut self, r: Receive) -> Result<(), DtlsError> {
-        let message = match r.contents {
-            DatagramRecv::Dtls(v) => v,
-            _ => {
-                trace!("Receive rejected, not DTLS");
-                return Ok(());
-            }
-        };
-
+    pub fn handle_receive(&mut self, message: &[u8]) -> Result<(), DtlsError> {
         self.tls.inner_mut().set_incoming(message);
 
         if self.handle_handshake()? {

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1298,7 +1298,7 @@ impl IceAgent {
         self.transmit.push_back(trans);
     }
 
-    fn stun_client_handle_response(&mut self, now: Instant, message: &StunMessage<'_>) {
+    fn stun_client_handle_response(&mut self, now: Instant, message: StunMessage<'_>) {
         // Find the candidate pair that this trans_id was sent for.
         let trans_id = message.trans_id();
         let maybe_pair = self

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -817,7 +817,7 @@ impl IceAgent {
 
         // Regardless of whether we have remote_creds at this point, we can
         // at least check the message integrity.
-        if !self.accepts_message(&message) {
+        if !self.accepts_message(message) {
             debug!("Message not accepted");
             return;
         }

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -812,19 +812,18 @@ impl IceAgent {
     ///
     /// Will not be used if [`IceAgent::accepts_message`] returns false.
     pub fn handle_receive(&mut self, now: Instant, packet: StunPacket) {
-        let message = &packet.message;
-        trace!("Handle receive: {:?}", message);
+        trace!("Handle receive: {:?}", &packet.message);
 
         // Regardless of whether we have remote_creds at this point, we can
         // at least check the message integrity.
-        if !self.accepts_message(message) {
+        if !self.accepts_message(&packet.message) {
             debug!("Message not accepted");
             return;
         }
 
         if packet.message.is_binding_request() {
             self.stun_server_handle_message(now, &packet);
-        } else if message.is_successful_binding_response() {
+        } else if packet.message.is_successful_binding_response() {
             self.stun_client_handle_response(now, packet.message);
         }
 

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -494,7 +494,7 @@ mod test {
                         proto: trans.proto,
                         source,
                         destination,
-                        message: &message,
+                        message,
                     };
                     t.span.in_scope(|| t.agent.handle_receive(t.time, packet));
                 }

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -73,7 +73,7 @@ mod test {
     use std::ops::{Deref, DerefMut};
     use std::time::{Duration, Instant};
 
-    use crate::io::{Protocol, StunMessage};
+    use crate::io::{Protocol, StunMessage, StunPacket};
     use tracing::Span;
 
     pub fn sock(s: impl Into<String>) -> SocketAddr {
@@ -490,10 +490,13 @@ mod test {
                     // drop packet
                     t.span.in_scope(|| t.agent.handle_timeout(t.time));
                 } else {
-                    t.span.in_scope(|| {
-                        t.agent
-                            .handle_receive(t.time, trans.proto, source, destination, message)
-                    });
+                    let packet = StunPacket {
+                        proto: trans.proto,
+                        source,
+                        destination,
+                        message: &message,
+                    };
+                    t.span.in_scope(|| t.agent.handle_receive(t.time, packet));
                 }
             } else {
                 // drop packet

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -493,7 +493,12 @@ mod test {
                     // drop packet
                     t.span.in_scope(|| t.agent.handle_timeout(t.time));
                 } else {
-                    t.span.in_scope(|| t.agent.handle_receive(t.time, receive));
+                    if let Ok(stun) = receive.contents.try_into_stun() {
+                        t.span.in_scope(|| {
+                            t.agent
+                                .handle_receive(t.time, receive.proto, source, destination, stun)
+                        });
+                    }
                 }
             } else {
                 // drop packet

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -127,9 +127,9 @@ impl<'a> Receive<'a> {
         })
     }
 
-    pub(crate) fn into_stun_packet(&self) -> StunPacket {
+    pub(crate) fn as_stun_packet(&self) -> StunPacket {
         let DatagramRecv::Stun(message) = &self.contents else {
-            panic!("into_stun_packet on non-stun packet");
+            panic!("as_stun_packet on non-stun packet");
         };
 
         StunPacket {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -140,6 +140,16 @@ pub enum DatagramRecv<'a> {
     Rtcp(&'a [u8]),
 }
 
+impl<'a> DatagramRecv<'a> {
+    #[cfg(test)]
+    pub(crate) fn try_into_stun(self) -> Result<StunMessage<'a>, Self> {
+        match self {
+            DatagramRecv::Stun(stun) => Ok(stun),
+            _ => Err(self),
+        }
+    }
+}
+
 impl<'a> TryFrom<&'a [u8]> for DatagramRecv<'a> {
     type Error = NetError;
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -126,26 +126,13 @@ impl<'a> Receive<'a> {
             contents,
         })
     }
-
-    pub(crate) fn as_stun_packet(&self) -> StunPacket {
-        let DatagramRecv::Stun(message) = &self.contents else {
-            panic!("as_stun_packet on non-stun packet");
-        };
-
-        StunPacket {
-            proto: self.proto,
-            source: self.source,
-            destination: self.destination,
-            message,
-        }
-    }
 }
 
-pub struct StunPacket<'a, 'b> {
+pub struct StunPacket<'a> {
     pub proto: Protocol,
     pub source: SocketAddr,
     pub destination: SocketAddr,
-    pub message: &'b StunMessage<'a>,
+    pub message: StunMessage<'a>,
 }
 
 /// Wrapper for a parsed payload to be received.

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -82,6 +82,12 @@ pub struct Transmit {
 #[derive(Debug)]
 pub struct DatagramSend(Vec<u8>);
 
+impl AsRef<[u8]> for DatagramSend {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
 impl From<Vec<u8>> for DatagramSend {
     fn from(value: Vec<u8>) -> Self {
         DatagramSend(value)
@@ -138,16 +144,6 @@ pub enum DatagramRecv<'a> {
     Rtp(&'a [u8]),
     #[doc(hidden)]
     Rtcp(&'a [u8]),
-}
-
-impl<'a> DatagramRecv<'a> {
-    #[cfg(test)]
-    pub(crate) fn try_into_stun(self) -> Result<StunMessage<'a>, Self> {
-        match self {
-            DatagramRecv::Stun(stun) => Ok(stun),
-            _ => Err(self),
-        }
-    }
 }
 
 impl<'a> TryFrom<&'a [u8]> for DatagramRecv<'a> {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -82,12 +82,6 @@ pub struct Transmit {
 #[derive(Debug)]
 pub struct DatagramSend(Vec<u8>);
 
-impl AsRef<[u8]> for DatagramSend {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
-    }
-}
-
 impl From<Vec<u8>> for DatagramSend {
     fn from(value: Vec<u8>) -> Self {
         DatagramSend(value)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1594,7 +1594,8 @@ impl Rtc {
                 .ice
                 .handle_receive(now, r.proto, r.source, r.destination, stun),
             Dtls(dtls) => self.dtls.handle_receive(dtls)?,
-            Rtp(_) | Rtcp(_) => self.session.handle_receive(now, r),
+            Rtp(rtp) => self.session.handle_rtp_receive(now, rtp),
+            Rtcp(rtcp) => self.session.handle_rtcp_receive(now, rtcp),
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1590,7 +1590,7 @@ impl Rtc {
         self.peer_bytes_rx += bytes_rx as u64;
 
         match r.contents {
-            Stun(_) => self.ice.handle_receive(now, r.into_stun_packet()),
+            Stun(_) => self.ice.handle_receive(now, r.as_stun_packet()),
             Dtls(dtls) => self.dtls.handle_receive(dtls)?,
             Rtp(rtp) => self.session.handle_rtp_receive(now, rtp),
             Rtcp(rtcp) => self.session.handle_rtcp_receive(now, rtcp),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1592,7 +1592,7 @@ impl Rtc {
         match r.contents {
             Stun(stun) => self.ice.handle_receive(
                 now,
-                StunPacket {
+                io::StunPacket {
                     proto: r.proto,
                     source: r.source,
                     destination: r.destination,
@@ -2199,8 +2199,6 @@ macro_rules! log_stat {
     };
 }
 pub(crate) use log_stat;
-
-use crate::io::StunPacket;
 
 #[cfg(test)]
 mod test {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1593,7 +1593,7 @@ impl Rtc {
             Stun(stun) => self
                 .ice
                 .handle_receive(now, r.proto, r.source, r.destination, stun),
-            Dtls(_) => self.dtls.handle_receive(r)?,
+            Dtls(dtls) => self.dtls.handle_receive(dtls)?,
             Rtp(_) | Rtcp(_) => self.session.handle_receive(now, r),
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1590,7 +1590,15 @@ impl Rtc {
         self.peer_bytes_rx += bytes_rx as u64;
 
         match r.contents {
-            Stun(_) => self.ice.handle_receive(now, r.as_stun_packet()),
+            Stun(stun) => self.ice.handle_receive(
+                now,
+                StunPacket {
+                    proto: r.proto,
+                    source: r.source,
+                    destination: r.destination,
+                    message: stun,
+                },
+            ),
             Dtls(dtls) => self.dtls.handle_receive(dtls)?,
             Rtp(rtp) => self.session.handle_rtp_receive(now, rtp),
             Rtcp(rtcp) => self.session.handle_rtcp_receive(now, rtcp),
@@ -2191,6 +2199,8 @@ macro_rules! log_stat {
     };
 }
 pub(crate) use log_stat;
+
+use crate::io::StunPacket;
 
 #[cfg(test)]
 mod test {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,7 +612,7 @@ pub mod ice {
 }
 
 mod io;
-use io::{DatagramRecv, StunPacket};
+use io::DatagramRecv;
 
 mod packet;
 
@@ -1590,14 +1590,7 @@ impl Rtc {
         self.peer_bytes_rx += bytes_rx as u64;
 
         match r.contents {
-            Stun(_) => {
-                // unwrap here is OK because the only thing that can fail converting
-                // Receive -> StunPacket is it not being STUN. That's matched in the
-                // surrounding enum.
-                let stun_packet = StunPacket::try_from(&r).unwrap();
-
-                self.ice.handle_receive(now, stun_packet)
-            }
+            Stun(_) => self.ice.handle_receive(now, r.into_stun_packet()),
             Dtls(dtls) => self.dtls.handle_receive(dtls)?,
             Rtp(rtp) => self.session.handle_rtp_receive(now, rtp),
             Rtcp(rtcp) => self.session.handle_rtcp_receive(now, rtcp),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1590,7 +1590,9 @@ impl Rtc {
         self.peer_bytes_rx += bytes_rx as u64;
 
         match r.contents {
-            Stun(_) => self.ice.handle_receive(now, r),
+            Stun(stun) => self
+                .ice
+                .handle_receive(now, r.proto, r.source, r.destination, stun),
             Dtls(_) => self.dtls.handle_receive(r)?,
             Rtp(_) | Rtcp(_) => self.session.handle_receive(now, r),
         }

--- a/src/session.rs
+++ b/src/session.rs
@@ -266,11 +266,12 @@ impl Session {
     }
 
     pub fn handle_rtp_receive(&mut self, now: Instant, message: &[u8]) {
-        if let Some(header) = RtpHeader::parse(message, &self.exts) {
-            self.handle_rtp(now, header, message);
-        } else {
+        let Some(header) = RtpHeader::parse(message, &self.exts) else {
             trace!("Failed to parse RTP header");
-        }
+            return;
+        };
+
+        self.handle_rtp(now, header, message);
     }
 
     pub fn handle_rtcp_receive(&mut self, now: Instant, message: &[u8]) {


### PR DESCRIPTION
Currently, `net::Receive` is used to parse and de-multiplex incoming messages between STUN, DTLS, RTP and RTCP. `Rtc` however does not use the parsed message and instead passes on the entire `net::Receive` struct to the sub-components. This requires each low-level component like `Dtls`, `Session` and `IceAgent` to revalidate that they are in fact only being passed the data that they can handle.

To fix this, we change the signatures of the various `handle_receive` functions to only take in the parsed message. For DTLS, RTP and RTCP, this is only a byte-buffer which isn't the most type-safe way to go about it. Those APIs are crate-private though so for now, this isn't be a big issue.