### PR TITLE
Correctly handle per m-line TWCC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   * New add_channel_with_config() for configured data channels #548
   * Fix RTX stops working after packet loss spike #566
   * Configure RTX ratio cap via `StreamTx::set_rtx_cache` #570
+  * Correctly handle per m-line TWCC #573
 
 # 0.6.1
   * Force openssl to be >=0.10.66 #545

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -1012,9 +1012,10 @@ fn update_session(session: &mut Session, sdp: &Sdp) {
         .id_of(Extension::TransportSequenceNumber)
         .is_some();
 
-    // Since twcc feedback is session wide and not per m-line or pt, we enable it if
-    // there are _any_ m-line with a a=rtcp-fb transport-cc parameter and the sequence
-    // number header is enabled.
+    // Since twcc feedback is session wide we enable it if there are _any_
+    // m-line with a a=rtcp-fb transport-cc parameter and the sequence number
+    // header is enabled. It can later be disabled for specific m-lines based
+    // on the extensions map.
     if has_transport_cc && has_twcc_header {
         session.enable_twcc_feedback();
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -12,7 +12,7 @@ use crate::media::Media;
 use crate::media::{MediaAdded, MediaChanged};
 use crate::packet::SendSideBandwithEstimator;
 use crate::packet::{LeakyBucketPacer, NullPacer, Pacer, PacerImpl};
-use crate::rtp::RawPacket;
+use crate::rtp::{Extension, RawPacket};
 use crate::rtp_::Direction;
 use crate::rtp_::Pt;
 use crate::rtp_::SeqNo;
@@ -732,8 +732,10 @@ impl Session {
 
         let protected = srtp_tx.protect_rtp(buf, &header, *seq_no);
 
-        self.twcc_tx_register
-            .register_seq(twcc_seq.into(), now, payload_size);
+        if exts.id_of(Extension::TransportSequenceNumber).is_some() {
+            self.twcc_tx_register
+                .register_seq(twcc_seq.into(), now, payload_size);
+        }
 
         // Technically we should wait for the next handle_timeout, but this speeds things up a bit
         // avoiding an extra poll_timeout.

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -14,7 +14,6 @@ use crate::packet::QueuePriority;
 use crate::packet::QueueSnapshot;
 use crate::packet::QueueState;
 use crate::rtp_::Bitrate;
-use crate::rtp_::Extension;
 use crate::rtp_::{extend_u16, Descriptions, ReportList, Rtcp};
 use crate::rtp_::{ExtensionMap, ReceptionReport, RtpHeader};
 use crate::rtp_::{ExtensionValues, Frequency, MediaTime, Mid, NackEntry};
@@ -362,7 +361,7 @@ impl StreamTx {
         &mut self,
         now: Instant,
         exts: &ExtensionMap,
-        twcc: &mut u64,
+        twcc: Option<&mut u64>,
         params: &[PayloadParams],
         buf: &mut Vec<u8>,
     ) -> Option<PacketReceipt> {
@@ -467,7 +466,9 @@ impl StreamTx {
         // These need to match `Extension::is_supported()` so we are sending what we are
         // declaring we support.
         header.ext_vals.abs_send_time = Some(now);
-        if exts.id_of(Extension::TransportSequenceNumber).is_some() {
+
+        // TWCC might not be enabled for this m-line.
+        if let Some(twcc) = twcc {
             header.ext_vals.transport_cc = Some(*twcc as u16);
             *twcc += 1;
         }

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -14,6 +14,7 @@ use crate::packet::QueuePriority;
 use crate::packet::QueueSnapshot;
 use crate::packet::QueueState;
 use crate::rtp_::Bitrate;
+use crate::rtp_::Extension;
 use crate::rtp_::{extend_u16, Descriptions, ReportList, Rtcp};
 use crate::rtp_::{ExtensionMap, ReceptionReport, RtpHeader};
 use crate::rtp_::{ExtensionValues, Frequency, MediaTime, Mid, NackEntry};
@@ -465,9 +466,13 @@ impl StreamTx {
 
         // These need to match `Extension::is_supported()` so we are sending what we are
         // declaring we support.
-        header.ext_vals.abs_send_time = Some(now);
-        header.ext_vals.transport_cc = Some(*twcc as u16);
-        *twcc += 1;
+        if exts.id_of(Extension::AbsoluteSendTime).is_some() {
+            header.ext_vals.abs_send_time = Some(now);
+        }
+        if exts.id_of(Extension::TransportSequenceNumber).is_some() {
+            header.ext_vals.transport_cc = Some(*twcc as u16);
+            *twcc += 1;
+        }
 
         buf.resize(DATAGRAM_MAX_PACKET_SIZE, 0);
 

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -466,9 +466,7 @@ impl StreamTx {
 
         // These need to match `Extension::is_supported()` so we are sending what we are
         // declaring we support.
-        if exts.id_of(Extension::AbsoluteSendTime).is_some() {
-            header.ext_vals.abs_send_time = Some(now);
-        }
+        header.ext_vals.abs_send_time = Some(now);
         if exts.id_of(Extension::TransportSequenceNumber).is_some() {
             header.ext_vals.transport_cc = Some(*twcc as u16);
             *twcc += 1;


### PR DESCRIPTION
So I've been noticing that some receivers report `PeerStats.egress_loss_fraction` sitting at 20-40% with no other indications of packet loss,  and `MediaEgressStats.loss` reporting ~0%. Further investigation showed that it only happens with Firefox receivers cause Firefox does not support TWCC for audio m-lines. Example SDP:

```
v=0
o=mozilla...THIS_IS_SDPARTA-99.0 812743268998139128 0 IN IP4 0.0.0.0
...
a=sendrecv
a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
a=extmap:2/recvonly urn:ietf:params:rtp-hdrext:csrc-audio-level
a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
...
a=sendrecv
a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:4 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
a=extmap:5 urn:ietf:params:rtp-hdrext:toffset
a=extmap:6/recvonly http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
a=extmap:7 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
...
```

So Firefox does not report audio in its TWCC reports, so str0m's TWCC-based loss calculation desides that all audio packets are lost.