### PR TITLE
Opus DTX support

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -323,7 +323,7 @@ impl PayloadParams {
         // the default.
         let either_dtx_specified = c0.format.use_dtx.is_some() || c1.format.use_dtx.is_some();
         if either_dtx_specified && c0.format.use_dtx != c1.format.use_dtx {
-            score = score.saturating_sub(1);
+            score = score.saturating_sub(4);
         }
 
         score

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -882,6 +882,9 @@ pub enum FormatParam {
     /// Specifies that the decoder can do Opus in-band FEC
     UseInbandFec(bool),
 
+    /// Specifies that the decoder can do Opus DTX
+    UseDtx(bool),
+
     /// Whether h264 sending media encoded at a different level in the offerer-to-answerer
     /// direction than the level in the answerer-to-offerer direction, is allowed.
     LevelAsymmetryAllowed(bool),
@@ -923,6 +926,7 @@ impl FormatParam {
                 }
             }
             "useinbandfec" => UseInbandFec(v == "1"),
+            "usedtx" => UseDtx(v == "1"),
             "level-asymmetry-allowed" => LevelAsymmetryAllowed(v == "1"),
             "packetization-mode" => {
                 if let Ok(v) = v.parse() {
@@ -967,6 +971,7 @@ impl fmt::Display for FormatParam {
         match self {
             MinPTime(v) => write!(f, "minptime={v}"),
             UseInbandFec(v) => write!(f, "useinbandfec={}", i32::from(*v)),
+            UseDtx(v) => write!(f, "usedtx={}", i32::from(*v)),
             LevelAsymmetryAllowed(v) => {
                 write!(f, "level-asymmetry-allowed={}", i32::from(*v))
             }


### PR DESCRIPTION
This adds support for an Opus format param `usedtx`, which signals a receiver's preference for DTX. DTX stands for [Discontinuous Transmission](https://datatracker.ietf.org/doc/html/rfc7587#autoid-7), and it's a feature in Opus that lowers the packet rate, not just the bitrate, during periods of silence. For instance, in my WebRTC environment, Chrome and Firefox will reduce the packet rate from 50 packets per second to 4 during silence. This makes it ideal for SFU-type applications, where any particular person spends most of the time not talking, and so we can save the CPU time spent processing such packets.

As mentioned in the above link, it does have slight effects on the resulting audio, and browsers don't currently negotiate it without SDP munging, so here I've set it off by default.

Known caveat: at a reduced rate of 4 packets per second, if your `StreamRx.pause_threshold` is less than 250 ms, str0m will emit stream pause/unpause events between each packet. That said, this could be considered expected behavior.