### PR TITLE
io/stun: Expose `split_username` publicly

### DIFF
--- a/src/io/stun.rs
+++ b/src/io/stun.rs
@@ -212,7 +212,7 @@ impl<'a> StunMessage<'a> {
     }
 
     /// If present, splits the value of the USERNAME attribute into local and remote (separated by `:`).
-    pub(crate) fn split_username(&self) -> Option<(&str, &str)> {
+    pub fn split_username(&self) -> Option<(&str, &str)> {
         self.attrs.split_username()
     }
 


### PR DESCRIPTION
In [litep2p](https://github.com/paritytech/litep2p/) we are using the low-level ice module to handle connections.

We'd need the to split the username attribute from a [StunMessage](https://github.com/algesten/str0m/blob/428e3dbe054cd4a11019394b5553b3049879be68/src/io/stun.rs#L71) object to instantiate an rtc client.
- https://github.com/paritytech/litep2p/blob/e03a6023882db111beeb24d8c0ceaac0721d3f0f/src/transport/webrtc/mod.rs#L347-L386

This is the missing functionality that currently blocks our migration from 0.4.1 to 0.5 (which includes a needed fix for us: https://github.com/algesten/str0m/commit/7ed5143381cf095f7074689cc254b8c9e50d25c5).

Would love to hear your thoughts on this, and if you think another approach would be more appropriate, thanks! 🙏 

