### PR TITLE
fix: don't form new pairs for invalidated candidates

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1188,6 +1188,11 @@ impl IceAgent {
             // If the pair is not already on the checklist:
             let local = &self.local_candidates[local_idx];
             let remote = &self.remote_candidates[remote_idx];
+
+            if local.discarded() {
+                return; // Ignore STUN requests to discarded candidates
+            }
+
             let prio = CandidatePair::calculate_prio(self.controlling, remote.prio(), local.prio());
 
             // *  Its state is set to Waiting. (this is the default)

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -249,6 +249,48 @@ mod test {
     }
 
     #[test]
+    pub fn no_respond_to_stun_request_on_invalidated_candidate() {
+        let mut a1 = TestAgent::new(info_span!("L"));
+        let mut a2 = TestAgent::new(info_span!("R"));
+
+        let c1 = host("1.1.1.1:1000", "udp");
+        a1.add_local_candidate(c1.clone());
+        a2.add_remote_candidate(c1.clone());
+        let c2 = host("2.2.2.2:1000", "udp");
+        a2.add_local_candidate(c2.clone());
+        a1.add_remote_candidate(c2);
+        a1.set_controlling(true);
+        a2.set_controlling(false);
+
+        loop {
+            if a1.state().is_connected() && a2.state().is_connected() {
+                break;
+            }
+            progress(&mut a1, &mut a2);
+        }
+
+        a1.agent.invalidate_candidate(&c1);
+
+        let timeout = a2.poll_timeout().unwrap();
+        a2.handle_timeout(timeout);
+        let transmit = a2.poll_transmit().unwrap();
+
+        assert!(a1.poll_transmit().is_none());
+
+        a1.handle_packet(
+            Instant::now(),
+            StunPacket {
+                proto: Protocol::Udp,
+                source: sock("2.2.2.2:1000"),
+                destination: sock("1.1.1.1:1000"),
+                message: StunMessage::parse(&transmit.contents).unwrap(),
+            },
+        );
+
+        assert!(a1.poll_transmit().is_none());
+    }
+
+    #[test]
     pub fn ice_lite_no_connection() {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));


### PR DESCRIPTION
When a candidate gets invalidated, we don't want it to be used anymore. At the moment, `str0m` will form new pairs upon receiving a STUN request for an invalidated candidate. With the new pair being created, `str0m` will restart sending binding requests for this candidate pair.