### PR TITLE
feat: allow user to trigger ICE restart upon invalidating candidate from nominated pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   * Header extension abs_send_time is now an Instant
   * Handle more optional a=candidate parameters
   * Support REMB (receiver estimated maximum bitrate) feedback packets (breaking)
+  * `IceAgent::invalidate_candidate` returns whether the candidate was part of the currently nominated pair (breaking)
 
 # 0.4.1
   * Generated DTLS certificates set issuer/subject for compat with OBS/libdatachannel

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1542,8 +1542,6 @@ impl IceAgent {
 }
 
 /// A candidate was successfully invalidated.
-///
-/// This struct returns further details on the new state of the agent.
 #[derive(Debug)]
 pub struct Invalidated {
     /// Whether the invalidated candidate was part of the nominated pair.

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -694,9 +694,10 @@ impl IceAgent {
                 other.set_discarded();
                 self.discard_candidate_pairs(idx);
 
-                let nominated_is_gone = self.nominated_send.is_some_and(|nominated| {
-                    self.candidate_pairs.iter().all(|p| p.id() != nominated)
-                });
+                let nominated_is_gone = match self.nominated_send {
+                    Some(nominated) => self.candidate_pairs.iter().all(|p| p.id() != nominated),
+                    None => false,
+                };
 
                 return Ok(Invalidated {
                     was_nominated: nominated_is_gone,

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -251,7 +251,7 @@ mod test {
     }
 
     #[test]
-    pub fn invalidating_candidate_of_nominated_pair_returns_true() {
+    pub fn invalidate_candidate() {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
@@ -289,9 +289,14 @@ mod test {
             "c1 and c2 should be the nominated pair"
         );
 
-        let invalidated = a1.invalidate_candidate(&c1).unwrap();
+        let invalidated = a1.invalidate_candidate(&c3).unwrap();
+        assert!(
+            !invalidated.was_nominated,
+            "expect `c3` to not be nominated"
+        );
 
-        assert!(invalidated.was_nominated);
+        let invalidated = a1.invalidate_candidate(&c1).unwrap();
+        assert!(invalidated.was_nominated, "expect `c1` to be nominated");
     }
 
     #[test]

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -4,7 +4,7 @@
 use thiserror::Error;
 
 mod agent;
-pub use agent::{IceAgent, IceAgentEvent, IceConnectionState, IceCreds};
+pub use agent::{IceAgent, IceAgentEvent, IceConnectionState, IceCreds, Invalidated};
 
 mod candidate;
 pub use candidate::{Candidate, CandidateKind};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,7 +612,7 @@ pub use ice_::{Candidate, CandidateKind, IceConnectionState};
 #[doc(hidden)]
 pub mod ice {
     pub use crate::ice_::IceCreds;
-    pub use crate::ice_::{IceAgent, IceAgentEvent};
+    pub use crate::ice_::{IceAgent, IceAgentEvent, Invalidated};
     pub use crate::io::{StunMessage, StunPacket};
 }
 


### PR DESCRIPTION
Currently, invalidating a candidate only returns `true` when we successfully invalidated the candidate. That isn't particularly helpful though. What I really want to know is whether the candidate was part of the currently nominated pair. In that case, I want to trigger an ICE restart to restore the connection.

It is temping to say: "We should automatically trigger an ICE restart for the user". Being a library though, I think `str0m` should refrain from such a _policy_ and instead stick to _mechanisms_. We expose the information that the candidate was part of the nominated pair. If desired, the user can immediately call `ice_restart` as a result.