### PR TITLE
SDP negotiation now considers ICE Lite when determining ICE role

### DIFF
--- a/docs/ice.md
+++ b/docs/ice.md
@@ -76,6 +76,13 @@ Global Ta pacing is out of scope this implementation.
 
 We do not switch ice-lite during a session.
 
+## One or both sides must be ICE-Full
+
+Handling connections where both sides are ICE-Lite requires specialized logic,
+such as assuming connectivity without checks, after-the-fact candidate pair
+reconciliation, and switching roles after initial determination. We consider
+both sides being ICE-Lite exceedingly rare and thus do not support this case.
+
 ## ICE role conflicts won't happen
 
 https://datatracker.ietf.org/doc/html/rfc8445#section-6.1.1

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -85,8 +85,11 @@ impl<'a> SdpApi<'a> {
         }
 
         if !self.rtc.dtls.is_inited() {
-            // The side that makes the first offer is the controlling side.
-            self.rtc.ice.set_controlling(false);
+            // The side that makes the first offer is the controlling side, unless they
+            // are ICE Lite and we are ICE Full, in which case the roles are reversed.
+            self.rtc
+                .ice
+                .set_controlling(offer.session.ice_lite() && !self.rtc.ice.ice_lite());
         }
 
         // Ensure setup=active/passive is corresponding remote and init dtls.
@@ -144,6 +147,14 @@ impl<'a> SdpApi<'a> {
         }
 
         add_ice_details(self.rtc, &answer, Some(&pending))?;
+
+        if !self.rtc.dtls.is_inited() && self.rtc.ice.ice_lite() && answer.session.ice_lite() {
+            // If we were the initial offerer running in ICE Lite, then we initially set ourselves
+            // as the controlled side, anticipating that the remote end may be ICE Full. However,
+            // if the remote end answers that they are also running ICE Lite, then RFC 5245
+            // dictates that we must become the controlling side again.
+            self.rtc.ice.set_controlling(true);
+        }
 
         // Ensure setup=active/passive is corresponding remote and init dtls.
         init_dtls(self.rtc, &answer)?;
@@ -561,8 +572,11 @@ fn apply_direct_changes(rtc: &mut Rtc, mut changes: Changes) {
 
 fn create_offer(rtc: &mut Rtc, changes: &Changes) -> SdpOffer {
     if !rtc.dtls.is_inited() {
-        // The side that makes the first offer is the controlling side.
-        rtc.ice.set_controlling(true);
+        // In ICE Full, the side that makes the first offer is the controlling
+        // side. In ICE Lite, we start as the controlled side, only switching
+        // back if the remote end reports that they are also using ICE Lite.
+        // (See RFC 5245 Sec 5.2)
+        rtc.ice.set_controlling(!rtc.ice.ice_lite());
     }
 
     let params = AsSdpParams::new(rtc, Some(changes));

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -279,6 +279,13 @@ impl IceAgent {
         self.max_candidate_pairs = Some(max);
     }
 
+    /// Whether ice_lite is enabled.
+    ///
+    /// Default is disabled.
+    pub fn ice_lite(&self) -> bool {
+        self.ice_lite
+    }
+
     /// Enable or disable ice_lite.
     ///
     /// Default is disabled.
@@ -383,9 +390,8 @@ impl IceAgent {
 
     /// Set whether we are the controlling side.
     ///
-    /// ### Panics
-    ///
-    /// Panics if we have started running the ice agent.
+    /// You should not call this function after ICE candidate pair formation
+    /// has started, as the controlling state influences candidate prio!
     pub fn set_controlling(&mut self, v: bool) {
         self.controlling = v;
     }


### PR DESCRIPTION
Resolves https://github.com/algesten/str0m/issues/513. However, it does not make Lite-to-Lite connections fully functional - details below.

[RFC 5245](https://www.rfc-editor.org/rfc/rfc5245#section-5.2) says:
- In a Full-to-Full connection, the initial offerer takes the controlling role in ICE.
- In a Full-to-Lite connection, the Full peer takes the controlling role, regardless of which side offered.
- In a Lite-to-Lite connection, again the initial offerer takes the controlling role.

However, behavior prior to this PR would always consider the initial offerer to be controlling, irrespective of ICE Lite. This discrepancy caused role confusion and thus connection issues when the initial offerer was ICE Lite, regardless of that offerer being str0m itself or another client.

The RFC's logic can be implemented quite directly in our SDP negotiation code. The only bit of complication is in the Lite-to-Lite case, where we initially set ourselves as controlled when offering, but have to switch roles once we learn the remote peer is also ICE Lite via its SDP answer.

With this, Full-to-Full and Full-to-Lite should be fully functional in both offering directions. Lite-to-Lite will at least have the correct role set now, but there are other deficiencies in the ICE implementation that keep this case non-functional, namely the clash between the code both requiring connectivity checks and being unable to perform them. I haven't had time to dig deep into these issues yet, so I can't point out specific code. Since this case is exceedingly rare, though, resolving issues for the much more common Full-to-Lite case is more immediately valuable.