### PR TITLE
Fix panic in Rtc::accepts() with STUN traffic

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -797,6 +797,12 @@ impl IceAgent {
             }
         }
 
+        // The integrity check below may panic if no remote ICE credentials yet exist
+        if self.remote_credentials.is_none() {
+            trace!("Message rejected, no remote ICE credentials");
+            return false;
+        }
+
         let (_, password) = self.stun_credentials(!message.is_response());
         if !message.check_integrity(&password) {
             trace!("Message rejected, integrity check failed");


### PR DESCRIPTION
Fixes https://github.com/algesten/str0m/issues/460

As a summary of that discussion, if you have two `Rtc` instances, one negotiated and the other not, and you pass incoming STUN traffic intended for the negotiated instance to the `Rtc::accepts()` of the non-negotiated instance, it will panic in `stun_credentials` because without an offer, no remote ICE credentials will have been sent. This PR simply checks for this case first.