### PR TITLE
Refactor crypto feature flags

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.cargo.features": "all"
+}

--- a/src/_internal_test_exports/fuzz.rs
+++ b/src/_internal_test_exports/fuzz.rs
@@ -56,6 +56,7 @@ pub fn rtp_packet(data: &[u8]) -> Option<()> {
     let mut session = Session::new(&config);
     session.set_keying_material(
         KeyingMaterial::new(rng.slice(16)?.to_vec()),
+        &crate::crypto::SrtpCrypto::new_openssl(),
         SrtpProfile::PassThrough,
         rng.bool()?,
     );

--- a/src/bwe.rs
+++ b/src/bwe.rs
@@ -36,21 +36,25 @@ impl<'a> Bwe<'a> {
     /// Staring at the lower layer, call:
     ///
     /// ```
+    /// # #[cfg(feature = "openssl")] {
     /// # use str0m::{Rtc, bwe::Bitrate};
     /// let mut rtc = Rtc::new();
     ///
     /// rtc.bwe().set_current_bitrate(Bitrate::kbps(250));
-    /// ````
+    /// # }
+    /// ```
     ///
     /// When a new estimate is made available that indicates a switch to the medium layer is
     /// possible, make the switch and then update the configuration:
     ///
     /// ```
+    /// # #[cfg(feature = "openssl")] {
     /// # use str0m::{Rtc, bwe::Bitrate};
     /// let mut rtc = Rtc::new();
     ///
     /// rtc.bwe().set_current_bitrate(Bitrate::kbps(750));
-    /// ````
+    /// # }
+    /// ```
     ///
     /// ## Accuracy
     ///

--- a/src/change/mod.rs
+++ b/src/change/mod.rs
@@ -18,6 +18,3 @@ pub use sdp::{SdpAnswer, SdpApi, SdpOffer, SdpPendingOffer};
 
 mod direct;
 pub use direct::DirectApi;
-
-pub use crate::crypto::Fingerprint;
-pub use crate::dtls::DtlsCert;

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -193,6 +193,7 @@ impl<'a> SdpApi<'a> {
     /// If changes have been made, nothing happens until we call [`SdpApi::apply()`].
     ///
     /// ```
+    /// # #[cfg(feature = "openssl")] {
     /// # use str0m::{Rtc, media::MediaKind, media::Direction};
     /// let mut rtc = Rtc::new();
     ///
@@ -201,6 +202,7 @@ impl<'a> SdpApi<'a> {
     ///
     /// let mid = changes.add_media(MediaKind::Audio, Direction::SendRecv, None, None);
     /// assert!(changes.has_changes());
+    /// # }
     /// ```
     pub fn has_changes(&self) -> bool {
         !self.changes.0.is_empty()
@@ -218,12 +220,14 @@ impl<'a> SdpApi<'a> {
     ///   CNAME in the RTP SDES.
     ///
     /// ```
+    /// # #[cfg(feature = "openssl")] {
     /// # use str0m::{Rtc, media::MediaKind, media::Direction};
     /// let mut rtc = Rtc::new();
     ///
     /// let mut changes = rtc.sdp_api();
     ///
     /// let mid = changes.add_media(MediaKind::Audio, Direction::SendRecv, None, None);
+    /// # }
     /// ```
     pub fn add_media(
         &mut self,
@@ -322,12 +326,14 @@ impl<'a> SdpApi<'a> {
     /// useful when multiple channels are in use at the same time.
     ///
     /// ```
+    /// # #[cfg(feature = "openssl")] {
     /// # use str0m::Rtc;
     /// let mut rtc = Rtc::new();
     ///
     /// let mut changes = rtc.sdp_api();
     ///
     /// let cid = changes.add_channel("my special channel".to_string());
+    /// # }
     /// ```
     pub fn add_channel(&mut self, label: String) -> ChannelId {
         self.add_channel_with_config(ChannelConfig {
@@ -341,6 +347,7 @@ impl<'a> SdpApi<'a> {
     /// Refer to `add_channel` for more details.
     ///
     /// ```
+    /// # #[cfg(feature = "openssl")] {
     /// # use str0m::{channel::{ChannelConfig, Reliability}, Rtc};
     /// let mut rtc = Rtc::new();
     ///
@@ -352,6 +359,7 @@ impl<'a> SdpApi<'a> {
     ///     ordered: false,
     ///     ..Default::default()
     /// });
+    /// # }
     /// ```
     pub fn add_channel_with_config(&mut self, config: ChannelConfig) -> ChannelId {
         let has_media = self.rtc.session.app().is_some();
@@ -405,11 +413,13 @@ impl<'a> SdpApi<'a> {
     /// the current [`SdpPendingOffer`].
     ///
     /// ```
+    /// # #[cfg(feature = "openssl")] {
     /// # use str0m::Rtc;
     /// let mut rtc = Rtc::new();
     ///
     /// let changes = rtc.sdp_api();
     /// assert!(changes.apply().is_none());
+    /// # }
     /// ```
     pub fn apply(self) -> Option<(SdpOffer, SdpPendingOffer)> {
         if self.changes.is_empty() {
@@ -1558,6 +1568,8 @@ mod test {
 
     #[test]
     fn test_out_of_order_error() {
+        crate::init_crypto_default();
+
         let mut rtc1 = Rtc::new();
         let mut rtc2 = Rtc::new();
 
@@ -1580,6 +1592,8 @@ mod test {
 
     #[test]
     fn sdp_api_merge_works() {
+        crate::init_crypto_default();
+
         let mut rtc = Rtc::new();
         let mut changes = rtc.sdp_api();
         changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None);
@@ -1596,6 +1610,8 @@ mod test {
 
     #[test]
     fn test_rtp_payload_priority() {
+        crate::init_crypto_default();
+
         let mut rtc1 = Rtc::builder()
             .clear_codecs()
             .enable_h264(true)

--- a/src/crypto/ossl/cert.rs
+++ b/src/crypto/ossl/cert.rs
@@ -12,6 +12,7 @@ use crate::crypto::dtls::DTLS_CERT_IDENTITY;
 use crate::crypto::Fingerprint;
 
 use super::CryptoError;
+use super::OsslDtlsImpl;
 
 const RSA_F4: u32 = 0x10001;
 
@@ -92,6 +93,10 @@ impl OsslDtlsCert {
             hash_func: "sha-256".into(),
             bytes: digest.to_vec(),
         }
+    }
+
+    pub(crate) fn new_dtls_impl(&self) -> Result<OsslDtlsImpl, CryptoError> {
+        OsslDtlsImpl::new(self.clone())
     }
 }
 

--- a/src/crypto/ossl/srtp.rs
+++ b/src/crypto/ossl/srtp.rs
@@ -12,7 +12,7 @@ impl SrtpCryptoImpl for OsslSrtpCryptoImpl {
     type Aes128CmSha1_80 = OsslAes128CmSha1_80;
     type AeadAes128Gcm = OsslAeadAes128Gcm;
 
-    fn srtp_aes_128_ecb_round(key: &[u8], input: &[u8], output: &mut [u8]) {
+    fn srtp_aes_128_ecb_round(&self, key: &[u8], input: &[u8], output: &mut [u8]) {
         let mut aes =
             Crypter::new(Cipher::aes_128_ecb(), Mode::Encrypt, key, None).expect("AES deriver");
 

--- a/src/crypto/ossl/stream.rs
+++ b/src/crypto/ossl/stream.rs
@@ -5,8 +5,7 @@ use openssl::hash::MessageDigest;
 use openssl::srtp::SrtpProfileId;
 use openssl::ssl::{HandshakeError, MidHandshakeSslStream, Ssl, SslStream};
 
-use crate::change::Fingerprint;
-use crate::crypto::{KeyingMaterial, SrtpProfile};
+use crate::crypto::{Fingerprint, KeyingMaterial, SrtpProfile};
 
 use super::CryptoError;
 

--- a/src/crypto/wincrypto/cert.rs
+++ b/src/crypto/wincrypto/cert.rs
@@ -1,3 +1,5 @@
+use super::CryptoError;
+use super::WinCryptoDtls;
 use crate::crypto::dtls::DTLS_CERT_IDENTITY;
 use crate::crypto::Fingerprint;
 use std::sync::Arc;
@@ -19,6 +21,10 @@ impl WinCryptoDtlsCert {
 
     pub fn fingerprint(&self) -> Fingerprint {
         create_fingerprint(&self.certificate).expect("Failed to calculate fingerprint")
+    }
+
+    pub(crate) fn new_dtls_impl(&self) -> Result<WinCryptoDtls, CryptoError> {
+        WinCryptoDtls::new(self.clone())
     }
 }
 

--- a/src/crypto/wincrypto/srtp.rs
+++ b/src/crypto/wincrypto/srtp.rs
@@ -12,7 +12,7 @@ impl SrtpCryptoImpl for WinCryptoSrtpCryptoImpl {
     type Aes128CmSha1_80 = WinCryptoAes128CmSha1_80;
     type AeadAes128Gcm = WinCryptoAeadAes128Gcm;
 
-    fn srtp_aes_128_ecb_round(key: &[u8], input: &[u8], output: &mut [u8]) {
+    fn srtp_aes_128_ecb_round(&self, key: &[u8], input: &[u8], output: &mut [u8]) {
         let key = SrtpKey::create_aes_ecb_key(key).expect("AES key");
         let count = srtp_aes_128_ecb_round(&key, input, output).expect("AES encrypt");
         assert_eq!(count, 16 + 16); // block size

--- a/src/rtp/mod.rs
+++ b/src/rtp/mod.rs
@@ -38,17 +38,11 @@ pub const MAX_BLANK_PADDING_PAYLOAD_SIZE: usize = 240;
 /// Errors that can arise in RTP.
 #[derive(Debug, Error)]
 pub enum RtpError {
-    /// Some error from OpenSSL layer (used for SRTP).
+    /// Error arising in the crypto
     #[error("{0}")]
-    #[cfg(feature = "openssl")]
-    OpenSsl(#[from] openssl::error::ErrorStack),
+    CryptoError(CryptoError),
 
-    /// Some error from Windows Crypto layer (used for SRTP).
-    #[error("{0}")]
-    #[cfg(feature = "wincrypto")]
-    WinCrypto(#[from] crate::crypto::wincrypto::WinCryptoError),
-
-    /// Other IO errors.
+    /// Other io error
     #[error("{0}")]
     Io(#[from] io::Error),
 
@@ -60,11 +54,8 @@ pub enum RtpError {
 impl From<CryptoError> for RtpError {
     fn from(value: CryptoError) -> Self {
         match value {
-            #[cfg(feature = "openssl")]
-            CryptoError::OpenSsl(e) => RtpError::OpenSsl(e),
-            #[cfg(feature = "wincrypto")]
-            CryptoError::WinCrypto(e) => RtpError::WinCrypto(e),
-            CryptoError::Io(e) => RtpError::Io(e),
+            CryptoError::Io(error) => RtpError::Io(error),
+            x => RtpError::CryptoError(x),
         }
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -2,8 +2,8 @@ use std::collections::{HashMap, VecDeque};
 use std::time::{Duration, Instant};
 
 use crate::bwe::BweKind;
-use crate::crypto::KeyingMaterial;
 use crate::crypto::SrtpProfile;
+use crate::crypto::{KeyingMaterial, SrtpCrypto};
 use crate::format::CodecConfig;
 use crate::format::PayloadParams;
 use crate::io::{DatagramSend, DATAGRAM_MTU, DATAGRAM_MTU_WARN};
@@ -192,6 +192,7 @@ impl Session {
     pub fn set_keying_material(
         &mut self,
         mat: KeyingMaterial,
+        srtp_crypto: &SrtpCrypto,
         srtp_profile: SrtpProfile,
         active: bool,
     ) {
@@ -200,8 +201,8 @@ impl Session {
         // hand side of the key material to derive input/output.
         let left = active;
 
-        self.srtp_rx = Some(SrtpContext::new(srtp_profile, &mat, !left));
-        self.srtp_tx = Some(SrtpContext::new(srtp_profile, &mat, left));
+        self.srtp_rx = Some(SrtpContext::new(srtp_crypto, srtp_profile, &mat, !left));
+        self.srtp_tx = Some(SrtpContext::new(srtp_crypto, srtp_profile, &mat, left));
     }
 
     pub fn handle_timeout(&mut self, now: Instant) -> Result<(), RtcError> {

--- a/tests/bidirectional.rs
+++ b/tests/bidirectional.rs
@@ -7,11 +7,12 @@ use str0m::{Candidate, Event, RtcError};
 use tracing::info_span;
 
 mod common;
-use common::{init_log, progress, TestRtc};
+use common::{init_crypto_default, init_log, progress, TestRtc};
 
 #[test]
 pub fn bidirectional_same_m_line() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -219,6 +219,10 @@ pub fn init_log() {
     });
 }
 
+pub fn init_crypto_default() {
+    str0m::config::CryptoProvider::from_feature_flags().__test_install_process_default();
+}
+
 pub fn connect_l_r() -> (TestRtc, TestRtc) {
     let rtc1 = Rtc::builder()
         .set_rtp_mode(true)

--- a/tests/contiguous.rs
+++ b/tests/contiguous.rs
@@ -7,11 +7,12 @@ use str0m::{Candidate, Event, RtcError};
 use tracing::info_span;
 
 mod common;
-use common::{init_log, progress, TestRtc};
+use common::{init_crypto_default, init_log, progress, TestRtc};
 
 #[test]
 pub fn contiguous_all_the_way() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let output = Server::with_vp8_input()
         .timeout(Duration::from_secs(5))
@@ -35,6 +36,7 @@ pub fn contiguous_all_the_way() -> Result<(), RtcError> {
 #[test]
 pub fn not_contiguous() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let output = Server::with_vp8_input()
         .skip_packet(14337)
@@ -62,6 +64,7 @@ pub fn not_contiguous() -> Result<(), RtcError> {
 #[test]
 pub fn vp9_contiguous_all_the_way() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let output = Server::with_vp9_input().get_output()?;
     let mut count = 0;
@@ -83,6 +86,7 @@ pub fn vp9_contiguous_all_the_way() -> Result<(), RtcError> {
 #[test]
 pub fn vp9_not_contiguous() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let output = Server::with_vp9_input().skip_packet(30952).get_output()?;
     let mut count = 0;

--- a/tests/data-channel-direct.rs
+++ b/tests/data-channel-direct.rs
@@ -6,11 +6,12 @@ use str0m::{Candidate, Event, RtcConfig, RtcError};
 use tracing::info_span;
 
 mod common;
-use common::{init_log, progress, TestRtc};
+use common::{init_crypto_default, init_log, progress, TestRtc};
 
 #[test]
 pub fn data_channel_direct() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let mut l = TestRtc::new(info_span!("L"));
 

--- a/tests/data-channel.rs
+++ b/tests/data-channel.rs
@@ -5,11 +5,12 @@ use str0m::{Candidate, RtcError};
 use tracing::info_span;
 
 mod common;
-use common::{init_log, progress, TestRtc};
+use common::{init_crypto_default, init_log, progress, TestRtc};
 
 #[test]
 pub fn data_channel() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));

--- a/tests/flappy-ice-state.rs
+++ b/tests/flappy-ice-state.rs
@@ -6,11 +6,12 @@ use str0m::{Candidate, Event, RtcError};
 use tracing::info_span;
 
 mod common;
-use common::{init_log, progress, TestRtc};
+use common::{init_crypto_default, init_log, progress, TestRtc};
 
 #[test]
 pub fn flappy_ice_lite_state() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let mut l = TestRtc::new(info_span!("L"));
 

--- a/tests/ice-restart.rs
+++ b/tests/ice-restart.rs
@@ -6,11 +6,12 @@ use str0m::{Candidate, RtcError};
 use tracing::info_span;
 
 mod common;
-use common::{init_log, progress, TestRtc};
+use common::{init_crypto_default, init_log, progress, TestRtc};
 
 #[test]
 pub fn ice_restart() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let mut l = TestRtc::new(info_span!("L"));
 

--- a/tests/keyframes.rs
+++ b/tests/keyframes.rs
@@ -7,12 +7,13 @@ use str0m::{Candidate, Event, RtcError};
 use tracing::info_span;
 
 mod common;
-use common::{h264_data, vp8_data, vp9_data};
+use common::{h264_data, init_crypto_default, vp8_data, vp9_data};
 use common::{init_log, progress, TestRtc};
 
 #[test]
 pub fn test_vp8_keyframes_detection() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));
@@ -104,6 +105,7 @@ pub fn test_vp8_keyframes_detection() -> Result<(), RtcError> {
 #[test]
 pub fn test_vp9_keyframes_detection() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));
@@ -196,6 +198,7 @@ pub fn test_vp9_keyframes_detection() -> Result<(), RtcError> {
 #[test]
 pub fn test_h264_keyframes_detection() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));

--- a/tests/nack.rs
+++ b/tests/nack.rs
@@ -8,13 +8,14 @@ use str0m::rtp::{ExtensionValues, RawPacket, SeqNo, Ssrc};
 use str0m::RtcError;
 
 mod common;
-use common::{connect_l_r, init_log, progress};
+use common::{connect_l_r, init_crypto_default, init_log, progress};
 
 use crate::common::progress_with_loss;
 
 #[test]
 pub fn loss_recovery() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let (mut l, mut r) = connect_l_r();
 
@@ -171,6 +172,7 @@ pub fn loss_recovery() -> Result<(), RtcError> {
 #[test]
 pub fn nack_delay() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let (mut l, mut r) = connect_l_r();
 

--- a/tests/remb.rs
+++ b/tests/remb.rs
@@ -7,11 +7,13 @@ use str0m::{Candidate, Event, Rtc, RtcError};
 use tracing::info_span;
 
 mod common;
-use common::{init_log, negotiate, progress, TestRtc};
+use common::{init_crypto_default, init_log, negotiate, progress, TestRtc};
 
 #[test]
 pub fn remb() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
+
     let l_rtc = Rtc::builder().build();
     let r_rtc = Rtc::builder().build();
 

--- a/tests/repeated.rs
+++ b/tests/repeated.rs
@@ -6,11 +6,12 @@ use str0m::rtp::{ExtensionValues, Ssrc};
 use str0m::{Event, RtcError};
 
 mod common;
-use common::{connect_l_r, init_log, progress};
+use common::{connect_l_r, init_crypto_default, init_log, progress};
 
 #[test]
 pub fn repeated() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let (mut l, mut r) = connect_l_r();
 

--- a/tests/rtp-direct-mid-rid.rs
+++ b/tests/rtp-direct-mid-rid.rs
@@ -7,11 +7,12 @@ use str0m::rtp::{ExtensionValues, Ssrc};
 use str0m::{Event, RtcError};
 
 mod common;
-use common::{connect_l_r, init_log, progress};
+use common::{connect_l_r, init_crypto_default, init_log, progress};
 
 #[test]
 pub fn rtp_direct_mid_rid() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let (mut l, mut r) = connect_l_r();
 

--- a/tests/rtp-direct-mid.rs
+++ b/tests/rtp-direct-mid.rs
@@ -7,11 +7,12 @@ use str0m::rtp::{ExtensionValues, Ssrc};
 use str0m::{Event, RtcError};
 
 mod common;
-use common::{connect_l_r, init_log, progress};
+use common::{connect_l_r, init_crypto_default, init_log, progress};
 
 #[test]
 pub fn rtp_direct_mid() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let (mut l, mut r) = connect_l_r();
 

--- a/tests/rtp-direct-ssrc.rs
+++ b/tests/rtp-direct-ssrc.rs
@@ -7,11 +7,12 @@ use str0m::rtp::{ExtensionValues, Ssrc};
 use str0m::{Event, RtcError};
 
 mod common;
-use common::{connect_l_r, init_log, progress};
+use common::{connect_l_r, init_crypto_default, init_log, progress};
 
 #[test]
 pub fn rtp_direct_ssrc() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let (mut l, mut r) = connect_l_r();
 

--- a/tests/rtp-direct-with-roc.rs
+++ b/tests/rtp-direct-with-roc.rs
@@ -8,11 +8,12 @@ use str0m::rtp::{ExtensionValues, Ssrc};
 use str0m::{Event, RtcError};
 
 mod common;
-use common::{connect_l_r, init_log, progress};
+use common::{connect_l_r, init_crypto_default, init_log, progress};
 
 #[test]
 pub fn rtp_direct_with_roc() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let (mut l, mut r) = connect_l_r();
 

--- a/tests/rtp_to_frame.rs
+++ b/tests/rtp_to_frame.rs
@@ -7,11 +7,12 @@ use str0m::rtp::{ExtensionValues, Ssrc};
 use str0m::{Event, Rtc, RtcError};
 
 mod common;
-use common::{connect_l_r_with_rtc, init_log, progress};
+use common::{connect_l_r_with_rtc, init_crypto_default, init_log, progress};
 
 #[test]
 pub fn audio_start_of_talk_spurt() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let rtc1 = Rtc::builder().set_rtp_mode(true).build();
     let rtc2 = Rtc::builder().set_reordering_size_audio(0).build();

--- a/tests/rtx-cache-0.rs
+++ b/tests/rtx-cache-0.rs
@@ -7,11 +7,12 @@ use str0m::rtp::{ExtensionValues, Ssrc};
 use str0m::{Event, RtcError};
 
 mod common;
-use common::{connect_l_r, init_log, progress};
+use common::{connect_l_r, init_crypto_default, init_log, progress};
 
 #[test]
 pub fn rtx_cache_0() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let (mut l, mut r) = connect_l_r();
 

--- a/tests/sdp-negotiation.rs
+++ b/tests/sdp-negotiation.rs
@@ -1,4 +1,5 @@
 mod common;
+use common::init_crypto_default;
 use common::init_log;
 use common::negotiate;
 use common::TestRtc;
@@ -18,6 +19,7 @@ use tracing::Span;
 #[test]
 pub fn change_default_pt() {
     init_log();
+    init_crypto_default();
 
     // First proposed PT is 100, R side adjusts its default from 102 -> 100
     let (l, r) = with_params(
@@ -40,6 +42,7 @@ pub fn change_default_pt() {
 #[test]
 pub fn answer_change_order() {
     init_log();
+    init_crypto_default();
 
     // First proposed PT are 100/102, but R side has a different order.
     let (l, r) = with_params(
@@ -74,6 +77,7 @@ pub fn answer_change_order() {
 #[test]
 pub fn answer_narrow() {
     init_log();
+    init_crypto_default();
 
     // First proposed PT are 100/102, the R side removes unsupported ones.
     let (l, r) = with_params(
@@ -115,6 +119,7 @@ pub fn answer_narrow() {
 #[test]
 pub fn answer_no_match() {
     init_log();
+    init_crypto_default();
 
     // L has one codec, and that is not matched by R. This should disable the m-line.
     let (l, r) = with_params(
@@ -145,6 +150,7 @@ pub fn answer_no_match() {
 #[test]
 pub fn answer_different_pt_to_offer() {
     init_log();
+    init_crypto_default();
 
     // This test case checks a scenario happening with Firefox.
     // 1. SDP -> FF: OFFER to sendonly VP8 PT 96.
@@ -213,6 +219,7 @@ pub fn answer_different_pt_to_offer() {
 #[test]
 fn answer_remaps() {
     init_log();
+    init_crypto_default();
 
     use Extension::*;
 
@@ -265,6 +272,7 @@ fn answer_remaps() {
 #[test]
 fn offers_unsupported_extension() {
     init_log();
+    init_crypto_default();
 
     use Extension::*;
 
@@ -310,6 +318,8 @@ fn offers_unsupported_extension() {
 #[test]
 fn non_media_creator_cannot_change_inactive_to_recvonly() {
     init_log();
+    init_crypto_default();
+
     let (mut l, mut r) = (
         TestRtc::new_with_rtc(
             info_span!("L"),
@@ -343,6 +353,8 @@ fn non_media_creator_cannot_change_inactive_to_recvonly() {
 #[test]
 fn media_creator_can_change_inactive_to_recvonly() {
     init_log();
+    init_crypto_default();
+
     let (mut l, mut r) = (
         TestRtc::new_with_rtc(
             info_span!("L"),

--- a/tests/srtp-replay-attack.rs
+++ b/tests/srtp-replay-attack.rs
@@ -7,7 +7,7 @@ use str0m::rtp::{ExtensionValues, RawPacket, SeqNo, Ssrc};
 use str0m::{Event, Input, Output, Rtc, RtcError};
 
 mod common;
-use common::{connect_l_r, connect_l_r_with_rtc, init_log, TestRtc};
+use common::{connect_l_r, connect_l_r_with_rtc, init_crypto_default, init_log, TestRtc};
 
 const EXPECTED_PACKETS: usize = 50;
 const REPLAY_PER_PACKET: usize = 5;
@@ -15,6 +15,7 @@ const REPLAY_PER_PACKET: usize = 5;
 #[test]
 pub fn srtp_replay_attack_rtp_mode() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let (mut l, mut r) = connect_l_r();
     let mid = "aud".into();
@@ -108,6 +109,7 @@ pub fn srtp_replay_attack_rtp_mode() -> Result<(), RtcError> {
 #[test]
 pub fn srtp_replay_attack_frame_mode() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let rtc1 = Rtc::builder()
         .set_rtp_mode(true)

--- a/tests/stats.rs
+++ b/tests/stats.rs
@@ -8,11 +8,12 @@ use str0m::{Candidate, Event, RtcConfig, RtcError};
 use tracing::info_span;
 
 mod common;
-use common::{init_log, progress, TestRtc};
+use common::{init_crypto_default, init_log, progress, TestRtc};
 
 #[test]
 pub fn stats() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let l_config = RtcConfig::new().set_stats_interval(Some(Duration::from_secs(10)));
     let r_config = RtcConfig::new().set_stats_interval(Some(Duration::from_secs(10)));

--- a/tests/twcc.rs
+++ b/tests/twcc.rs
@@ -8,11 +8,13 @@ use str0m::{Candidate, Rtc, RtcError};
 use tracing::info_span;
 
 mod common;
-use common::{init_log, negotiate, progress, TestRtc};
+use common::{init_crypto_default, init_log, negotiate, progress, TestRtc};
 
 #[test]
 pub fn twcc() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
+
     let l_rtc = Rtc::builder().enable_raw_packets(true).build();
     let r_rtc = Rtc::builder().enable_raw_packets(true).build();
 

--- a/tests/unidirectional-r-create-media.rs
+++ b/tests/unidirectional-r-create-media.rs
@@ -8,11 +8,12 @@ use str0m::{Candidate, Event, RtcError};
 use tracing::info_span;
 
 mod common;
-use common::{init_log, progress, TestRtc};
+use common::{init_crypto_default, init_log, progress, TestRtc};
 
 #[test]
 pub fn unidirectional_r_create_media() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));

--- a/tests/unidirectional.rs
+++ b/tests/unidirectional.rs
@@ -7,11 +7,12 @@ use str0m::{Candidate, Event, RtcError};
 use tracing::info_span;
 
 mod common;
-use common::{init_log, progress, TestRtc};
+use common::{init_crypto_default, init_log, progress, TestRtc};
 
 #[test]
 pub fn unidirectional() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));

--- a/tests/user-rtp-header-extension.rs
+++ b/tests/user-rtp-header-extension.rs
@@ -12,11 +12,12 @@ use str0m::{Candidate, Event, RtcError};
 use tracing::info_span;
 
 mod common;
-use common::{init_log, progress, TestRtc};
+use common::{init_crypto_default, init_log, progress, TestRtc};
 
 #[test]
 pub fn user_rtp_header_extension() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     #[derive(Debug, PartialEq, Eq)]
     struct MyValue(u16);
@@ -163,6 +164,7 @@ pub fn user_rtp_header_extension() -> Result<(), RtcError> {
 #[test]
 pub fn user_rtp_header_extension_two_byte_form() -> Result<(), RtcError> {
     init_log();
+    init_crypto_default();
 
     #[derive(Debug, PartialEq, Eq, Clone)]
     struct MyValue(Vec<u8>);


### PR DESCRIPTION
This is a refactor to make less use of the feature flags **openssl** and **wincrypto** for conditional compilation. It plugs in "dummy" impls that panics if the corresponding feature is not turned on. The goal is:

* Able to compile with `--all-features` (no mutually exclusive feature flags)
* Always default to a specific crypto (currently openssl), even if that fails runtime. This is to ensure consumers make the correct config instead of relying on feature flags to get a desired behavior
* Minimize amount of code behind conditional compilation to aid refactoring