### PR TITLE
Take into account RTP packets header sizes when calculating BWE and pacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * Configure RTX ratio cap via `StreamTx::set_rtx_cache` #570
   * Correctly handle per m-line TWCC #573
   * Correctly handle per m-line Absolute Send Time #575
+  * Take into account RTP packets header sizes when calculating BWE and pacing #581
 
 # 0.6.1
   * Force openssl to be >=0.10.66 #545

--- a/src/session.rs
+++ b/src/session.rs
@@ -730,7 +730,7 @@ impl Session {
             crate::log_stat!("PACKET_SENT", header.ssrc, payload_size, kind);
         }
 
-        self.pacer.register_send(now, payload_size.into(), mid);
+        self.pacer.register_send(now, buf.len().into(), mid);
 
         if let Some(raw_packets) = &mut self.raw_packets {
             raw_packets.push_back(Box::new(RawPacket::RtpTx(header.clone(), buf.clone())));
@@ -740,7 +740,7 @@ impl Session {
 
         if twcc_enabled {
             self.twcc_tx_register
-                .register_seq(twcc_seq.into(), now, payload_size);
+                .register_seq(twcc_seq.into(), now, buf.len());
         }
 
         // Technically we should wait for the next handle_timeout, but this speeds things up a bit


### PR DESCRIPTION
So while debugging str0m's bandwidth estimation and I've noticed that `AckedBitrateEstimator::current_estimate()` [right here](https://github.com/algesten/str0m/blob/d046952099de390f571ab9eb2fa09a19eae74de4/src/packet/bwe/mod.rs#L116) produces consistently lower values then libwebrtc implementation [right here](https://source.chromium.org/chromium/chromium/src/+/main:third_party/webrtc/modules/congestion_controller/goog_cc/goog_cc_network_control.cc;l=508;drc=8037fc6ffa131805248c2a63c3edec69155b05cf) for the same RTP stream. I've disabled BWE probing so its not the case. So the difference between implementations is that libwebrtc actually includes RTP header sizes in pacing and bwe calculations, while str0m does not: [1](https://github.com/algesten/str0m/blob/d046952099de390f571ab9eb2fa09a19eae74de4/src/session.rs#L742-L743), [2](https://github.com/algesten/str0m/blob/d046952099de390f571ab9eb2fa09a19eae74de4/src/session.rs#L733).

So this is how size of packets is calculated when estimating bitrate based on acked packets:
```c++
// acknowledged_bitrate_estimator.cc
void AcknowledgedBitrateEstimator::IncomingPacketFeedbackVector(const std::vector<PacketResult>& packet_feedback_vector) {
    // ...
    DataSize acknowledged_estimate = packet.sent_packet.size; // here
    acknowledged_estimate += packet.sent_packet.prior_unacked_data;
    bitrate_estimator_->Update(packet.receive_time, acknowledged_estimate, in_alr_); // this is  AckedBitrateEstimator::update

```
```c++
// transport_feedback_adapter.cc
void TransportFeedbackAdapter::AddPacket(const RtpPacketSendInfo& packet_info,
                                         size_t overhead_bytes,
                                         Timestamp creation_time) {
  packet.sent.size = DataSize::Bytes(packet_info.length + overhead_bytes); // here
```
```c++
// rtp_packet_send_info.cc
RtpPacketSendInfo RtpPacketSendInfo::From(const RtpPacketToSend& packet,
                                          const PacedPacketInfo& pacing_info) {
  packet_info.length = packet.size();
```

```c++
// rtp_packet.h
class RtpPacket {
// ...
  size_t headers_size() const { return payload_offset_; } // payload_offset_ == headers_size
// ...
  size_t size() const {
    return payload_offset_ + payload_size_ + padding_size_; // so its pretty much the whole packet with both header and payload
  }
```

And here is pacing: 
```c++
// pacing_controller.cc
void PacingController::ProcessPackets() {
// ...
  DataSize packet_size = DataSize::Bytes(rtp_packet->payload_size() +
                                         rtp_packet->padding_size());

  if (include_overhead_) { // include_overhead_ is true in default libwebrtc build
    packet_size += DataSize::Bytes(rtp_packet->headers_size()) +
                   transport_overhead_per_packet_; // i dont really know what transport_overhead_per_packet_ is, but it is 40 or 50 in my tests
  }
// ...
```

Another interesting thing is that str0m's `AckedBitrateEstimator` is  based on `BitrateEstimator(bitrate_estimator.cc)` + `AcknowledgedBitrateEstimator(acknowledged_bitrate_estimator.cc)`, and the implementation that libwebrtc seems to use is `RobustThroughputEstimator(robust_throughput_estimator.cc)`.

It is created here:
```c++
// acknowledged_bitrate_estimator_interface.cc
std::unique_ptr<AcknowledgedBitrateEstimatorInterface>
AcknowledgedBitrateEstimatorInterface::Create(
    const FieldTrialsView* key_value_config) {
  RobustThroughputEstimatorSettings simplified_estimator_settings(
      key_value_config);
  if (simplified_estimator_settings.enabled) {
    return std::make_unique<RobustThroughputEstimator>(
        simplified_estimator_settings);
  }
  return std::make_unique<AcknowledgedBitrateEstimator>(key_value_config);
}
```

And `simplified_estimator_settings.enabled == true` at least in my libwebrtc build, which is pretty default. Maybe Chromium build uses `AcknowledgedBitrateEstimator`, havent checked that.