### PR TITLE
Move openssl vendored featureflag to default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,19 @@ exclude = ["/cargo_deny.sh", "/deny.toml", "/run-fuzz.sh"]
 # MSRV
 rust-version = "1.65"
 
+# Notes on OpenSSL
+# - Vendored (static link source build) ensures version consistency and easier 
+#   to build but increases size.
+# - Non-vendored (dynamic link) uses system libraries, reducing size but may
+#   cause compatibility issues. 
+# Choose based on security and footprint needs.
+# For large deployments sharing OS images, OS updates can be easier for
+# security patching than updating statically linked software.
+
 [features]
-default = ["openssl", "sha1"]
+default = ["openssl", "vendored", "sha1"]
 openssl = ["dep:openssl", "dep:openssl-sys", "dep:libc"]
+vendored = ["openssl?/vendored"]
 
 # Without the sha1 feature, str0m uses the openssl sha1 impl which is slower.
 sha1 = ["dep:sha1"]
@@ -33,9 +43,7 @@ sctp-proto = "0.3.0"
 combine = "4.6.6"
 
 # Sadly no DTLS support in rustls.
-# If you want to use a system provided openssl you can set env variable
-# OPENSSL_NO_VENDOR=1 to override the feature flag vendored
-openssl = { version = ">=0.10.66", features = ["vendored"], optional = true }
+openssl = { version = ">=0.10.66", optional = true }
 openssl-sys = { version = "0.9.80", optional = true }
 libc = { version = "0.2", optional = true }
 


### PR DESCRIPTION
Some security requirements might be that a user must use system provided OpenSSL.

Added a new feature called openssl-vendored which uses openssl feature and also add the vendored flag.

Easy way to test if open ssl is vendored or not is to.

cargo tree | grep openssl-src -> vendored

changed default to be openssl-vendored to ensure no functionality change

