### PR TITLE
chore: only add on INFO log about new candidates if we actually change state

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -379,8 +379,6 @@ impl IceAgent {
     /// Adding loopback addresses or multicast/broadcast addresses causes
     /// an error.
     pub fn add_local_candidate(&mut self, mut c: Candidate) -> bool {
-        info!("Add local candidate: {:?}", c);
-
         let ip = c.addr().ip();
 
         if self.ice_lite {
@@ -493,6 +491,8 @@ impl IceAgent {
             .filter(|(_, v)| !v.discarded() && v.addr().is_ipv4() == ip.is_ipv4())
             .map(|(i, _)| i)
             .collect();
+
+        info!("Add local candidate: {:?}", c);
 
         self.local_candidates.push(c);
 

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -518,8 +518,6 @@ impl IceAgent {
     /// Adding loopback addresses or multicast/broadcast addresses causes
     /// an error.
     pub fn add_remote_candidate(&mut self, mut c: Candidate) {
-        info!("Add remote candidate: {:?}", c);
-
         // This is a a:rtcp-mux-only implementation. The only component
         // we accept is 1 for RTP.
         if c.component_id() != 1 {
@@ -565,6 +563,8 @@ impl IceAgent {
             *existing = c;
             idx
         } else {
+            info!("Add remote candidate: {:?}", c);
+
             self.remote_candidates.push(c);
             self.remote_candidates.len() - 1
         };

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -471,15 +471,15 @@ impl IceAgent {
                     other, c
                 );
                 return false;
-            } else {
-                // Stop using the current candidate in favor of the new one.
-                debug!(
-                    "Replace redundant candidate, current: {:?} replaced with: {:?}",
-                    other, c
-                );
-                other.set_discarded();
-                self.discard_candidate_pairs(idx);
             }
+
+            // Stop using the current candidate in favor of the new one.
+            debug!(
+                "Replace redundant candidate, current: {:?} replaced with: {:?}",
+                other, c
+            );
+            other.set_discarded();
+            self.discard_candidate_pairs(idx);
         }
 
         // Tie this ufrag to this ICE-session.


### PR DESCRIPTION
Similar as to #465.