### PR TITLE
Configure RTX ratio cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Fix bug using unreliable channels by default #548
   * New add_channel_with_config() for configured data channels #548
   * Fix RTX stops working after packet loss spike #566
+  * Configure RTX ratio cap via `StreamTx::set_rtx_cache` #570
 
 # 0.6.1
   * Force openssl to be >=0.10.66 #545

--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -3,7 +3,9 @@ use crate::crypto::Fingerprint;
 use crate::media::{Media, MediaKind};
 use crate::rtp_::{Mid, Rid, Ssrc};
 use crate::sctp::ChannelConfig;
-use crate::streams::{StreamRx, StreamTx, DEFAULT_RTX_CACHE_DURATION};
+use crate::streams::{
+    StreamRx, StreamTx, DEFAULT_RTX_CACHE_DROP_RATIO, DEFAULT_RTX_CACHE_DURATION,
+};
 use crate::IceCreds;
 use crate::Rtc;
 use crate::RtcError;
@@ -246,7 +248,11 @@ impl<'a> DirectApi<'a> {
             self.rtc.session.send_buffer_video
         };
 
-        stream.set_rtx_cache(size, DEFAULT_RTX_CACHE_DURATION);
+        stream.set_rtx_cache(
+            size,
+            DEFAULT_RTX_CACHE_DURATION,
+            DEFAULT_RTX_CACHE_DROP_RATIO,
+        );
 
         stream
     }

--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -3,9 +3,7 @@ use crate::crypto::Fingerprint;
 use crate::media::{Media, MediaKind};
 use crate::rtp_::{Mid, Rid, Ssrc};
 use crate::sctp::ChannelConfig;
-use crate::streams::{
-    StreamRx, StreamTx, DEFAULT_RTX_CACHE_DROP_RATIO, DEFAULT_RTX_CACHE_DURATION,
-};
+use crate::streams::{StreamRx, StreamTx, DEFAULT_RTX_CACHE_DURATION, DEFAULT_RTX_RATIO_CAP};
 use crate::IceCreds;
 use crate::Rtc;
 use crate::RtcError;
@@ -248,11 +246,7 @@ impl<'a> DirectApi<'a> {
             self.rtc.session.send_buffer_video
         };
 
-        stream.set_rtx_cache(
-            size,
-            DEFAULT_RTX_CACHE_DURATION,
-            DEFAULT_RTX_CACHE_DROP_RATIO,
-        );
+        stream.set_rtx_cache(size, DEFAULT_RTX_CACHE_DURATION, DEFAULT_RTX_RATIO_CAP);
 
         stream
     }

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -22,8 +22,7 @@ use crate::RtcError;
 use crate::{Candidate, IceCreds};
 
 pub use crate::sdp::{SdpAnswer, SdpOffer};
-use crate::streams::Streams;
-use crate::streams::DEFAULT_RTX_CACHE_DURATION;
+use crate::streams::{Streams, DEFAULT_RTX_CACHE_DROP_RATIO, DEFAULT_RTX_CACHE_DURATION};
 
 /// Changes to the Rtc via SDP Offer/Answer dance.
 pub struct SdpApi<'a> {
@@ -863,7 +862,11 @@ fn ensure_stream_tx(session: &mut Session) {
                 session.send_buffer_video
             };
 
-            stream.set_rtx_cache(size, DEFAULT_RTX_CACHE_DURATION);
+            stream.set_rtx_cache(
+                size,
+                DEFAULT_RTX_CACHE_DURATION,
+                DEFAULT_RTX_CACHE_DROP_RATIO,
+            );
         }
     }
 }
@@ -899,7 +902,11 @@ fn add_pending_changes(session: &mut Session, pending: Changes) {
                 session.send_buffer_video
             };
 
-            stream.set_rtx_cache(size, DEFAULT_RTX_CACHE_DURATION);
+            stream.set_rtx_cache(
+                size,
+                DEFAULT_RTX_CACHE_DURATION,
+                DEFAULT_RTX_CACHE_DROP_RATIO,
+            );
         }
     }
 }

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -22,7 +22,7 @@ use crate::RtcError;
 use crate::{Candidate, IceCreds};
 
 pub use crate::sdp::{SdpAnswer, SdpOffer};
-use crate::streams::{Streams, DEFAULT_RTX_CACHE_DROP_RATIO, DEFAULT_RTX_CACHE_DURATION};
+use crate::streams::{Streams, DEFAULT_RTX_CACHE_DURATION, DEFAULT_RTX_RATIO_CAP};
 
 /// Changes to the Rtc via SDP Offer/Answer dance.
 pub struct SdpApi<'a> {
@@ -862,11 +862,7 @@ fn ensure_stream_tx(session: &mut Session) {
                 session.send_buffer_video
             };
 
-            stream.set_rtx_cache(
-                size,
-                DEFAULT_RTX_CACHE_DURATION,
-                DEFAULT_RTX_CACHE_DROP_RATIO,
-            );
+            stream.set_rtx_cache(size, DEFAULT_RTX_CACHE_DURATION, DEFAULT_RTX_RATIO_CAP);
         }
     }
 }
@@ -902,11 +898,7 @@ fn add_pending_changes(session: &mut Session, pending: Changes) {
                 session.send_buffer_video
             };
 
-            stream.set_rtx_cache(
-                size,
-                DEFAULT_RTX_CACHE_DURATION,
-                DEFAULT_RTX_CACHE_DROP_RATIO,
-            );
+            stream.set_rtx_cache(size, DEFAULT_RTX_CACHE_DURATION, DEFAULT_RTX_RATIO_CAP);
         }
     }
 }

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -24,7 +24,7 @@ pub(crate) mod rtx_cache_buf;
 mod send;
 mod send_queue;
 
-pub(crate) use send::DEFAULT_RTX_CACHE_DURATION;
+pub(crate) use send::{DEFAULT_RTX_CACHE_DROP_RATIO, DEFAULT_RTX_CACHE_DURATION};
 
 // Time between regular receiver reports.
 // https://www.rfc-editor.org/rfc/rfc8829#section-5.1.2

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -24,7 +24,7 @@ pub(crate) mod rtx_cache_buf;
 mod send;
 mod send_queue;
 
-pub(crate) use send::{DEFAULT_RTX_CACHE_DROP_RATIO, DEFAULT_RTX_CACHE_DURATION};
+pub(crate) use send::{DEFAULT_RTX_CACHE_DURATION, DEFAULT_RTX_RATIO_CAP};
 
 // Time between regular receiver reports.
 // https://www.rfc-editor.org/rfc/rfc8829#section-5.1.2

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -251,8 +251,12 @@ impl StreamTx {
         // Dump old cache to avoid having to deal with resizing logic inside the cache impl.
         self.rtx_cache = RtxCache::new(max_packets, max_age);
         if rtx_ratio_cap.is_some() {
-            self.stats.bytes_transmitted = Some(ValueHistory::default());
-            self.stats.bytes_retransmitted = Some(ValueHistory::default());
+            self.stats
+                .bytes_transmitted
+                .get_or_insert_with(ValueHistory::default);
+            self.stats
+                .bytes_retransmitted
+                .get_or_insert_with(ValueHistory::default);
         } else {
             self.stats.bytes_transmitted = None;
             self.stats.bytes_retransmitted = None;

--- a/tests/rtx-cache-0.rs
+++ b/tests/rtx-cache-0.rs
@@ -27,7 +27,7 @@ pub fn rtx_cache_0() -> Result<(), RtcError> {
         .declare_stream_tx(ssrc_tx, None, mid, Some(rid))
         //
         // disable RTX cache by setting 0
-        .set_rtx_cache(0, Duration::ZERO);
+        .set_rtx_cache(0, Duration::ZERO, Some(0.15));
 
     r.direct_api()
         .declare_media(mid, MediaKind::Audio)


### PR DESCRIPTION
https://github.com/algesten/str0m/pull/566#issuecomment-2377171154

> Another thing is it would be great to be able to configure that `0.15` RTX cache drop ratio, mind if i do it in another PR? Probably as an additional argument to `StreamTx::set_rtx_cache`, so it will be `fn set_rtx_cache(&mut self, max_packets: usize, max_age: Duration, rtx_cache_drop_ratio: Option<f32>)` with `None` completely disabling this mechanic.