### PR TITLE
Move StreamRx.reset_roc() to expect_stream_rx(..)

### DIFF
--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -1090,7 +1090,15 @@ fn update_media(
 
                 // If remote communicated a main a=ssrc, but no RTX, we will not send nacks.
                 let suppress_nack = repair_ssrc.is_none();
-                streams.expect_stream_rx(i.ssrc, repair_ssrc, media.mid(), None, suppress_nack);
+                streams.expect_stream_rx(
+                    i.ssrc,
+                    repair_ssrc,
+                    media.mid(),
+                    None,
+                    suppress_nack,
+                    // The starting ROC cannot be set via SDP.
+                    None,
+                );
             }
         }
 

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -282,7 +282,8 @@ impl Streams {
         let suppress_nack = payload.resend.is_none();
 
         // If stream already exists, this might only "fill in" the RTX.
-        self.expect_stream_rx(ssrc_main, rtx, mid, rid, suppress_nack);
+        // Dynamic mapping does not allow us to set a starting ROC.
+        self.expect_stream_rx(ssrc_main, rtx, mid, rid, suppress_nack, None);
     }
 
     pub fn expect_stream_rx(
@@ -292,6 +293,7 @@ impl Streams {
         mid: Mid,
         rid: Option<Rid>,
         suppress_nack: bool,
+        roc: Option<u64>,
     ) -> &mut StreamRx {
         // New stream might have enabled nacks.
         self.any_nack_active = None;
@@ -299,7 +301,7 @@ impl Streams {
         let stream = self
             .streams_rx
             .entry(ssrc)
-            .or_insert_with(|| StreamRx::new(ssrc, mid, rid, suppress_nack));
+            .or_insert_with(|| StreamRx::new(ssrc, mid, rid, suppress_nack, roc));
 
         if let Some(rtx) = rtx {
             stream.maybe_reset_rtx(rtx);

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -130,7 +130,13 @@ pub(crate) struct StreamRxStats {
 }
 
 impl StreamRx {
-    pub(crate) fn new(ssrc: Ssrc, mid: Mid, rid: Option<Rid>, suppress_nack: bool) -> Self {
+    pub(crate) fn new(
+        ssrc: Ssrc,
+        mid: Mid,
+        rid: Option<Rid>,
+        suppress_nack: bool,
+        roc: Option<u64>,
+    ) -> Self {
         debug!("Create StreamRx for SSRC: {}", ssrc);
 
         StreamRx {
@@ -144,7 +150,7 @@ impl StreamRx {
             last_used: already_happened(),
             last_clock_rate: None,
             sender_info: None,
-            reset_roc: None,
+            reset_roc: roc,
             register: None,
             register_rtx: None,
             last_time: None,
@@ -677,25 +683,6 @@ impl StreamRx {
 
         self.rtx = Some(rtx);
         self.register_rtx = None;
-    }
-
-    /// Reset the current rollover counter (ROC).
-    ///
-    /// This is used in scenarios where we use a single sequence number across all
-    /// receivers of the same stream (as opposed to a sequence number unique per peer).
-    ///
-    /// [RFC3711](https://datatracker.ietf.org/doc/html/rfc3711#section-3.3.1):
-    ///
-    /// > Receivers joining an on-going session MUST be given the
-    /// > current ROC value using out-of-band signaling such as key-management
-    /// > signaling.  Furthermore, the receiver SHALL initialize s_l to the RTP
-    /// > sequence number (SEQ) of the first observed SRTP packet (unless the
-    /// > initial value is provided by out of band signaling such as key
-    /// > management).
-    pub fn reset_roc(&mut self, roc: u64) {
-        self.register = None;
-        self.register_rtx = None;
-        self.reset_roc = Some(roc);
     }
 }
 

--- a/tests/nack.rs
+++ b/tests/nack.rs
@@ -32,7 +32,7 @@ pub fn loss_recovery() -> Result<(), RtcError> {
     r.direct_api().declare_media(mid, MediaKind::Video);
 
     r.direct_api()
-        .expect_stream_rx(ssrc_tx, Some(ssrc_rtx), mid, None);
+        .expect_stream_rx(ssrc_tx, Some(ssrc_rtx), mid, None, None);
 
     let max = l.last.max(r.last);
     l.last = max;
@@ -188,7 +188,7 @@ pub fn nack_delay() -> Result<(), RtcError> {
     r.direct_api().declare_media(mid, MediaKind::Video);
 
     r.direct_api()
-        .expect_stream_rx(ssrc_tx, Some(ssrc_rtx), mid, None);
+        .expect_stream_rx(ssrc_tx, Some(ssrc_rtx), mid, None, None);
 
     let max = l.last.max(r.last);
     l.last = max;

--- a/tests/repeated.rs
+++ b/tests/repeated.rs
@@ -26,7 +26,7 @@ pub fn repeated() -> Result<(), RtcError> {
 
     r.direct_api().declare_media(mid, MediaKind::Audio);
 
-    r.direct_api().expect_stream_rx(ssrc, None, mid, None);
+    r.direct_api().expect_stream_rx(ssrc, None, mid, None, None);
 
     let max = l.last.max(r.last);
     l.last = max;

--- a/tests/rtp-direct-ssrc.rs
+++ b/tests/rtp-direct-ssrc.rs
@@ -27,7 +27,7 @@ pub fn rtp_direct_ssrc() -> Result<(), RtcError> {
 
     r.direct_api().declare_media(mid, MediaKind::Audio);
 
-    r.direct_api().expect_stream_rx(ssrc, None, mid, None);
+    r.direct_api().expect_stream_rx(ssrc, None, mid, None, None);
 
     let max = l.last.max(r.last);
     l.last = max;

--- a/tests/rtp-direct-with-roc.rs
+++ b/tests/rtp-direct-with-roc.rs
@@ -28,14 +28,13 @@ pub fn rtp_direct_with_roc() -> Result<(), RtcError> {
     r.direct_api().declare_media(mid, MediaKind::Audio);
 
     let mut d = r.direct_api();
-    let rx = d.expect_stream_rx(ssrc_tx, None, mid, None);
 
     // Above 2^16, which means we have ROC:ed.
     let seq_no_offset: SeqNo = 100_000.into();
 
     // By telling the receiver side to start at a specific ROC, we can send first ever
     // packet from a high sequence number.
-    rx.reset_roc(seq_no_offset.roc());
+    d.expect_stream_rx(ssrc_tx, None, mid, None, Some(seq_no_offset.roc()));
 
     let max = l.last.max(r.last);
     l.last = max;


### PR DESCRIPTION
Resetting the ROC can only happen when starting a new stream. There is
no point in having this as a function.
