### PR TITLE
Don't allocate while parsing `StunMessage`

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -129,6 +129,7 @@ impl<'a> Receive<'a> {
 }
 
 /// Wrapper for a parsed payload to be received.
+#[allow(clippy::large_enum_variant)] // We purposely don't want to allocate.
 pub enum DatagramRecv<'a> {
     #[doc(hidden)]
     Stun(StunMessage<'a>),

--- a/src/io/stun.rs
+++ b/src/io/stun.rs
@@ -243,7 +243,7 @@ impl<'a> StunMessage<'a> {
     /// Serialize this message into the provided buffer, returning the final length of the message.
     ///
     /// The provided password is used to authenticate the message.
-    pub(crate) fn to_bytes(&self, password: &str, buf: &mut [u8]) -> Result<usize, StunError> {
+    pub(crate) fn to_bytes(self, password: &str, buf: &mut [u8]) -> Result<usize, StunError> {
         const MSG_HEADER_LEN: usize = 20;
         const MSG_INTEGRITY_LEN: usize = 20;
         const FPRINT_LEN: usize = 4;
@@ -435,7 +435,7 @@ impl<'a> Attributes<'a> {
         username + ice_controlled + ice_controlling + priority + address + use_candidate
     }
 
-    fn to_bytes(&self, vec: &mut dyn Write, trans_id: &[u8]) -> io::Result<()> {
+    fn to_bytes(self, vec: &mut dyn Write, trans_id: &[u8]) -> io::Result<()> {
         if let Some(v) = self.username {
             vec.write_all(&0x0006_u16.to_be_bytes())?;
             vec.write_all(&(v.as_bytes().len() as u16).to_be_bytes())?;

--- a/src/io/stun.rs
+++ b/src/io/stun.rs
@@ -518,12 +518,12 @@ impl<'a> Attributes<'a> {
             }
             let typ = (buf[0] as u16) << 8 | buf[1] as u16;
             let len = (buf[2] as usize) << 8 | buf[3] as usize;
-            trace!(
-                "STUN attribute typ 0x{:04x?} len {}: {:02x?}",
-                typ,
-                len,
-                buf
-            );
+            // trace!(
+            //     "STUN attribute typ 0x{:04x?} len {}: {:02x?}",
+            //     typ,
+            //     len,
+            //     buf
+            // );
             if len > buf.len() - 4 {
                 return Err(StunError::Parse(format!(
                     "Bad STUN attribute length: {} > {}",

--- a/src/io/stun.rs
+++ b/src/io/stun.rs
@@ -67,7 +67,7 @@ impl TransId {
 ///
 /// STUN is a very flexible protocol.
 /// This implementations only provides what we need for our ICE implementation.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct StunMessage<'a> {
     method: Method,
     class: Class,

--- a/src/io/stun.rs
+++ b/src/io/stun.rs
@@ -172,24 +172,18 @@ impl<'a> StunMessage<'a> {
         prio: u32,
         use_candidate: bool,
     ) -> Self {
-        let mut attrs = Attributes::default();
-        attrs.username = Some(username);
-        if controlling {
-            attrs.ice_controlling = Some(control_tie_breaker);
-        } else {
-            attrs.ice_controlled = Some(control_tie_breaker);
-        }
-        attrs.priority = Some(prio);
-
-        if use_candidate {
-            attrs.use_candidate = Some(true);
-        }
-
         StunMessage {
             class: Class::Request,
             method: Method::Binding,
             trans_id,
-            attrs,
+            attrs: Attributes {
+                username: Some(username),
+                ice_controlling: controlling.then_some(control_tie_breaker),
+                ice_controlled: (!controlling).then_some(control_tie_breaker),
+                priority: Some(prio),
+                use_candidate: use_candidate.then_some(true),
+                ..Default::default()
+            },
             integrity: &[],
             integrity_len: 0,
         }
@@ -197,14 +191,14 @@ impl<'a> StunMessage<'a> {
 
     /// Constructs a new STUN BINDING reply.
     pub(crate) fn reply(trans_id: TransId, mapped_address: SocketAddr) -> StunMessage<'a> {
-        let mut attrs = Attributes::default();
-        attrs.xor_mapped_address = Some(mapped_address);
-
         StunMessage {
             class: Class::Success,
             method: Method::Binding,
             trans_id,
-            attrs,
+            attrs: Attributes {
+                xor_mapped_address: Some(mapped_address),
+                ..Default::default()
+            },
             integrity: &[],
             integrity_len: 0,
         }

--- a/src/io/stun.rs
+++ b/src/io/stun.rs
@@ -414,24 +414,35 @@ use super::Sha1;
 
 impl<'a> Attributes<'a> {
     fn padded_len(&self) -> usize {
+        const ATTR_TLV_LENGTH: usize = 4;
+
         let username = self
             .username
             .map(|v| {
                 let pad = 4 - (v.as_bytes().len() % 4) % 4;
-                4 + v.len() + pad
+                ATTR_TLV_LENGTH + v.len() + pad
             })
             .unwrap_or_default();
-        let ice_controlled = self.ice_controlled.map(|_| 4 + 8).unwrap_or_default();
-        let ice_controlling = self.ice_controlling.map(|_| 4 + 8).unwrap_or_default();
+        let ice_controlled = self
+            .ice_controlled
+            .map(|_| ATTR_TLV_LENGTH + 8)
+            .unwrap_or_default();
+        let ice_controlling = self
+            .ice_controlling
+            .map(|_| ATTR_TLV_LENGTH + 8)
+            .unwrap_or_default();
         let priority = self
             .priority
-            .map(|p| 4 + p.to_le_bytes().len())
+            .map(|p| ATTR_TLV_LENGTH + p.to_le_bytes().len())
             .unwrap_or_default();
         let address = self
             .xor_mapped_address
-            .map(|a| 4 + if a.is_ipv4() { 8 } else { 20 })
+            .map(|a| ATTR_TLV_LENGTH + if a.is_ipv4() { 8 } else { 20 })
             .unwrap_or_default();
-        let use_candidate = self.use_candidate.map(|_| 4).unwrap_or_default();
+        let use_candidate = self
+            .use_candidate
+            .map(|_| ATTR_TLV_LENGTH)
+            .unwrap_or_default();
 
         username + ice_controlled + ice_controlling + priority + address + use_candidate
     }

--- a/src/io/stun.rs
+++ b/src/io/stun.rs
@@ -381,7 +381,6 @@ pub struct Attributes<'a> {
     ice_controlling: Option<u64>, // 0x802a
     // https://tools.ietf.org/html/draft-thatcher-ice-network-cost-00
     network_cost: Option<(u16, u16)>, // 0xc057
-                                      // Unknown: u16,
 }
 
 impl<'a> Attributes<'a> {

--- a/src/io/stun.rs
+++ b/src/io/stun.rs
@@ -516,8 +516,8 @@ impl<'a> Attributes<'a> {
             if buf.is_empty() {
                 break;
             }
-            let typ = (buf[0] as u16) << 8 | buf[1] as u16;
-            let len = (buf[2] as usize) << 8 | buf[3] as usize;
+            let typ = u16::from_le_bytes([buf[1], buf[0]]);
+            let len = u16::from_le_bytes([buf[3], buf[2]]) as usize;
             // trace!(
             //     "STUN attribute typ 0x{:04x?} len {}: {:02x?}",
             //     typ,

--- a/src/io/stun.rs
+++ b/src/io/stun.rs
@@ -389,17 +389,18 @@ impl<'a> Attributes<'a> {
         // usernames are on the form gfNK:062g where
         // gfNK is my local sdp ice username and
         // 062g is the remote.
-        if let Some(v) = self.username {
-            let idx = v.find(':');
-            if let Some(idx) = idx {
-                if idx + 1 < v.len() {
-                    let local = &v[..idx];
-                    let remote = &v[(idx + 1)..];
-                    return Some((local, remote));
-                }
-            }
+
+        let v = self.username?;
+        let idx = v.find(':')?;
+
+        if idx + 1 >= v.len() {
+            return None;
         }
-        None
+
+        let local = &v[..idx];
+        let remote = &v[(idx + 1)..];
+
+        Some((local, remote))
     }
 
     fn use_candidate(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -957,6 +957,7 @@ impl Event {
 
 /// Input as expected by [`Rtc::handle_input()`]. Either network data or a timeout.
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)] // We purposely don't want to allocate.
 pub enum Input<'a> {
     /// A timeout without any network input.
     Timeout(Instant),


### PR DESCRIPTION
Currently, attributes are parsed into a `Vec` which results in an allocation for each STUN message that is parsed. We only support a limited set of attributes in `str0m` so this can also be expressed using `Option`s which allows us to parse STUN messages allocation free.

As a result, `StunMessage` now implements `Copy`!