### PR TITLE
Feature _internal_test_exports for tests and fuzz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 target
 chrome-user-data-dir
 .DS_Store
-fuzz
 tracing*
 *.svg
 xamples
 .vscode
+fuzz/corpus
+fuzz/artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,13 @@
 version = 3
 
 [[package]]
+name = "_str0m_test"
+version = "0.1.0"
+dependencies = [
+ "str0m",
+]
+
+[[package]]
 name = "adler32"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +935,7 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 name = "str0m"
 version = "0.4.1"
 dependencies = [
+ "_str0m_test",
  "combine",
  "crc",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 [features]
 default = []
 _internal_dont_use_log_stats = []
+_internal_test_exports = []
 
 [dependencies]
 thiserror = "1.0.38"
@@ -41,6 +42,7 @@ rouille = { version = "3.5.0", features = ["ssl"] }
 serde_json = "1.0"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "std"] }
 systemstat = "0.2.2"
+_str0m_test = { path = "_str0m_test" } # dummy package that enables "_internal_test_exports"
 
 # This is to ensure MSRV 1.65
 # Remove when we move MSRV

--- a/_str0m_test/Cargo.lock
+++ b/_str0m_test/Cargo.lock
@@ -3,10 +3,11 @@
 version = 3
 
 [[package]]
-name = "arbitrary"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
+name = "_str0m_test"
+version = "0.1.0"
+dependencies = [
+ "str0m",
+]
 
 [[package]]
 name = "autocfg"
@@ -16,9 +17,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "block-buffer"
@@ -31,15 +32,15 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
@@ -47,7 +48,6 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
- "jobserver",
  "libc",
 ]
 
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crypto-common"
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "libc",
@@ -167,30 +167,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
-
-[[package]]
-name = "libfuzzer-sys"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
-dependencies = [
- "arbitrary",
- "cc",
- "once_cell",
-]
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "log"
@@ -200,21 +180,21 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.6.2"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5486aed0026218e61b8a01d5fbd5a0a134649abb71a0e53b7bc088529dced86e"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -238,18 +218,18 @@ dependencies = [
 
 [[package]]
 name = "openssl-src"
-version = "111.27.0+1.1.1v"
+version = "300.2.1+3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e8f197c82d7511c5b014030c9b1efeda40d7d5f99d23b4ceed3524a5e63f02"
+checksum = "3fe476c29791a5ca0d1273c697e96085bbabbbea2ef7afd5617e78a4b40332d3"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.92"
+version = "0.9.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
+checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
 dependencies = [
  "cc",
  "libc",
@@ -266,9 +246,9 @@ checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
 name = "ppv-lite86"
@@ -278,9 +258,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
 dependencies = [
  "unicode-ident",
 ]
@@ -341,18 +321,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -408,14 +388,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "str0m-fuzz"
-version = "0.0.0"
-dependencies = [
- "libfuzzer-sys",
- "str0m",
-]
-
-[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,9 +395,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -434,18 +406,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "83a48fd946b02c0a526b2e9481c8e2a17755e47039164a86c4070446e3a4614d"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "e7fbe9b594d6568a6a1443250a7e67d80b74e1e96f6d1715e1e21cc1888291d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -454,11 +426,10 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -466,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -477,24 +448,24 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "vcpkg"

--- a/_str0m_test/Cargo.toml
+++ b/_str0m_test/Cargo.toml
@@ -1,0 +1,11 @@
+# Dummy package to enable the _internal_test_exports for the integration tests.
+# This is a hack until Rust lets us enable features per profile (dev/test profile)
+# https://github.com/rust-lang/cargo/issues/2911
+
+[package]
+name = "_str0m_test"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+str0m = { path = "..", features = ["_internal_test_exports"] }

--- a/_str0m_test/src/lib.rs
+++ b/_str0m_test/src/lib.rs
@@ -1,0 +1,2 @@
+//! This can be empty since feature flags are additive, and the _internal_test_exports
+//! is enabled for str0m in the main compilation unit.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,6 +12,7 @@ libfuzzer-sys = "0.4"
 
 [dependencies.str0m]
 path = ".."
+features = ["_internal_test_exports"]
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/fuzz/fuzz_targets/rtx_buffer.rs
+++ b/fuzz/fuzz_targets/rtx_buffer.rs
@@ -1,27 +1,6 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use std::time::{Duration, Instant};
-use str0m::fuzz::*;
+use str0m::_internal_test_exports::fuzz::*;
 
-fuzz_target!(|data: &[u8]| {
-    if data.len() < 4 {
-        return;
-    }
-
-    let buf_size = u16::from_be_bytes([data[0], data[1]]);
-    let max_age = data[2] as u64;
-    let mut buf = EvictingBuffer::new(buf_size as usize, Duration::from_secs(max_age));
-    let mut now = Instant::now();
-    let mut pos = 0;
-
-    for d in &data[4..] {
-        now += Duration::from_millis(*d as u64);
-        if d % 2 == 0 {
-            buf.maybe_evict(now)
-        } else {
-            pos += *d as u64;
-            buf.push(pos, now, d);
-        }
-    }
-});
+fuzz_target!(|data: &[u8]| rtx_buffer(data));

--- a/run-fuzz.sh
+++ b/run-fuzz.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 
-cargo +nightly fuzz run rtx_buffer -- --stop-after-first-failure
+if [ "$1" == "" ]; then
+    cargo +nightly fuzz list
+else
+    cargo +nightly fuzz run $1 -- --stop-after-first-failure
+fi

--- a/src/_internal_test_exports/fuzz.rs
+++ b/src/_internal_test_exports/fuzz.rs
@@ -1,0 +1,29 @@
+//! Exported fuzz targets to get them part of the compilation with feature `_internal_test_exports`.
+
+use std::time::Duration;
+use std::time::Instant;
+
+use crate::streams::rtx_cache_buf::EvictingBuffer;
+
+pub fn rtx_buffer(data: &[u8]) {
+    if data.len() < 4 {
+        return;
+    }
+
+    let buf_size = u16::from_be_bytes([data[0], data[1]]);
+    let max_age = data[2] as u64;
+    let max_size = data[3] as usize;
+    let mut buf = EvictingBuffer::new(buf_size as usize, Duration::from_secs(max_age), max_size);
+    let mut now = Instant::now();
+    let mut pos = 0;
+
+    for d in &data[4..] {
+        now += Duration::from_millis(*d as u64);
+        if d % 2 == 0 {
+            buf.maybe_evict(now)
+        } else {
+            pos += *d as u64;
+            buf.push(pos, now, d);
+        }
+    }
+}

--- a/src/_internal_test_exports/mod.rs
+++ b/src/_internal_test_exports/mod.rs
@@ -1,0 +1,41 @@
+//! Exported things with feature `_internal_test_exports`.
+
+use crate::format::PayloadParams;
+use crate::ice_::IceCreds;
+use crate::media::Media;
+use crate::media::Mid;
+use crate::rtp::{ExtensionMap, RtpHeader};
+use crate::Rtc;
+
+pub mod fuzz;
+
+impl Rtc {
+    /// UNSTABLE: not public API!
+    pub fn _mids(&self) -> Vec<Mid> {
+        self.session.medias.iter().map(Media::mid).collect()
+    }
+
+    /// UNSTABLE: not public API!
+    pub fn _exts(&self) -> &ExtensionMap {
+        &self.session.exts
+    }
+
+    /// UNSTABLE: not public API!
+    pub fn _local_ice_creds(&self) -> IceCreds {
+        self.ice.local_credentials().clone()
+    }
+}
+
+impl RtpHeader {
+    /// UNSTABLE: not public API!
+    pub fn _parse(buf: &[u8], exts: &ExtensionMap) -> Option<RtpHeader> {
+        Self::parse(buf, exts)
+    }
+}
+
+impl PayloadParams {
+    /// UNSTABLE: not public API!
+    pub fn _is_locked(&self) -> bool {
+        self.locked
+    }
+}

--- a/src/format.rs
+++ b/src/format.rs
@@ -390,12 +390,6 @@ impl PayloadParams {
             }
         }
     }
-
-    /// Exposed for integration tests.
-    #[doc(hidden)]
-    pub fn is_locked(&self) -> bool {
-        self.locked
-    }
 }
 
 impl CodecConfig {

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -411,8 +411,7 @@ impl Candidate {
         self.ufrag = Some(ufrag.into());
     }
 
-    #[doc(hidden)]
-    pub fn ufrag(&self) -> Option<&str> {
+    pub(crate) fn ufrag(&self) -> Option<&str> {
         self.ufrag.as_deref()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1661,24 +1661,6 @@ impl Rtc {
     pub fn codec_config(&self) -> &CodecConfig {
         &self.session.codec_config
     }
-
-    /// All media mids (not application). For integration tests.
-    #[doc(hidden)]
-    pub fn mids(&self) -> Vec<Mid> {
-        self.session.medias.iter().map(Media::mid).collect()
-    }
-
-    /// All current RTP header extensions. For integration tests.
-    #[doc(hidden)]
-    pub fn exts(&self) -> &ExtensionMap {
-        &self.session.exts
-    }
-
-    /// Current local ICE credentials. For integration tests.
-    #[doc(hidden)]
-    pub fn local_ice_creds(&self) -> IceCreds {
-        self.ice.local_credentials().clone()
-    }
 }
 
 /// Customized config for creating an [`Rtc`] instance.
@@ -2229,8 +2211,6 @@ mod test {
     }
 }
 
-#[cfg(fuzzing)]
+#[cfg(feature = "_internal_test_exports")]
 #[allow(missing_docs)]
-pub mod fuzz {
-    pub use crate::streams::rtx_cache_buf::EvictingBuffer;
-}
+pub mod _internal_test_exports;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -575,6 +575,7 @@
 #![allow(clippy::bool_to_int_with_if)]
 #![allow(clippy::assertions_on_constants)]
 #![allow(clippy::manual_range_contains)]
+#![allow(clippy::get_first)]
 #![deny(missing_docs)]
 
 #[macro_use]

--- a/src/rtp/header.rs
+++ b/src/rtp/header.rs
@@ -130,8 +130,7 @@ impl RtpHeader {
         true
     }
 
-    #[doc(hidden)]
-    pub fn parse(buf: &[u8], exts: &ExtensionMap) -> Option<RtpHeader> {
+    pub(crate) fn parse(buf: &[u8], exts: &ExtensionMap) -> Option<RtpHeader> {
         let orig_len = buf.len();
         if buf.len() < 12 {
             trace!("RTP header too short < 12: {}", buf.len());

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -25,38 +25,33 @@ pub struct Sdp {
 }
 
 impl Sdp {
-    #[doc(hidden)]
-    pub fn parse(input: &str) -> Result<Sdp, SdpError> {
+    pub(crate) fn parse(input: &str) -> Result<Sdp, SdpError> {
         sdp_parser()
             .easy_parse(input)
             .map(|(sdp, _)| sdp)
             .map_err(|e| SdpError::ParseError(e.to_string()))
     }
 
-    #[doc(hidden)]
-    pub fn assert_consistency(&self) -> Result<(), SdpError> {
+    pub(crate) fn assert_consistency(&self) -> Result<(), SdpError> {
         match self.do_assert_consistency() {
             None => Ok(()),
             Some(error) => Err(SdpError::Inconsistent(error)),
         }
     }
 
-    #[doc(hidden)]
-    pub fn fingerprint(&self) -> Option<Fingerprint> {
+    pub(crate) fn fingerprint(&self) -> Option<Fingerprint> {
         self.session
             .fingerprint()
             .or_else(|| self.media_lines.iter().find_map(|m| m.fingerprint()))
     }
 
-    #[doc(hidden)]
-    pub fn ice_creds(&self) -> Option<IceCreds> {
+    pub(crate) fn ice_creds(&self) -> Option<IceCreds> {
         self.session
             .ice_creds()
             .or_else(|| self.media_lines.iter().find_map(|m| m.ice_creds()))
     }
 
-    #[doc(hidden)]
-    pub fn ice_candidates(&self) -> impl Iterator<Item = &Candidate> {
+    pub(crate) fn ice_candidates(&self) -> impl Iterator<Item = &Candidate> {
         let mut candidates: HashSet<&Candidate> = HashSet::new();
 
         // Session level ice candidates.
@@ -70,8 +65,7 @@ impl Sdp {
         candidates.into_iter()
     }
 
-    #[doc(hidden)]
-    pub fn setup(&self) -> Option<Setup> {
+    pub(crate) fn setup(&self) -> Option<Setup> {
         self.session
             .setup()
             .or_else(|| self.media_lines.iter().find_map(|m| m.setup()))

--- a/src/sdp/parser.rs
+++ b/src/sdp/parser.rs
@@ -317,8 +317,7 @@ where
 }
 
 /// Parser for a=candidate lines.
-#[doc(hidden)]
-pub fn candidate_attribute<Input>() -> impl Parser<Input, Output = Candidate>
+pub(crate) fn candidate_attribute<Input>() -> impl Parser<Input, Output = Candidate>
 where
     Input: Stream<Token = char>,
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -295,7 +295,7 @@ pub fn vp8_data() -> Vec<(Duration, RtpHeader, Vec<u8>)> {
         // This magic number 42 is the ethernet/IP/UDP framing of the packet.
         let rtp_data = &pkt.data[42..];
 
-        let header = RtpHeader::parse(rtp_data, &exts).unwrap();
+        let header = RtpHeader::_parse(rtp_data, &exts).unwrap();
         let payload = &rtp_data[header.header_len..];
 
         ret.push((relative_time, header, payload.to_vec()));
@@ -325,7 +325,7 @@ pub fn vp9_data() -> Vec<(Duration, RtpHeader, Vec<u8>)> {
         // This magic number 42 is the ethernet/IP/UDP framing of the packet.
         let rtp_data = &pkt.data[42..];
 
-        let header = RtpHeader::parse(rtp_data, &exts).unwrap();
+        let header = RtpHeader::_parse(rtp_data, &exts).unwrap();
         let payload = &rtp_data[header.header_len..];
 
         ret.push((relative_time, header, payload.to_vec()));
@@ -355,7 +355,7 @@ pub fn h264_data() -> Vec<(Duration, RtpHeader, Vec<u8>)> {
         // This magic number 42 is the ethernet/IP/UDP framing of the packet.
         let rtp_data = &pkt.data[42..];
 
-        let header = RtpHeader::parse(rtp_data, &exts).unwrap();
+        let header = RtpHeader::_parse(rtp_data, &exts).unwrap();
         let payload = &rtp_data[header.header_len..];
 
         ret.push((relative_time, header, payload.to_vec()));

--- a/tests/ice-restart.rs
+++ b/tests/ice-restart.rs
@@ -43,8 +43,8 @@ pub fn ice_restart() -> Result<(), RtcError> {
         progress(&mut l, &mut r)?;
     }
 
-    let l_creds = l.local_ice_creds();
-    let r_creds = r.local_ice_creds();
+    let l_creds = l._local_ice_creds();
+    let r_creds = r._local_ice_creds();
 
     let (offer, pending) = r.span.in_scope(|| {
         let mut change = r.rtc.sdp_api();
@@ -76,12 +76,12 @@ pub fn ice_restart() -> Result<(), RtcError> {
 
     assert_ne!(
         r_creds,
-        r.local_ice_creds(),
+        r._local_ice_creds(),
         "After an ICE restart ICE credentials should have changed"
     );
     assert_ne!(
         l_creds,
-        l.local_ice_creds(),
+        l._local_ice_creds(),
         "After an ICE restart ICE credentials should have changed"
     );
 

--- a/tests/sdp-negotiation.rs
+++ b/tests/sdp-negotiation.rs
@@ -30,11 +30,11 @@ pub fn change_default_pt() {
 
     // Test left side.
     assert_eq!(&[opus(100)], &**l.codec_config());
-    assert!(l.codec_config()[0].is_locked());
+    assert!(l.codec_config()[0]._is_locked());
 
     // Test right side.
     assert_eq!(&[opus(100)], &**r.codec_config());
-    assert!(r.codec_config()[0].is_locked());
+    assert!(r.codec_config()[0]._is_locked());
 }
 
 #[test]
@@ -50,11 +50,11 @@ pub fn answer_change_order() {
         &[h264(96), vp8(98)],
     );
 
-    let mid = l.mids()[0];
+    let mid = l._mids()[0];
 
     // Test left side.
     assert_eq!(&[vp8(100), h264(102)], &**l.codec_config());
-    assert!(l.codec_config().iter().all(|p| p.is_locked()));
+    assert!(l.codec_config().iter().all(|p| p._is_locked()));
     assert_eq!(
         l.media(mid).unwrap().remote_pts(),
         // R side has expressed its preference order, but amended the PT to match the OFFER.
@@ -63,7 +63,7 @@ pub fn answer_change_order() {
 
     // Test right side.
     assert_eq!(&[h264(102), vp8(100)], &**r.codec_config());
-    assert!(r.codec_config().iter().all(|p| p.is_locked()));
+    assert!(r.codec_config().iter().all(|p| p._is_locked()));
     assert_eq!(
         r.media(mid).unwrap().remote_pts(),
         // OFFER straight up.
@@ -84,14 +84,14 @@ pub fn answer_narrow() {
         &[h264(96)],
     );
 
-    let mid = l.mids()[0];
+    let mid = l._mids()[0];
 
     // Test left side.
     assert_eq!(&[vp8(100), h264(102)], &**l.codec_config());
     assert_eq!(
         l.codec_config()
             .iter()
-            .map(|p| p.is_locked())
+            .map(|p| p._is_locked())
             .collect::<Vec<_>>(),
         // VP8 is not locked, H264 is
         vec![false, true]
@@ -104,7 +104,7 @@ pub fn answer_narrow() {
 
     // Test right side. The PT of h264 is updated with what L OFFERed.
     assert_eq!(&[h264(102)], &**r.codec_config());
-    assert!(r.codec_config().iter().all(|p| p.is_locked()));
+    assert!(r.codec_config().iter().all(|p| p._is_locked()));
     assert_eq!(
         r.media(mid).unwrap().remote_pts(),
         // OFFER straight up.
@@ -125,17 +125,17 @@ pub fn answer_no_match() {
         &[h264(96)],
     );
 
-    let mid = l.mids()[0];
+    let mid = l._mids()[0];
 
     // Test left side. Nothing has changed. The codec is not locked.
     assert_eq!(&[vp8(100)], &**l.codec_config());
-    assert!(!l.codec_config()[0].is_locked());
+    assert!(!l.codec_config()[0]._is_locked());
     // No remote PTs.
     assert_eq!(l.media(mid).unwrap().remote_pts(), &[]);
 
     // Test right side. Nothing has changed. The codec is not locked.
     assert_eq!(&[h264(96)], &**r.codec_config());
-    assert!(!r.codec_config()[0].is_locked());
+    assert!(!r.codec_config()[0]._is_locked());
     // No remote PTs.
     assert_eq!(r.media(mid).unwrap().remote_pts(), &[]);
 
@@ -226,10 +226,10 @@ fn answer_remaps() {
     // This negotiates a video track.
     let (l, r) = with_exts(exts_l, exts_r);
 
-    let v_l: Vec<_> = l.exts().iter_video().collect();
-    let v_r: Vec<_> = r.exts().iter_video().collect();
-    let a_l: Vec<_> = l.exts().iter_audio().collect();
-    let a_r: Vec<_> = r.exts().iter_audio().collect();
+    let v_l: Vec<_> = l._exts().iter_video().collect();
+    let v_r: Vec<_> = r._exts().iter_video().collect();
+    let a_l: Vec<_> = l._exts().iter_audio().collect();
+    let a_r: Vec<_> = r._exts().iter_audio().collect();
 
     // L locks 3 and changes it from 14
     // R keeps 3 and changes it from 14.
@@ -282,15 +282,15 @@ fn offers_unsupported_extension() {
     let (l, r) = with_exts(exts_l, exts_r);
 
     assert_eq!(
-        l.exts().iter_video().collect::<Vec<_>>(),
+        l._exts().iter_video().collect::<Vec<_>>(),
         vec![(3, &VideoOrientation), (8, &ColorSpace)]
     );
     assert_eq!(
-        r.exts().iter_video().collect::<Vec<_>>(),
+        r._exts().iter_video().collect::<Vec<_>>(),
         vec![(3, &VideoOrientation)]
     );
 
-    let mid = l.mids()[0];
+    let mid = l._mids()[0];
     let m_l = l.media(mid).unwrap();
     let m_r = r.media(mid).unwrap();
 
@@ -324,7 +324,7 @@ fn non_media_creator_cannot_change_inactive_to_recvonly() {
     negotiate(&mut l, &mut r, |change| {
         change.add_media(MediaKind::Video, Direction::Inactive, None, None);
     });
-    let mid = r.mids()[0];
+    let mid = r._mids()[0];
     let m_r = r.media(mid).unwrap();
     assert_eq!(m_r.direction(), Direction::Inactive);
 
@@ -357,7 +357,7 @@ fn media_creator_can_change_inactive_to_recvonly() {
     negotiate(&mut l, &mut r, |change| {
         change.add_media(MediaKind::Video, Direction::Inactive, None, None);
     });
-    let mid = r.mids()[0];
+    let mid = r._mids()[0];
     let m_r = r.media(mid).unwrap();
     assert_eq!(m_r.direction(), Direction::Inactive);
 


### PR DESCRIPTION
The feature `_internal_test_exports` enables code that is used for integration tests and fuzzing. This PR also makes `pub(crate)` of a bunch of `fn`s that were `#[doc(hidden)]`. That might break someone's code downstream, but we want to at least have code documentation on which functions are de-facto public API (or consider making them proper public API).
