### PR TITLE
Rework some #[doc(hidden)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -613,7 +613,7 @@ pub mod ice {
 }
 
 mod io;
-use io::DatagramRecv;
+use io::DatagramRecvInner;
 
 mod packet;
 
@@ -1502,7 +1502,7 @@ impl Rtc {
 
         // STUN can use the ufrag/password to identify that a message belongs
         // to this Rtc instance.
-        if let DatagramRecv::Stun(v) = &r.contents {
+        if let DatagramRecvInner::Stun(v) = &r.contents.inner {
             return self.ice.accepts_message(v);
         }
 
@@ -1581,9 +1581,9 @@ impl Rtc {
 
         trace!("IN {:?}", r);
         self.last_now = now;
-        use net::DatagramRecv::*;
+        use DatagramRecvInner::*;
 
-        let bytes_rx = match r.contents {
+        let bytes_rx = match r.contents.inner {
             // TODO: stun is already parsed (depacketized) here
             Stun(_) => 0,
             Dtls(v) | Rtp(v) | Rtcp(v) => v.len(),
@@ -1591,7 +1591,7 @@ impl Rtc {
 
         self.peer_bytes_rx += bytes_rx as u64;
 
-        match r.contents {
+        match r.contents.inner {
             Stun(stun) => self.ice.handle_packet(
                 now,
                 io::StunPacket {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,7 +605,11 @@ use ice_::IceAgentEvent;
 pub use ice_::{Candidate, CandidateKind, IceConnectionState};
 
 /// Low level ICE access.
-#[doc(hidden)] // Only for advanced users.
+// The ICE API is not necessary to interact with directly for "regular"
+// use of str0m. This is exported for other libraries that want to
+// reuse str0m's ICE implementation. In the future we might turn this
+// into a separate crate.
+#[doc(hidden)]
 pub mod ice {
     pub use crate::ice_::IceCreds;
     pub use crate::ice_::{IceAgent, IceAgentEvent};

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -704,6 +704,8 @@ pub enum MediaType {
     Audio,
     Video,
     Application,
+    // If a parsed SDP has a value we don't recognize, we stick it
+    // in here. We could consider making that a parse exception instead.
     #[doc(hidden)]
     Unknown(String),
 }


### PR DESCRIPTION
- Properply hide contents of DatagramRecv
- Code doc for some #[doc(hidden)]
- Refactor away Event::Error hack
