### PR TITLE
Robust(er) RTX PT allocation for StreamTx

### DIFF
--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -440,11 +440,13 @@ impl Media {
         self.remote_created
     }
 
-    pub(crate) fn first_pt_with_rtx(&self, config: &CodecConfig) -> Option<Pt> {
+    pub(crate) fn first_rtx_pt(&self, config: &CodecConfig) -> Option<Pt> {
         config
             .all_for_kind(self.kind)
-            .find(|p| p.resend().is_some() && self.remote_pts.contains(&p.pt))
-            .map(|p| p.pt())
+            // Only consider negotiated PTs
+            .filter(|p| self.remote_pts.contains(&p.pt))
+            // Map to the first RTX found
+            .find_map(|p| p.resend())
     }
 
     pub(crate) fn reset_depayloader(&mut self, payload_type: Pt, rid: Option<Rid>) {

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -116,10 +116,6 @@ impl RtpPacket {
             timestamp: already_happened(),
         }
     }
-
-    pub(crate) fn is_pt_set(&self) -> bool {
-        self.header.payload_type != BLANK_PACKET_DEFAULT_PT
-    }
 }
 
 /// Holder of incoming/outgoing encoded streams.

--- a/src/streams/rtx_cache.rs
+++ b/src/streams/rtx_cache.rs
@@ -30,6 +30,7 @@ impl RtxCache {
     }
 
     pub fn cache_sent_packet(&mut self, packet: RtpPacket, now: Instant) {
+        assert!(packet.nackable);
         let seq_no = packet.seq_no;
         let quantized_size = packet.payload.len() / RTX_CACHE_SIZE_QUANTIZER;
         self.packet_by_seq_no.push(*seq_no, now, packet);


### PR DESCRIPTION
[One of our users reports](https://str0m.zulipchat.com/#narrow/stream/377845-general/topic/Getting.20panic.20.22pt_rtx.20resend.2Fblank.22/near/412721167) that we got an `expect()` that trips. Any expect/unwrap that trips means we have a bug.

`/src/streams/send.rs:382:45: pt_rtx resend/blank`

The code in question:

```rs
  NextPacketKind::Resend(_) | NextPacketKind::Blank(_) => {
      let pt_rtx = param.resend().expect("pt_rtx resend/blank");
```

Whenever we have a `Resend` or `Blank` packet, we assume the RTX PT is known. This is sometimes (apparently) not true. Rather than dwelling on exact root cause, I've rewritten the code in question to have a more robust way of detecting which RTX PT to use. It should also be impossible to produce a `Resend` or `Blank` if the PT isn't known.