### PR TITLE
fix(ice): controlled agent follows nomination of same prio socket

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1570,7 +1570,7 @@ impl IceAgent {
 mod test {
     use super::*;
     use std::net::SocketAddr;
-    use std::sync::Once;
+    use tracing_subscriber::util::SubscriberInitExt;
 
     impl IceAgent {
         fn pair_indexes(&self) -> Vec<(usize, usize)> {
@@ -1745,21 +1745,10 @@ mod test {
 
     #[test]
     fn form_pairs_replace_remote_redundant() {
-        use std::env;
-        use tracing_subscriber::{fmt, prelude::*, EnvFilter};
-
-        if env::var("RUST_LOG").is_err() {
-            env::set_var("RUST_LOG", "debug");
-        }
-
-        static START: Once = Once::new();
-
-        START.call_once(|| {
-            tracing_subscriber::registry()
-                .with(fmt::layer())
-                .with(EnvFilter::from_default_env())
-                .init();
-        });
+        let _guard = tracing_subscriber::fmt()
+            .with_env_filter("debug")
+            .with_test_writer()
+            .set_default();
 
         let mut agent = IceAgent::new();
         agent.set_ice_lite(true);

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1459,7 +1459,7 @@ impl IceAgent {
 
         if let Some(best_prio) = best_prio {
             if let Some(nominated) = nominated_pair_priority {
-                if nominated == best_prio.prio() {
+                if nominated == best_prio.prio() && self.controlling {
                     // The best prio is also the current nominated prio. Make
                     // no changes since there can be multiple pairs having the
                     // same best_prio.

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1460,9 +1460,8 @@ impl IceAgent {
         if let Some(best_prio) = best_prio {
             if let Some(nominated) = nominated_pair_priority {
                 if nominated == best_prio.prio() && self.controlling {
-                    // The best prio is also the current nominated prio. Make
-                    // no changes since there can be multiple pairs having the
-                    // same best_prio.
+                    // The best prio is also the current nominated prio.
+                    // If we are the controlling agent, don't nominate it to avoid socket hopping.
                     return;
                 }
             }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -16,7 +16,9 @@ use str0m::rtp::RtpHeader;
 use str0m::Candidate;
 use str0m::{Event, Input, Output, Rtc, RtcError};
 use tracing::info_span;
+use tracing::subscriber::DefaultGuard;
 use tracing::Span;
+use tracing_subscriber::util::SubscriberInitExt as _;
 
 pub struct TestRtc {
     pub span: Span,
@@ -201,22 +203,11 @@ impl DerefMut for TestRtc {
     }
 }
 
-pub fn init_log() {
-    use std::env;
-    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
-
-    if env::var("RUST_LOG").is_err() {
-        env::set_var("RUST_LOG", "str0m=debug");
-    }
-
-    static START: Once = Once::new();
-
-    START.call_once(|| {
-        tracing_subscriber::registry()
-            .with(fmt::layer())
-            .with(EnvFilter::from_default_env())
-            .init();
-    });
+pub fn init_log() -> DefaultGuard {
+    tracing_subscriber::fmt()
+        .with_env_filter("str0m=debug")
+        .with_test_writer()
+        .set_default()
 }
 
 pub fn connect_l_r() -> (TestRtc, TestRtc) {

--- a/tests/sdp-negotiation.rs
+++ b/tests/sdp-negotiation.rs
@@ -17,7 +17,7 @@ use tracing::Span;
 
 #[test]
 pub fn change_default_pt() {
-    init_log();
+    let _g = init_log();
 
     // First proposed PT is 100, R side adjusts its default from 102 -> 100
     let (l, r) = with_params(
@@ -39,7 +39,7 @@ pub fn change_default_pt() {
 
 #[test]
 pub fn answer_change_order() {
-    init_log();
+    let _g = init_log();
 
     // First proposed PT are 100/102, but R side has a different order.
     let (l, r) = with_params(
@@ -73,7 +73,7 @@ pub fn answer_change_order() {
 
 #[test]
 pub fn answer_narrow() {
-    init_log();
+    let _g = init_log();
 
     // First proposed PT are 100/102, the R side removes unsupported ones.
     let (l, r) = with_params(
@@ -114,7 +114,7 @@ pub fn answer_narrow() {
 
 #[test]
 pub fn answer_no_match() {
-    init_log();
+    let _g = init_log();
 
     // L has one codec, and that is not matched by R. This should disable the m-line.
     let (l, r) = with_params(
@@ -144,7 +144,7 @@ pub fn answer_no_match() {
 
 #[test]
 pub fn answer_different_pt_to_offer() {
-    init_log();
+    let _g = init_log();
 
     // This test case checks a scenario happening with Firefox.
     // 1. SDP -> FF: OFFER to sendonly VP8 PT 96.
@@ -212,7 +212,7 @@ pub fn answer_different_pt_to_offer() {
 
 #[test]
 fn answer_remaps() {
-    init_log();
+    let _g = init_log();
 
     use Extension::*;
 
@@ -264,7 +264,7 @@ fn answer_remaps() {
 
 #[test]
 fn offers_unsupported_extension() {
-    init_log();
+    let _g = init_log();
 
     use Extension::*;
 
@@ -309,7 +309,7 @@ fn offers_unsupported_extension() {
 
 #[test]
 fn non_media_creator_cannot_change_inactive_to_recvonly() {
-    init_log();
+    let _g = init_log();
     let (mut l, mut r) = (
         TestRtc::new_with_rtc(
             info_span!("L"),
@@ -342,7 +342,7 @@ fn non_media_creator_cannot_change_inactive_to_recvonly() {
 
 #[test]
 fn media_creator_can_change_inactive_to_recvonly() {
-    init_log();
+    let _g = init_log();
     let (mut l, mut r) = (
         TestRtc::new_with_rtc(
             info_span!("L"),


### PR DESCRIPTION
If a candidate on the controlling `IceAgent` is invalidated but a same priority candidate is added, the controlling agent currently does not follow this nomination right away and instead runs into the ICE timeout before it switches over.

The controlling agent is the one that picks the nominated candidate and thus, only that one should bail early on nomination of same priority candidates to avoid socket hopping.