### PR TITLE
Dedupe remote ICE candidates

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -390,16 +390,14 @@ impl IceAgent {
         self.candidate_pairs
             .iter()
             .filter(|cand| cand.state() == CheckState::Succeeded)
-            .find_map(|pair| {
+            .find(|pair| {
                 let o = &self.remote_candidates[pair.remote_idx()];
 
-                let same = c.addr() == o.addr()
+                c.addr() == o.addr()
                     && c.base() == o.base()
                     && c.proto() == o.proto()
                     && c.kind() == o.kind()
-                    && c.raddr() == o.raddr();
-
-                same.then(|| pair)
+                    && c.raddr() == o.raddr()
             })
     }
 
@@ -684,7 +682,7 @@ impl IceAgent {
             let existing_discarded = existing_idx.and_then(|idx| {
                 let o = &mut self.remote_candidates[idx];
 
-                o.discarded().then(|| (idx, o))
+                o.discarded().then_some((idx, o))
             });
 
             if let Some((idx, other)) = existing_discarded {


### PR DESCRIPTION
The changes in `5c4c9d5` caused problems because we'd end up creating new identical pairs. For example, if an existing pair, `0-0`, exists as local: 192.168.1.33:5445, remote: 192.168.1.33:63461. Then, after processing a new offer another remote candidate would be added for 192.168.1.33:63461, call this pair `0-1`. When determining which pair an incoming binding request belonged too we'd then identify `0-1` instead of `0-0`(because `max_by_key`) returns the last value on ties. In Chrome this would work correctly, but in Firefox connectivity would be lost.

Ultimately adding a new remote candidate that is exactly the same as one that's already part of a viable pair is redundant, so we resolve this issue by simply skipping such candidates.