### PR TITLE
feat: immediately queue STUN request after forming pair

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -671,6 +671,20 @@ impl IceAgent {
             let pair = self.candidate_pairs.pop();
             debug!("Remove overflow pair {:?}", pair);
         }
+
+        let newly_formed_pairs = self
+            .candidate_pairs
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, p)| {
+                (local_idxs.contains(&p.local_idx()) && remote_idxs.contains(&p.remote_idx()))
+                    .then_some(idx)
+            })
+            .collect::<Vec<_>>();
+
+        for idx in newly_formed_pairs {
+            self.stun_client_binding_request(self.last_now.unwrap(), idx)
+        }
     }
 
     /// Invalidate a candidate and remove it from the connection.


### PR DESCRIPTION
In my testing, I've found this to improve connection setup latency by about 0.7 seconds. There might be a better way of solving this but I wanted to open a PR to start the discussion.

The reason this makes things faster is because we would otherwise only queue the STUN requests upon the next `handle_timeout` to the `IceAgent`.