### PR TITLE
refactor: re-export crypto items under same name to avoid `cfg`s

### DIFF
--- a/src/crypto/dtls.rs
+++ b/src/crypto/dtls.rs
@@ -63,35 +63,6 @@ impl fmt::Debug for DtlsCert {
     }
 }
 
-pub trait DtlsInner: Sized {
-    /// Set whether this instance is active or passive.
-    ///
-    /// i.e. initiating the client hello or not. This must be called
-    /// exactly once before starting to handshake (I/O).
-    fn set_active(&mut self, active: bool);
-
-    /// Handle the handshake. Once this succeeds, it becomes a no-op.
-    fn handle_handshake(&mut self, o: &mut VecDeque<DtlsEvent>) -> Result<bool, CryptoError>;
-
-    /// If set_active, returns what was set.
-    fn is_active(&self) -> Option<bool>;
-
-    /// Handles an incoming DTLS datagrams.
-    fn handle_receive(&mut self, m: &[u8], o: &mut VecDeque<DtlsEvent>) -> Result<(), CryptoError>;
-
-    /// Poll for the next datagram to send.
-    fn poll_datagram(&mut self) -> Option<DatagramSend>;
-
-    /// Poll for next timeout. This is only used during DTLS handshake.
-    fn poll_timeout(&mut self, now: Instant) -> Option<Instant>;
-
-    /// Handling incoming data to be sent as DTLS datagrams.
-    fn handle_input(&mut self, data: &[u8]) -> Result<(), CryptoError>;
-
-    /// Whether the DTLS connection is established.
-    fn is_connected(&self) -> bool;
-}
-
 pub struct DtlsImpl(super::_impl::Dtls);
 
 impl DtlsImpl {

--- a/src/crypto/dummy.rs
+++ b/src/crypto/dummy.rs
@@ -1,0 +1,127 @@
+#![allow(unused_variables)]
+
+use crate::crypto::srtp::{aead_aes_128_gcm, aes_128_cm_sha1_80};
+use crate::crypto::CryptoError;
+use crate::crypto::DtlsEvent;
+use crate::crypto::Fingerprint;
+use crate::net::DatagramSend;
+use std::collections::VecDeque;
+use std::time::Instant;
+
+#[derive(Clone, Debug)]
+pub struct Cert {}
+
+pub struct Dtls {}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {}
+
+impl Cert {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn fingerprint(&self) -> Fingerprint {
+        unimplemented!("dummy crypto")
+    }
+}
+
+impl Dtls {
+    pub fn new(_: Cert) -> Result<Self, CryptoError> {
+        Ok(Self {})
+    }
+
+    pub fn set_active(&mut self, active: bool) {
+        unimplemented!("dummy crypto")
+    }
+
+    pub fn handle_handshake(&mut self, o: &mut VecDeque<DtlsEvent>) -> Result<bool, CryptoError> {
+        unimplemented!("dummy crypto")
+    }
+
+    pub fn is_active(&self) -> Option<bool> {
+        unimplemented!("dummy crypto")
+    }
+
+    pub fn handle_receive(
+        &mut self,
+        m: &[u8],
+        o: &mut VecDeque<DtlsEvent>,
+    ) -> Result<(), CryptoError> {
+        unimplemented!("dummy crypto")
+    }
+
+    pub fn poll_datagram(&mut self) -> Option<DatagramSend> {
+        unimplemented!("dummy crypto")
+    }
+
+    pub fn poll_timeout(&mut self, now: Instant) -> Option<Instant> {
+        unimplemented!("dummy crypto")
+    }
+
+    pub fn handle_input(&mut self, data: &[u8]) -> Result<(), CryptoError> {
+        unimplemented!("dummy crypto")
+    }
+
+    pub fn is_connected(&self) -> bool {
+        unimplemented!("dummy crypto")
+    }
+}
+
+pub struct Aes128CmSha1_80;
+
+pub struct AeadAes128Gcm;
+
+pub fn srtp_aes_128_ecb_round(key: &[u8], input: &[u8], output: &mut [u8]) {
+    unimplemented!("dummy crypto")
+}
+
+impl Aes128CmSha1_80 {
+    pub(crate) fn new(key: aes_128_cm_sha1_80::AesKey, encrypt: bool) -> Self {
+        Self {}
+    }
+
+    pub(crate) fn encrypt(
+        &mut self,
+        iv: &aes_128_cm_sha1_80::RtpIv,
+        input: &[u8],
+        output: &mut [u8],
+    ) -> Result<(), CryptoError> {
+        unimplemented!("dummy crypto")
+    }
+
+    pub(crate) fn decrypt(
+        &mut self,
+        iv: &aes_128_cm_sha1_80::RtpIv,
+        input: &[u8],
+        output: &mut [u8],
+    ) -> Result<(), CryptoError> {
+        unimplemented!("dummy crypto")
+    }
+}
+
+impl AeadAes128Gcm {
+    pub(crate) fn new(key: aead_aes_128_gcm::AeadKey, encrypt: bool) -> Self {
+        Self {}
+    }
+
+    pub(crate) fn encrypt(
+        &mut self,
+        iv: &[u8; aead_aes_128_gcm::IV_LEN],
+        aad: &[u8],
+        input: &[u8],
+        output: &mut [u8],
+    ) -> Result<(), CryptoError> {
+        unimplemented!("dummy crypto")
+    }
+
+    pub(crate) fn decrypt(
+        &mut self,
+        iv: &[u8; aead_aes_128_gcm::IV_LEN],
+        aads: &[&[u8]],
+        input: &[u8],
+        output: &mut [u8],
+    ) -> Result<usize, CryptoError> {
+        unimplemented!("dummy crypto")
+    }
+}

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -49,29 +49,10 @@ pub fn sha1_hmac(key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {
     hmac.finalize().into_bytes().into()
 }
 
-/// If openssl is enabled and sha1 is not, it uses `openssl` crate.
-#[cfg(all(feature = "openssl", not(feature = "sha1")))]
-pub fn sha1_hmac(key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {
-    use openssl::hash::MessageDigest;
-    use openssl::pkey::PKey;
-    use openssl::sign::Signer;
-
-    let key = PKey::hmac(key).expect("valid hmac key");
-    let mut signer = Signer::new(MessageDigest::sha1(), &key).expect("valid signer");
-
-    for payload in payloads {
-        signer.update(payload).expect("signer update");
-    }
-
-    let mut hash = [0u8; 20];
-    signer.sign(&mut hash).expect("sign to array");
-    hash
-}
-
-/// If wincrypto is enabled and sha1 is not, it uses `wincrypto` crate.
+/// if sha1 is not enabled, delegate to the crypto impl.
 #[cfg(all(feature = "wincrypto", not(feature = "sha1")))]
 pub fn sha1_hmac(key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {
-    wincrypto::sha1_hmac(key, payloads)
+    _impl::sha1_hmac(key, payloads)
 }
 
 /// Errors that can arise in DTLS.

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -50,7 +50,7 @@ pub fn sha1_hmac(key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {
 }
 
 /// if sha1 is not enabled, delegate to the crypto impl.
-#[cfg(all(feature = "wincrypto", not(feature = "sha1")))]
+#[cfg(not(feature = "sha1"))]
 pub fn sha1_hmac(key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {
     _impl::sha1_hmac(key, payloads)
 }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -21,6 +21,7 @@ mod keying;
 pub use keying::KeyingMaterial;
 
 mod srtp;
+pub use _impl::{AeadAes128Gcm, Aes128CmSha1_80};
 pub use srtp::{aead_aes_128_gcm, aes_128_cm_sha1_80, new_aead_aes_128_gcm};
 pub use srtp::{new_aes_128_cm_sha1_80, srtp_aes_128_ecb_round, SrtpProfile};
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -3,11 +3,11 @@
 use std::io;
 use thiserror::Error;
 
-#[cfg(all(not(windows), feature = "openssl"))]
+#[cfg(all(not(target_family = "windows"), feature = "openssl"))]
 #[path = "ossl/mod.rs"]
 mod _impl;
 
-#[cfg(all(windows, feature = "wincrypto"))]
+#[cfg(all(target_family = "windows", feature = "wincrypto"))]
 #[path = "wincrypt/mod.rs"]
 mod _impl;
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 mod _impl;
 
 #[cfg(all(target_family = "windows", feature = "wincrypto"))]
-#[path = "wincrypt/mod.rs"]
+#[path = "wincrypto/mod.rs"]
 mod _impl;
 
 #[cfg(any(

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -11,6 +11,13 @@ mod _impl;
 #[path = "wincrypt/mod.rs"]
 mod _impl;
 
+#[cfg(any(
+    all(target_family = "windows", not(feature = "wincrypto")),
+    all(not(target_family = "windows"), not(feature = "openssl"))
+))]
+#[path = "dummy.rs"]
+mod _impl;
+
 mod dtls;
 pub use dtls::{DtlsCert, DtlsEvent, DtlsImpl};
 

--- a/src/crypto/ossl/mod.rs
+++ b/src/crypto/ossl/mod.rs
@@ -11,7 +11,9 @@ mod stream;
 pub use cert::OsslDtlsCert as Cert;
 pub use dtls::OsslDtlsImpl as Dtls;
 pub use openssl::error::ErrorStack as Error;
-pub use srtp::OsslSrtpCryptoImpl as SrtpCrypto;
+pub use srtp::srtp_aes_128_ecb_round;
+pub use srtp::OsslAeadAes128Gcm as AeadAes128Gcm;
+pub use srtp::OsslAes128CmSha1_80 as Aes128CmSha1_80;
 
 impl SrtpProfile {
     /// What this profile is called in OpenSSL parlance.

--- a/src/crypto/ossl/mod.rs
+++ b/src/crypto/ossl/mod.rs
@@ -3,16 +3,15 @@
 use super::{CryptoError, SrtpProfile};
 
 mod cert;
-pub use cert::OsslDtlsCert;
-
+mod dtls;
 mod io_buf;
+mod srtp;
 mod stream;
 
-mod dtls;
-pub use dtls::OsslDtlsImpl;
-
-mod srtp;
-pub use srtp::OsslSrtpCryptoImpl;
+pub use cert::OsslDtlsCert as Cert;
+pub use dtls::OsslDtlsImpl as Dtls;
+pub use openssl::error::ErrorStack as Error;
+pub use srtp::OsslSrtpCryptoImpl as SrtpCrypto;
 
 impl SrtpProfile {
     /// What this profile is called in OpenSSL parlance.

--- a/src/crypto/ossl/mod.rs
+++ b/src/crypto/ossl/mod.rs
@@ -26,3 +26,21 @@ impl SrtpProfile {
         }
     }
 }
+
+#[cfg(not(feature = "sha1"))]
+pub fn sha1_hmac(key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {
+    use openssl::hash::MessageDigest;
+    use openssl::pkey::PKey;
+    use openssl::sign::Signer;
+
+    let key = PKey::hmac(key).expect("valid hmac key");
+    let mut signer = Signer::new(MessageDigest::sha1(), &key).expect("valid signer");
+
+    for payload in payloads {
+        signer.update(payload).expect("signer update");
+    }
+
+    let mut hash = [0u8; 20];
+    signer.sign(&mut hash).expect("sign to array");
+    hash
+}

--- a/src/crypto/srtp.rs
+++ b/src/crypto/srtp.rs
@@ -41,20 +41,9 @@ pub fn new_aes_128_cm_sha1_80(
     key: AesKey,
     encrypt: bool,
 ) -> Box<dyn aes_128_cm_sha1_80::CipherCtx> {
-    #[cfg(feature = "openssl")]
-    {
-        let ctx = super::ossl::OsslSrtpCryptoImpl::new_aes_128_cm_sha1_80(key, encrypt);
-        Box::new(ctx)
-    }
-    #[cfg(feature = "wincrypto")]
-    {
-        let ctx = super::wincrypto::WinCryptoSrtpCryptoImpl::new_aes_128_cm_sha1_80(key, encrypt);
-        Box::new(ctx)
-    }
-    #[cfg(not(any(feature = "openssl", feature = "wincrypto")))]
-    {
-        panic!("No SRTP implementation. Enable openssl feature");
-    }
+    Box::new(super::_impl::SrtpCrypto::new_aes_128_cm_sha1_80(
+        key, encrypt,
+    ))
 }
 
 // TODO: Can we avoice dynamic dispatch in this signature? The parameters are:
@@ -66,20 +55,7 @@ pub fn new_aead_aes_128_gcm(key: AeadKey, encrypt: bool) -> Box<dyn aead_aes_128
     /// TODO: The exact mechanism for passing which crypto to use from
     ///       RtcConfig to here. We're not going to instantiate openssl
     ///       automatically.
-    #[cfg(feature = "openssl")]
-    {
-        let ctx = super::ossl::OsslSrtpCryptoImpl::new_aead_aes_128_gcm(key, encrypt);
-        Box::new(ctx)
-    }
-    #[cfg(feature = "wincrypto")]
-    {
-        let ctx = super::wincrypto::WinCryptoSrtpCryptoImpl::new_aead_aes_128_gcm(key, encrypt);
-        Box::new(ctx)
-    }
-    #[cfg(not(any(feature = "openssl", feature = "wincrypto")))]
-    {
-        panic!("No SRTP implementation. Enable openssl feature");
-    }
+    Box::new(super::_impl::SrtpCrypto::new_aead_aes_128_gcm(key, encrypt))
 }
 
 #[allow(unused)]
@@ -87,18 +63,7 @@ pub fn srtp_aes_128_ecb_round(key: &[u8], input: &[u8], output: &mut [u8]) {
     /// TODO: The exact mechanism for passing which crypto to use from
     ///       RtcConfig to here. We're not going to instantiate openssl
     ///       automatically.
-    #[cfg(feature = "openssl")]
-    {
-        super::ossl::OsslSrtpCryptoImpl::srtp_aes_128_ecb_round(key, input, output)
-    }
-    #[cfg(feature = "wincrypto")]
-    {
-        super::wincrypto::WinCryptoSrtpCryptoImpl::srtp_aes_128_ecb_round(key, input, output)
-    }
-    #[cfg(not(any(feature = "openssl", feature = "wincrypto")))]
-    {
-        panic!("No SRTP implementation. Enable openssl feature");
-    }
+    super::_impl::SrtpCrypto::srtp_aes_128_ecb_round(key, input, output);
 }
 
 pub trait SrtpCryptoImpl {

--- a/src/crypto/wincrypto/dtls.rs
+++ b/src/crypto/wincrypto/dtls.rs
@@ -1,7 +1,6 @@
 use std::collections::VecDeque;
 use std::time::Instant;
 
-use crate::crypto::dtls::DtlsInner;
 use crate::crypto::CryptoError;
 use crate::crypto::DtlsEvent;
 use crate::crypto::{KeyingMaterial, SrtpProfile};
@@ -17,22 +16,20 @@ impl WinCryptoDtls {
             cert.certificate.clone(),
         )?))
     }
-}
 
-impl DtlsInner for WinCryptoDtls {
-    fn set_active(&mut self, active: bool) {
+    pub fn set_active(&mut self, active: bool) {
         self.0.set_as_client(active).expect("Set client failed");
     }
 
-    fn is_active(&self) -> Option<bool> {
+    pub fn is_active(&self) -> Option<bool> {
         self.0.is_client()
     }
 
-    fn is_connected(&self) -> bool {
+    pub fn is_connected(&self) -> bool {
         self.0.is_connected()
     }
 
-    fn handle_receive(
+    pub fn handle_receive(
         &mut self,
         datagram: &[u8],
         output_events: &mut VecDeque<DtlsEvent>,
@@ -41,7 +38,7 @@ impl DtlsInner for WinCryptoDtls {
         Ok(())
     }
 
-    fn handle_handshake(
+    pub fn handle_handshake(
         &mut self,
         output_events: &mut VecDeque<DtlsEvent>,
     ) -> Result<bool, CryptoError> {
@@ -53,7 +50,7 @@ impl DtlsInner for WinCryptoDtls {
     }
 
     // This is DATA sent from client over SCTP/DTLS
-    fn handle_input(&mut self, data: &[u8]) -> Result<(), CryptoError> {
+    pub fn handle_input(&mut self, data: &[u8]) -> Result<(), CryptoError> {
         match self.0.send_data(data) {
             Ok(true) => Ok(()),
             Ok(false) => Err(std::io::Error::new(
@@ -65,7 +62,7 @@ impl DtlsInner for WinCryptoDtls {
         }
     }
 
-    fn poll_datagram(&mut self) -> Option<crate::net::DatagramSend> {
+    pub fn poll_datagram(&mut self) -> Option<crate::net::DatagramSend> {
         let datagram: Option<crate::io::DatagramSend> = self.0.pull_datagram().map(|v| v.into());
         if let Some(datagram) = &datagram {
             if datagram.len() > DATAGRAM_MTU_WARN {
@@ -76,7 +73,7 @@ impl DtlsInner for WinCryptoDtls {
         datagram
     }
 
-    fn poll_timeout(&mut self, now: Instant) -> Option<Instant> {
+    pub fn poll_timeout(&mut self, now: Instant) -> Option<Instant> {
         self.0.next_timeout(now)
     }
 }

--- a/src/crypto/wincrypto/mod.rs
+++ b/src/crypto/wincrypto/mod.rs
@@ -3,16 +3,14 @@
 use super::CryptoError;
 
 mod cert;
-pub use cert::WinCryptoDtlsCert;
-
 mod dtls;
-pub use dtls::WinCryptoDtls;
-
-mod srtp;
-pub use srtp::WinCryptoSrtpCryptoImpl;
-
 mod sha1;
+mod srtp;
+
+pub use cert::WinCryptoDtlsCert as Cert;
+pub use dtls::WinCryptoDtls as Dtls;
+pub use srtp::WinCryptoSrtpCryptoImpl as SrtpCrypto;
+pub use str0m_wincrypto::WinCryptoError as Error;
+
 #[allow(unused_imports)] // If 'sha1' feature is enabled this is not used.
 pub use sha1::sha1_hmac;
-
-pub use str0m_wincrypto::WinCryptoError;

--- a/src/crypto/wincrypto/mod.rs
+++ b/src/crypto/wincrypto/mod.rs
@@ -9,7 +9,9 @@ mod srtp;
 
 pub use cert::WinCryptoDtlsCert as Cert;
 pub use dtls::WinCryptoDtls as Dtls;
-pub use srtp::WinCryptoSrtpCryptoImpl as SrtpCrypto;
+pub use srtp::srtp_aes_128_ecb_round;
+pub use srtp::WinCryptoAeadAes128Gcm as AeadAes128Gcm;
+pub use srtp::WinCryptoAes128CmSha1_80 as Aes128CmSha1_80;
 pub use str0m_wincrypto::WinCryptoError as Error;
 
 #[allow(unused_imports)] // If 'sha1' feature is enabled this is not used.

--- a/src/crypto/wincrypto/srtp.rs
+++ b/src/crypto/wincrypto/srtp.rs
@@ -1,14 +1,12 @@
-use crate::crypto::srtp::SrtpCryptoImpl;
 use crate::crypto::srtp::{aead_aes_128_gcm, aes_128_cm_sha1_80};
 use crate::crypto::CryptoError;
 use str0m_wincrypto::{
-    srtp_aead_aes_128_gcm_decrypt, srtp_aead_aes_128_gcm_encrypt, srtp_aes_128_cm,
-    srtp_aes_128_ecb_round, SrtpKey,
+    srtp_aead_aes_128_gcm_decrypt, srtp_aead_aes_128_gcm_encrypt, srtp_aes_128_cm, SrtpKey,
 };
 
 pub fn srtp_aes_128_ecb_round(key: &[u8], input: &[u8], output: &mut [u8]) {
     let key = SrtpKey::create_aes_ecb_key(key).expect("AES key");
-    let count = srtp_aes_128_ecb_round(&key, input, output).expect("AES encrypt");
+    let count = str0m_wincrypto::srtp_aes_128_ecb_round(&key, input, output).expect("AES encrypt");
     assert_eq!(count, 16 + 16); // block size
 }
 

--- a/src/dtls.rs
+++ b/src/dtls.rs
@@ -11,16 +11,9 @@ use crate::net::DatagramSend;
 /// Errors that can arise in DTLS.
 #[derive(Debug, Error)]
 pub enum DtlsError {
-    /// Some error from OpenSSL layer (used for DTLS).
+    /// Some error from crypto layer (used for DTLS).
     #[error("{0}")]
-    #[cfg(feature = "openssl")]
-    OpenSsl(#[from] openssl::error::ErrorStack),
-
-    /// Some error from Windows Crypto layer (used for DTLS).
-    #[error("{0}")]
-    #[cfg(feature = "wincrypto")]
-    WinCrypto(#[from] crate::crypto::wincrypto::WinCryptoError),
-
+    Crypto(#[from] CryptoError),
     /// Other IO errors.
     #[error("{0}")]
     Io(#[from] io::Error),
@@ -34,18 +27,6 @@ impl DtlsError {
             return false;
         };
         e.kind() == io::ErrorKind::WouldBlock
-    }
-}
-
-impl From<CryptoError> for DtlsError {
-    fn from(value: CryptoError) -> Self {
-        match value {
-            #[cfg(feature = "openssl")]
-            CryptoError::OpenSsl(e) => DtlsError::OpenSsl(e),
-            #[cfg(feature = "wincrypto")]
-            CryptoError::WinCrypto(e) => DtlsError::WinCrypto(e),
-            CryptoError::Io(e) => DtlsError::Io(e),
-        }
     }
 }
 

--- a/src/dtls.rs
+++ b/src/dtls.rs
@@ -21,11 +21,12 @@ pub enum DtlsError {
 
 impl DtlsError {
     pub(crate) fn is_would_block(&self) -> bool {
-        #[allow(irrefutable_let_patterns)]
-        let DtlsError::Io(e) = self
-        else {
-            return false;
+        let e = match self {
+            DtlsError::Crypto(CryptoError::Io(io)) => io,
+            DtlsError::Io(io) => io,
+            DtlsError::Crypto(_) => return false,
         };
+
         e.kind() == io::ErrorKind::WouldBlock
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1108,18 +1108,7 @@ impl Rtc {
         let dtls_cert = if let Some(c) = config.dtls_cert {
             c
         } else {
-            #[cfg(feature = "openssl")]
-            {
-                DtlsCert::new_openssl()
-            }
-            #[cfg(feature = "wincrypto")]
-            {
-                DtlsCert::new_wincrypto()
-            }
-            #[cfg(not(any(feature = "openssl", feature = "wincrypto")))]
-            {
-                panic!("No DTLS implementation. Enable crypto feature");
-            }
+            DtlsCert::new()
         };
 
         Rtc {

--- a/src/rtp/srtp.rs
+++ b/src/rtp/srtp.rs
@@ -545,13 +545,13 @@ enum Derived {
     Aes128CmSha1_80 {
         key: [u8; 20],
         salt: aes_128_cm_sha1_80::RtpSalt,
-        enc: Box<dyn aes_128_cm_sha1_80::CipherCtx>,
-        dec: Box<dyn aes_128_cm_sha1_80::CipherCtx>,
+        enc: crate::crypto::Aes128CmSha1_80,
+        dec: crate::crypto::Aes128CmSha1_80,
     },
     AeadAes128Gcm {
         salt: aead_aes_128_gcm::RtpSalt,
-        enc: Box<dyn aead_aes_128_gcm::CipherCtx>,
-        dec: Box<dyn aead_aes_128_gcm::CipherCtx>,
+        enc: crate::crypto::AeadAes128Gcm,
+        dec: crate::crypto::AeadAes128Gcm,
     },
 }
 


### PR DESCRIPTION
This is how we handle platform-specific code in Firezone and it works quite well for us. I went ahead and decided that `openssl` can't at all be used on Windows anymore because it makes the `_impl` module nicely platform specific and avoids the issue of `--all-features` not working.

Let me know what you think.