### PR TITLE
refactor(ice): always use latest timing config

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -693,8 +693,7 @@ impl IceAgent {
 
                 let prio =
                     CandidatePair::calculate_prio(self.controlling, remote.prio(), local.prio());
-                let mut pair =
-                    CandidatePair::new(*local_idx, *remote_idx, prio, &self.timing_config);
+                let mut pair = CandidatePair::new(*local_idx, *remote_idx, prio);
 
                 trace!("Form pair local: {:?} remote: {:?}", local, remote);
 
@@ -1347,7 +1346,7 @@ impl IceAgent {
             // *  Its state is set to Waiting. (this is the default)
             // *  The pair is inserted into the checklist based on its priority.
             // *  The pair is enqueued into the triggered-check queue.
-            let pair = CandidatePair::new(local_idx, remote_idx, prio, &self.timing_config);
+            let pair = CandidatePair::new(local_idx, remote_idx, prio);
 
             debug!("Created new pair for STUN request: {:?}", pair);
 

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -694,7 +694,7 @@ impl IceAgent {
                 let prio =
                     CandidatePair::calculate_prio(self.controlling, remote.prio(), local.prio());
                 let mut pair =
-                    CandidatePair::new(*local_idx, *remote_idx, prio, self.timing_config);
+                    CandidatePair::new(*local_idx, *remote_idx, prio, &self.timing_config);
 
                 trace!("Form pair local: {:?} remote: {:?}", local, remote);
 
@@ -1022,7 +1022,7 @@ impl IceAgent {
             let keep = if self.ice_lite {
                 p.has_recent_remote_binding_request(now)
             } else {
-                p.is_still_possible(now)
+                p.is_still_possible(now, &self.timing_config)
             };
             if !keep {
                 debug!("Remove failed pair: {:?}", p);
@@ -1060,7 +1060,7 @@ impl IceAgent {
             .candidate_pairs
             .iter_mut()
             .enumerate()
-            .map(|(i, c)| (i, c.next_binding_attempt(now)))
+            .map(|(i, c)| (i, c.next_binding_attempt(now, &self.timing_config)))
             .min_by_key(|(_, t)| *t);
 
         if let Some((idx, deadline)) = next {
@@ -1111,7 +1111,7 @@ impl IceAgent {
         } else {
             self.candidate_pairs
                 .iter_mut()
-                .map(|c| c.next_binding_attempt(last_now))
+                .map(|c| c.next_binding_attempt(last_now, &self.timing_config))
                 .min()
         };
 
@@ -1347,7 +1347,7 @@ impl IceAgent {
             // *  Its state is set to Waiting. (this is the default)
             // *  The pair is inserted into the checklist based on its priority.
             // *  The pair is enqueued into the triggered-check queue.
-            let pair = CandidatePair::new(local_idx, remote_idx, prio, self.timing_config);
+            let pair = CandidatePair::new(local_idx, remote_idx, prio, &self.timing_config);
 
             debug!("Created new pair for STUN request: {:?}", pair);
 
@@ -1421,7 +1421,7 @@ impl IceAgent {
         // Only the controlling side sends USE-CANDIDATE.
         let use_candidate = self.controlling && pair.is_nominated();
 
-        let trans_id = pair.new_attempt(now);
+        let trans_id = pair.new_attempt(now, &self.timing_config);
 
         self.stats.bind_request_sent += 1;
 
@@ -1637,7 +1637,7 @@ impl IceAgent {
         for p in &self.candidate_pairs {
             if p.is_nominated() {
                 any_nomination = true;
-            } else if p.is_still_possible(now) {
+            } else if p.is_still_possible(now, &self.timing_config) {
                 any_still_possible = true;
             }
         }

--- a/src/ice/pair.rs
+++ b/src/ice/pair.rs
@@ -31,7 +31,8 @@ pub struct CandidatePair {
 
     /// Record of the latest STUN messages we've tried using this pair.
     ///
-    /// This list will never grow beyond STUN_MAX_RETRANS + 1
+    /// This list will usually not grow beyond [`DEFAULT_MAX_RETRANSMITS`] * 2
+    /// unless the user configures a very large retransmission counter.
     binding_attempts: VecDeque<BindingAttempt>,
 
     /// The next time we are to do a binding attempt, cached, since we
@@ -236,7 +237,7 @@ impl CandidatePair {
 
         self.binding_attempts.push_back(attempt);
 
-        // Never keep more than STUN_MAX_RETRANS attempts.
+        // Never keep more than the maximum allowed retransmits.
         while self.binding_attempts.len() > timing_config.max_retransmits() {
             self.binding_attempts.pop_front();
         }

--- a/src/ice/pair.rs
+++ b/src/ice/pair.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::fmt;
 use std::time::{Duration, Instant};
 
-use crate::io::{Id, StunTiming, TransId};
+use crate::io::{Id, StunTiming, TransId, DEFAULT_MAX_RETRANSMITS};
 use crate::Candidate;
 
 // When running ice-lite we need a cutoff when we consider the remote definitely gone.
@@ -112,12 +112,12 @@ impl Default for PairId {
 }
 
 impl CandidatePair {
-    pub fn new(local_idx: usize, remote_idx: usize, prio: u64, timing_config: &StunTiming) -> Self {
+    pub fn new(local_idx: usize, remote_idx: usize, prio: u64) -> Self {
         CandidatePair {
             local_idx,
             remote_idx,
             prio,
-            binding_attempts: VecDeque::with_capacity(timing_config.max_retransmits() + 1),
+            binding_attempts: VecDeque::with_capacity(DEFAULT_MAX_RETRANSMITS * 2),
             id: Default::default(),
             valid_idx: Default::default(),
             state: Default::default(),

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -12,7 +12,10 @@ use thiserror::Error;
 
 mod stun;
 pub use stun::StunMessage;
-pub(crate) use stun::{Class as StunClass, Method as StunMethod, StunError, StunTiming, TransId};
+pub(crate) use stun::{
+    Class as StunClass, Method as StunMethod, StunError, StunTiming, TransId,
+    DEFAULT_MAX_RETRANSMITS,
+};
 
 mod id;
 // this is only exported from this crate to avoid needing

--- a/src/io/stun.rs
+++ b/src/io/stun.rs
@@ -8,6 +8,8 @@ use crc::{Crc, CRC_32_ISO_HDLC};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+pub(crate) const DEFAULT_MAX_RETRANSMITS: usize = 9;
+
 #[derive(Debug, Clone, Copy)]
 pub struct StunTiming {
     pub(crate) initial_rto: Duration,
@@ -59,7 +61,7 @@ impl Default for StunTiming {
     fn default() -> Self {
         Self {
             initial_rto: Duration::from_millis(250),
-            max_retransmits: 9,
+            max_retransmits: DEFAULT_MAX_RETRANSMITS,
             max_rto: Duration::from_millis(3000), // libwebrtc uses 8000 here but we want faster detection of gone peers.
         }
     }

--- a/src/io/stun.rs
+++ b/src/io/stun.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 
 pub(crate) const DEFAULT_MAX_RETRANSMITS: usize = 9;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug)] // Purposely not `Clone` / `Copy` to ensure we always use the latest one everywhere.
 pub struct StunTiming {
     pub(crate) initial_rto: Duration,
     pub(crate) max_retransmits: usize,


### PR DESCRIPTION
Currently, the `StunTiming` configuration gets copied into every new `CandidatePair` that is created. This means that changes to the timing configuration afterwards are not reflected in existing candidate pairs.

To fix this, we remove the `StunTiming` field from `CandidatePair` and instead pass in a reference everywhere where it is needed.

The usecase that I want to support with this is to allow lowering the frequency of STUN bindings in certain situations like idle connections. When a connection is not in use (i.e. there is no other traffic being sent over the UDP socket), detecting a failed connection isn't as time critical because the user isn't using the application. This allows the CPU to go to sleep and preserves battery on e.g. mobile devices.