### PR TITLE
fix: mirror nomination state when replacing candidate pair

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -728,8 +728,7 @@ impl IceAgent {
                                 check, pair
                             );
 
-                            let was_nominated = self.candidate_pairs[check_idx].is_nominated();
-                            pair.nominate(was_nominated);
+                            pair.copy_nominated_and_success_state(&self.candidate_pairs[check_idx]);
 
                             if self.ice_lite {
                                 debug!("Retain incoming binding requests for pair");

--- a/src/ice/pair.rs
+++ b/src/ice/pair.rs
@@ -208,6 +208,16 @@ impl CandidatePair {
         }
     }
 
+    pub fn copy_nominated_and_success_state(&mut self, other: &CandidatePair) {
+        match other.nomination_state {
+            NominationState::Nominated | NominationState::Success => {
+                self.nomination_state = other.nomination_state;
+            }
+            NominationState::None => {} // None is the default, no need to copy
+            NominationState::Attempt => {} // Attempt can't be copied because we don't have sent binding requests in the new pair.
+        }
+    }
+
     /// Records a new binding request attempt.
     ///
     /// Returns the transaction id to use in the STUN message.


### PR DESCRIPTION
When we encounter a new candidate pair that replaces an existing one, we currently set the `NominationState` of the new pair to `Nominated` or `Success`, depending on whether the replaced one was `Nominated`.

This can result in an erroneous nomination of a candidate pair that previously had its `NominationState` set to `None`. `was_nominated` is `false` in that case which ends up setting the new `NominationState` to `Nominated`.

The correct behaviour is to strictly mirror the nomination state only if it is either `Nominated` or `Success`.