### PR TITLE
ChannelConfig for data channels in SdpApi

### DIFF
--- a/src/sctp/mod.rs
+++ b/src/sctp/mod.rs
@@ -129,7 +129,7 @@ enum StreamEntryState {
 }
 
 /// (Low level) configuration for a data channel.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ChannelConfig {
     /// The label to use for the user to identify the channel.
     pub label: String,
@@ -144,6 +144,17 @@ pub struct ChannelConfig {
     ///
     /// Defaults to ""
     pub protocol: String,
+}
+impl Default for ChannelConfig {
+    fn default() -> Self {
+        Self {
+            label: Default::default(),
+            ordered: true,
+            reliability: Default::default(),
+            negotiated: Default::default(),
+            protocol: Default::default(),
+        }
+    }
 }
 
 /// Reliability setting of a data channel.


### PR DESCRIPTION
Make it possible to configure reliability and ordering when creating data channels through the SdpApi by having `SdpApi::add_channel` take a ChannelConfig.

It might make sense to add convenience methods for common configs e.g. `ChannelConfig::reliable(label)` or `SdpApi::add_reliable_channel(label)`.

With this change it's not clear how to create out-of-band negotiated channels, since on the side that will generate the initial answer applying added channels will create an offer. My guess is adding them after accepting the initial offer would work, but this should be documented.