### PR TITLE
Remember max rx SeqNo per SSRC

### DIFF
--- a/src/_internal_test_exports/fuzz.rs
+++ b/src/_internal_test_exports/fuzz.rs
@@ -126,7 +126,7 @@ pub fn depack(data: &[u8]) -> Option<()> {
 
 pub fn receive_register(data: &[u8]) -> Option<()> {
     let mut rng = Rng::new(data);
-    let mut rr = ReceiverRegister::new();
+    let mut rr = ReceiverRegister::new(None);
     let start = Instant::now();
     loop {
         match rng.u8(2)? {

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -606,9 +606,13 @@ impl Streams {
         }
     }
 
-    pub(crate) fn reset_buffers_rx(&mut self, mid: Mid) {
+    pub(crate) fn reset_buffers_rx(
+        &mut self,
+        mid: Mid,
+        max_seq_lookup: impl Fn(Ssrc) -> Option<SeqNo>,
+    ) {
         for s in self.streams_rx_by_mid(mid) {
-            s.reset_buffers();
+            s.reset_buffers(&max_seq_lookup);
         }
     }
 

--- a/src/streams/register.rs
+++ b/src/streams/register.rs
@@ -61,9 +61,9 @@ impl TimePoint {
 }
 
 impl ReceiverRegister {
-    pub fn new() -> Self {
+    pub fn new(max_seq_no: Option<SeqNo>) -> Self {
         ReceiverRegister {
-            nack: NackRegister::new(),
+            nack: NackRegister::new(max_seq_no),
             first: None,
             count: 0,
             time_point_prior: None,
@@ -119,8 +119,8 @@ impl ReceiverRegister {
         self.nack.max_seq()
     }
 
-    pub fn clear(&mut self) {
-        self.nack = NackRegister::new();
+    pub fn clear(&mut self, max_seq_no: Option<SeqNo>) {
+        self.nack = NackRegister::new(max_seq_no);
         self.count = 0;
         self.first = None;
         self.time_point_prior = None;
@@ -255,7 +255,7 @@ mod test {
 
     #[test]
     fn jitter_at_0() {
-        let mut r = ReceiverRegister::new();
+        let mut r = ReceiverRegister::new(None);
 
         // 100 fps in clock rate 90kHz => 90_000/100 = 900 per frame
         // 1/100 * 1_000_000 = 10_000 microseconds per frame.
@@ -272,7 +272,7 @@ mod test {
 
     #[test]
     fn jitter_at_20() {
-        let mut r = ReceiverRegister::new();
+        let mut r = ReceiverRegister::new(None);
 
         // 100 fps in clock rate 90kHz => 90_000/100 = 900 per frame
         // 1/100 * 1_000_000 = 10_000 microseconds per frame.
@@ -324,7 +324,7 @@ mod test {
 
     #[test]
     fn receiver_report() {
-        let mut r = ReceiverRegister::new();
+        let mut r = ReceiverRegister::new(None);
         let now = Instant::now();
         let rtp_time = 0;
 


### PR DESCRIPTION
We got code for dynamically discovering SSRC changes. This is detected when a mid/rid or mid/pt header combo starts on one SSRC and then changes to another. 

As a special case, it could happen that the sender reuses an SSRC it used previously. 

A -> B -> A

The SRTP IV is derived from the extended sequence number. If one IV is reused even once, the encryption is broken. Hence the sender is not allowed to reuse sequence numbers. 

That means the above scenario, where we reuse a previously used SSRC, we must remember the old sequence number to be able to restart from the correct ROC. 