### PR TITLE
chore: remove superfluous "ICE restart" log

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -713,7 +713,6 @@ impl IceAgent {
     /// process.
     #[allow(unused)]
     pub fn ice_restart(&mut self, local_credentials: IceCreds, keep_local_candidates: bool) {
-        info!("ICE restart");
         // An ICE agent MAY restart ICE for existing data streams.  An ICE
         // restart causes all previous states of the data streams, excluding the
         // roles of the agents, to be flushed.  The only difference between an


### PR DESCRIPTION
When calling `IceAgent::ice_restart`, we always see the following logs:

```
2024-03-13T23:54:12.115048Z  INFO str0m::ice_::agent: ICE restart
2024-03-13T23:54:12.115057Z  INFO str0m::ice_::agent: State change (ice restart): Completed -> Checking
```

This PR removes the first one because it is superfluous.