### PR TITLE
Refactor Crypto APIs to have a provider scheme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,8 +82,8 @@ url = "=2.5.0"
 
 [[example]]
 name = "chat"
-required-features = ["openssl"]
+required-features = ["1openssl"]
 
 [[example]]
 name = "http-post"
-required-features = ["openssl"]
+required-features = ["1openssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,8 +82,8 @@ url = "=2.5.0"
 
 [[example]]
 name = "chat"
-required-features = ["1openssl"]
+required-features = ["openssl"]
 
 [[example]]
 name = "http-post"
-required-features = ["1openssl"]
+required-features = ["openssl"]

--- a/src/_internal_test_exports/fuzz.rs
+++ b/src/_internal_test_exports/fuzz.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 use crate::change::{SdpAnswer, SdpOffer};
-use crate::crypto::CryptoProvider;
+use crate::crypto::CryptoProviderId;
 use crate::crypto::KeyingMaterial;
 use crate::crypto::SrtpProfile;
 use crate::format::Codec;
@@ -50,14 +50,14 @@ pub fn rtp_header(data: &[u8]) -> Option<()> {
 #[cfg(feature = "_internal_test_exports")]
 pub fn rtp_packet(data: &[u8]) -> Option<()> {
     use crate::Session;
-    let crypto_context = CryptoProvider::default().into();
+    let crypto_provider = CryptoProviderId::default().into();
     let mut rng = Rng::new(data);
 
     let config = random_config(&mut rng)?;
 
     let mut session = Session::new(&config);
     session.set_keying_material(
-        crypto_context,
+        crypto_provider,
         KeyingMaterial::new(rng.slice(16)?.to_vec()),
         SrtpProfile::PassThrough,
         rng.bool()?,

--- a/src/_internal_test_exports/fuzz.rs
+++ b/src/_internal_test_exports/fuzz.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 use crate::change::{SdpAnswer, SdpOffer};
+use crate::crypto::CryptoProvider;
 use crate::crypto::KeyingMaterial;
 use crate::crypto::SrtpProfile;
 use crate::format::Codec;
@@ -49,12 +50,14 @@ pub fn rtp_header(data: &[u8]) -> Option<()> {
 #[cfg(feature = "_internal_test_exports")]
 pub fn rtp_packet(data: &[u8]) -> Option<()> {
     use crate::Session;
+    let crypto_context = CryptoProvider::default().into();
     let mut rng = Rng::new(data);
 
     let config = random_config(&mut rng)?;
 
     let mut session = Session::new(&config);
     session.set_keying_material(
+        crypto_context,
         KeyingMaterial::new(rng.slice(16)?.to_vec()),
         SrtpProfile::PassThrough,
         rng.bool()?,

--- a/src/_internal_test_exports/fuzz.rs
+++ b/src/_internal_test_exports/fuzz.rs
@@ -4,9 +4,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 use crate::change::{SdpAnswer, SdpOffer};
-use crate::crypto::CryptoProviderId;
-use crate::crypto::KeyingMaterial;
-use crate::crypto::SrtpProfile;
+use crate::crypto::{CryptoProviderId, KeyingMaterial, SrtpProfile};
 use crate::format::Codec;
 use crate::packet::{DepacketizingBuffer, RtpMeta};
 use crate::rtp_::{Frequency, MediaTime, RtpHeader};

--- a/src/crypto/dtls.rs
+++ b/src/crypto/dtls.rs
@@ -7,7 +7,9 @@ use std::time::Instant;
 
 use crate::net::DatagramSend;
 
-use super::{CryptoError, CryptoProvider, Fingerprint, KeyingMaterial, SrtpProfile};
+use super::{
+    CryptoError, CryptoProvider, CryptoProviderId, Fingerprint, KeyingMaterial, SrtpProfile,
+};
 
 pub(crate) trait DtlsIdentity: fmt::Debug {
     fn fingerprint(&self) -> Fingerprint;
@@ -69,14 +71,15 @@ impl Clone for DtlsCert {
 
 impl DtlsCert {
     /// Create a new DtlsCert using the given provider.
-    pub fn new(crypto_provider: CryptoProvider) -> Self {
+    pub fn new(crypto_provider_id: CryptoProviderId) -> Self {
+        let crypto_provider: CryptoProvider = crypto_provider_id.into();
         DtlsCert(crypto_provider.create_dtls_identity())
     }
 
     #[cfg(feature = "openssl")]
     /// Create a new OpenSSL variant of the certificate.
     pub fn new_openssl() -> Self {
-        Self::new(super::CryptoProviderId::default().into())
+        Self::new(super::CryptoProviderId::default())
     }
 
     /// Creates a fingerprint for this certificate.

--- a/src/crypto/dtls.rs
+++ b/src/crypto/dtls.rs
@@ -2,6 +2,7 @@
 
 use std::collections::VecDeque;
 use std::fmt;
+use std::panic::UnwindSafe;
 use std::time::Instant;
 
 use crate::net::DatagramSend;
@@ -15,8 +16,7 @@ pub(crate) trait DtlsIdentity: fmt::Debug {
     fn boxed_clone(&self) -> Box<dyn DtlsIdentity>;
 }
 
-// TODO(efer): Make more private
-pub trait DtlsContext: Send + Sync + core::panic::UnwindSafe {
+pub(crate) trait DtlsContext: UnwindSafe + Send + Sync {
     // Returns the crypto context.
     fn crypto_provider(&self) -> CryptoProvider;
 

--- a/src/crypto/dtls.rs
+++ b/src/crypto/dtls.rs
@@ -6,15 +6,40 @@ use std::time::Instant;
 
 use crate::net::DatagramSend;
 
-use super::{CryptoError, Fingerprint, KeyingMaterial, SrtpProfile};
+use super::{CryptoContext, CryptoError, Fingerprint, KeyingMaterial, SrtpProfile};
 
-// libWebRTC says "WebRTC" here when doing OpenSSL, for BoringSSL they seem
-// to generate a random 8 characters.
-// https://webrtc.googlesource.com/src/+/1568f1b1330f94494197696fe235094e6293b258/rtc_base/rtc_certificate_generator.cc#27
-//
-// Pion also sets this to "WebRTC", maybe for compatibility reasons.
-// https://github.com/pion/webrtc/blob/eed2bb2d3b9f204f9de1cd7e1046ca5d652778d2/constants.go#L31
-pub const DTLS_CERT_IDENTITY: &str = "WebRTC";
+pub(crate) trait DtlsIdentity: fmt::Debug {
+    fn fingerprint(&self) -> Fingerprint;
+    fn create_context(&self) -> Result<Box<dyn DtlsContext>, CryptoError>;
+    fn crypto_context(&self) -> CryptoContext;
+    fn boxed_clone(&self) -> Box<dyn DtlsIdentity>;
+}
+
+// TODO(efer): Make more private
+pub trait DtlsContext {
+    // Returns the crypto context.
+    fn crypto_context(&self) -> CryptoContext;
+
+    // Returns the local certificate fingerprint.
+    fn local_fingerprint(&self) -> Fingerprint;
+
+    // DTLS session management
+    fn set_active(&mut self, active: bool) -> ();
+    fn is_active(&self) -> Option<bool>;
+    fn is_connected(&self) -> bool;
+    fn handle_handshake(
+        &mut self,
+        out_events: &mut VecDeque<DtlsEvent>,
+    ) -> Result<bool, CryptoError>;
+    fn handle_receive(
+        &mut self,
+        datagram: &[u8],
+        out_events: &mut VecDeque<DtlsEvent>,
+    ) -> Result<(), CryptoError>;
+    fn poll_datagram(&mut self) -> Option<DatagramSend>;
+    fn poll_timeout(&mut self, now: Instant) -> Option<Instant>;
+    fn handle_input(&mut self, data: &[u8]) -> Result<(), CryptoError>;
+}
 
 /// Events arising from a [`Dtls`] instance.
 pub enum DtlsEvent {
@@ -34,190 +59,48 @@ pub enum DtlsEvent {
 }
 
 /// Certificate used for DTLS.
-#[derive(Clone)]
-pub struct DtlsCert(DtlsCertInner);
+pub struct DtlsCert(Box<dyn DtlsIdentity>);
 
-#[derive(Debug, Clone)]
-enum DtlsCertInner {
-    #[cfg(feature = "openssl")]
-    OpenSsl(super::ossl::OsslDtlsCert),
-    #[cfg(feature = "wincrypto")]
-    WinCrypto(super::wincrypto::WinCryptoDtlsCert),
+impl Clone for DtlsCert {
+    fn clone(&self) -> Self {
+        Self(self.0.boxed_clone())
+    }
 }
 
 impl DtlsCert {
+    /// Create a new DtlsCert using the given provider.
+    pub fn new(crypto_context: CryptoContext) -> Self {
+        DtlsCert(crypto_context.create_dtls_identity())
+    }
+
     #[cfg(feature = "openssl")]
     /// Create a new OpenSSL variant of the certificate.
     pub fn new_openssl() -> Self {
-        let cert = super::ossl::OsslDtlsCert::new();
-        DtlsCert(DtlsCertInner::OpenSsl(cert))
-    }
-
-    #[cfg(feature = "wincrypto")]
-    /// Create a new Windows Crypto variant of the certificate.
-    pub fn new_wincrypto() -> Self {
-        let cert = super::wincrypto::WinCryptoDtlsCert::new();
-        DtlsCert(DtlsCertInner::WinCrypto(cert))
+        Self::new(super::CryptoProvider::default().into())
     }
 
     /// Creates a fingerprint for this certificate.
     ///
     /// Fingerprints are used to verify a remote peer's certificate.
     pub fn fingerprint(&self) -> Fingerprint {
-        match &self.0 {
-            #[cfg(feature = "openssl")]
-            DtlsCertInner::OpenSsl(v) => v.fingerprint(),
-            #[cfg(feature = "wincrypto")]
-            DtlsCertInner::WinCrypto(v) => v.fingerprint(),
-            _ => unreachable!(),
-        }
+        self.0.fingerprint()
     }
 
-    pub(crate) fn create_dtls_impl(&self) -> Result<DtlsImpl, CryptoError> {
-        match &self.0 {
-            #[cfg(feature = "openssl")]
-            DtlsCertInner::OpenSsl(c) => Ok(DtlsImpl::OpenSsl(super::ossl::OsslDtlsImpl::new(
-                c.clone(),
-            )?)),
-            #[cfg(feature = "wincrypto")]
-            DtlsCertInner::WinCrypto(c) => Ok(DtlsImpl::WinCrypto(
-                super::wincrypto::WinCryptoDtls::new(c.clone())?,
-            )),
-            _ => unreachable!(),
-        }
+    /// Creates a DTLS context using this certificate as the identity.
+    ///
+    /// Multiple contexts may be created using the same identity.
+    pub(crate) fn create_context(&self) -> Result<Box<dyn DtlsContext>, CryptoError> {
+        self.0.create_context()
+    }
+
+    /// Obtains the CryptoContext that this Cert was built with.
+    pub(crate) fn crypto_context(&self) -> CryptoContext {
+        self.0.crypto_context()
     }
 }
 
 impl fmt::Debug for DtlsCert {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.0 {
-            #[cfg(feature = "openssl")]
-            DtlsCertInner::OpenSsl(c) => c.fmt(f),
-            #[cfg(feature = "wincrypto")]
-            DtlsCertInner::WinCrypto(c) => c.fmt(f),
-            _ => unreachable!(),
-        }
-    }
-}
-
-pub trait DtlsInner: Sized {
-    /// Set whether this instance is active or passive.
-    ///
-    /// i.e. initiating the client hello or not. This must be called
-    /// exactly once before starting to handshake (I/O).
-    fn set_active(&mut self, active: bool);
-
-    /// Handle the handshake. Once this succeeds, it becomes a no-op.
-    fn handle_handshake(&mut self, o: &mut VecDeque<DtlsEvent>) -> Result<bool, CryptoError>;
-
-    /// If set_active, returns what was set.
-    fn is_active(&self) -> Option<bool>;
-
-    /// Handles an incoming DTLS datagrams.
-    fn handle_receive(&mut self, m: &[u8], o: &mut VecDeque<DtlsEvent>) -> Result<(), CryptoError>;
-
-    /// Poll for the next datagram to send.
-    fn poll_datagram(&mut self) -> Option<DatagramSend>;
-
-    /// Poll for next timeout. This is only used during DTLS handshake.
-    fn poll_timeout(&mut self, now: Instant) -> Option<Instant>;
-
-    /// Handling incoming data to be sent as DTLS datagrams.
-    fn handle_input(&mut self, data: &[u8]) -> Result<(), CryptoError>;
-
-    /// Whether the DTLS connection is established.
-    fn is_connected(&self) -> bool;
-}
-
-pub enum DtlsImpl {
-    #[cfg(feature = "openssl")]
-    OpenSsl(super::ossl::OsslDtlsImpl),
-    #[cfg(feature = "wincrypto")]
-    WinCrypto(super::wincrypto::WinCryptoDtls),
-}
-
-impl DtlsImpl {
-    pub fn set_active(&mut self, active: bool) {
-        match self {
-            #[cfg(feature = "openssl")]
-            DtlsImpl::OpenSsl(i) => i.set_active(active),
-            #[cfg(feature = "wincrypto")]
-            DtlsImpl::WinCrypto(i) => i.set_active(active),
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn handle_handshake(&mut self, o: &mut VecDeque<DtlsEvent>) -> Result<bool, CryptoError> {
-        match self {
-            #[cfg(feature = "openssl")]
-            DtlsImpl::OpenSsl(i) => i.handle_handshake(o),
-            #[cfg(feature = "wincrypto")]
-            DtlsImpl::WinCrypto(i) => i.handle_handshake(o),
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn is_active(&self) -> Option<bool> {
-        match self {
-            #[cfg(feature = "openssl")]
-            DtlsImpl::OpenSsl(i) => i.is_active(),
-            #[cfg(feature = "wincrypto")]
-            DtlsImpl::WinCrypto(i) => i.is_active(),
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn handle_receive(
-        &mut self,
-        m: &[u8],
-        o: &mut VecDeque<DtlsEvent>,
-    ) -> Result<(), CryptoError> {
-        match self {
-            #[cfg(feature = "openssl")]
-            DtlsImpl::OpenSsl(i) => i.handle_receive(m, o),
-            #[cfg(feature = "wincrypto")]
-            DtlsImpl::WinCrypto(i) => i.handle_receive(m, o),
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn poll_datagram(&mut self) -> Option<DatagramSend> {
-        match self {
-            #[cfg(feature = "openssl")]
-            DtlsImpl::OpenSsl(i) => i.poll_datagram(),
-            #[cfg(feature = "wincrypto")]
-            DtlsImpl::WinCrypto(i) => i.poll_datagram(),
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn poll_timeout(&mut self, now: Instant) -> Option<Instant> {
-        match self {
-            #[cfg(feature = "openssl")]
-            DtlsImpl::OpenSsl(i) => i.poll_timeout(now),
-            #[cfg(feature = "wincrypto")]
-            DtlsImpl::WinCrypto(i) => i.poll_timeout(now),
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn handle_input(&mut self, data: &[u8]) -> Result<(), CryptoError> {
-        match self {
-            #[cfg(feature = "openssl")]
-            DtlsImpl::OpenSsl(i) => i.handle_input(data),
-            #[cfg(feature = "wincrypto")]
-            DtlsImpl::WinCrypto(i) => i.handle_input(data),
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn is_connected(&self) -> bool {
-        match self {
-            #[cfg(feature = "openssl")]
-            DtlsImpl::OpenSsl(i) => i.is_connected(),
-            #[cfg(feature = "wincrypto")]
-            DtlsImpl::WinCrypto(i) => i.is_connected(),
-            _ => unreachable!(),
-        }
+        self.0.fmt(f)
     }
 }

--- a/src/crypto/dtls.rs
+++ b/src/crypto/dtls.rs
@@ -16,7 +16,7 @@ pub(crate) trait DtlsIdentity: fmt::Debug {
 }
 
 // TODO(efer): Make more private
-pub trait DtlsContext {
+pub trait DtlsContext: Send + Sync + core::panic::UnwindSafe {
     // Returns the crypto context.
     fn crypto_context(&self) -> CryptoContext;
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -43,24 +43,28 @@ pub enum CryptoError {
     Io(#[from] io::Error),
 }
 
+/// An ID specifying which Crypto implementation to use.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CryptoProviderId {
     #[cfg(feature = "openssl")]
+    /// Use OpenSSL
     OpenSsl,
     #[cfg(all(feature = "openssl", feature = "sha1"))]
+    /// Use OpenSSL for most ciphers, but use sha1 crate for SHA1 hashes.
     OpenSslWithSha1Crate,
     #[cfg(feature = "wincrypto")]
+    /// Use Windows Cryptography APIs
     WinCrypto,
 }
 
-#[cfg(feature = "openssl")]
 impl Default for CryptoProviderId {
+    #[allow(unreachable_code)]
     fn default() -> Self {
-        if cfg!(feature = "sha1") {
-            CryptoProviderId::OpenSslWithSha1Crate
-        } else {
-            CryptoProviderId::OpenSsl
-        }
+        #[cfg(all(feature = "openssl", feature = "sha1"))]
+        return CryptoProviderId::OpenSslWithSha1Crate;
+        #[cfg(feature = "openssl")]
+        return CryptoProviderId::OpenSsl;
+        panic!("No default for CryptoProviderId!")
     }
 }
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -43,6 +43,7 @@ pub enum CryptoError {
     Io(#[from] io::Error),
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CryptoProviderId {
     #[cfg(feature = "openssl")]
     OpenSsl,
@@ -77,8 +78,9 @@ impl From<CryptoProviderId> for CryptoProvider {
 }
 
 /// RTP/SRTP ciphers and hashes
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CryptoProvider {
+    pub(crate) crypto_provider_id: CryptoProviderId,
     pub(super) create_dtls_identity_impl: fn(CryptoProvider) -> Box<dyn DtlsIdentity>,
     pub(super) create_aes_128_cm_sha1_80_cipher_impl:
         fn(&aes_128_cm_sha1_80::AesKey, bool) -> Box<dyn aes_128_cm_sha1_80::CipherCtx>,
@@ -93,7 +95,7 @@ impl CryptoProvider {
         (self.create_dtls_identity_impl)(*self)
     }
 
-    pub fn create_aes_128_cm_sha1_80_cipher(
+    pub(crate) fn create_aes_128_cm_sha1_80_cipher(
         &self,
         key: &aes_128_cm_sha1_80::AesKey,
         encrypt: bool,
@@ -101,7 +103,7 @@ impl CryptoProvider {
         (self.create_aes_128_cm_sha1_80_cipher_impl)(key, encrypt)
     }
 
-    pub fn create_aead_aes_128_gcm_cipher(
+    pub(crate) fn create_aead_aes_128_gcm_cipher(
         &self,
         key: &aead_aes_128_gcm::AeadKey,
         encrypt: bool,
@@ -109,11 +111,11 @@ impl CryptoProvider {
         (self.create_aead_aes_128_gcm_cipher_impl)(key, encrypt)
     }
 
-    pub fn srtp_aes_128_ecb_round(&self, key: &[u8], input: &[u8], output: &mut [u8]) {
+    pub(crate) fn srtp_aes_128_ecb_round(&self, key: &[u8], input: &[u8], output: &mut [u8]) {
         (self.srtp_aes_128_ecb_round_impl)(key, input, output)
     }
 
-    pub fn sha1_hmac(&self, key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {
+    pub(crate) fn sha1_hmac(&self, key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {
         (self.sha1_hmac_impl)(key, payloads)
     }
 }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -7,10 +7,11 @@ use thiserror::Error;
 mod ossl;
 
 #[cfg(feature = "wincrypto")]
-pub mod wincrypto;
+mod wincrypto;
 
 mod dtls;
-pub use dtls::{DtlsCert, DtlsEvent, DtlsImpl};
+pub use dtls::{DtlsCert, DtlsEvent};
+pub(crate) use dtls::{DtlsContext, DtlsIdentity};
 
 mod finger;
 pub use finger::Fingerprint;
@@ -19,55 +20,10 @@ mod keying;
 pub use keying::KeyingMaterial;
 
 mod srtp;
-pub use srtp::{aead_aes_128_gcm, aes_128_cm_sha1_80, new_aead_aes_128_gcm};
-pub use srtp::{new_aes_128_cm_sha1_80, srtp_aes_128_ecb_round, SrtpProfile};
+pub use srtp::{aead_aes_128_gcm, aes_128_cm_sha1_80, SrtpProfile};
 
-#[cfg(all(feature = "openssl", feature = "wincrypto"))]
-compile_error!("features `openssl` and `wincrypto` are mutually exclusive");
 #[cfg(not(any(feature = "openssl", feature = "wincrypto")))]
 compile_error!("either `openssl` or `wincrypto` must be enabled");
-
-/// SHA1 HMAC as used for STUN and older SRTP.
-/// If sha1 feature is enabled, it uses `rust-crypto` crate.
-#[cfg(feature = "sha1")]
-pub fn sha1_hmac(key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {
-    use hmac::Hmac;
-    use hmac::Mac;
-    use sha1::Sha1;
-
-    let mut hmac = Hmac::<Sha1>::new_from_slice(key).expect("hmac to normalize size to 20");
-
-    for payload in payloads {
-        hmac.update(payload);
-    }
-
-    hmac.finalize().into_bytes().into()
-}
-
-/// If openssl is enabled and sha1 is not, it uses `openssl` crate.
-#[cfg(all(feature = "openssl", not(feature = "sha1")))]
-pub fn sha1_hmac(key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {
-    use openssl::hash::MessageDigest;
-    use openssl::pkey::PKey;
-    use openssl::sign::Signer;
-
-    let key = PKey::hmac(key).expect("valid hmac key");
-    let mut signer = Signer::new(MessageDigest::sha1(), &key).expect("valid signer");
-
-    for payload in payloads {
-        signer.update(payload).expect("signer update");
-    }
-
-    let mut hash = [0u8; 20];
-    signer.sign(&mut hash).expect("sign to array");
-    hash
-}
-
-/// If wincrypto is enabled and sha1 is not, it uses `wincrypto` crate.
-#[cfg(all(feature = "wincrypto", not(feature = "sha1")))]
-pub fn sha1_hmac(key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {
-    wincrypto::sha1_hmac(key, payloads)
-}
 
 /// Errors that can arise in DTLS.
 #[derive(Debug, Error)]
@@ -85,4 +41,86 @@ pub enum CryptoError {
     /// Other IO errors.
     #[error("{0}")]
     Io(#[from] io::Error),
+}
+
+pub enum CryptoProvider {
+    #[cfg(feature = "openssl")]
+    OpenSsl,
+    #[cfg(all(feature = "openssl", feature = "sha1"))]
+    OpenSslWithSha1Crate,
+    #[cfg(feature = "wincrypto")]
+    WinCrypto,
+}
+
+#[cfg(feature = "openssl")]
+impl Default for CryptoProvider {
+    fn default() -> Self {
+        if cfg!(feature = "sha1") {
+            CryptoProvider::OpenSslWithSha1Crate
+        } else {
+            CryptoProvider::OpenSsl
+        }
+    }
+}
+
+impl From<CryptoProvider> for CryptoContext {
+    fn from(value: CryptoProvider) -> Self {
+        match value {
+            #[cfg(feature = "openssl")]
+            CryptoProvider::OpenSsl => ossl::create_crypto_context(),
+            #[cfg(all(feature = "openssl", feature = "sha1"))]
+            CryptoProvider::OpenSslWithSha1Crate => ossl::sha1_crate::create_crypto_context(),
+            #[cfg(feature = "wincrypto")]
+            CryptoProvider::WinCrypto => wincrypto::create_crypto_context(),
+        }
+    }
+}
+
+/// RTP/SRTP ciphers and hashes
+#[derive(Clone, Copy, Debug)]
+pub struct CryptoContext {
+    pub(super) create_dtls_identity_impl: fn(CryptoContext) -> Box<dyn DtlsIdentity>,
+    pub(super) create_aes_128_cm_sha1_80_cipher_impl:
+        fn(&aes_128_cm_sha1_80::AesKey, bool) -> Box<dyn aes_128_cm_sha1_80::CipherCtx>,
+    pub(super) create_aead_aes_128_gcm_cipher_impl:
+        fn(&aead_aes_128_gcm::AeadKey, bool) -> Box<dyn aead_aes_128_gcm::CipherCtx>,
+    pub(super) srtp_aes_128_ecb_round_impl: fn(&[u8], &[u8], &mut [u8]) -> (),
+    pub(super) sha1_hmac_impl: fn(&[u8], &[&[u8]]) -> [u8; 20],
+}
+
+impl CryptoContext {
+    pub(super) fn create_dtls_identity(&self) -> Box<dyn DtlsIdentity> {
+        (self.create_dtls_identity_impl)(*self)
+    }
+
+    pub fn create_aes_128_cm_sha1_80_cipher(
+        &self,
+        key: &aes_128_cm_sha1_80::AesKey,
+        encrypt: bool,
+    ) -> Box<dyn aes_128_cm_sha1_80::CipherCtx> {
+        (self.create_aes_128_cm_sha1_80_cipher_impl)(key, encrypt)
+    }
+
+    pub fn create_aead_aes_128_gcm_cipher(
+        &self,
+        key: &aead_aes_128_gcm::AeadKey,
+        encrypt: bool,
+    ) -> Box<dyn aead_aes_128_gcm::CipherCtx> {
+        (self.create_aead_aes_128_gcm_cipher_impl)(key, encrypt)
+    }
+
+    pub fn srtp_aes_128_ecb_round(&self, key: &[u8], input: &[u8], output: &mut [u8]) {
+        (self.srtp_aes_128_ecb_round_impl)(key, input, output)
+    }
+
+    pub fn sha1_hmac(&self, key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {
+        (self.sha1_hmac_impl)(key, payloads)
+    }
+}
+
+impl Default for CryptoContext {
+    fn default() -> Self {
+        // TODO(efer): Figure this out.
+        ossl::create_crypto_context()
+    }
 }

--- a/src/crypto/ossl/cert.rs
+++ b/src/crypto/ossl/cert.rs
@@ -8,10 +8,8 @@ use openssl::pkey::{PKey, Private};
 use openssl::rsa::Rsa;
 use openssl::x509::{X509Name, X509};
 
-use crate::crypto::{
-    dtls::{DtlsContext, DtlsIdentity},
-    CryptoProvider, Fingerprint,
-};
+use crate::crypto::dtls::{DtlsContext, DtlsIdentity};
+use crate::crypto::{CryptoProvider, Fingerprint};
 
 use super::dtls::DtlsContextImpl;
 use super::CryptoError;

--- a/src/crypto/ossl/dtls.rs
+++ b/src/crypto/ossl/dtls.rs
@@ -45,8 +45,8 @@ impl DtlsContextImpl {
 }
 
 impl DtlsContext for DtlsContextImpl {
-    fn crypto_context(&self) -> crate::crypto::CryptoContext {
-        self.cert.crypto_context()
+    fn crypto_provider(&self) -> crate::crypto::CryptoProvider {
+        self.cert.crypto_provider()
     }
 
     fn local_fingerprint(&self) -> crate::crypto::Fingerprint {

--- a/src/crypto/ossl/mod.rs
+++ b/src/crypto/ossl/mod.rs
@@ -1,6 +1,6 @@
 //! OpenSSL implementation of cryptographic functions.
 
-use super::{CryptoError, CryptoProvider, SrtpProfile};
+use super::{CryptoError, CryptoProvider, CryptoProviderId, SrtpProfile};
 
 mod cert;
 mod dtls;
@@ -23,6 +23,7 @@ impl SrtpProfile {
 
 pub(crate) fn create_crypto_provider() -> CryptoProvider {
     CryptoProvider {
+        crypto_provider_id: CryptoProviderId::OpenSsl,
         create_dtls_identity_impl: cert::create_dtls_identity_impl,
         create_aes_128_cm_sha1_80_cipher_impl: srtp::Aes128CmSha1_80Impl::new,
         create_aead_aes_128_gcm_cipher_impl: srtp::AeadAes128GcmImpl::new,
@@ -33,7 +34,7 @@ pub(crate) fn create_crypto_provider() -> CryptoProvider {
 
 #[cfg(feature = "sha1")]
 pub(super) mod sha1_crate {
-    use super::{cert, srtp, CryptoProvider};
+    use super::{cert, srtp, CryptoProvider, CryptoProviderId};
     use hmac::Hmac;
     use hmac::Mac;
     use sha1::Sha1;
@@ -50,6 +51,7 @@ pub(super) mod sha1_crate {
 
     pub(crate) fn create_crypto_provider() -> CryptoProvider {
         CryptoProvider {
+            crypto_provider_id: CryptoProviderId::OpenSslWithSha1Crate,
             create_dtls_identity_impl: cert::create_dtls_identity_impl,
             create_aes_128_cm_sha1_80_cipher_impl: srtp::Aes128CmSha1_80Impl::new,
             create_aead_aes_128_gcm_cipher_impl: srtp::AeadAes128GcmImpl::new,

--- a/src/crypto/ossl/mod.rs
+++ b/src/crypto/ossl/mod.rs
@@ -1,18 +1,13 @@
 //! OpenSSL implementation of cryptographic functions.
 
-use super::{CryptoError, SrtpProfile};
+use super::{CryptoContext, CryptoError, SrtpProfile};
 
 mod cert;
-pub use cert::OsslDtlsCert;
-
-mod io_buf;
-mod stream;
-
 mod dtls;
-pub use dtls::OsslDtlsImpl;
-
+mod io_buf;
+mod sha1;
 mod srtp;
-pub use srtp::OsslSrtpCryptoImpl;
+mod stream;
 
 impl SrtpProfile {
     /// What this profile is called in OpenSSL parlance.
@@ -22,6 +17,44 @@ impl SrtpProfile {
             SrtpProfile::PassThrough => "NULL",
             SrtpProfile::Aes128CmSha1_80 => "SRTP_AES128_CM_SHA1_80",
             SrtpProfile::AeadAes128Gcm => "SRTP_AEAD_AES_128_GCM",
+        }
+    }
+}
+
+pub(crate) fn create_crypto_context() -> CryptoContext {
+    CryptoContext {
+        create_dtls_identity_impl: cert::create_dtls_identity_impl,
+        create_aes_128_cm_sha1_80_cipher_impl: srtp::Aes128CmSha1_80Impl::new,
+        create_aead_aes_128_gcm_cipher_impl: srtp::AeadAes128GcmImpl::new,
+        srtp_aes_128_ecb_round_impl: srtp::srtp_aes_128_ecb_round,
+        sha1_hmac_impl: sha1::sha1_hmac,
+    }
+}
+
+#[cfg(feature = "sha1")]
+pub(super) mod sha1_crate {
+    use super::{cert, srtp, CryptoContext};
+    use hmac::Hmac;
+    use hmac::Mac;
+    use sha1::Sha1;
+
+    pub(super) fn sha1_hmac(key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {
+        let mut hmac = Hmac::<Sha1>::new_from_slice(key).expect("hmac to normalize size to 20");
+
+        for payload in payloads {
+            hmac.update(payload);
+        }
+
+        hmac.finalize().into_bytes().into()
+    }
+
+    pub(crate) fn create_crypto_context() -> CryptoContext {
+        CryptoContext {
+            create_dtls_identity_impl: cert::create_dtls_identity_impl,
+            create_aes_128_cm_sha1_80_cipher_impl: srtp::Aes128CmSha1_80Impl::new,
+            create_aead_aes_128_gcm_cipher_impl: srtp::AeadAes128GcmImpl::new,
+            srtp_aes_128_ecb_round_impl: srtp::srtp_aes_128_ecb_round,
+            sha1_hmac_impl: sha1_hmac,
         }
     }
 }

--- a/src/crypto/ossl/mod.rs
+++ b/src/crypto/ossl/mod.rs
@@ -1,6 +1,6 @@
 //! OpenSSL implementation of cryptographic functions.
 
-use super::{CryptoContext, CryptoError, SrtpProfile};
+use super::{CryptoError, CryptoProvider, SrtpProfile};
 
 mod cert;
 mod dtls;
@@ -21,8 +21,8 @@ impl SrtpProfile {
     }
 }
 
-pub(crate) fn create_crypto_context() -> CryptoContext {
-    CryptoContext {
+pub(crate) fn create_crypto_provider() -> CryptoProvider {
+    CryptoProvider {
         create_dtls_identity_impl: cert::create_dtls_identity_impl,
         create_aes_128_cm_sha1_80_cipher_impl: srtp::Aes128CmSha1_80Impl::new,
         create_aead_aes_128_gcm_cipher_impl: srtp::AeadAes128GcmImpl::new,
@@ -33,7 +33,7 @@ pub(crate) fn create_crypto_context() -> CryptoContext {
 
 #[cfg(feature = "sha1")]
 pub(super) mod sha1_crate {
-    use super::{cert, srtp, CryptoContext};
+    use super::{cert, srtp, CryptoProvider};
     use hmac::Hmac;
     use hmac::Mac;
     use sha1::Sha1;
@@ -48,8 +48,8 @@ pub(super) mod sha1_crate {
         hmac.finalize().into_bytes().into()
     }
 
-    pub(crate) fn create_crypto_context() -> CryptoContext {
-        CryptoContext {
+    pub(crate) fn create_crypto_provider() -> CryptoProvider {
+        CryptoProvider {
             create_dtls_identity_impl: cert::create_dtls_identity_impl,
             create_aes_128_cm_sha1_80_cipher_impl: srtp::Aes128CmSha1_80Impl::new,
             create_aead_aes_128_gcm_cipher_impl: srtp::AeadAes128GcmImpl::new,

--- a/src/crypto/ossl/sha1.rs
+++ b/src/crypto/ossl/sha1.rs
@@ -1,0 +1,16 @@
+use openssl::hash::MessageDigest;
+use openssl::pkey::PKey;
+use openssl::sign::Signer;
+
+pub(super) fn sha1_hmac(key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {
+    let key = PKey::hmac(key).expect("valid hmac key");
+    let mut signer = Signer::new(MessageDigest::sha1(), &key).expect("valid signer");
+
+    for payload in payloads {
+        signer.update(payload).expect("signer update");
+    }
+
+    let mut hash = [0u8; 20];
+    signer.sign(&mut hash).expect("sign to array");
+    hash
+}

--- a/src/crypto/srtp.rs
+++ b/src/crypto/srtp.rs
@@ -32,7 +32,7 @@ impl SrtpProfile {
 pub mod aes_128_cm_sha1_80 {
     use std::panic::UnwindSafe;
 
-    use crate::crypto::{CryptoContext, CryptoError};
+    use crate::crypto::{CryptoError, CryptoProvider};
 
     pub const KEY_LEN: usize = 16;
     pub const SALT_LEN: usize = 14;
@@ -59,7 +59,7 @@ pub mod aes_128_cm_sha1_80 {
     }
 
     pub fn rtp_hmac(
-        ctx: &CryptoContext,
+        ctx: &CryptoProvider,
         key: &[u8],
         buf: &mut [u8],
         srtp_index: u64,
@@ -71,7 +71,7 @@ pub mod aes_128_cm_sha1_80 {
     }
 
     pub fn rtp_verify(
-        ctx: &CryptoContext,
+        ctx: &CryptoProvider,
         key: &[u8],
         buf: &[u8],
         srtp_index: u64,
@@ -96,13 +96,13 @@ pub mod aes_128_cm_sha1_80 {
         iv
     }
 
-    pub fn rtcp_hmac(ctx: &CryptoContext, key: &[u8], buf: &mut [u8], hmac_index: usize) {
+    pub fn rtcp_hmac(ctx: &CryptoProvider, key: &[u8], buf: &mut [u8], hmac_index: usize) {
         let tag = ctx.sha1_hmac(key, &[&buf[0..hmac_index]]);
 
         buf[hmac_index..(hmac_index + HMAC_TAG_LEN)].copy_from_slice(&tag[0..HMAC_TAG_LEN]);
     }
 
-    pub fn rtcp_verify(ctx: &CryptoContext, key: &[u8], buf: &[u8], cmp: &[u8]) -> bool {
+    pub fn rtcp_verify(ctx: &CryptoProvider, key: &[u8], buf: &[u8], cmp: &[u8]) -> bool {
         let tag = ctx.sha1_hmac(key, &[buf]);
 
         &tag[0..HMAC_TAG_LEN] == cmp

--- a/src/crypto/wincrypto/cert.rs
+++ b/src/crypto/wincrypto/cert.rs
@@ -1,10 +1,10 @@
-use super::dtls::DtlsContextImpl;
-use crate::crypto::{
-    dtls::{DtlsContext, DtlsIdentity},
-    CryptoProvider, CryptoError, Fingerprint,
-};
 use std::sync::Arc;
 use str0m_wincrypto::WinCryptoError;
+
+use crate::crypto::dtls::{DtlsContext, DtlsIdentity};
+use crate::crypto::{CryptoError, CryptoProvider, Fingerprint};
+
+use super::dtls::DtlsContextImpl;
 
 pub(super) fn create_dtls_identity_impl(crypto_ctx: CryptoProvider) -> Box<dyn DtlsIdentity> {
     let certificate = Arc::new(

--- a/src/crypto/wincrypto/cert.rs
+++ b/src/crypto/wincrypto/cert.rs
@@ -1,12 +1,12 @@
 use super::dtls::DtlsContextImpl;
 use crate::crypto::{
     dtls::{DtlsContext, DtlsIdentity},
-    CryptoContext, CryptoError, Fingerprint,
+    CryptoProvider, CryptoError, Fingerprint,
 };
 use std::sync::Arc;
 use str0m_wincrypto::WinCryptoError;
 
-pub(super) fn create_dtls_identity_impl(crypto_ctx: CryptoContext) -> Box<dyn DtlsIdentity> {
+pub(super) fn create_dtls_identity_impl(crypto_ctx: CryptoProvider) -> Box<dyn DtlsIdentity> {
     let certificate = Arc::new(
         str0m_wincrypto::Certificate::new_self_signed("CN=WebRTC")
             .expect("Failed to create self-signed certificate"),
@@ -19,7 +19,7 @@ pub(super) fn create_dtls_identity_impl(crypto_ctx: CryptoContext) -> Box<dyn Dt
 
 #[derive(Clone, Debug)]
 pub(super) struct DtlsIdentityImpl {
-    crypto_ctx: CryptoContext,
+    crypto_ctx: CryptoProvider,
     pub(super) certificate: Arc<str0m_wincrypto::Certificate>,
 }
 
@@ -36,7 +36,7 @@ impl DtlsIdentity for DtlsIdentityImpl {
         Box::new(self.clone())
     }
 
-    fn crypto_context(&self) -> CryptoContext {
+    fn crypto_provider(&self) -> CryptoProvider {
         self.crypto_ctx
     }
 }

--- a/src/crypto/wincrypto/cert.rs
+++ b/src/crypto/wincrypto/cert.rs
@@ -1,24 +1,43 @@
-use crate::crypto::dtls::DTLS_CERT_IDENTITY;
-use crate::crypto::Fingerprint;
+use super::dtls::DtlsContextImpl;
+use crate::crypto::{
+    dtls::{DtlsContext, DtlsIdentity},
+    CryptoContext, CryptoError, Fingerprint,
+};
 use std::sync::Arc;
 use str0m_wincrypto::WinCryptoError;
 
-#[derive(Clone, Debug)]
-pub struct WinCryptoDtlsCert {
-    pub(crate) certificate: Arc<str0m_wincrypto::Certificate>,
+pub(super) fn create_dtls_identity_impl(crypto_ctx: CryptoContext) -> Box<dyn DtlsIdentity> {
+    let certificate = Arc::new(
+        str0m_wincrypto::Certificate::new_self_signed("CN=WebRTC")
+            .expect("Failed to create self-signed certificate"),
+    );
+    Box::new(DtlsIdentityImpl {
+        certificate,
+        crypto_ctx,
+    })
 }
 
-impl WinCryptoDtlsCert {
-    pub fn new() -> Self {
-        let certificate = Arc::new(
-            str0m_wincrypto::Certificate::new_self_signed(&format!("CN={}", DTLS_CERT_IDENTITY))
-                .expect("Failed to create self-signed certificate"),
-        );
-        Self { certificate }
+#[derive(Clone, Debug)]
+pub(super) struct DtlsIdentityImpl {
+    crypto_ctx: CryptoContext,
+    pub(super) certificate: Arc<str0m_wincrypto::Certificate>,
+}
+
+impl DtlsIdentity for DtlsIdentityImpl {
+    fn fingerprint(&self) -> Fingerprint {
+        create_fingerprint(&self.certificate).expect("Failed to calculate fingerprint")
     }
 
-    pub fn fingerprint(&self) -> Fingerprint {
-        create_fingerprint(&self.certificate).expect("Failed to calculate fingerprint")
+    fn create_context(&self) -> Result<Box<dyn DtlsContext>, CryptoError> {
+        Ok(DtlsContextImpl::new(self)?)
+    }
+
+    fn boxed_clone(&self) -> Box<dyn DtlsIdentity> {
+        Box::new(self.clone())
+    }
+
+    fn crypto_context(&self) -> CryptoContext {
+        self.crypto_ctx
     }
 }
 

--- a/src/crypto/wincrypto/dtls.rs
+++ b/src/crypto/wincrypto/dtls.rs
@@ -1,10 +1,12 @@
-use super::cert::{create_sha256_fingerprint, DtlsIdentityImpl};
+use std::{collections::VecDeque, time::Instant};
+
+use crate::crypto::dtls::{DtlsContext, DtlsIdentity};
 use crate::crypto::{
-    dtls::{DtlsContext, DtlsIdentity},
-    CryptoProvider, CryptoError, DtlsEvent, Fingerprint, KeyingMaterial, SrtpProfile,
+    CryptoError, CryptoProvider, DtlsEvent, Fingerprint, KeyingMaterial, SrtpProfile,
 };
 use crate::io::DATAGRAM_MTU_WARN;
-use std::{collections::VecDeque, time::Instant};
+
+use super::cert::{create_sha256_fingerprint, DtlsIdentityImpl};
 
 pub(super) struct DtlsContextImpl {
     crypto_provider: CryptoProvider,

--- a/src/crypto/wincrypto/dtls.rs
+++ b/src/crypto/wincrypto/dtls.rs
@@ -1,13 +1,13 @@
 use super::cert::{create_sha256_fingerprint, DtlsIdentityImpl};
 use crate::crypto::{
     dtls::{DtlsContext, DtlsIdentity},
-    CryptoContext, CryptoError, DtlsEvent, Fingerprint, KeyingMaterial, SrtpProfile,
+    CryptoProvider, CryptoError, DtlsEvent, Fingerprint, KeyingMaterial, SrtpProfile,
 };
 use crate::io::DATAGRAM_MTU_WARN;
 use std::{collections::VecDeque, time::Instant};
 
 pub(super) struct DtlsContextImpl {
-    crypto_context: CryptoContext,
+    crypto_provider: CryptoProvider,
     dtls: str0m_wincrypto::Dtls,
     fingerprint: Fingerprint,
 }
@@ -16,7 +16,7 @@ impl DtlsContextImpl {
     pub(super) fn new(cert: &DtlsIdentityImpl) -> Result<Box<dyn DtlsContext>, super::CryptoError> {
         let fingerprint = cert.fingerprint();
         Ok(Box::new(DtlsContextImpl {
-            crypto_context: cert.crypto_context(),
+            crypto_provider: cert.crypto_provider(),
             dtls: str0m_wincrypto::Dtls::new(cert.certificate.clone())?,
             fingerprint,
         }))
@@ -24,8 +24,8 @@ impl DtlsContextImpl {
 }
 
 impl DtlsContext for DtlsContextImpl {
-    fn crypto_context(&self) -> CryptoContext {
-        self.crypto_context
+    fn crypto_provider(&self) -> CryptoProvider {
+        self.crypto_provider
     }
 
     fn local_fingerprint(&self) -> Fingerprint {

--- a/src/crypto/wincrypto/dtls.rs
+++ b/src/crypto/wincrypto/dtls.rs
@@ -1,35 +1,47 @@
-use std::collections::VecDeque;
-use std::time::Instant;
-
-use crate::crypto::dtls::DtlsInner;
-use crate::crypto::CryptoError;
-use crate::crypto::DtlsEvent;
-use crate::crypto::{KeyingMaterial, SrtpProfile};
+use super::cert::{create_sha256_fingerprint, DtlsIdentityImpl};
+use crate::crypto::{
+    dtls::{DtlsContext, DtlsIdentity},
+    CryptoContext, CryptoError, DtlsEvent, Fingerprint, KeyingMaterial, SrtpProfile,
+};
 use crate::io::DATAGRAM_MTU_WARN;
+use std::{collections::VecDeque, time::Instant};
 
-use super::cert::{create_sha256_fingerprint, WinCryptoDtlsCert};
+pub(super) struct DtlsContextImpl {
+    crypto_context: CryptoContext,
+    dtls: str0m_wincrypto::Dtls,
+    fingerprint: Fingerprint,
+}
 
-pub struct WinCryptoDtls(str0m_wincrypto::Dtls);
-
-impl WinCryptoDtls {
-    pub fn new(cert: WinCryptoDtlsCert) -> Result<Self, super::CryptoError> {
-        Ok(WinCryptoDtls(str0m_wincrypto::Dtls::new(
-            cert.certificate.clone(),
-        )?))
+impl DtlsContextImpl {
+    pub(super) fn new(cert: &DtlsIdentityImpl) -> Result<Box<dyn DtlsContext>, super::CryptoError> {
+        let fingerprint = cert.fingerprint();
+        Ok(Box::new(DtlsContextImpl {
+            crypto_context: cert.crypto_context(),
+            dtls: str0m_wincrypto::Dtls::new(cert.certificate.clone())?,
+            fingerprint,
+        }))
     }
 }
 
-impl DtlsInner for WinCryptoDtls {
+impl DtlsContext for DtlsContextImpl {
+    fn crypto_context(&self) -> CryptoContext {
+        self.crypto_context
+    }
+
+    fn local_fingerprint(&self) -> Fingerprint {
+        self.fingerprint.clone()
+    }
+
     fn set_active(&mut self, active: bool) {
-        self.0.set_as_client(active).expect("Set client failed");
+        self.dtls.set_as_client(active).expect("Set client failed");
     }
 
     fn is_active(&self) -> Option<bool> {
-        self.0.is_client()
+        self.dtls.is_client()
     }
 
     fn is_connected(&self) -> bool {
-        self.0.is_connected()
+        self.dtls.is_connected()
     }
 
     fn handle_receive(
@@ -37,7 +49,7 @@ impl DtlsInner for WinCryptoDtls {
         datagram: &[u8],
         output_events: &mut VecDeque<DtlsEvent>,
     ) -> Result<(), CryptoError> {
-        transform_dtls_event(self.0.handle_receive(Some(datagram))?, output_events);
+        transform_dtls_event(self.dtls.handle_receive(Some(datagram))?, output_events);
         Ok(())
     }
 
@@ -48,13 +60,13 @@ impl DtlsInner for WinCryptoDtls {
         if self.is_connected() || self.is_active().is_none() {
             return Ok(false);
         }
-        transform_dtls_event(self.0.handle_receive(None)?, output_events);
-        Ok(!self.0.is_connected())
+        transform_dtls_event(self.dtls.handle_receive(None)?, output_events);
+        Ok(!self.dtls.is_connected())
     }
 
     // This is DATA sent from client over SCTP/DTLS
     fn handle_input(&mut self, data: &[u8]) -> Result<(), CryptoError> {
-        match self.0.send_data(data) {
+        match self.dtls.send_data(data) {
             Ok(true) => Ok(()),
             Ok(false) => Err(std::io::Error::new(
                 std::io::ErrorKind::WouldBlock,
@@ -66,7 +78,7 @@ impl DtlsInner for WinCryptoDtls {
     }
 
     fn poll_datagram(&mut self) -> Option<crate::net::DatagramSend> {
-        let datagram: Option<crate::io::DatagramSend> = self.0.pull_datagram().map(|v| v.into());
+        let datagram: Option<crate::io::DatagramSend> = self.dtls.pull_datagram().map(|v| v.into());
         if let Some(datagram) = &datagram {
             if datagram.len() > DATAGRAM_MTU_WARN {
                 warn!("DTLS above MTU {}: {}", DATAGRAM_MTU_WARN, datagram.len());
@@ -77,7 +89,7 @@ impl DtlsInner for WinCryptoDtls {
     }
 
     fn poll_timeout(&mut self, now: Instant) -> Option<Instant> {
-        self.0.next_timeout(now)
+        self.dtls.next_timeout(now)
     }
 }
 

--- a/src/crypto/wincrypto/mod.rs
+++ b/src/crypto/wincrypto/mod.rs
@@ -1,6 +1,6 @@
 //! Windows SChannel + CNG implementation of cryptographic functions.
 
-use super::{CryptoError, CryptoProvider};
+use super::{CryptoError, CryptoProvider, CryptoProviderId};
 
 mod cert;
 mod dtls;
@@ -9,6 +9,7 @@ mod srtp;
 
 pub(crate) fn create_crypto_provider() -> CryptoProvider {
     CryptoProvider {
+        crypto_provider_id: CryptoProviderId::WinCrypto,
         create_dtls_identity_impl: cert::create_dtls_identity_impl,
         create_aes_128_cm_sha1_80_cipher_impl: srtp::Aes128CmSha1_80Impl::new,
         create_aead_aes_128_gcm_cipher_impl: srtp::AeadAes128GcmImpl::new,

--- a/src/crypto/wincrypto/mod.rs
+++ b/src/crypto/wincrypto/mod.rs
@@ -1,6 +1,6 @@
 //! Windows SChannel + CNG implementation of cryptographic functions.
 
-use super::{CryptoProvider, CryptoError};
+use super::{CryptoError, CryptoProvider};
 
 mod cert;
 mod dtls;
@@ -10,8 +10,8 @@ mod srtp;
 pub(crate) fn create_crypto_provider() -> CryptoProvider {
     CryptoProvider {
         create_dtls_identity_impl: cert::create_dtls_identity_impl,
-        create_aes_128_cm_sha1_80_cipher_impl: srtp::WinCryptoAes128CmSha1_80::new,
-        create_aead_aes_128_gcm_cipher_impl: srtp::WinCryptoAeadAes128Gcm::new,
+        create_aes_128_cm_sha1_80_cipher_impl: srtp::Aes128CmSha1_80Impl::new,
+        create_aead_aes_128_gcm_cipher_impl: srtp::AeadAes128GcmImpl::new,
         srtp_aes_128_ecb_round_impl: srtp::srtp_aes_128_ecb_round,
         sha1_hmac_impl: sha1::sha1_hmac,
     }

--- a/src/crypto/wincrypto/mod.rs
+++ b/src/crypto/wincrypto/mod.rs
@@ -1,14 +1,14 @@
 //! Windows SChannel + CNG implementation of cryptographic functions.
 
-use super::{CryptoContext, CryptoError};
+use super::{CryptoProvider, CryptoError};
 
 mod cert;
 mod dtls;
 mod sha1;
 mod srtp;
 
-pub(crate) fn create_crypto_context() -> CryptoContext {
-    CryptoContext {
+pub(crate) fn create_crypto_provider() -> CryptoProvider {
+    CryptoProvider {
         create_dtls_identity_impl: cert::create_dtls_identity_impl,
         create_aes_128_cm_sha1_80_cipher_impl: srtp::WinCryptoAes128CmSha1_80::new,
         create_aead_aes_128_gcm_cipher_impl: srtp::WinCryptoAeadAes128Gcm::new,

--- a/src/crypto/wincrypto/mod.rs
+++ b/src/crypto/wincrypto/mod.rs
@@ -1,18 +1,20 @@
 //! Windows SChannel + CNG implementation of cryptographic functions.
 
-use super::CryptoError;
+use super::{CryptoContext, CryptoError};
 
 mod cert;
-pub use cert::WinCryptoDtlsCert;
-
 mod dtls;
-pub use dtls::WinCryptoDtls;
-
-mod srtp;
-pub use srtp::WinCryptoSrtpCryptoImpl;
-
 mod sha1;
-#[allow(unused_imports)] // If 'sha1' feature is enabled this is not used.
-pub use sha1::sha1_hmac;
+mod srtp;
+
+pub(crate) fn create_crypto_context() -> CryptoContext {
+    CryptoContext {
+        create_dtls_identity_impl: cert::create_dtls_identity_impl,
+        create_aes_128_cm_sha1_80_cipher_impl: srtp::WinCryptoAes128CmSha1_80::new,
+        create_aead_aes_128_gcm_cipher_impl: srtp::WinCryptoAeadAes128Gcm::new,
+        srtp_aes_128_ecb_round_impl: srtp::srtp_aes_128_ecb_round,
+        sha1_hmac_impl: sha1::sha1_hmac,
+    }
+}
 
 pub use str0m_wincrypto::WinCryptoError;

--- a/src/crypto/wincrypto/sha1.rs
+++ b/src/crypto/wincrypto/sha1.rs
@@ -1,4 +1,4 @@
-pub fn sha1_hmac(key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {
+pub(super) fn sha1_hmac(key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {
     match str0m_wincrypto::sha1_hmac(key, payloads) {
         Ok(hash) => hash,
         Err(e) => panic!("sha1_hmac failed in WinCrypto: {e}"),

--- a/src/crypto/wincrypto/srtp.rs
+++ b/src/crypto/wincrypto/srtp.rs
@@ -11,11 +11,11 @@ pub(super) fn srtp_aes_128_ecb_round(key: &[u8], input: &[u8], output: &mut [u8]
     assert_eq!(count, 16 + 16); // block size
 }
 
-pub(super) struct WinCryptoAes128CmSha1_80 {
+pub(super) struct Aes128CmSha1_80Impl {
     key: SrtpKey,
 }
 
-impl WinCryptoAes128CmSha1_80 {
+impl Aes128CmSha1_80Impl {
     /// Create a new context for AES-128-CM-SHA1-80 encryption/decryption.
     ///
     /// The encrypt flag is ignored, since the same operation is used for both encryption and
@@ -30,7 +30,7 @@ impl WinCryptoAes128CmSha1_80 {
     }
 }
 
-impl aes_128_cm_sha1_80::CipherCtx for WinCryptoAes128CmSha1_80 {
+impl aes_128_cm_sha1_80::CipherCtx for Aes128CmSha1_80Impl {
     fn encrypt(
         &mut self,
         iv: &aes_128_cm_sha1_80::RtpIv,
@@ -52,11 +52,11 @@ impl aes_128_cm_sha1_80::CipherCtx for WinCryptoAes128CmSha1_80 {
     }
 }
 
-pub(super) struct WinCryptoAeadAes128Gcm {
+pub(super) struct AeadAes128GcmImpl {
     key: SrtpKey,
 }
 
-impl WinCryptoAeadAes128Gcm {
+impl AeadAes128GcmImpl {
     /// Create a new context for AES-128-GCM encryption/decryption.
     ///
     /// The encrypt flag is ignored, since it is not needed and the same
@@ -71,7 +71,7 @@ impl WinCryptoAeadAes128Gcm {
     }
 }
 
-impl aead_aes_128_gcm::CipherCtx for WinCryptoAeadAes128Gcm {
+impl aead_aes_128_gcm::CipherCtx for AeadAes128GcmImpl {
     fn encrypt(
         &mut self,
         iv: &[u8; aead_aes_128_gcm::IV_LEN],

--- a/src/crypto/wincrypto/srtp.rs
+++ b/src/crypto/wincrypto/srtp.rs
@@ -1,42 +1,35 @@
-use crate::crypto::srtp::SrtpCryptoImpl;
 use crate::crypto::srtp::{aead_aes_128_gcm, aes_128_cm_sha1_80};
 use crate::crypto::CryptoError;
 use str0m_wincrypto::{
-    srtp_aead_aes_128_gcm_decrypt, srtp_aead_aes_128_gcm_encrypt, srtp_aes_128_cm,
-    srtp_aes_128_ecb_round, SrtpKey,
+    srtp_aead_aes_128_gcm_decrypt, srtp_aead_aes_128_gcm_encrypt, srtp_aes_128_cm, SrtpKey,
 };
 
-pub struct WinCryptoSrtpCryptoImpl;
-
-impl SrtpCryptoImpl for WinCryptoSrtpCryptoImpl {
-    type Aes128CmSha1_80 = WinCryptoAes128CmSha1_80;
-    type AeadAes128Gcm = WinCryptoAeadAes128Gcm;
-
-    fn srtp_aes_128_ecb_round(key: &[u8], input: &[u8], output: &mut [u8]) {
-        let key = SrtpKey::create_aes_ecb_key(key).expect("AES key");
-        let count = srtp_aes_128_ecb_round(&key, input, output).expect("AES encrypt");
-        assert_eq!(count, 16 + 16); // block size
-    }
+pub(super) fn srtp_aes_128_ecb_round(key: &[u8], input: &[u8], output: &mut [u8]) {
+    let key = SrtpKey::new_aes_ecb_key(key).expect("AES key");
+    let count = str0m_wincrypto::srtp_aes_128_ecb_round(&key, input, output).expect("AES encrypt");
+    assert_eq!(count, 16 + 16); // block size
 }
 
-pub struct WinCryptoAes128CmSha1_80 {
+pub(super) struct WinCryptoAes128CmSha1_80 {
     key: SrtpKey,
 }
 
-impl aes_128_cm_sha1_80::CipherCtx for WinCryptoAes128CmSha1_80 {
+impl WinCryptoAes128CmSha1_80 {
     /// Create a new context for AES-128-CM-SHA1-80 encryption/decryption.
     ///
     /// The encrypt flag is ignored, since the same operation is used for both encryption and
     /// decryption.
-    fn new(key: aes_128_cm_sha1_80::AesKey, _encrypt: bool) -> Self
-    where
-        Self: Sized,
-    {
-        Self {
-            key: SrtpKey::create_aes_ctr_key(&key).expect("generate sym key"),
-        }
+    pub(super) fn new(
+        key: &aes_128_cm_sha1_80::AesKey,
+        _encrypt: bool,
+    ) -> Box<dyn aes_128_cm_sha1_80::CipherCtx> {
+        Box::new(Self {
+            key: SrtpKey::new_aes_ctr_key(key).expect("generate sym key"),
+        })
     }
+}
 
+impl aes_128_cm_sha1_80::CipherCtx for WinCryptoAes128CmSha1_80 {
     fn encrypt(
         &mut self,
         iv: &aes_128_cm_sha1_80::RtpIv,
@@ -58,24 +51,26 @@ impl aes_128_cm_sha1_80::CipherCtx for WinCryptoAes128CmSha1_80 {
     }
 }
 
-pub struct WinCryptoAeadAes128Gcm {
+pub(super) struct WinCryptoAeadAes128Gcm {
     key: SrtpKey,
 }
 
-impl aead_aes_128_gcm::CipherCtx for WinCryptoAeadAes128Gcm {
+impl WinCryptoAeadAes128Gcm {
     /// Create a new context for AES-128-GCM encryption/decryption.
     ///
     /// The encrypt flag is ignored, since it is not needed and the same
     /// key can be used for both encryption and decryption.
-    fn new(key: aead_aes_128_gcm::AeadKey, _encrypt: bool) -> Self
-    where
-        Self: Sized,
-    {
-        Self {
-            key: SrtpKey::create_aes_gcm_key(&key).expect("generate sym key"),
-        }
+    pub(super) fn new(
+        key: &aead_aes_128_gcm::AeadKey,
+        _encrypt: bool,
+    ) -> Box<dyn aead_aes_128_gcm::CipherCtx> {
+        Box::new(Self {
+            key: SrtpKey::new_aes_gcm_key(key).expect("generate sym key"),
+        })
     }
+}
 
+impl aead_aes_128_gcm::CipherCtx for WinCryptoAeadAes128Gcm {
     fn encrypt(
         &mut self,
         iv: &[u8; aead_aes_128_gcm::IV_LEN],

--- a/src/crypto/wincrypto/srtp.rs
+++ b/src/crypto/wincrypto/srtp.rs
@@ -1,8 +1,9 @@
-use crate::crypto::srtp::{aead_aes_128_gcm, aes_128_cm_sha1_80};
-use crate::crypto::CryptoError;
 use str0m_wincrypto::{
     srtp_aead_aes_128_gcm_decrypt, srtp_aead_aes_128_gcm_encrypt, srtp_aes_128_cm, SrtpKey,
 };
+
+use crate::crypto::srtp::{aead_aes_128_gcm, aes_128_cm_sha1_80};
+use crate::crypto::CryptoError;
 
 pub(super) fn srtp_aes_128_ecb_round(key: &[u8], input: &[u8], output: &mut [u8]) {
     let key = SrtpKey::new_aes_ecb_key(key).expect("AES key");

--- a/src/dtls.rs
+++ b/src/dtls.rs
@@ -19,7 +19,7 @@ pub enum DtlsError {
     /// Some error from Windows Crypto layer (used for DTLS).
     #[error("{0}")]
     #[cfg(feature = "wincrypto")]
-    WinCrypto(#[from] crate::crypto::wincrypto::WinCryptoError),
+    WinCrypto(#[from] str0m_wincrypto::WinCryptoError),
 
     /// Other IO errors.
     #[error("{0}")]

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
-use crate::crypto::CryptoProvider;
+use crate::crypto::{CryptoProvider, CryptoProviderId};
 use crate::io::{Id, StunClass, StunMethod, StunTiming, DATAGRAM_MTU_WARN};
 use crate::io::{Protocol, StunPacket};
 use crate::io::{StunMessage, TransId};
@@ -254,7 +254,7 @@ impl IceAgent {
     /// Create a new [`IceAgent`] with randomly generated credentials.
     #[allow(unused)]
     pub fn new() -> Self {
-        Self::with_local_credentials(CryptoProvider::default(), IceCreds::new())
+        Self::with_local_credentials(CryptoProviderId::default().into(), IceCreds::new())
     }
 
     /// Create a new [`IceAgent`] with a specific set of credentials.

--- a/src/io/stun.rs
+++ b/src/io/stun.rs
@@ -4,7 +4,7 @@ use std::net::IpAddr;
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use crate::crypto::CryptoContext;
+use crate::crypto::CryptoProvider;
 use crc::{Crc, CRC_32_ISO_HDLC};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -269,7 +269,7 @@ impl<'a> StunMessage<'a> {
 
     /// Verify the integrity of this message against the provided password.
     #[must_use]
-    pub(crate) fn check_integrity(&self, ctx: &CryptoContext, password: &str) -> bool {
+    pub(crate) fn check_integrity(&self, ctx: &CryptoProvider, password: &str) -> bool {
         if let Some(integ) = self.attrs.message_integrity {
             let comp = ctx.sha1_hmac(
                 password.as_bytes(),
@@ -291,7 +291,7 @@ impl<'a> StunMessage<'a> {
     /// The provided password is used to authenticate the message.
     pub(crate) fn to_bytes(
         self,
-        ctx: &CryptoContext,
+        ctx: &CryptoProvider,
         password: &str,
         buf: &mut [u8],
     ) -> Result<usize, StunError> {
@@ -823,7 +823,7 @@ impl<'a> fmt::Debug for StunMessage<'a> {
 
 #[cfg(test)]
 mod test {
-    use crate::CryptoProvider;
+    use crate::CryptoProviderId;
 
     use super::*;
     use std::net::SocketAddrV4;
@@ -841,11 +841,11 @@ mod test {
             0xaa, 0xf9, 0x83, 0x9c, 0xa0, 0x76, 0xc6, 0xd5, 0x80, 0x28, 0x00, 0x04, 0x36, 0x0e,
             0x21, 0x9f,
         ];
-        let crypto_context = CryptoProvider::default().into();
+        let crypto_provider = CryptoProviderId::default().into();
 
         let packet = PACKET.to_vec();
         let message = StunMessage::parse(&packet).unwrap();
-        assert!(message.check_integrity(&crypto_context, "xJcE9AQAR7kczUDVOXRUCl"));
+        assert!(message.check_integrity(&crypto_provider, "xJcE9AQAR7kczUDVOXRUCl"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2390,14 +2390,14 @@ mod test {
     fn rtc_is_send() {
         fn is_send<T: Send>(_t: T) {}
         fn is_sync<T: Sync>(_t: T) {}
-        //is_send(Rtc::new());
-        // is_sync(Rtc::new());
+        is_send(Rtc::new());
+        is_sync(Rtc::new());
     }
 
     #[test]
     fn rtc_is_unwind_safe() {
         fn is_unwind_safe<T: UnwindSafe>(_t: T) {}
-        //is_unwind_safe(Rtc::new());
+        is_unwind_safe(Rtc::new());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -596,7 +596,8 @@ use thiserror::Error;
 use util::InstantExt;
 
 mod crypto;
-use crypto::{CryptoProvider, CryptoProviderId, Fingerprint};
+pub use crypto::CryptoProviderId;
+use crypto::{CryptoProvider, Fingerprint};
 
 mod dtls;
 use dtls::DtlsCert;

--- a/src/rtp/mod.rs
+++ b/src/rtp/mod.rs
@@ -46,7 +46,7 @@ pub enum RtpError {
     /// Some error from Windows Crypto layer (used for SRTP).
     #[error("{0}")]
     #[cfg(feature = "wincrypto")]
-    WinCrypto(#[from] crate::crypto::wincrypto::WinCryptoError),
+    WinCrypto(#[from] str0m_wincrypto::WinCryptoError),
 
     /// Other IO errors.
     #[error("{0}")]

--- a/src/rtp/srtp.rs
+++ b/src/rtp/srtp.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 
-use crate::crypto::{aead_aes_128_gcm, aes_128_cm_sha1_80, SrtpProfile};
-use crate::crypto::{CryptoProvider, KeyingMaterial};
+use crate::crypto::{
+    aead_aes_128_gcm, aes_128_cm_sha1_80, CryptoProvider, KeyingMaterial, SrtpProfile,
+};
 
 use super::header::RtpHeader;
 
@@ -708,10 +709,11 @@ fn error_details(header: &RtpHeader, srtp_index: u64) -> String {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::crypto::CryptoProviderId;
 
     #[test]
     fn derive_key() {
-        let crypto_provider = CryptoProvider::default();
+        let crypto_provider = CryptoProviderId::default().into();
 
         // https://tools.ietf.org/html/rfc3711#appendix-B.3
         //
@@ -808,10 +810,14 @@ mod test {
 
         #[test]
         fn unprotect_rtcp() {
-            let crypto_provider = CryptoProvider::default();
+            let crypto_provider = CryptoProviderId::default().into();
             let key_mat = KeyingMaterial::new(MAT.to_vec());
-            let mut ctx_rx =
-                SrtpContext::new(crypto_provider, SrtpProfile::Aes128CmSha1_80, &key_mat, true);
+            let mut ctx_rx = SrtpContext::new(
+                crypto_provider,
+                SrtpProfile::Aes128CmSha1_80,
+                &key_mat,
+                true,
+            );
             ctx_rx.srtcp_index = 1;
 
             let decrypted = ctx_rx.unprotect_rtcp(SRTCP).unwrap();
@@ -1029,7 +1035,7 @@ mod test {
 
         fn make_rtp_context() -> SrtpContext {
             SrtpContext::new_aead_aes_128_gcm(
-                CryptoProvider::default(),
+                CryptoProviderId::default().into(),
                 rfc7714::KEY,
                 rfc7714::SALT,
                 rfc7714::KEY,
@@ -1040,7 +1046,7 @@ mod test {
 
         fn make_rtcp_context() -> SrtpContext {
             SrtpContext::new_aead_aes_128_gcm(
-                CryptoProvider::default(),
+                CryptoProviderId::default().into(),
                 rfc7714::KEY,
                 rfc7714::SALT,
                 rfc7714::KEY,

--- a/src/session.rs
+++ b/src/session.rs
@@ -2,8 +2,8 @@ use std::collections::{HashMap, VecDeque};
 use std::time::{Duration, Instant};
 
 use crate::bwe::BweKind;
-use crate::crypto::KeyingMaterial;
 use crate::crypto::SrtpProfile;
+use crate::crypto::{CryptoContext, KeyingMaterial};
 use crate::format::CodecConfig;
 use crate::format::PayloadParams;
 use crate::io::{DatagramSend, DATAGRAM_MTU, DATAGRAM_MTU_WARN};
@@ -191,6 +191,7 @@ impl Session {
 
     pub fn set_keying_material(
         &mut self,
+        crypto_context: CryptoContext,
         mat: KeyingMaterial,
         srtp_profile: SrtpProfile,
         active: bool,
@@ -200,8 +201,8 @@ impl Session {
         // hand side of the key material to derive input/output.
         let left = active;
 
-        self.srtp_rx = Some(SrtpContext::new(srtp_profile, &mat, !left));
-        self.srtp_tx = Some(SrtpContext::new(srtp_profile, &mat, left));
+        self.srtp_rx = Some(SrtpContext::new(crypto_context, srtp_profile, &mat, !left));
+        self.srtp_tx = Some(SrtpContext::new(crypto_context, srtp_profile, &mat, left));
     }
 
     pub fn handle_timeout(&mut self, now: Instant) -> Result<(), RtcError> {

--- a/src/session.rs
+++ b/src/session.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 
 use crate::bwe::BweKind;
 use crate::crypto::SrtpProfile;
-use crate::crypto::{CryptoContext, KeyingMaterial};
+use crate::crypto::{CryptoProvider, KeyingMaterial};
 use crate::format::CodecConfig;
 use crate::format::PayloadParams;
 use crate::io::{DatagramSend, DATAGRAM_MTU, DATAGRAM_MTU_WARN};
@@ -191,7 +191,7 @@ impl Session {
 
     pub fn set_keying_material(
         &mut self,
-        crypto_context: CryptoContext,
+        crypto_provider: CryptoProvider,
         mat: KeyingMaterial,
         srtp_profile: SrtpProfile,
         active: bool,
@@ -201,8 +201,8 @@ impl Session {
         // hand side of the key material to derive input/output.
         let left = active;
 
-        self.srtp_rx = Some(SrtpContext::new(crypto_context, srtp_profile, &mat, !left));
-        self.srtp_tx = Some(SrtpContext::new(crypto_context, srtp_profile, &mat, left));
+        self.srtp_rx = Some(SrtpContext::new(crypto_provider, srtp_profile, &mat, !left));
+        self.srtp_tx = Some(SrtpContext::new(crypto_provider, srtp_profile, &mat, left));
     }
 
     pub fn handle_timeout(&mut self, now: Instant) -> Result<(), RtcError> {

--- a/wincrypto/src/srtp.rs
+++ b/wincrypto/src/srtp.rs
@@ -23,13 +23,13 @@ unsafe impl Sync for SrtpKey {}
 
 impl SrtpKey {
     /// Creates a key from the given data for operating AES in Counter (CTR/CM) mode.
-    pub fn create_aes_ctr_key(key: &[u8]) -> Result<Self, WinCryptoError> {
+    pub fn new_aes_ctr_key(key: &[u8]) -> Result<Self, WinCryptoError> {
         // CTR mode is build on top of ECB mode, so we use the same key.
-        Self::create_aes_ecb_key(key)
+        Self::new_aes_ecb_key(key)
     }
 
     /// Creates a key from the given data for operating AES in ECB mode.
-    pub fn create_aes_ecb_key(key: &[u8]) -> Result<Self, WinCryptoError> {
+    pub fn new_aes_ecb_key(key: &[u8]) -> Result<Self, WinCryptoError> {
         let mut key_handle = BCRYPT_KEY_HANDLE::default();
         // SAFETY: The key and key_handle will exist before and after this call.
         unsafe {
@@ -45,7 +45,7 @@ impl SrtpKey {
     }
 
     /// Creates a key from the given data for operating AES in GCM mode.
-    pub fn create_aes_gcm_key(key: &[u8]) -> Result<Self, WinCryptoError> {
+    pub fn new_aes_gcm_key(key: &[u8]) -> Result<Self, WinCryptoError> {
         let mut key_handle = BCRYPT_KEY_HANDLE::default();
         // SAFETY: The key and key_handle will exist before and after this call.
         unsafe {
@@ -271,7 +271,7 @@ mod test {
     #[test]
     fn test_srtp_aes_128_ecb_round_test_vec_1() {
         let key =
-            SrtpKey::create_aes_ecb_key(&hex_to_vec("2b7e151628aed2a6abf7158809cf4f3c")).unwrap();
+            SrtpKey::new_aes_ecb_key(&hex_to_vec("2b7e151628aed2a6abf7158809cf4f3c")).unwrap();
         let mut out = [0u8; 32];
         srtp_aes_128_ecb_round(
             &key,
@@ -285,7 +285,7 @@ mod test {
     #[test]
     fn test_srtp_aes_128_ecb_round_test_vec_2() {
         let key =
-            SrtpKey::create_aes_ecb_key(&hex_to_vec("2b7e151628aed2a6abf7158809cf4f3c")).unwrap();
+            SrtpKey::new_aes_ecb_key(&hex_to_vec("2b7e151628aed2a6abf7158809cf4f3c")).unwrap();
         let mut out = [0u8; 32];
         srtp_aes_128_ecb_round(
             &key,
@@ -299,7 +299,7 @@ mod test {
     #[test]
     fn test_srtp_aes_128_ecb_round_test_vec_3() {
         let key =
-            SrtpKey::create_aes_ecb_key(&hex_to_vec("2b7e151628aed2a6abf7158809cf4f3c")).unwrap();
+            SrtpKey::new_aes_ecb_key(&hex_to_vec("2b7e151628aed2a6abf7158809cf4f3c")).unwrap();
         let mut out = [0u8; 32];
         srtp_aes_128_ecb_round(
             &key,
@@ -313,7 +313,7 @@ mod test {
     #[test]
     fn test_srtp_aes_128_ecb_round_test_vec_4() {
         let key =
-            SrtpKey::create_aes_ecb_key(&hex_to_vec("2b7e151628aed2a6abf7158809cf4f3c")).unwrap();
+            SrtpKey::new_aes_ecb_key(&hex_to_vec("2b7e151628aed2a6abf7158809cf4f3c")).unwrap();
         let mut out = [0u8; 32];
         srtp_aes_128_ecb_round(
             &key,


### PR DESCRIPTION
CryptoProvider is a struct which provided functions for performing the various ciphers and hashes Str0m needs. Additionally, it can produce a DtlsIdentity, which in run can be used to create one or more DtlsContext.

CryptoProvider is just function pointers, so it can be cheaply copied as needed. DtlsIdentity holds the "DTLS certificate" instance today, and can then create one or more DTLS Contexts from it. Each DTLS Context manages a DTLS session.

CryptoProvider <- All new thing.
DtlsIndentity <- A trait but the analog was DtlsCertInner
DtlsContext  <- A trait but the analog was DtlsInner

Changes in addition to providing a CryptoProvider in many places:
- DtlsContext is used directly (through a Box<dyn>), vs. the DTLS pass through
- RtcConfig can now have a CryptoProviderId set. If OpenSsl is enabled, this defaults to one of the OpenSsl providers.
- RtcConfig can still have DtlsCert set, if it is set then the CryptoProviderId matches the cert. You can't set both the cert and provider, they override each other.