### PR TITLE
Fix loss based BWE stuck in loss limited window

### DIFF
--- a/src/packet/bwe/loss_controller.rs
+++ b/src/packet/bwe/loss_controller.rs
@@ -231,8 +231,6 @@ impl LossController {
                     } else {
                         self.acknowledged_bitrate * self.config.bandwidth_rampup_upper_bound_factor
                     };
-
-                self.recovering_after_loss_timestamp = self.last_send_time_most_recent_observation;
             }
         }
 

--- a/src/packet/bwe/loss_controller.rs
+++ b/src/packet/bwe/loss_controller.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, Instant};
 
 use crate::packet::bwe::macros::log_inherent_loss;
 use crate::packet::bwe::macros::log_loss_based_bitrate_estimate;
+use crate::packet::bwe::macros::log_loss_bw_limit_in_window;
 use crate::rtp_::TwccSendRecord;
 use crate::{Bitrate, DataSize};
 
@@ -264,6 +265,7 @@ impl LossController {
                 .max(loss_limited_bandwidth * CONF_MAX_INCREASE_FACTOR);
 
             self.recovering_after_loss_timestamp = self.last_send_time_most_recent_observation;
+            log_loss_bw_limit_in_window!(self.bandwidth_limit_in_current_window.as_f64());
         }
     }
 

--- a/src/packet/bwe/loss_controller.rs
+++ b/src/packet/bwe/loss_controller.rs
@@ -912,7 +912,7 @@ impl Default for Config {
             newton_step_size: 0.75,
             not_increase_if_inherent_loss_less_than_average_loss: true,
             delayed_increase_window: Duration::from_millis(1000),
-            bandwidth_rampup_upper_bound_factor: 1000000.0,
+            bandwidth_rampup_upper_bound_factor: 1_000_000.0,
             candidate_factor: [1.02, 1.0, 0.95],
             append_acknowledged_rate_candidate: true,
             append_delay_based_estimate_candidate: true,

--- a/src/packet/bwe/macros.rs
+++ b/src/packet/bwe/macros.rs
@@ -70,11 +70,18 @@ macro_rules! log_loss {
     }
 }
 
+macro_rules! log_loss_bw_limit_in_window {
+    ($($arg:expr),+) => {
+        crate::log_stat!("LOSS_BW_LIMIT_IN_WINDOW", $($arg),+);
+    }
+}
+
 pub(crate) use log_bitrate_estimate;
 pub(crate) use log_delay_variation;
 pub(crate) use log_inherent_loss;
 pub(crate) use log_loss;
 pub(crate) use log_loss_based_bitrate_estimate;
+pub(crate) use log_loss_bw_limit_in_window;
 pub(crate) use log_pacer_media_debt;
 pub(crate) use log_pacer_padding_debt;
 pub(crate) use log_rate_control_applied_change;


### PR DESCRIPTION
When loss limited, but increasing we shouldn't reset the loss limit
window, this prevents the recovery from happening.

This would cause estimates to get stuck in unrecoverable lows after big
spikes in loss.
