### PR TITLE
fix: don't panic on parsing `StunMessage` from 0-length buffer

### DIFF
--- a/src/io/stun.rs
+++ b/src/io/stun.rs
@@ -844,4 +844,11 @@ mod test {
             r#"Attributes { username: "foo", message_integrity: [48, 48, 48, 48], error_code: (401, "Unauthorized"), realm: "baz", nonce: "abcd", xor_mapped_address: 127.0.0.1:0, software: "str0m", fingerprint: 9999, priority: 1, use_candidate: true, ice_controlled: 10, ice_controlling: 100, network_cost: (10, 10) }"#
         );
     }
+
+    #[test]
+    fn parse_zero_length_buffer() {
+        let result = StunMessage::parse(&[]);
+
+        assert!(result.is_err());
+    }
 }

--- a/src/io/stun.rs
+++ b/src/io/stun.rs
@@ -79,6 +79,10 @@ pub struct StunMessage<'a> {
 impl<'a> StunMessage<'a> {
     /// Parse a STUN message from a slice of bytes.
     pub fn parse(buf: &[u8]) -> Result<StunMessage, StunError> {
+        if buf.len() < 4 {
+            return Err(StunError::Parse("Buffer too short".into()));
+        }
+
         let typ = (buf[0] as u16 & 0b0011_1111) << 8 | buf[1] as u16;
         let len = (buf[2] as u16) << 8 | buf[3] as u16;
         if len & 0b0000_0011 > 0 {


### PR DESCRIPTION
This API is most likely called with a buffer read from the network. We need to guard against being given a buffer that is too short.