### PR TITLE
Change the `unix_time` function to return `libc::time_t` instead of a hard-coded `i64`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,7 @@ dependencies = [
  "crc",
  "fastrand",
  "hmac",
+ "libc",
  "once_cell",
  "openssl",
  "openssl-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.65"
 
 [features]
 default = ["openssl"]
-openssl = ["dep:openssl", "dep:openssl-sys"]
+openssl = ["dep:openssl", "dep:openssl-sys", "dep:libc"]
 _internal_dont_use_log_stats = []
 _internal_test_exports = []
 
@@ -32,6 +32,7 @@ combine = "4.6.6"
 # OPENSSL_NO_VENDOR=1 to override the feature flag vendored
 openssl = { version = ">=0.10.66", features = ["vendored"], optional = true }
 openssl-sys = { version = "0.9.80", optional = true }
+libc = { version = "0.2", optional = true }
 # STUN
 hmac = "0.12.1"
 crc = "3.0.0"

--- a/src/crypto/ossl/cert.rs
+++ b/src/crypto/ossl/cert.rs
@@ -101,9 +101,9 @@ impl OsslDtlsCert {
 //
 // This is not a super high priority since it's only used for setting a before
 // time in the generated certificate, and one hour back from that.
-pub fn unix_time() -> i64 {
+pub fn unix_time() -> libc::time_t {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
-        .as_secs() as i64
+        .as_secs() as libc::time_t
 }


### PR DESCRIPTION
Change the `unix_time` function to return `libc::time_t` instead of a hard-coded `i64`.
This PR attempts to fix the following error when compiling to the armv7 platform.

```
cargo build --target armv7-unknown-linux-gnueabihf
   Compiling str0m v0.5.1 (/home/magine/str0m)
error[E0308]: mismatched types
   --> src/crypto/ossl/cert.rs:50:42
    |
50  |         let before = Asn1Time::from_unix(unix_time() - 3600)?;
    |                      ------------------- ^^^^^^^^^^^^^^^^^^ expected `i32`, found `i64`
    |                      |
    |                      arguments to this function are incorrect
    |
note: associated function defined here
   --> /home/magine/.cargo/registry/src/index.crates.io-6f17d22bba15001f/openssl-0.10.59/src/asn1.rs:330:12
    |
330 |     pub fn from_unix(time: time_t) -> Result<Asn1Time, ErrorStack> {
    |            ^^^^^^^^^
help: you can convert an `i64` to an `i32` and panic if the converted value doesn't fit
    |
50  |         let before = Asn1Time::from_unix((unix_time() - 3600).try_into().unwrap())?;
    |                                          +                  +++++++++++++++++++++

For more information about this error, try `rustc --explain E0308`.
error: could not compile `str0m` (lib) due to 1 previous error
```