### PR TITLE
feat: explicitly set `base` of server-reflexive addresses

### DIFF
--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -177,8 +177,10 @@ impl Candidate {
     ///
     /// Server reflexive candidates are local sockets mapped to external ip discovered
     /// via a STUN binding request.
+    /// The `base` is the local interface that this address corresponds to.
     pub fn server_reflexive(
         addr: SocketAddr,
+        base: SocketAddr,
         proto: impl TryInto<Protocol>,
     ) -> Result<Self, IceError> {
         if !is_valid_ip(addr.ip()) {
@@ -191,7 +193,7 @@ impl Candidate {
             parse_proto(proto)?,
             None,
             addr,
-            Some(addr),
+            Some(base),
             CandidateKind::ServerReflexive,
             None,
             None,


### PR DESCRIPTION
Without further adjustments, this will set `Transmit.source` to the provided base here. Opening this here because we are (temporarily) depending on it.

Resolves: #453.