### PR TITLE
Fix panic in `DatagramRecv::try_from` with empty buffer

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -226,6 +226,10 @@ impl<'a> TryFrom<&'a [u8]> for MultiplexKind {
     type Error = io::Error;
 
     fn try_from(value: &'a [u8]) -> Result<Self, io::Error> {
+        if value.is_empty() {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "Empty datagram"));
+        }
+
         let byte0 = value[0];
         let len = value.len();
 


### PR DESCRIPTION
`MultiplexKind` (and, by extension, callers such as `DatagramRecv`) didn't check for an empty buffer before attempting to read the first byte, causing a panic.