### PR TITLE
chore: set logger without mucking around with env vars

### DIFF
--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -19,25 +19,25 @@ use str0m::media::{Direction, KeyframeRequest, MediaData, Mid, Rid};
 use str0m::media::{KeyframeRequestKind, MediaKind};
 use str0m::net::Protocol;
 use str0m::{net::Receive, Candidate, Event, IceConnectionState, Input, Output, Rtc, RtcError};
+use tracing::subscriber::DefaultGuard;
+use tracing_subscriber::util::SubscriberInitExt as _;
+use tracing_subscriber::EnvFilter;
 
 mod util;
 
-fn init_log() {
-    use std::env;
-    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
-
-    if env::var("RUST_LOG").is_err() {
-        env::set_var("RUST_LOG", "chat=info,str0m=info");
-    }
-
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_default_env())
-        .init();
+fn init_log() -> DefaultGuard {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive("chat=info,str0m=info".parse().unwrap())
+                .from_env()
+                .unwrap(),
+        )
+        .set_default()
 }
 
 pub fn main() {
-    init_log();
+    let _guard = init_log();
 
     let certificate = include_bytes!("cer.pem").to_vec();
     let private_key = include_bytes!("key.pem").to_vec();

--- a/examples/http-post.rs
+++ b/examples/http-post.rs
@@ -14,25 +14,25 @@ use str0m::change::SdpOffer;
 use str0m::net::Protocol;
 use str0m::net::Receive;
 use str0m::{Candidate, Event, IceConnectionState, Input, Output, Rtc, RtcError};
+use tracing::subscriber::DefaultGuard;
+use tracing_subscriber::util::SubscriberInitExt as _;
+use tracing_subscriber::EnvFilter;
 
 mod util;
 
-fn init_log() {
-    use std::env;
-    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
-
-    if env::var("RUST_LOG").is_err() {
-        env::set_var("RUST_LOG", "http_post=debug,str0m=debug");
-    }
-
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_default_env())
-        .init();
+fn init_log() -> DefaultGuard {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive("http_post=debug,str0m=debug".parse().unwrap())
+                .from_env()
+                .unwrap(),
+        )
+        .set_default()
 }
 
 pub fn main() {
-    init_log();
+    let _guard = init_log();
 
     let certificate = include_bytes!("cer.pem").to_vec();
     let private_key = include_bytes!("key.pem").to_vec();

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1571,7 +1571,7 @@ impl IceAgent {
 mod test {
     use super::*;
     use std::net::SocketAddr;
-    use std::sync::Once;
+    use tracing_subscriber::util::SubscriberInitExt as _;
 
     impl IceAgent {
         fn pair_indexes(&self) -> Vec<(usize, usize)> {
@@ -1746,21 +1746,10 @@ mod test {
 
     #[test]
     fn form_pairs_replace_remote_redundant() {
-        use std::env;
-        use tracing_subscriber::{fmt, prelude::*, EnvFilter};
-
-        if env::var("RUST_LOG").is_err() {
-            env::set_var("RUST_LOG", "debug");
-        }
-
-        static START: Once = Once::new();
-
-        START.call_once(|| {
-            tracing_subscriber::registry()
-                .with(fmt::layer())
-                .with(EnvFilter::from_default_env())
-                .init();
-        });
+        let _guard = tracing_subscriber::fmt()
+            .with_env_filter("debug")
+            .with_test_writer()
+            .set_default();
 
         let mut agent = IceAgent::new();
         agent.set_ice_lite(true);

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -398,20 +398,6 @@ mod test {
         );
     }
 
-    // pub fn init_log() {
-    //     use std::env;
-    //     use tracing_subscriber::{fmt, prelude::*, EnvFilter};
-
-    //     if env::var("RUST_LOG").is_err() {
-    //         env::set_var("RUST_LOG", "trace");
-    //     }
-
-    //     tracing_subscriber::registry()
-    //         .with(fmt::layer())
-    //         .with(EnvFilter::from_default_env())
-    //         .init();
-    // }
-
     #[test]
     pub fn ice_lite_disconnect_reconnect() {
         // init_log();

--- a/tests/bidirectional.rs
+++ b/tests/bidirectional.rs
@@ -11,7 +11,7 @@ use common::{init_log, progress, TestRtc};
 
 #[test]
 pub fn bidirectional_same_m_line() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -212,7 +212,6 @@ pub fn init_log() -> DefaultGuard {
                 .from_env()
                 .unwrap(),
         )
-        .with_test_writer()
         .set_default()
 }
 

--- a/tests/contiguous.rs
+++ b/tests/contiguous.rs
@@ -11,7 +11,7 @@ use common::{init_log, progress, TestRtc};
 
 #[test]
 pub fn contiguous_all_the_way() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let output = Server::with_vp8_input()
         .timeout(Duration::seconds(5))
@@ -34,7 +34,7 @@ pub fn contiguous_all_the_way() -> Result<(), RtcError> {
 
 #[test]
 pub fn not_contiguous() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let output = Server::with_vp8_input()
         .skip_packet(14337)
@@ -61,7 +61,7 @@ pub fn not_contiguous() -> Result<(), RtcError> {
 
 #[test]
 pub fn vp9_contiguous_all_the_way() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let output = Server::with_vp9_input().get_output()?;
     let mut count = 0;
@@ -82,7 +82,7 @@ pub fn vp9_contiguous_all_the_way() -> Result<(), RtcError> {
 
 #[test]
 pub fn vp9_not_contiguous() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let output = Server::with_vp9_input().skip_packet(30952).get_output()?;
     let mut count = 0;

--- a/tests/data-channel-direct.rs
+++ b/tests/data-channel-direct.rs
@@ -10,7 +10,7 @@ use common::{init_log, progress, TestRtc};
 
 #[test]
 pub fn data_channel_direct() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let mut l = TestRtc::new(info_span!("L"));
 

--- a/tests/data-channel.rs
+++ b/tests/data-channel.rs
@@ -9,7 +9,7 @@ use common::{init_log, progress, TestRtc};
 
 #[test]
 pub fn data_channel() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));

--- a/tests/flappy-ice-state.rs
+++ b/tests/flappy-ice-state.rs
@@ -10,7 +10,7 @@ use common::{init_log, progress, TestRtc};
 
 #[test]
 pub fn flappy_ice_lite_state() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let mut l = TestRtc::new(info_span!("L"));
 

--- a/tests/ice-restart.rs
+++ b/tests/ice-restart.rs
@@ -10,7 +10,7 @@ use common::{init_log, progress, TestRtc};
 
 #[test]
 pub fn ice_restart() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let mut l = TestRtc::new(info_span!("L"));
 

--- a/tests/keyframes.rs
+++ b/tests/keyframes.rs
@@ -12,7 +12,7 @@ use common::{init_log, progress, TestRtc};
 
 #[test]
 pub fn test_vp8_keyframes_detection() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));
@@ -103,7 +103,7 @@ pub fn test_vp8_keyframes_detection() -> Result<(), RtcError> {
 
 #[test]
 pub fn test_vp9_keyframes_detection() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));
@@ -195,7 +195,7 @@ pub fn test_vp9_keyframes_detection() -> Result<(), RtcError> {
 
 #[test]
 pub fn test_h264_keyframes_detection() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));

--- a/tests/nack.rs
+++ b/tests/nack.rs
@@ -14,7 +14,7 @@ use crate::common::progress_with_loss;
 
 #[test]
 pub fn loss_recovery() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let (mut l, mut r) = connect_l_r();
 
@@ -170,7 +170,7 @@ pub fn loss_recovery() -> Result<(), RtcError> {
 
 #[test]
 pub fn nack_delay() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let (mut l, mut r) = connect_l_r();
 

--- a/tests/remb.rs
+++ b/tests/remb.rs
@@ -11,7 +11,7 @@ use common::{init_log, negotiate, progress, TestRtc};
 
 #[test]
 pub fn remb() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
     let l_rtc = Rtc::builder().build();
     let r_rtc = Rtc::builder().build();
 

--- a/tests/repeated.rs
+++ b/tests/repeated.rs
@@ -10,7 +10,7 @@ use common::{connect_l_r, init_log, progress};
 
 #[test]
 pub fn repeated() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let (mut l, mut r) = connect_l_r();
 

--- a/tests/rtp-direct-mid-rid.rs
+++ b/tests/rtp-direct-mid-rid.rs
@@ -11,7 +11,7 @@ use common::{connect_l_r, init_log, progress};
 
 #[test]
 pub fn rtp_direct_mid_rid() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let (mut l, mut r) = connect_l_r();
 

--- a/tests/rtp-direct-mid.rs
+++ b/tests/rtp-direct-mid.rs
@@ -11,7 +11,7 @@ use common::{connect_l_r, init_log, progress};
 
 #[test]
 pub fn rtp_direct_mid() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let (mut l, mut r) = connect_l_r();
 

--- a/tests/rtp-direct-ssrc.rs
+++ b/tests/rtp-direct-ssrc.rs
@@ -11,7 +11,7 @@ use common::{connect_l_r, init_log, progress};
 
 #[test]
 pub fn rtp_direct_ssrc() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let (mut l, mut r) = connect_l_r();
 

--- a/tests/rtp-direct-with-roc.rs
+++ b/tests/rtp-direct-with-roc.rs
@@ -12,7 +12,7 @@ use common::{connect_l_r, init_log, progress};
 
 #[test]
 pub fn rtp_direct_with_roc() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let (mut l, mut r) = connect_l_r();
 

--- a/tests/rtx-cache-0.rs
+++ b/tests/rtx-cache-0.rs
@@ -11,7 +11,7 @@ use common::{connect_l_r, init_log, progress};
 
 #[test]
 pub fn rtx_cache_0() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let (mut l, mut r) = connect_l_r();
 

--- a/tests/sdp-negotiation.rs
+++ b/tests/sdp-negotiation.rs
@@ -17,7 +17,7 @@ use tracing::Span;
 
 #[test]
 pub fn change_default_pt() {
-    init_log();
+    let _guard = init_log();
 
     // First proposed PT is 100, R side adjusts its default from 102 -> 100
     let (l, r) = with_params(
@@ -39,7 +39,7 @@ pub fn change_default_pt() {
 
 #[test]
 pub fn answer_change_order() {
-    init_log();
+    let _guard = init_log();
 
     // First proposed PT are 100/102, but R side has a different order.
     let (l, r) = with_params(
@@ -73,7 +73,7 @@ pub fn answer_change_order() {
 
 #[test]
 pub fn answer_narrow() {
-    init_log();
+    let _guard = init_log();
 
     // First proposed PT are 100/102, the R side removes unsupported ones.
     let (l, r) = with_params(
@@ -114,7 +114,7 @@ pub fn answer_narrow() {
 
 #[test]
 pub fn answer_no_match() {
-    init_log();
+    let _guard = init_log();
 
     // L has one codec, and that is not matched by R. This should disable the m-line.
     let (l, r) = with_params(
@@ -144,7 +144,7 @@ pub fn answer_no_match() {
 
 #[test]
 pub fn answer_different_pt_to_offer() {
-    init_log();
+    let _guard = init_log();
 
     // This test case checks a scenario happening with Firefox.
     // 1. SDP -> FF: OFFER to sendonly VP8 PT 96.
@@ -212,7 +212,7 @@ pub fn answer_different_pt_to_offer() {
 
 #[test]
 fn answer_remaps() {
-    init_log();
+    let _guard = init_log();
 
     use Extension::*;
 
@@ -264,7 +264,7 @@ fn answer_remaps() {
 
 #[test]
 fn offers_unsupported_extension() {
-    init_log();
+    let _guard = init_log();
 
     use Extension::*;
 
@@ -309,7 +309,7 @@ fn offers_unsupported_extension() {
 
 #[test]
 fn non_media_creator_cannot_change_inactive_to_recvonly() {
-    init_log();
+    let _guard = init_log();
     let (mut l, mut r) = (
         TestRtc::new_with_rtc(
             info_span!("L"),
@@ -342,7 +342,7 @@ fn non_media_creator_cannot_change_inactive_to_recvonly() {
 
 #[test]
 fn media_creator_can_change_inactive_to_recvonly() {
-    init_log();
+    let _guard = init_log();
     let (mut l, mut r) = (
         TestRtc::new_with_rtc(
             info_span!("L"),

--- a/tests/stats.rs
+++ b/tests/stats.rs
@@ -12,7 +12,7 @@ use common::{init_log, progress, TestRtc};
 
 #[test]
 pub fn stats() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let l_config = RtcConfig::new().set_stats_interval(Some(Duration::from_secs(10)));
     let r_config = RtcConfig::new().set_stats_interval(Some(Duration::from_secs(10)));

--- a/tests/twcc.rs
+++ b/tests/twcc.rs
@@ -12,7 +12,7 @@ use common::{init_log, negotiate, progress, TestRtc};
 
 #[test]
 pub fn twcc() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
     let l_rtc = Rtc::builder().enable_raw_packets(true).build();
     let r_rtc = Rtc::builder().enable_raw_packets(true).build();
 

--- a/tests/unidirectional-r-create-media.rs
+++ b/tests/unidirectional-r-create-media.rs
@@ -12,7 +12,7 @@ use common::{init_log, progress, TestRtc};
 
 #[test]
 pub fn unidirectional_r_create_media() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));

--- a/tests/unidirectional.rs
+++ b/tests/unidirectional.rs
@@ -11,7 +11,7 @@ use common::{init_log, progress, TestRtc};
 
 #[test]
 pub fn unidirectional() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));

--- a/tests/user-rtp-header-extension.rs
+++ b/tests/user-rtp-header-extension.rs
@@ -15,7 +15,7 @@ use common::{init_log, progress, TestRtc};
 
 #[test]
 pub fn user_rtp_header_extension() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     #[derive(Debug, PartialEq, Eq)]
     struct MyValue(u16);
@@ -159,7 +159,7 @@ pub fn user_rtp_header_extension() -> Result<(), RtcError> {
 
 #[test]
 pub fn user_rtp_header_extension_two_byte_form() -> Result<(), RtcError> {
-    init_log();
+    let _guard = init_log();
 
     #[derive(Debug, PartialEq, Eq, Clone)]
     struct MyValue(Vec<u8>);


### PR DESCRIPTION
Env vars are global to a process. Setting them from within the tests is problematic because those tests are run concurrently in the same process.

`tracing` allows us to set a logger for the current stack scope using `set_default`. Instead of fighting over which test should initialize the logger, we can only set it for the current scope of each test.