### PR TITLE
fix: is_video func missing h265

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -842,7 +842,7 @@ impl Codec {
     /// Tells if codec is video.
     pub fn is_video(&self) -> bool {
         use Codec::*;
-        matches!(self, H264 | Vp8 | Vp9 | Av1)
+        matches!(self, H265 | H264 | Vp8 | Vp9 | Av1)
     }
 
     /// Audio/Video.


### PR DESCRIPTION
Current Codec.is_video function is missing H265 type. This PR just add H265 Codec type to is_video function.