### PR TITLE
fix: nominate "valid" local candidate

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1563,7 +1563,9 @@ impl IceAgent {
                 best_prio.nominate(self.ice_lite);
             }
 
-            let local = best_prio.local_candidate(&self.local_candidates);
+            let local = best_prio
+                .local_valid_candidate(&self.local_candidates)
+                .unwrap_or(best_prio.local_candidate(&self.local_candidates));
             let remote = best_prio.remote_candidate(&self.remote_candidates);
 
             self.nominated_send = Some(best_prio.id());

--- a/src/ice/pair.rs
+++ b/src/ice/pair.rs
@@ -159,6 +159,10 @@ impl CandidatePair {
         &cs[self.local_idx]
     }
 
+    pub fn local_valid_candidate<'a>(&self, cs: &'a [Candidate]) -> Option<&'a Candidate> {
+        self.valid_idx.map(|idx| &cs[idx])
+    }
+
     pub fn remote_candidate<'a>(&self, cs: &'a [Candidate]) -> &'a Candidate {
         &cs[self.remote_idx]
     }


### PR DESCRIPTION
A showcase for a potential fix for #525. I couldn't think of how to write a test for this because the `NominatedSend` event only contains the local address to send from which is the same for host and srflx candidates.

Fixes: #525.