### PR TITLE
Add `extmap-allow-mixed` SDP attribute

### DIFF
--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -741,6 +741,7 @@ fn as_sdp(session: &Session, params: AsSdpParams) -> Sdp {
             typ: "BUNDLE".into(),
             mids,
         },
+        SessionAttribute::AllowMixedExts,
         SessionAttribute::MsidSemantic {
             semantic: "WMS".to_string(),
             stream_ids,

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -736,6 +736,11 @@ fn as_sdp(session: &Session, params: AsSdpParams) -> Sdp {
         (lines, mids, stream_ids)
     };
 
+    // AllowMixedExts adds "a=extmap-allow-mixed" at session level to signal
+    // support for mixing one-byte and two-byte RTP header extensions.
+    // TODO: It would make sense to perform an actual negotiation, however
+    //       just adding this line should work fine:
+    //       https://github.com/meetecho/janus-gateway/blob/d2e74fdf9bb8aa7a39ed68ed28394afe1e0cd22d/src/sdp.c#L1519
     let mut attrs = vec![
         SessionAttribute::Group {
             typ: "BUNDLE".into(),

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -200,6 +200,7 @@ pub enum SessionAttribute {
         semantic: String, // WMS
         stream_ids: Vec<String>,
     },
+    AllowMixedExts,
     IceLite,
     IceUfrag(String),
     IcePwd(String),
@@ -1164,6 +1165,7 @@ impl fmt::Display for SessionAttribute {
                 let mids: Vec<_> = mids.iter().map(|m| m.to_string()).collect();
                 write!(f, "a=group:{} {}\r\n", typ, mids.join(" "))?;
             }
+            AllowMixedExts => write!(f, "a=extmap-allow-mixed\r\n")?,
             MsidSemantic {
                 semantic,
                 stream_ids,


### PR DESCRIPTION
So I`ve been experimenting with AV1 SVC, and it seems that Chrome won't send  [Dependency Descriptor RTP Header Extension](https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension) if [a=extmap-allow-mixed](https://www.rfc-editor.org/rfc/rfc8285.html#section-6) is not signaled by the remote, so here it is.