### PR TITLE
Timeouts during DTLS handshake

### DIFF
--- a/src/crypto/dtls.rs
+++ b/src/crypto/dtls.rs
@@ -2,6 +2,7 @@
 
 use std::collections::VecDeque;
 use std::fmt;
+use std::time::Instant;
 
 use crate::net::DatagramSend;
 
@@ -101,6 +102,9 @@ pub trait DtlsInner: Sized {
     /// Poll for the next datagram to send.
     fn poll_datagram(&mut self) -> Option<DatagramSend>;
 
+    /// Poll for next timeout. This is only used during DTLS handshake.
+    fn poll_timeout(&mut self, now: Instant) -> Option<Instant>;
+
     /// Handling incoming data to be sent as DTLS datagrams.
     fn handle_input(&mut self, data: &[u8]) -> Result<(), CryptoError>;
 
@@ -154,6 +158,14 @@ impl DtlsImpl {
         match self {
             #[cfg(feature = "openssl")]
             DtlsImpl::OpenSsl(i) => i.poll_datagram(),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn poll_timeout(&mut self, now: Instant) -> Option<Instant> {
+        match self {
+            #[cfg(feature = "openssl")]
+            DtlsImpl::OpenSsl(i) => i.poll_timeout(now),
             _ => unreachable!(),
         }
     }

--- a/src/crypto/ossl/dtls.rs
+++ b/src/crypto/ossl/dtls.rs
@@ -95,7 +95,7 @@ impl DtlsInner for OsslDtlsImpl {
     }
 
     fn handle_handshake(&mut self, output: &mut VecDeque<DtlsEvent>) -> Result<bool, CryptoError> {
-        if self.tls.is_handshaken() {
+        if self.tls.is_connected() {
             // Nice. Nothing to do.
             Ok(false)
         } else if self.tls.complete_handshake_until_block()? {

--- a/src/crypto/ossl/stream.rs
+++ b/src/crypto/ossl/stream.rs
@@ -67,6 +67,10 @@ where
         }
     }
 
+    pub fn is_handshaking(&self) -> bool {
+        matches!(self.state, State::Init(_, _) | State::Handshaking(_))
+    }
+
     pub fn is_connected(&self) -> bool {
         matches!(self.state, State::Established(_))
     }

--- a/src/crypto/ossl/stream.rs
+++ b/src/crypto/ossl/stream.rs
@@ -47,10 +47,6 @@ where
         self.active
     }
 
-    pub fn is_connected(&self) -> bool {
-        matches!(self.state, State::Established(_))
-    }
-
     pub fn set_active(&mut self, active: bool) {
         assert!(
             self.active.is_none(),
@@ -71,7 +67,7 @@ where
         }
     }
 
-    pub fn is_handshaken(&self) -> bool {
+    pub fn is_connected(&self) -> bool {
         matches!(self.state, State::Established(_))
     }
 

--- a/src/dtls.rs
+++ b/src/dtls.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::time::Instant;
 use std::{fmt, io};
 use thiserror::Error;
 
@@ -107,6 +108,11 @@ impl Dtls {
     /// Poll for the next datagram to send.
     pub fn poll_datagram(&mut self) -> Option<DatagramSend> {
         self.dtls_impl.poll_datagram()
+    }
+
+    /// Poll for a timeout.
+    pub fn poll_timeout(&mut self, now: Instant) -> Option<Instant> {
+        self.dtls_impl.poll_timeout(now)
     }
 
     /// Poll for an event.


### PR DESCRIPTION
The openssl DTLS handshake does have internal timeouts that does resends. If we just poll the dtls subsystem, we will get resends. This PR adds a timeout during dtls handshake to poll for the resends.

* The built-in timer is 1 second with a backoff for each resend. This can be further configured, but the necessary functions are not exposed in the openssl crate.
* We can't test this because openssl notion of time is _real_ time. I don't see a way to pass in what the current time is.

Close #564 