### PR TITLE
Support getting stream_id and track_id of Media

### DIFF
--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -206,6 +206,14 @@ impl Media {
     pub(crate) fn msid(&self) -> &Msid {
         &self.msid
     }
+    /// Identifier for the group this Media belongs to.
+    pub fn stream_id(&self) -> &str {
+        &self.msid().stream_id
+    }
+    /// Identifier for this Media. Should be unique for the given stream id.
+    pub fn track_id(&self) -> &str {
+        &self.msid().track_id
+    }
 
     /// Whether this media is audio or video.
     ///
@@ -462,10 +470,7 @@ impl Default for Media {
             index: 0,
             app_tmp: false,
             cname: Id::<20>::random().to_string(),
-            msid: Msid {
-                stream_id: Id::<30>::random().to_string(),
-                track_id: Id::<30>::random().to_string(),
-            },
+            msid: Msid::random(),
             kind: MediaKind::Video,
             remote_pts: vec![],
             remote_exts: ExtensionMap::empty(),
@@ -491,9 +496,9 @@ impl Media {
         Media {
             mid: l.mid(),
             index,
-            // These two are not reflected back, and thus added by add_pending_changes().
+            // This is not reflected back, and thus added by add_pending_changes().
             // cname,
-            // msid,
+            msid: l.msid().unwrap_or(Msid::random()),
             kind: l.typ.clone().into(),
             dir: l.direction().invert(), // remote direction is reverse.
             remote_created,

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -206,10 +206,12 @@ impl Media {
     pub(crate) fn msid(&self) -> &Msid {
         &self.msid
     }
+
     /// Identifier for the group this Media belongs to.
     pub fn stream_id(&self) -> &str {
         &self.msid().stream_id
     }
+
     /// Identifier for this Media. Should be unique for the given stream id.
     pub fn track_id(&self) -> &str {
         &self.msid().track_id

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -243,6 +243,7 @@ impl MediaLine {
             // a mid line. This is checked by `check_consistent`.
             .expect("missing a=mid")
     }
+
     pub fn msid(&self) -> Option<Msid> {
         self.attrs.iter().find_map(|a| {
             if let MediaAttribute::Msid(m) = a {
@@ -1126,6 +1127,7 @@ pub struct Msid {
     pub stream_id: String,
     pub track_id: String,
 }
+
 impl Msid {
     pub fn random() -> Self {
         Msid {

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -12,6 +12,7 @@ use crate::format::Codec;
 use crate::format::CodecSpec;
 use crate::format::FormatParams;
 use crate::format::PayloadParams;
+use crate::io::Id;
 use crate::rtp_::{Direction, Extension, Frequency, Mid, Pt, Rid, SessionId, Ssrc};
 use crate::{Candidate, IceCreds, VERSION};
 
@@ -241,6 +242,15 @@ impl MediaLine {
             // We should only use `mid()` once we're certain there is
             // a mid line. This is checked by `check_consistent`.
             .expect("missing a=mid")
+    }
+    pub fn msid(&self) -> Option<Msid> {
+        self.attrs.iter().find_map(|a| {
+            if let MediaAttribute::Msid(m) = a {
+                Some(m.clone())
+            } else {
+                None
+            }
+        })
     }
 
     pub fn direction(&self) -> Direction {
@@ -1115,6 +1125,14 @@ impl Deref for SimulcastGroups {
 pub struct Msid {
     pub stream_id: String,
     pub track_id: String,
+}
+impl Msid {
+    pub fn random() -> Self {
+        Msid {
+            stream_id: Id::<30>::random().to_string(),
+            track_id: Id::<30>::random().to_string(),
+        }
+    }
 }
 
 impl fmt::Display for SimulcastGroups {


### PR DESCRIPTION
Get the stream_id and track_id from the incoming MediaLine and expose them to users on the resulting Media so they can tell incoming Media apart. Should the incoming Media not have a Msid attribute this falls back to the previous behavior of generating random ids