### PR TITLE
fix(ice): match remote candidate of stun request by priority

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1242,7 +1242,8 @@ impl IceAgent {
             .remote_candidates
             .iter()
             .enumerate()
-            .find(|(_, c)| !c.discarded() && c.proto() == req.proto && c.addr() == req.source);
+            .filter(|(_, c)| !c.discarded() && c.proto() == req.proto && c.addr() == req.source)
+            .max_by_key(|(_, c)| c.prio()); // We may have multiple candidates with the same address (i.e. host and server-reflexive could be the same).
 
         let remote_idx = if let Some((idx, _)) = found_in_remote {
             trace!("Remote candidate for STUN request found");

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1703,6 +1703,10 @@ mod test {
     use std::net::SocketAddr;
 
     impl IceAgent {
+        pub(crate) fn num_candidate_pairs(&self) -> usize {
+            self.candidate_pairs.len()
+        }
+
         fn pair_indexes(&self) -> Vec<(usize, usize)> {
             self.candidate_pairs
                 .iter()


### PR DESCRIPTION
Candidates are redundant when their protocol and address are identical. When such a redundant candidate is added, `str0m` correctly either rejects the newly formed pair or replaces the existing one in case the priority is better.

However, new candidate pairs are still formed as part of looking for the remote candidate of an incoming STUN binding. In the presence of redundant candidates, whether we pick the correct one currently depends on in which order the original candidates have been added.

To make this deterministic and prevent the forming of new, redundant candidate pairs, we now explicitly pick the remote candidate with the highest priority.