### PR TITLE
fix: crash when set custom rtp extension

### DIFF
--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -1032,14 +1032,13 @@ fn update_media(
     media.set_remote_pts(pts);
 
     let mut remote_extmap = ExtensionMap::empty();
-    for (id, ext) in m.extmaps().into_iter() {
+    for (id, _ext) in m.extmaps().into_iter() {
         // The remapping of extensions should already have happened, which
         // means the ID are matching in the session to the remote.
-        if exts.lookup(id) != Some(ext) {
-            // Don't set any extensions that aren't enabled in Session.
-            continue;
+        // Only set extensions that are enabled in Session.
+        if let Some(ext) = exts.lookup(id) {
+            remote_extmap.set(id, ext.clone());
         }
-        remote_extmap.set(id, ext.clone());
     }
     media.set_remote_extmap(remote_extmap);
 

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -1032,13 +1032,24 @@ fn update_media(
     media.set_remote_pts(pts);
 
     let mut remote_extmap = ExtensionMap::empty();
-    for (id, _ext) in m.extmaps().into_iter() {
+    for (id, ext) in m.extmaps().into_iter() {
         // The remapping of extensions should already have happened, which
         // means the ID are matching in the session to the remote.
-        // Only set extensions that are enabled in Session.
-        if let Some(ext) = exts.lookup(id) {
-            remote_extmap.set(id, ext.clone());
+
+        // Does the ID exist in session?
+        let in_session = match exts.lookup(id) {
+            Some(v) => v,
+            None => continue,
+        };
+
+        if in_session != ext {
+            // Don't set any extensions that aren't enabled in Session.
+            continue;
         }
+
+        // Use the Extension from session, since there might be a special
+        // serializer for cases like VLA.
+        remote_extmap.set(id, in_session.clone());
     }
     media.set_remote_extmap(remote_extmap);
 

--- a/tests/user-rtp-header-extension.rs
+++ b/tests/user-rtp-header-extension.rs
@@ -1,6 +1,7 @@
 use std::net::Ipv4Addr;
 use std::time::Duration;
 
+use str0m::change::SdpOffer;
 use str0m::format::Codec;
 use str0m::media::{Direction, MediaKind};
 use str0m::rtp::Extension;
@@ -89,8 +90,10 @@ pub fn user_rtp_header_extension() -> Result<(), RtcError> {
     let mut change = l.sdp_api();
     let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None);
     let (offer, pending) = change.apply().unwrap();
-
-    let answer = r.rtc.sdp_api().accept_offer(offer)?;
+    let offer_str = offer.to_sdp_string();
+    let offer_parsed =
+        SdpOffer::from_sdp_string(&offer_str).expect("Should parse offer from string");
+    let answer = r.rtc.sdp_api().accept_offer(offer_parsed)?;
     l.rtc.sdp_api().accept_answer(pending, answer)?;
 
     // Verify that the extension is negotiated.


### PR DESCRIPTION
If I enable VLA rtp extension, then the str0m will crash with error: `internal error: entered unreachable code: Incorrect ExtensionSerializer::is_video` (full crash log is attached in bellow).

The reason is when str0m parse SDP string, it will parse all non-str0m-standared extensions as a SdpUnknowUri. Then when creating an answer, it uses SdpUnknowUri instead of config from RtcConfig as described in https://github.com/algesten/str0m/blob/3902a6d27f1b0b5dbf91d91394853d6711bb009a/src/change/sdp.rs#L1034-144

```rust
let mut remote_extmap = ExtensionMap::empty();
    for (id, ext) in m.extmaps().into_iter() {
        // The remapping of extensions should already have happened, which
        // means the ID are matching in the session to the remote.
        if exts.lookup(id) != Some(ext) {
            // Don't set any extensions that aren't enabled in Session.
            continue;
        }
        remote_extmap.set(id, ext.clone());
    }
    media.set_remote_extmap(remote_extmap);
```

This PR switches to use extension serializer from RtcConfig and changes user-rtp-header-extension test to cover this case.

Crash Log:
```
internal error: entered unreachable code: Incorrect ExtensionSerializer::is_video
stack backtrace:
   0: rust_begin_unwind
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panicking.rs:647:5
   1: core::panicking::panic_fmt
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/panicking.rs:72:14
   2: <str0m::rtp_::ext::SdpUnknownUri as str0m::rtp_::ext::ExtensionSerializer>::is_video
             at /Users/giangminh/Workspace/bluesea/research/str0m/src/rtp/ext.rs:163:9
   3: str0m::rtp_::ext::Extension::is_video
             at /Users/giangminh/Workspace/bluesea/research/str0m/src/rtp/ext.rs:303:20
   4: str0m::rtp_::ext::ExtensionMap::iter_by_media_type::{{closure}}
             at /Users/giangminh/Workspace/bluesea/research/str0m/src/rtp/ext.rs:436:17
   5: core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/ops/function.rs:294:13
   6: core::iter::traits::iterator::Iterator::find::check::{{closure}}
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/iter/traits/iterator.rs:2927:20
   7: core::iter::adapters::map::map_try_fold::{{closure}}
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/iter/adapters/map.rs:96:21
   8: core::iter::adapters::filter_map::filter_map_try_fold::{{closure}}
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/iter/adapters/filter_map.rs:49:20
   9: <core::iter::adapters::enumerate::Enumerate<I> as core::iter::traits::iterator::Iterator>::try_fold::enumerate::{{closure}}
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/iter/adapters/enumerate.rs:86:27
  10: core::iter::traits::iterator::Iterator::try_fold
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/iter/traits/iterator.rs:2462:21
  11: <core::iter::adapters::enumerate::Enumerate<I> as core::iter::traits::iterator::Iterator>::try_fold
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/iter/adapters/enumerate.rs:92:9
  12: <core::iter::adapters::filter_map::FilterMap<I,F> as core::iter::traits::iterator::Iterator>::try_fold
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/iter/adapters/filter_map.rs:140:9
  13: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::try_fold
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/iter/adapters/map.rs:122:9
  14: core::iter::traits::iterator::Iterator::find
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/iter/traits/iterator.rs:2931:9
  15: <core::iter::adapters::filter::Filter<I,P> as core::iter::traits::iterator::Iterator>::next
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/iter/adapters/filter.rs:60:9
  16: <str0m::media::Media as str0m::change::sdp::AsSdpMediaLine>::as_media_line
             at /Users/giangminh/Workspace/bluesea/research/str0m/src/change/sdp.rs:1180:26
  17: str0m::change::sdp::as_sdp::{{closure}}
             at /Users/giangminh/Workspace/bluesea/research/str0m/src/change/sdp.rs:685:17
  18: core::iter::adapters::map::map_fold::{{closure}}
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/iter/adapters/map.rs:89:28
  19: <core::slice::iter::Iter<T> as core::iter::traits::iterator::Iterator>::fold
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/slice/iter/macros.rs:232:27
  20: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::fold
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/iter/adapters/map.rs:129:9
  21: core::iter::traits::iterator::Iterator::for_each
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/iter/traits/iterator.rs:858:9
  22: alloc::vec::Vec<T,A>::extend_trusted
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/alloc/src/vec/mod.rs:2962:17
  23: <alloc::vec::Vec<T,A> as alloc::vec::spec_extend::SpecExtend<T,I>>::spec_extend
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/alloc/src/vec/spec_extend.rs:26:9
  24: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/alloc/src/vec/spec_from_iter_nested.rs:62:9
  25: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/alloc/src/vec/spec_from_iter.rs:33:9
  26: <alloc::vec::Vec<T> as core::iter::traits::collect::FromIterator<T>>::from_iter
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/alloc/src/vec/mod.rs:2836:9
  27: core::iter::traits::iterator::Iterator::collect
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/iter/traits/iterator.rs:2054:9
  28: str0m::change::sdp::as_sdp
             at /Users/giangminh/Workspace/bluesea/research/str0m/src/change/sdp.rs:662:25
  29: str0m::change::sdp::SdpApi::accept_offer
             at /Users/giangminh/Workspace/bluesea/research/str0m/src/change/sdp.rs:105:19
  30: transport_webrtc::transport::TransportWebrtc::new
             at /Users/giangminh/Workspace/8xff/dev/atm0s-media-server/packages/transport_webrtc/src/transport.rs:105:22
  31: transport_webrtc::worker::MediaWorkerWebrtc::spawn
             at /Users/giangminh/Workspace/8xff/dev/atm0s-media-server/packages/transport_webrtc/src/worker.rs:69:34
  32: media_server_runner::worker::MediaServerWorker::process_rpc
             at /Users/giangminh/Workspace/8xff/dev/atm0s-media-server/packages/media_runner/src/worker.rs:297:53
  33: media_server_runner::worker::MediaServerWorker::on_event
             at /Users/giangminh/Workspace/8xff/dev/atm0s-media-server/packages/media_runner/src/worker.rs:128:43
  34: <atm0s_media_server::server::media::runtime_worker::MediaRuntimeWorker as sans_io_runtime::worker::WorkerInner<media_server_runner::worker::Owner,atm0s_media_server::server::media::runtime_worker::ExtIn,atm0s_media_server::server::media::runtime_worker::ExtOut,atm0s_media_server::server::media::runtime_worker::Channel,atm0s_sdn_network::worker::SdnWorkerBusEvent<media_server_core::cluster::ClusterRoomHash,atm0s_sdn_network::services::visualization::Control,atm0s_sdn_network::services::visualization::Event,(),()>,atm0s_media_server::server::media::runtime_worker::ICfg,()>>::on_event
             at ./src/server/media/runtime_worker.rs:105:19
  35: sans_io_runtime::worker::Worker<Owner,ExtIn,ExtOut,ChannelId,Event,Inner,ICfg,SCfg,B,_>::on_input_event
             at /Users/giangminh/.cargo/git/checkouts/sans-io-runtime-bc0909352245330d/9d16b9c/src/worker.rs:411:28
  36: sans_io_runtime::worker::Worker<Owner,ExtIn,ExtOut,ChannelId,Event,Inner,ICfg,SCfg,B,_>::process
             at /Users/giangminh/.cargo/git/checkouts/sans-io-runtime-bc0909352245330d/9d16b9c/src/worker.rs:208:21
  37: sans_io_runtime::controller::Controller<ExtIn,ExtOut,SCfg,ChannelId,Event,_>::add_worker::{{closure}}
             at /Users/giangminh/.cargo/git/checkouts/sans-io-runtime-bc0909352245330d/9d16b9c/src/controller.rs:102:21
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```