### PR TITLE
Fix RTX stops working after packet loss spike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Ensure compatibility with some 32-bit targets #533
   * Fix bug using unreliable channels by default #548
   * New add_channel_with_config() for configured data channels #548
+  * Fix RTX stops working after packet loss spike #566
 
 # 0.6.1
   * Force openssl to be >=0.10.66 #545

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -530,8 +530,11 @@ impl StreamTx {
         }
 
         // bytes stats refer to the last second by default
-        let bytes_transmitted = self.stats.bytes_transmitted.sum(now);
-        let bytes_retransmitted = self.stats.bytes_retransmitted.sum(now);
+        self.stats.bytes_transmitted.purge_old(now);
+        self.stats.bytes_retransmitted.purge_old(now);
+
+        let bytes_transmitted = self.stats.bytes_transmitted.sum();
+        let bytes_retransmitted = self.stats.bytes_retransmitted.sum();
         let ratio = bytes_retransmitted as f32 / (bytes_retransmitted + bytes_transmitted) as f32;
         let ratio = if ratio.is_finite() { ratio } else { 0_f32 };
         self.rtx_ratio = (ratio, now);

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -530,8 +530,8 @@ impl StreamTx {
         }
 
         // bytes stats refer to the last second by default
-        let bytes_transmitted = self.stats.bytes_transmitted.sum();
-        let bytes_retransmitted = self.stats.bytes_retransmitted.sum();
+        let bytes_transmitted = self.stats.bytes_transmitted.sum(now);
+        let bytes_retransmitted = self.stats.bytes_retransmitted.sum(now);
         let ratio = bytes_retransmitted as f32 / (bytes_retransmitted + bytes_transmitted) as f32;
         let ratio = if ratio.is_finite() { ratio } else { 0_f32 };
         self.rtx_ratio = (ratio, now);

--- a/src/util/value_history.rs
+++ b/src/util/value_history.rs
@@ -72,12 +72,12 @@ mod test {
             ..Default::default()
         };
 
-        assert_eq!(h.sum(now), h.value);
+        assert_eq!(h.sum(now), 11);
         h.push(now - Duration::from_millis(1500), 22);
         h.push(now - Duration::from_millis(500), 22);
-        assert_eq!(h.sum(now), h.value + 22);
+        assert_eq!(h.sum(now), 11 + 22);
         h.push(now, 0);
-        assert_eq!(h.sum(now), h.value + 22);
+        assert_eq!(h.sum(now), 11 + 22);
     }
 
     #[test]


### PR DESCRIPTION
So i've noticed remote receivers sending PLIs too often even after minor packet loss. Debugging NACKs and RTXs showed that everything actually works fine for some time and at some point receivers start flooding SFU with NACKs  for that same packets again and again and no RTXs are being sent at all which results in receiver ending up with a PLI request.

So whats going on is:
1. At some point packet loss spikes and RTX ratio exceeds 15%.
2. This results in `poll_packet_resend` always returning `None` because of [this](https://github.com/algesten/str0m/blob/35d9bbafa1f4a6146c09be87fdea8a94f5c58ae5/src/streams/send.rs#L545-L548)
3. Since no resends are made it never get to [this point](https://github.com/algesten/str0m/blob/35d9bbafa1f4a6146c09be87fdea8a94f5c58ae5/src/streams/send.rs#L573), so RTX ratio is not being recalculated [here](https://github.com/algesten/str0m/blob/35d9bbafa1f4a6146c09be87fdea8a94f5c58ae5/src/util/value_history.rs#L38).
4. At this point it is basically stuck with RTX ratio locked at `> 0.15` with the only option of it being fixed is if bytes transmitted sum becoming high enough which does not normally happen.

So i believe that ratio recalculation is supposed to happen during the `ValueHistory::sum()` call.

And here is before and after videos of how that works:

<details>
<summary>Before</summary>

[before.webm](https://github.com/user-attachments/assets/0da802e3-16cd-44ad-a86e-819c4a3aafae)

</details>

<details>
<summary>After</summary>

[after.webm](https://github.com/user-attachments/assets/d755d152-e803-49bc-a4af-8794203b228d)

</details>

On the after video tx sum drop is when SVC kicks in so ignore that.

Another thing is it would be great to be able to configure that `0.15` RTX cache drop ratio, mind if i do it in another PR?Probably as an additional argument to `StreamTx::set_rtx_cache`, so it will be `fn set_rtx_cache(&mut self, max_packets: usize, max_age: Duration, rtx_cache_drop_ratio: Option<f32>)` with `None` completely disabling this mechanic.