### PR TITLE
Fix panic on STUN binding failure while multiplexing

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -798,7 +798,7 @@ impl IceAgent {
             }
         }
 
-        if message.is_successful_binding_response() {
+        if message.is_response() {
             let belongs_to_a_candidate_pair = self
                 .candidate_pairs
                 .iter()

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -12,7 +12,10 @@ use thiserror::Error;
 mod stun;
 pub(crate) use stun::stun_resend_delay;
 pub use stun::StunMessage;
-pub(crate) use stun::{StunError, TransId, STUN_MAX_RETRANS, STUN_MAX_RTO_MILLIS, STUN_TIMEOUT};
+pub(crate) use stun::{
+    Class as StunClass, Method as StunMethod, StunError, TransId, STUN_MAX_RETRANS,
+    STUN_MAX_RTO_MILLIS, STUN_TIMEOUT,
+};
 
 mod id;
 // this is only exported from this crate to avoid needing

--- a/src/io/stun.rs
+++ b/src/io/stun.rs
@@ -143,14 +143,17 @@ impl<'a> StunMessage<'a> {
         })
     }
 
+    pub(crate) fn method(&self) -> Method {
+        self.method
+    }
+
+    pub(crate) fn class(&self) -> Class {
+        self.class
+    }
+
     /// Whether this STUN message is a BINDING request.
     pub(crate) fn is_binding_request(&self) -> bool {
         self.method == Method::Binding && self.class == Class::Request
-    }
-
-    /// Whether this STUN message is a response.
-    pub(crate) fn is_response(&self) -> bool {
-        matches!(self.class, Class::Success | Class::Failure)
     }
 
     /// Whether this STUN message is a _successful_ BINDING response.
@@ -316,7 +319,7 @@ impl<'a> StunMessage<'a> {
 const MAGIC: &[u8] = &[0x21, 0x12, 0xA4, 0x42];
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-enum Class {
+pub(crate) enum Class {
     Request,
     Indication,
     Success,
@@ -349,7 +352,7 @@ impl Class {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-enum Method {
+pub(crate) enum Method {
     Binding,
     Unknown,
 }


### PR DESCRIPTION
An unrelated bug I had in my application was causing STUN to fail, and a `Class::Failure` message to come back. Because like in the chat example, I'm still using a single multiplexed UDP socket, this message first went to the `Rtc::accepts()` of a separate client that had not negotiated, which caused it to panic with "Remote ICE Credentials".

This is the same underlying panic as in https://github.com/algesten/str0m/pull/461, but this time the logic was allowed to fall through to the `stun_credentials()` call because we were only doing the preceding candidate-pair test for `Class::Success` responses, not `Class::Failure`.

I wanted to add a test for this, but with the current field visibility on `StunMessage`, I couldn't create a failure message in a test. I wasn't sure if adding a helper to `impl StunMessage` was appropriate.