### PR TITLE
Fix lazy NACK timeouts enabling

### DIFF
--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -211,7 +211,7 @@ impl<'a> DirectApi<'a> {
 
     /// Obtain a recv stream by looking it up via mid/rid.
     pub fn stream_rx_by_mid(&mut self, mid: Mid, rid: Option<Rid>) -> Option<&mut StreamRx> {
-        self.rtc.session.streams.rx_by_mid_rid(mid, rid)
+        self.rtc.session.streams.stream_rx_by_mid_rid(mid, rid)
     }
 
     /// Declare the intention to send data using the given SSRC.
@@ -267,6 +267,6 @@ impl<'a> DirectApi<'a> {
 
     /// Obtain a send stream by looking it up via mid/rid.
     pub fn stream_tx_by_mid(&mut self, mid: Mid, rid: Option<Rid>) -> Option<&mut StreamTx> {
-        self.rtc.session.streams.tx_by_mid_rid(mid, rid)
+        self.rtc.session.streams.stream_tx_by_mid_rid(mid, rid)
     }
 }

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -379,7 +379,7 @@ impl Media {
 
         let is_audio = self.kind.is_audio();
 
-        let stream = streams.tx_by_mid_rid(self.mid, *rid);
+        let stream = streams.stream_tx_by_mid_rid(self.mid, *rid);
 
         let Some(stream) = stream else {
             return Err(RtcError::NoSenderSource);

--- a/src/media/writer.rs
+++ b/src/media/writer.rs
@@ -199,7 +199,7 @@ impl<'a> Writer<'a> {
         let stream = self
             .session
             .streams
-            .rx_by_mid_rid(self.mid, rid)
+            .stream_rx_by_mid_rid(self.mid, rid)
             .ok_or_else(|| RtcError::NoReceiverSource(rid))?;
 
         stream.request_keyframe(kind);

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -442,18 +442,6 @@ impl Streams {
         }
     }
 
-    pub(crate) fn tx_by_mid_rid(&mut self, mid: Mid, rid: Option<Rid>) -> Option<&mut StreamTx> {
-        self.streams_tx
-            .values_mut()
-            .find(|s| s.mid() == mid && (rid.is_none() || s.rid() == rid))
-    }
-
-    pub(crate) fn rx_by_mid_rid(&mut self, mid: Mid, rid: Option<Rid>) -> Option<&mut StreamRx> {
-        self.streams_rx
-            .values_mut()
-            .find(|s| s.mid() == mid && (rid.is_none() || s.rid() == rid))
-    }
-
     pub(crate) fn poll_keyframe_request(&mut self) -> Option<KeyframeRequest> {
         self.streams_tx.values_mut().find_map(|s| {
             let kind = s.poll_keyframe_request()?;


### PR DESCRIPTION
In commit "Lazily enable nack timeouts" ([f72b690][1]) was introduced optimization of NACK timeouts enabling, this commit added `Streams::any_nack_enabled` resetting in `Streams::stream_rx_by_mid_rid()`, but `Streams` has exact the same method called `Streams::rx_by_mid_rid` (which is used under the hood in `Direct::stream_rx_by_mid`) which wasn't updated. So if you're getting `StreamRx` from Direct API and call `suppress_nack(false)` on it, then `any_nack_enabled` is not updated, resulting in NACKs not being transmitted.

This PR removes this duplication of methods `rx_by_mid_rid` and `tx_by_mid_rid` in favor of `stream_tx_by_mid_rid` and `stream_rx_by_mid_rid`.

[1]: https://github.com/algesten/str0m/commit/f72b690dc7961dc40d1c30f1bbbc692d83b13125