### PR TITLE
Re-add invalidated remote/local candidates

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -494,7 +494,7 @@ impl IceAgent {
                 "Replace redundant candidate, current: {:?} replaced with: {:?}",
                 other, c
             );
-            other.set_discarded();
+            other.set_discarded(true);
             self.discard_candidate_pairs_by_local(idx);
         }
 
@@ -710,7 +710,7 @@ impl IceAgent {
         }) {
             if !other.discarded() {
                 info!("Local candidate to discard {:?}", other);
-                other.set_discarded();
+                other.set_discarded(true);
                 self.discard_candidate_pairs_by_local(idx);
                 return true;
             }
@@ -729,7 +729,7 @@ impl IceAgent {
         {
             if !other.discarded() {
                 info!("Remote candidate to discard {:?}", other);
-                other.set_discarded();
+                other.set_discarded(true);
                 self.discard_candidate_pairs_by_remote(idx);
                 return true;
             }

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -22,7 +22,8 @@ const TIMING_ADVANCE: Duration = Duration::from_millis(50);
 /// Handles the ICE protocol for a given peer.
 ///
 /// Each connection between two peers corresponds to one [`IceAgent`] on either end.
-/// To form connections to multiple peers, a peer needs to create a dedicated [`IceAgent`] for each one.
+/// To form connections to multiple peers, a peer needs to create a dedicated [`IceAgent`] for
+/// each one.
 #[derive(Debug)]
 pub struct IceAgent {
     /// Last time handle_timeout run (paced by timing_advance).
@@ -925,7 +926,8 @@ impl IceAgent {
 
     /// Provide the current time to the [`IceAgent`].
     ///
-    /// Typically, you will want to call [`IceAgent::poll_timeout`] and "wake-up" the agent once that time is reached.
+    /// Typically, you will want to call [`IceAgent::poll_timeout`] and "wake-up"
+    /// the agent once that time is reached.
     pub fn handle_timeout(&mut self, now: Instant) {
         // This happens exactly once because evaluate_state() below will
         // switch away from New -> Checking.
@@ -1250,8 +1252,10 @@ impl IceAgent {
         }) {
             Some((i, _)) => i,
             None => {
-                // Receiving traffic for an IP address that neither is a HOST nor RELAY is most likely a configuration fault where the user forgot to add a candidate for the local interface.
-                // We are network-connected application so we need to handle this gracefully: Log a message and discard the packet.
+                // Receiving traffic for an IP address that neither is a HOST nor RELAY
+                // is most likely a configuration fault where the user forgot to add a
+                // candidate for the local interface. We are network-connected application
+                // so we need to handle this gracefully: Log a message and discard the packet.
 
                 debug!(
                     "Discarding STUN request on unknown interface: {}",

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1169,6 +1169,18 @@ impl IceAgent {
             trace!("Remote candidate for STUN request found");
             idx
         } else {
+            let maybe_discarded = self
+                .remote_candidates
+                .iter()
+                .any(|c| c.discarded() && c.proto() == req.proto && c.addr() == req.source);
+
+            if maybe_discarded {
+                // The remote has been discarded, we do not want to create a
+                // peer reflexive in this case.
+                trace!("STUN request ignored because remote candidate is discarded");
+                return;
+            }
+
             // o  The priority is the value of the PRIORITY attribute in the Binding
             //     request.
             //

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1852,6 +1852,36 @@ mod test {
     }
 
     #[test]
+    fn form_pairs_skip_invalidated_local() {
+        let mut agent = IceAgent::new();
+
+        let local = Candidate::test_peer_rflx(ipv4_2(), ipv4_1(), "udp");
+
+        agent.add_local_candidate(local.clone());
+        agent.invalidate_candidate(&local);
+
+        agent.add_remote_candidate(Candidate::host(ipv4_3(), "udp").unwrap());
+
+        // There should be no pairs since we invalidated the local candidate.
+        assert_eq!(agent.pair_indexes(), []);
+    }
+
+    #[test]
+    fn form_pairs_skip_invalidated_remote() {
+        let mut agent = IceAgent::new();
+
+        let remote = Candidate::host(ipv4_3(), "udp").unwrap();
+
+        agent.add_remote_candidate(remote.clone());
+        agent.invalidate_candidate(&remote);
+
+        agent.add_local_candidate(Candidate::test_peer_rflx(ipv4_2(), ipv4_1(), "udp"));
+
+        // There should be no pairs since we invalidated the local candidate.
+        assert_eq!(agent.pair_indexes(), []);
+    }
+
+    #[test]
     fn poll_time_must_timing_advance() {
         let mut agent = IceAgent::new();
         agent.add_local_candidate(Candidate::host(ipv4_1(), "udp").unwrap());

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1602,7 +1602,6 @@ impl IceAgent {
 mod test {
     use super::*;
     use std::net::SocketAddr;
-    use std::sync::Once;
 
     impl IceAgent {
         fn pair_indexes(&self) -> Vec<(usize, usize)> {
@@ -1806,22 +1805,6 @@ mod test {
 
     #[test]
     fn form_pairs_replace_remote_redundant() {
-        use std::env;
-        use tracing_subscriber::{fmt, prelude::*, EnvFilter};
-
-        if env::var("RUST_LOG").is_err() {
-            env::set_var("RUST_LOG", "debug");
-        }
-
-        static START: Once = Once::new();
-
-        START.call_once(|| {
-            tracing_subscriber::registry()
-                .with(fmt::layer())
-                .with(EnvFilter::from_default_env())
-                .init();
-        });
-
         let mut agent = IceAgent::new();
         agent.set_ice_lite(true);
 

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -401,8 +401,8 @@ impl Candidate {
         self.local_preference = Some(v);
     }
 
-    pub(crate) fn set_discarded(&mut self) {
-        self.discarded = true;
+    pub(crate) fn set_discarded(&mut self, discarded: bool) {
+        self.discarded = discarded;
     }
 
     pub(crate) fn discarded(&self) -> bool {

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -362,6 +362,96 @@ mod test {
     }
 
     #[test]
+    pub fn re_adding_invalidated_local_candidate() {
+        let mut a1 = TestAgent::new(info_span!("L"));
+        let mut a2 = TestAgent::new(info_span!("R"));
+
+        let c1 = host("1.1.1.1:1000", "udp");
+        a1.add_local_candidate(c1.clone());
+        a2.add_remote_candidate(c1.clone());
+        let c2 = host("2.2.2.2:1000", "udp");
+        a2.add_local_candidate(c2.clone());
+        a1.add_remote_candidate(c2);
+        a1.set_controlling(true);
+        a2.set_controlling(false);
+
+        loop {
+            if a1.state().is_connected() && a2.state().is_connected() {
+                break;
+            }
+            progress(&mut a1, &mut a2);
+        }
+
+        a1.agent.invalidate_candidate(&c1);
+
+        // Let time pass until it disconnects.
+        loop {
+            if a1.state().is_disconnected() && a2.state().is_disconnected() {
+                break;
+            }
+            progress(&mut a1, &mut a2);
+        }
+
+        // Add back the invalidated candidate
+        a1.add_local_candidate(c1);
+
+        // progress() fails after 100 number of polls.
+        a1.progress_count = 0;
+        a2.progress_count = 0;
+        loop {
+            if a1.state().is_connected() && a2.state().is_connected() {
+                break;
+            }
+            progress(&mut a1, &mut a2);
+        }
+    }
+
+    #[test]
+    pub fn re_adding_invalidated_remote_candidate() {
+        let mut a1 = TestAgent::new(info_span!("L"));
+        let mut a2 = TestAgent::new(info_span!("R"));
+
+        let c1 = host("1.1.1.1:1000", "udp");
+        a1.add_local_candidate(c1.clone());
+        a2.add_remote_candidate(c1);
+        let c2 = host("2.2.2.2:1000", "udp");
+        a2.add_local_candidate(c2.clone());
+        a1.add_remote_candidate(c2.clone());
+        a1.set_controlling(true);
+        a2.set_controlling(false);
+
+        loop {
+            if a1.state().is_connected() && a2.state().is_connected() {
+                break;
+            }
+            progress(&mut a1, &mut a2);
+        }
+
+        a1.agent.invalidate_candidate(&c2);
+
+        // Let time pass until it disconnects.
+        loop {
+            if a1.state().is_disconnected() && a2.state().is_disconnected() {
+                break;
+            }
+            progress(&mut a1, &mut a2);
+        }
+
+        // Add back the invalidated candidate
+        a1.add_remote_candidate(c2);
+
+        // progress() fails after 100 number of polls.
+        a1.progress_count = 0;
+        a2.progress_count = 0;
+        loop {
+            if a1.state().is_connected() && a2.state().is_connected() {
+                break;
+            }
+            progress(&mut a1, &mut a2);
+        }
+    }
+
+    #[test]
     pub fn ice_lite_no_connection() {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));


### PR DESCRIPTION
This fixes re-adding of previously invalidated ice candidates.

Close #507

