### PR TITLE
Refactor crypto features

### DIFF
--- a/src/change/mod.rs
+++ b/src/change/mod.rs
@@ -18,6 +18,3 @@ pub use sdp::{SdpAnswer, SdpApi, SdpOffer, SdpPendingOffer};
 
 mod direct;
 pub use direct::DirectApi;
-
-pub use crate::crypto::Fingerprint;
-pub use crate::dtls::DtlsCert;

--- a/src/crypto/dtls.rs
+++ b/src/crypto/dtls.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 
 use crate::net::DatagramSend;
 
+use super::CryptoProvider;
 use super::{CryptoError, Fingerprint, KeyingMaterial, SrtpProfile};
 
 // libWebRTC says "WebRTC" here when doing OpenSSL, for BoringSSL they seem
@@ -41,23 +42,57 @@ pub struct DtlsCert(DtlsCertInner);
 enum DtlsCertInner {
     #[cfg(feature = "openssl")]
     OpenSsl(super::ossl::OsslDtlsCert),
+    #[cfg(not(feature = "openssl"))]
+    OpenSsl(DummyCert),
     #[cfg(feature = "wincrypto")]
     WinCrypto(super::wincrypto::WinCryptoDtlsCert),
+    #[cfg(not(feature = "wincrypto"))]
+    WinCrypto(DummyCert),
 }
 
 impl DtlsCert {
-    #[cfg(feature = "openssl")]
-    /// Create a new OpenSSL variant of the certificate.
-    pub fn new_openssl() -> Self {
-        let cert = super::ossl::OsslDtlsCert::new();
-        DtlsCert(DtlsCertInner::OpenSsl(cert))
+    /// Creates a new DTLS certificate.
+    ///
+    /// The certificate is bound to an actual crypto implementation. Pass the
+    /// desired provider. The provider implementations will need turning on
+    /// using the feature flags:
+    ///
+    /// * **openssl** (defaults to on) for crypto backed by OpenSSL.
+    /// * **wincrypto** for crypto backed by windows crypto.
+    pub fn new(p: CryptoProvider) -> Self {
+        let inner = match p {
+            CryptoProvider::OpenSsl => {
+                #[cfg(feature = "openssl")]
+                {
+                    let cert = super::ossl::OsslDtlsCert::new();
+                    DtlsCertInner::OpenSsl(cert)
+                }
+                #[cfg(not(feature = "openssl"))]
+                {
+                    DtlsCertInner::OpenSsl(DummyCert(p))
+                }
+            }
+            CryptoProvider::WinCrypto => {
+                #[cfg(feature = "wincrypto")]
+                {
+                    let cert = super::wincrypto::WinCryptoDtlsCert::new();
+                    DtlsCertInner::WinCrypto(cert)
+                }
+                #[cfg(not(feature = "wincrypto"))]
+                {
+                    DtlsCertInner::WinCrypto(DummyCert(p))
+                }
+            }
+        };
+
+        DtlsCert(inner)
     }
 
-    #[cfg(feature = "wincrypto")]
-    /// Create a new Windows Crypto variant of the certificate.
-    pub fn new_wincrypto() -> Self {
-        let cert = super::wincrypto::WinCryptoDtlsCert::new();
-        DtlsCert(DtlsCertInner::WinCrypto(cert))
+    pub(crate) fn crypto_provider(&self) -> CryptoProvider {
+        match self.0 {
+            DtlsCertInner::OpenSsl(_) => CryptoProvider::OpenSsl,
+            DtlsCertInner::WinCrypto(_) => CryptoProvider::WinCrypto,
+        }
     }
 
     /// Creates a fingerprint for this certificate.
@@ -65,35 +100,26 @@ impl DtlsCert {
     /// Fingerprints are used to verify a remote peer's certificate.
     pub fn fingerprint(&self) -> Fingerprint {
         match &self.0 {
-            #[cfg(feature = "openssl")]
             DtlsCertInner::OpenSsl(v) => v.fingerprint(),
-            #[cfg(feature = "wincrypto")]
             DtlsCertInner::WinCrypto(v) => v.fingerprint(),
             _ => unreachable!(),
         }
     }
 
     pub(crate) fn create_dtls_impl(&self) -> Result<DtlsImpl, CryptoError> {
-        match &self.0 {
-            #[cfg(feature = "openssl")]
-            DtlsCertInner::OpenSsl(c) => Ok(DtlsImpl::OpenSsl(super::ossl::OsslDtlsImpl::new(
-                c.clone(),
-            )?)),
-            #[cfg(feature = "wincrypto")]
-            DtlsCertInner::WinCrypto(c) => Ok(DtlsImpl::WinCrypto(
-                super::wincrypto::WinCryptoDtls::new(c.clone())?,
-            )),
-            _ => unreachable!(),
-        }
+        let imp = match &self.0 {
+            DtlsCertInner::OpenSsl(v) => DtlsImpl::OpenSsl(v.new_dtls_impl()?),
+            DtlsCertInner::WinCrypto(v) => DtlsImpl::WinCrypto(v.new_dtls_impl()?),
+        };
+
+        Ok(imp)
     }
 }
 
 impl fmt::Debug for DtlsCert {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
-            #[cfg(feature = "openssl")]
             DtlsCertInner::OpenSsl(c) => c.fmt(f),
-            #[cfg(feature = "wincrypto")]
             DtlsCertInner::WinCrypto(c) => c.fmt(f),
             _ => unreachable!(),
         }
@@ -129,41 +155,38 @@ pub trait DtlsInner: Sized {
     fn is_connected(&self) -> bool;
 }
 
-pub enum DtlsImpl {
+pub(crate) enum DtlsImpl {
     #[cfg(feature = "openssl")]
     OpenSsl(super::ossl::OsslDtlsImpl),
+    #[cfg(not(feature = "openssl"))]
+    #[allow(private_interfaces)]
+    OpenSsl(DummyDtlsImpl),
     #[cfg(feature = "wincrypto")]
     WinCrypto(super::wincrypto::WinCryptoDtls),
+    #[cfg(not(feature = "wincrypto"))]
+    #[allow(private_interfaces)]
+    WinCrypto(DummyDtlsImpl),
 }
 
 impl DtlsImpl {
     pub fn set_active(&mut self, active: bool) {
         match self {
-            #[cfg(feature = "openssl")]
-            DtlsImpl::OpenSsl(i) => i.set_active(active),
-            #[cfg(feature = "wincrypto")]
-            DtlsImpl::WinCrypto(i) => i.set_active(active),
-            _ => unreachable!(),
+            DtlsImpl::OpenSsl(v) => v.set_active(active),
+            DtlsImpl::WinCrypto(v) => v.set_active(active),
         }
     }
 
     pub fn handle_handshake(&mut self, o: &mut VecDeque<DtlsEvent>) -> Result<bool, CryptoError> {
         match self {
-            #[cfg(feature = "openssl")]
             DtlsImpl::OpenSsl(i) => i.handle_handshake(o),
-            #[cfg(feature = "wincrypto")]
             DtlsImpl::WinCrypto(i) => i.handle_handshake(o),
-            _ => unreachable!(),
         }
     }
 
     pub fn is_active(&self) -> Option<bool> {
         match self {
-            #[cfg(feature = "openssl")]
             DtlsImpl::OpenSsl(i) => i.is_active(),
-            #[cfg(feature = "wincrypto")]
             DtlsImpl::WinCrypto(i) => i.is_active(),
-            _ => unreachable!(),
         }
     }
 
@@ -173,51 +196,85 @@ impl DtlsImpl {
         o: &mut VecDeque<DtlsEvent>,
     ) -> Result<(), CryptoError> {
         match self {
-            #[cfg(feature = "openssl")]
             DtlsImpl::OpenSsl(i) => i.handle_receive(m, o),
-            #[cfg(feature = "wincrypto")]
             DtlsImpl::WinCrypto(i) => i.handle_receive(m, o),
-            _ => unreachable!(),
         }
     }
 
     pub fn poll_datagram(&mut self) -> Option<DatagramSend> {
         match self {
-            #[cfg(feature = "openssl")]
             DtlsImpl::OpenSsl(i) => i.poll_datagram(),
-            #[cfg(feature = "wincrypto")]
             DtlsImpl::WinCrypto(i) => i.poll_datagram(),
-            _ => unreachable!(),
         }
     }
 
     pub fn poll_timeout(&mut self, now: Instant) -> Option<Instant> {
         match self {
-            #[cfg(feature = "openssl")]
             DtlsImpl::OpenSsl(i) => i.poll_timeout(now),
-            #[cfg(feature = "wincrypto")]
             DtlsImpl::WinCrypto(i) => i.poll_timeout(now),
-            _ => unreachable!(),
         }
     }
 
     pub fn handle_input(&mut self, data: &[u8]) -> Result<(), CryptoError> {
         match self {
-            #[cfg(feature = "openssl")]
             DtlsImpl::OpenSsl(i) => i.handle_input(data),
-            #[cfg(feature = "wincrypto")]
             DtlsImpl::WinCrypto(i) => i.handle_input(data),
-            _ => unreachable!(),
         }
     }
 
     pub fn is_connected(&self) -> bool {
         match self {
-            #[cfg(feature = "openssl")]
             DtlsImpl::OpenSsl(i) => i.is_connected(),
-            #[cfg(feature = "wincrypto")]
             DtlsImpl::WinCrypto(i) => i.is_connected(),
-            _ => unreachable!(),
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct DummyCert(CryptoProvider);
+
+impl DummyCert {
+    fn fingerprint(&self) -> Fingerprint {
+        panic!("Must enable feature: {}", self.0)
+    }
+
+    fn new_dtls_impl(&self) -> Result<DummyDtlsImpl, CryptoError> {
+        panic!("Must enable feature: {}", self.0)
+    }
+}
+
+struct DummyDtlsImpl(CryptoProvider);
+
+impl DummyDtlsImpl {
+    fn set_active(&self, active: bool) {
+        panic!("Must enable feature: {}", self.0)
+    }
+
+    fn handle_handshake(&self, o: &mut VecDeque<DtlsEvent>) -> Result<bool, CryptoError> {
+        panic!("Must enable feature: {}", self.0)
+    }
+
+    fn is_active(&self) -> Option<bool> {
+        panic!("Must enable feature: {}", self.0)
+    }
+
+    fn handle_receive(&self, m: &[u8], o: &mut VecDeque<DtlsEvent>) -> Result<(), CryptoError> {
+        panic!("Must enable feature: {}", self.0)
+    }
+
+    fn poll_datagram(&self) -> Option<DatagramSend> {
+        panic!("Must enable feature: {}", self.0)
+    }
+
+    fn poll_timeout(&self, now: Instant) -> Option<Instant> {
+        panic!("Must enable feature: {}", self.0)
+    }
+
+    fn handle_input(&self, data: &[u8]) -> Result<(), CryptoError> {
+        panic!("Must enable feature: {}", self.0)
+    }
+
+    fn is_connected(&self) -> bool {
+        panic!("Must enable feature: {}", self.0)
     }
 }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -4,9 +4,22 @@ use std::fmt;
 use std::io;
 use thiserror::Error;
 
+/// Crypto provider setting.
+///
+/// The provider implementations will need turning on using the feature flags:
+///
+/// * **openssl** (defaults to on) for crypto backed by OpenSSL.
+/// * **wincrypto** for crypto backed by windows crypto.
+///
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CryptoProvider {
+    /// OpenSSL (the default)
+    ///
+    /// Requires feature flag **openssl**.
     OpenSsl,
+    /// Windows SChannel + CNG implementation of cryptographic functions.
+    ///
+    /// Requires feature flag **wincrypto**.
     WinCrypto,
 }
 

--- a/src/crypto/ossl/cert.rs
+++ b/src/crypto/ossl/cert.rs
@@ -12,6 +12,7 @@ use crate::crypto::dtls::DTLS_CERT_IDENTITY;
 use crate::crypto::Fingerprint;
 
 use super::CryptoError;
+use super::OsslDtlsImpl;
 
 const RSA_F4: u32 = 0x10001;
 
@@ -92,6 +93,10 @@ impl OsslDtlsCert {
             hash_func: "sha-256".into(),
             bytes: digest.to_vec(),
         }
+    }
+
+    pub(crate) fn new_dtls_impl(&self) -> Result<OsslDtlsImpl, CryptoError> {
+        OsslDtlsImpl::new(self.clone())
     }
 }
 

--- a/src/crypto/ossl/stream.rs
+++ b/src/crypto/ossl/stream.rs
@@ -5,8 +5,7 @@ use openssl::hash::MessageDigest;
 use openssl::srtp::SrtpProfileId;
 use openssl::ssl::{HandshakeError, MidHandshakeSslStream, Ssl, SslStream};
 
-use crate::change::Fingerprint;
-use crate::crypto::{KeyingMaterial, SrtpProfile};
+use crate::crypto::{Fingerprint, KeyingMaterial, SrtpProfile};
 
 use super::CryptoError;
 

--- a/src/crypto/wincrypto/cert.rs
+++ b/src/crypto/wincrypto/cert.rs
@@ -20,6 +20,10 @@ impl WinCryptoDtlsCert {
     pub fn fingerprint(&self) -> Fingerprint {
         create_fingerprint(&self.certificate).expect("Failed to calculate fingerprint")
     }
+
+    pub(crate) fn new_dtls_impl(&self) -> Result<OsslDtlsImpl, CryptoError> {
+        OsslDtlsImpl::new(self.clone())
+    }
 }
 
 pub(super) fn create_fingerprint(

--- a/src/dtls.rs
+++ b/src/dtls.rs
@@ -5,7 +5,8 @@ use thiserror::Error;
 
 use crate::crypto::{CryptoError, DtlsImpl, Fingerprint};
 
-pub use crate::crypto::{DtlsCert, DtlsEvent};
+pub use crate::crypto::DtlsCert;
+pub(crate) use crate::crypto::DtlsEvent;
 use crate::net::DatagramSend;
 
 /// Errors that can arise in DTLS.


### PR DESCRIPTION
This is a refactor to make less use of the feature flags **openssl** and **wincrypto** for conditional compilation. It plugs in "dummy" impls that panics if the corresponding feature is not turned on. The goal is:

* Able to compile with `--all-features` (no mutually exclusive feature flags)
* Always default to a specific crypto (currently openssl), even if that fails runtime. This is to ensure consumers make the correct config instead of relying on feature flags to get a desired behavior
* Minimize amount of code behind conditional compilation to aid refactoring