### PR TITLE
chore: re-export `StunPacket`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -615,7 +615,7 @@ pub use ice_::{Candidate, CandidateKind, IceConnectionState};
 pub mod ice {
     pub use crate::ice_::IceCreds;
     pub use crate::ice_::{IceAgent, IceAgentEvent};
-    pub use crate::io::StunMessage;
+    pub use crate::io::{StunMessage, StunPacket};
 }
 
 mod io;


### PR DESCRIPTION
Unless I am missing something, `StunPacket` isn't re-exported anywhere so the current `IceAgent` API cannot be used from outside the crate.