### PR TITLE
Fix missing return in TrendlineEstimator::detect

### DIFF
--- a/src/packet/bwe/trendline_estimator.rs
+++ b/src/packet/bwe/trendline_estimator.rs
@@ -171,6 +171,7 @@ impl TrendlineEstimator {
     fn detect(&mut self, trend: f64, variation: InterGroupDelayDelta, now: Instant) {
         if self.num_delay_variations < 2 {
             self.update_hypothesis(BandwithUsage::Normal);
+            return;
         }
 
         let modified_trend = self.num_delay_variations.min(*DELAY_COUNT_RANGE.start()) as f64


### PR DESCRIPTION
Then intent is to set the initial hypothesis to `BandwithUsage::Normal`, but due to the lack of `return` this didn't happen.