### PR TITLE
feat: expose `Candidate::discarded`

### DIFF
--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -405,7 +405,10 @@ impl Candidate {
         self.discarded = true;
     }
 
-    pub(crate) fn discarded(&self) -> bool {
+    /// Whether the candidate has been discarded.
+    ///
+    /// For example, it might be redundant or invalidated via [`IceAgent::invalidate_candidate`].
+    pub fn discarded(&self) -> bool {
         self.discarded
     }
 

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -407,7 +407,7 @@ impl Candidate {
 
     /// Whether the candidate has been discarded.
     ///
-    /// For example, it might be redundant or invalidated via [`IceAgent::invalidate_candidate`].
+    /// For example, it might be redundant or invalidated via [`IceAgent::invalidate_candidate`](crate::ice::IceAgent::invalidate_candidate).
     pub fn discarded(&self) -> bool {
         self.discarded
     }


### PR DESCRIPTION
This is useful / necessary to differentiate between active and invalidated candidates when accessing them via `IceAgent::local_candidates`.

Alternatively, we could also filter them directly there or prune all discarded candidates from the agent?