### PR TITLE
Avoid a panic by ignoring DTLS input before set_active call

### DIFF
--- a/src/dtls.rs
+++ b/src/dtls.rs
@@ -125,6 +125,11 @@ impl Dtls {
 
     /// Handles an incoming DTLS datagrams.
     pub fn handle_receive(&mut self, message: &[u8]) -> Result<(), DtlsError> {
+        if self.dtls_impl.is_active().is_none() {
+            debug!("Ignoring DTLS datagram prior to DTLS start");
+            return Ok(());
+        }
+
         Ok(self.dtls_impl.handle_receive(message, &mut self.events)?)
     }
 


### PR DESCRIPTION
Resolves https://github.com/algesten/str0m/issues/494

This simply ignores received DTLS traffic before DTLS is activated by way of receiving remote SDP. This guard struck me as useful for any DTLS implementation, so I put it up here instead of inside `OsslDtlsImpl`.