### PR TITLE
fix(ice): do not disconnect whilst we still check new candidates

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1673,6 +1673,8 @@ impl IceAgent {
                     if !any_still_possible {
                         self.set_connection_state(Completed, "no more possible to try");
                     }
+                } else if any_still_possible {
+                    self.set_connection_state(Checking, "got new possible");
                 } else {
                     self.set_connection_state(Disconnected, "none nominated");
                 }
@@ -1682,6 +1684,8 @@ impl IceAgent {
                     if any_still_possible && !self.ice_lite {
                         self.set_connection_state(Connected, "got new possible");
                     }
+                } else if any_still_possible {
+                    self.set_connection_state(Checking, "got new possible");
                 } else {
                     self.set_connection_state(Disconnected, "none nominated");
                 }


### PR DESCRIPTION
In case the active candidate pair gets invalidated, str0m currently instantly emits a `Disconnected` event. For example, if a candidate pair with a peer-reflexive candidate gets nominated and later replaced. This results in a disconnected event despite us not actually being disconnected (a peer-reflexive candidate that gets replaced is after all the exact same socket).

To avoid this false-positive disconnection, we transition back to `Checking` in case we are still evaluating other candidates.