### PR TITLE
Do not decrypt already received packets

### DIFF
--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -346,6 +346,17 @@ impl StreamRx {
         }
     }
 
+    pub(crate) fn is_new_packet(&self, is_repair: bool, seq_no: SeqNo) -> bool {
+        let register_ref = if is_repair {
+            self.register_rtx.as_ref()
+        } else {
+            self.register.as_ref()
+        };
+
+        // Unwrap is OK because we always call extend_seq() for the same is_repair flag beforehand
+        register_ref.unwrap().accepts(seq_no)
+    }
+
     pub(crate) fn update_register(
         &mut self,
         now: Instant,

--- a/src/streams/register.rs
+++ b/src/streams/register.rs
@@ -73,6 +73,10 @@ impl ReceiverRegister {
         }
     }
 
+    pub fn accepts(&self, seq: SeqNo) -> bool {
+        self.nack.accepts(seq)
+    }
+
     pub fn update(&mut self, seq: SeqNo, arrival: Instant, rtp_time: u32, clock_rate: u32) -> bool {
         if self.first.is_none() {
             self.first = Some(seq);


### PR DESCRIPTION
This is to protect str0m against SRTP replay attacks where already received packets are being repeated. Before this PR, this would force str0m to spend CPU decrypting it over and over again. With this PR, str0m checks the NACK register whether the packet is one we expect before doing the decryption.