### PR TITLE
Implement VP9 `PayloadParams` fuzzy matching

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -294,6 +294,10 @@ impl PayloadParams {
             return Self::match_h264_score(c0, c1);
         }
 
+        if c0.codec == Codec::Vp9 {
+            return Self::match_vp9_score(c0, c1);
+        }
+
         // TODO: Fuzzy matching for any other audio codecs
         // TODO: Fuzzy matching for video
 
@@ -327,6 +331,18 @@ impl PayloadParams {
         }
 
         score
+    }
+
+    fn match_vp9_score(c0: CodecSpec, c1: CodecSpec) -> Option<usize> {
+        // Default profile_id is 0. https://datatracker.ietf.org/doc/html/draft-ietf-payload-vp9-16#section-6
+        let c0_profile_id = c0.format.profile_id.unwrap_or(0);
+        let c1_profile_id = c1.format.profile_id.unwrap_or(0);
+
+        if c0_profile_id != c1_profile_id {
+            return None;
+        }
+
+        Some(100)
     }
 
     fn match_h264_score(c0: CodecSpec, c1: CodecSpec) -> Option<usize> {


### PR DESCRIPTION
Currently, VP9 is only matched by exact match, leading to potential issues with sessions in Chrome and Firefox browsers. The problem arises from Firefox not setting the `profile_id`, causing str0m to interpret Firefox's `PayloadParams` as incompatible with Chrome. According to [the VP9 specification][0], when `profile_id` is unset, it should default to `0`. This pull request addresses this issue by implementing the functionality to default `profile_id` to `0` in the fuzzy match of VP9.

> If no profile-id is present, Profile 0 MUST be inferred.  (The profile-id parameter was added relatively late in the development of this specification, so some existing implementations may not send it.)

[_draft-ietf-payload-vp9-16#section-6_][0]

[0]: https://datatracker.ietf.org/doc/html/draft-ietf-payload-vp9-16#section-6