### PR TITLE
fix: invalidate nominated pair if we invalidated one of its candidates

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -692,6 +692,13 @@ impl IceAgent {
                 debug!("Local candidate to discard {:?}", other);
                 other.set_discarded();
                 self.discard_candidate_pairs(idx);
+
+                if let Some(nominated) = self.nominated_send {
+                    if self.candidate_pairs.iter().all(|p| p.id() != nominated) {
+                        self.nominated_send = None;
+                    }
+                }
+
                 return true;
             }
         }


### PR DESCRIPTION
I didn't manage to write a test for this but I think it is an artifact of the test harness which "simply" flips `source` and `destination` and thus still allows traffic from `1.1.1.1` despite us invalidating that candidate.