### PR TITLE
fix: TwccRecvRegister max_seq slow

### DIFF
--- a/src/rtp/rtcp/twcc.rs
+++ b/src/rtp/rtcp/twcc.rs
@@ -262,11 +262,7 @@ impl TwccRecvRegister {
     }
 
     pub fn max_seq(&self) -> SeqNo {
-        self.queue
-            .iter()
-            .map(|r| r.seq)
-            .max_by_key(|r| *r)
-            .unwrap_or_else(|| 0.into())
+        self.queue.back().map(|r| r.seq).unwrap_or_else(|| 0.into())
     }
 
     pub fn update_seq(&mut self, seq: SeqNo, time: Instant) {


### PR DESCRIPTION
TwccRecvRegister queue is sorted list so we don't have to finding max seq with bellow code.

https://github.com/algesten/str0m/blob/b73fe14cd06a7b630ee7cf5ac0129e852fe12bcc/src/rtp/rtcp/twcc.rs#L264-L270

After change bellow simple publisher-viewer single audio track benchmark speedup from 5.2 Kelm/s to 356.15 Kelm/s

```rust
    let (mut l, mut r) = connect_l_r();

    let mid = "aud".into();

    // In this example we are not using RID to identify the stream, we are simply
    // using SSRC 1 as knowledge shared between sending and receiving side.
    let ssrc: Ssrc = 1.into();

    l.direct_api().declare_media(mid, MediaKind::Audio);

    l.direct_api().declare_stream_tx(ssrc, None, mid, None);

    r.direct_api().declare_media(mid, MediaKind::Audio);

    r.direct_api().expect_stream_rx(ssrc, None, mid, None);

    let max = l.last.max(r.last);
    l.last = max;
    r.last = max;

    let params = l.params_opus();
    let ssrc = l.direct_api().stream_tx_by_mid(mid, None).unwrap().ssrc();
    assert_eq!(params.spec().codec, Codec::Opus);
    let pt = params.pt();

    loop {
        progress(&mut l, &mut r).expect("");

        if l.duration() > Duration::from_millis(300) {
            break;
        }
    }

    // Repeat the 3 a bunch of times.
    let mut seq_no = 0;
    let mut count_event = 0;

    let mut group = c.benchmark_group("audio-send-recv");
    group.throughput(Throughput::Elements(1));

    group.bench_function("single-rtp", |b| {
        b.iter(|| {
            seq_no += 1;
            let wallclock = l.start + l.duration();
            let mut direct = l.direct_api();
            let stream = direct.stream_tx(&ssrc).unwrap();
            let time = (seq_no * 20 * 48) as u32;

            let exts = ExtensionValues {
                audio_level: None,
                voice_activity: None,
                ..Default::default()
            };

            stream
                .write_rtp(
                    pt,
                    seq_no.into(),
                    time,
                    wallclock,
                    false,
                    exts,
                    false,
                    vec![0x01, 0x02, 0x03, 0x04],
                )
                .expect("clean write");

            progress(&mut l, &mut r).expect("");
            while let Some(e) = l.events.pop() {}
            while let Some(e) = r.events.pop() {
                count_event += 1;
            }
        })
    });
    group.finish();
```

```sh
     Running benches/bench_audio/main.rs (target/release/deps/bench_audio-09fa0c5cc0e1a496)
audio-send-recv/single-rtp
                        time:   [186.97 µs 191.95 µs 196.30 µs]
                        thrpt:  [5.0943 Kelem/s 5.2097 Kelem/s 5.3484 Kelem/s]
                 change:
                        time:   [-2.6925% +0.8088% +4.4693%] (p = 0.66 > 0.05)
                        thrpt:  [-4.2781% -0.8023% +2.7670%]
                        No change in performance detected.

     Running benches/bench_audio/main.rs (target/release/deps/bench_audio-09fa0c5cc0e1a496)
audio-send-recv/single-rtp
                        time:   [2.8040 µs 2.8078 µs 2.8119 µs]
                        thrpt:  [355.64 Kelem/s 356.15 Kelem/s 356.63 Kelem/s]
                 change:
                        time:   [-98.398% -98.341% -98.265%] (p = 0.00 < 0.05)
                        thrpt:  [+5664.1% +5926.8% +6143.6%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
```