### PR TITLE
fix: only invalidate candidates of the same kind

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -700,11 +700,12 @@ impl IceAgent {
     /// Returns `true` if the candidate was found and invalidated.
     #[allow(unused)]
     pub fn invalidate_candidate(&mut self, c: &Candidate) -> bool {
-        if let Some((idx, other)) =
-            self.local_candidates.iter_mut().enumerate().find(|(_, v)| {
-                v.addr() == c.addr() && v.base() == c.base() && v.raddr() == c.raddr()
-            })
-        {
+        if let Some((idx, other)) = self.local_candidates.iter_mut().enumerate().find(|(_, v)| {
+            v.addr() == c.addr()
+                && v.base() == c.base()
+                && v.raddr() == c.raddr()
+                && v.kind() == c.kind()
+        }) {
             if !other.discarded() {
                 info!("Local candidate to discard {:?}", other);
                 other.set_discarded();
@@ -717,7 +718,12 @@ impl IceAgent {
             .remote_candidates
             .iter_mut()
             .enumerate()
-            .find(|(_, v)| v.addr() == c.addr() && v.base() == c.base() && v.raddr() == c.raddr())
+            .find(|(_, v)| {
+                v.addr() == c.addr()
+                    && v.base() == c.base()
+                    && v.raddr() == c.raddr()
+                    && v.kind() == c.kind()
+            })
         {
             if !other.discarded() {
                 info!("Remote candidate to discard {:?}", other);
@@ -1655,6 +1661,35 @@ mod test {
         // this is redundant given we have the direct host candidate above.
         let x1 = agent.add_local_candidate(Candidate::test_peer_rflx(ipv4_1(), ipv4_1(), "udp"));
         assert!(!x1);
+    }
+
+    #[test]
+    fn does_not_invalidate_local_candidate_with_same_ip_but_different_kind() {
+        let mut agent = IceAgent::new();
+        let host = Candidate::host(ipv4_1(), "udp").unwrap();
+        let srflx = Candidate::server_reflexive(ipv4_1(), ipv4_1(), "udp").unwrap();
+
+        agent.add_local_candidate(host.clone());
+        let invalidated = agent.invalidate_candidate(&srflx);
+        assert!(!invalidated);
+
+        let invalidated = agent.invalidate_candidate(&host);
+        assert!(invalidated);
+    }
+
+    #[test]
+    fn does_not_invalidate_remote_candidate_with_same_ip_but_different_kind() {
+        let mut agent = IceAgent::new();
+        let host = Candidate::host(ipv4_1(), "udp").unwrap();
+        let srflx = Candidate::server_reflexive(ipv4_1(), ipv4_1(), "udp").unwrap();
+
+        agent.add_remote_candidate(host.clone());
+        let invalidated = agent.invalidate_candidate(&srflx);
+
+        assert!(!invalidated);
+
+        let invalidated = agent.invalidate_candidate(&host);
+        assert!(invalidated);
     }
 
     #[test]


### PR DESCRIPTION
We ran into a bug where a candidate was incorrectly invalidated based on IP only without considering the kind of candidate. The bug was in our software because we didn't invalidate a host candidate and our tests didn't catch it because there, we invalidated it "accidentially" by wanting to invalidate the corresponding srflx candidate. The (unit)-tests don't have a NAT so there host == srflx. But in the real world, we had a NAT but the two nodes were on the same subnet, thus they ended up making a host-host connection and failed to migrate that to another candidate because it was never invalidated.