### PR TITLE
Add simulcast sending support

### DIFF
--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -495,8 +495,13 @@ impl Client {
             if let TrackOutState::ToOpen = track.state {
                 if let Some(track_in) = track.track_in.upgrade() {
                     let stream_id = track_in.origin.to_string();
-                    let mid =
-                        change.add_media(track_in.kind, Direction::SendOnly, Some(stream_id), None);
+                    let mid = change.add_media(
+                        track_in.kind,
+                        Direction::SendOnly,
+                        Some(stream_id),
+                        None,
+                        None,
+                    );
                     track.state = TrackOutState::Negotiating(mid);
                 }
             }

--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -232,13 +232,18 @@ impl<'a> DirectApi<'a> {
         mid: Mid,
         rid: Option<Rid>,
     ) -> &mut StreamTx {
-        let Some(media) = self.rtc.session.media_by_mid(mid) else {
+        let Some(media) = self.rtc.session.media_by_mid_mut(mid) else {
             panic!("No media declared for mid: {}", mid);
         };
 
         let is_audio = media.kind().is_audio();
 
         let midrid = MidRid(mid, rid);
+
+        // If there is a RID tx, declare it so we an use it in Writer API
+        if let Some(rid) = rid {
+            media.add_to_rid_tx(rid);
+        }
 
         let stream = self
             .rtc

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -8,7 +8,7 @@ use crate::crypto::Fingerprint;
 use crate::format::CodecConfig;
 use crate::format::PayloadParams;
 use crate::io::Id;
-use crate::media::Media;
+use crate::media::{Media, Simulcast};
 use crate::packet::MediaKind;
 use crate::rtp_::MidRid;
 use crate::rtp_::Rid;
@@ -128,7 +128,7 @@ impl<'a> SdpApi<'a> {
     /// let mut rtc = Rtc::new();
     ///
     /// let mut changes = rtc.sdp_api();
-    /// let mid = changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None);
+    /// let mid = changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None, None);
     /// let (offer, pending) = changes.apply().unwrap();
     ///
     /// // send offer to remote peer, receive answer back
@@ -201,7 +201,7 @@ impl<'a> SdpApi<'a> {
     /// let mut changes = rtc.sdp_api();
     /// assert!(!changes.has_changes());
     ///
-    /// let mid = changes.add_media(MediaKind::Audio, Direction::SendRecv, None, None);
+    /// let mid = changes.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
     /// assert!(changes.has_changes());
     /// # }
     /// ```
@@ -227,7 +227,7 @@ impl<'a> SdpApi<'a> {
     ///
     /// let mut changes = rtc.sdp_api();
     ///
-    /// let mid = changes.add_media(MediaKind::Audio, Direction::SendRecv, None, None);
+    /// let mid = changes.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
     /// # }
     /// ```
     pub fn add_media(
@@ -236,6 +236,7 @@ impl<'a> SdpApi<'a> {
         dir: Direction,
         stream_id: Option<String>,
         track_id: Option<String>,
+        simulcast: Option<crate::media::Simulcast>,
     ) -> Mid {
         let mid = self.rtc.new_mid();
 
@@ -266,8 +267,15 @@ impl<'a> SdpApi<'a> {
             Id::<20>::random().to_string()
         };
 
-        let rtx = kind.is_video().then(|| self.rtc.session.streams.new_ssrc());
-        let ssrcs = vec![(self.rtc.session.streams.new_ssrc(), rtx)];
+        let mut ssrcs = Vec::new();
+
+        // Main SSRC, not counting RTX.
+        let main_ssrc_count = simulcast.as_ref().map(|s| s.send.len()).unwrap_or(1);
+
+        for _ in 0..main_ssrc_count {
+            let rtx = kind.is_video().then(|| self.rtc.session.streams.new_ssrc());
+            ssrcs.push((self.rtc.session.streams.new_ssrc(), rtx));
+        }
 
         // TODO: let user configure stream/track name.
         let msid = Msid {
@@ -282,6 +290,7 @@ impl<'a> SdpApi<'a> {
             kind,
             dir,
             ssrcs,
+            simulcast,
 
             // Added later
             pts: vec![],
@@ -459,11 +468,11 @@ impl<'a> SdpApi<'a> {
     /// # use str0m::Rtc;
     /// let mut rtc = Rtc::new();
     /// let mut changes = rtc.sdp_api();
-    /// changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None);
+    /// changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None, None);
     /// let (_offer, pending) = changes.apply().unwrap();
     ///
     /// let mut changes = rtc.sdp_api();
-    /// changes.add_media(MediaKind::Video, Direction::SendOnly, None, None);
+    /// changes.add_media(MediaKind::Video, Direction::SendOnly, None, None, None);
     /// changes.merge(pending);
     ///
     /// // This `SdpOffer` will have changes from the first `SdpPendingChanges`
@@ -489,7 +498,7 @@ impl<'a> SdpApi<'a> {
 /// let mut rtc = Rtc::new();
 ///
 /// let mut changes = rtc.sdp_api();
-/// let mid = changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None);
+/// let mid = changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None, None);
 /// let (offer, pending) = changes.apply().unwrap();
 ///
 /// // send offer to remote peer, receive answer back
@@ -561,6 +570,7 @@ pub(crate) struct AddMedia {
     pub kind: MediaKind,
     pub dir: Direction,
     pub ssrcs: Vec<(Ssrc, Option<Ssrc>)>,
+    pub simulcast: Option<Simulcast>,
 
     // pts and index are filled in when creating the SDP OFFER.
     // The default PT order is set by the Session (BUNDLE).
@@ -894,9 +904,12 @@ fn add_pending_changes(session: &mut Session, pending: Changes) {
         media.set_cname(add_media.cname);
         media.set_msid(add_media.msid);
 
-        for (ssrc, rtx) in add_media.ssrcs {
-            // TODO: When we allow sending RID, we need to add that here.
-            let midrid = MidRid(add_media.mid, None);
+        // If there are RIDs, the SSRC order matches that of the rid order.
+        let rids = add_media.simulcast.map(|x| x.send).unwrap_or(vec![]);
+
+        for (i, (ssrc, rtx)) in add_media.ssrcs.into_iter().enumerate() {
+            let maybe_rid = rids.get(i).cloned();
+            let midrid = MidRid(add_media.mid, maybe_rid);
 
             let stream = session.streams.declare_stream_tx(ssrc, rtx, midrid);
 
@@ -1068,8 +1081,14 @@ fn update_media(
         media.set_direction(new_dir);
     }
 
-    for rid in m.rids().iter() {
-        media.expect_rid(*rid);
+    if new_dir.is_sending() {
+        // The other side has declared how it EXPECTING to receive. We must only send
+        // the RIDs declared in the answer.
+        media.set_rid_tx(m.rids().into());
+    }
+    if new_dir.is_receiving() {
+        // The other side has declared what it proposes to send. We are accepting it.
+        media.set_rid_rx(m.rids().into());
     }
 
     // Narrowing/ordering of of PT
@@ -1102,43 +1121,46 @@ fn update_media(
     }
     media.set_remote_extmap(remote_extmap);
 
-    if new_dir.is_receiving() {
-        // SSRC changes
-        // This will always be for ReceiverSource since any incoming a=ssrc line will be
-        // about the remote side's SSRC.
-        let infos = m.ssrc_info();
-        let main = infos.iter().filter(|i| i.repairs.is_none());
+    // SSRC changes
+    // This will always be for ReceiverSource since any incoming a=ssrc line will be
+    // about the remote side's SSRC.
+    if !new_dir.is_receiving() {
+        return;
+    }
 
-        if m.simulcast().is_none() {
-            // Only use pre-communicated SSRC if we are running without simulcast.
-            // We found a bug in FF where the order of the simulcast lines does not
-            // correspond to the order of the simulcast declarations. In this case
-            // it's better to fall back on mid/rid dynamic mapping.
-
-            for i in main {
-                // TODO: If the remote is communicating _BOTH_ rid and a=ssrc this will fail.
-                info!("Adding pre-communicated SSRC: {:?}", i);
-                let repair_ssrc = infos
-                    .iter()
-                    .find(|r| r.repairs == Some(i.ssrc))
-                    .map(|r| r.ssrc);
-
-                // If remote communicated a main a=ssrc, but no RTX, we will not send nacks.
-                let midrid = MidRid(media.mid(), None);
-                let suppress_nack = repair_ssrc.is_none();
-                streams.expect_stream_rx(i.ssrc, repair_ssrc, midrid, suppress_nack);
-            }
+    // Simulcast configuration
+    if let Some(s) = m.simulcast() {
+        if s.is_munged {
+            warn!("Not supporting simulcast via munging SDP");
+        } else if media.simulcast().is_none() {
+            // Invert before setting, since it has a recv and send config.
+            media.set_simulcast(s.invert());
         }
+    }
 
-        // Simulcast configuration
-        if let Some(s) = m.simulcast() {
-            if s.is_munged {
-                warn!("Not supporting simulcast via munging SDP");
-            } else if media.simulcast().is_none() {
-                // Invert before setting, since it has a recv and send config.
-                media.set_simulcast(s.invert());
-            }
-        }
+    // Only use pre-communicated SSRC if we are running without simulcast.
+    // We found a bug in FF where the order of the simulcast lines does not
+    // correspond to the order of the simulcast declarations. In this case
+    // it's better to fall back on mid/rid dynamic mapping.
+    if m.simulcast().is_some() {
+        return;
+    }
+
+    let infos = m.ssrc_info();
+    let main = infos.iter().filter(|i| i.repairs.is_none());
+
+    for i in main {
+        // TODO: If the remote is communicating _BOTH_ rid and a=ssrc this will fail.
+        info!("Adding pre-communicated SSRC: {:?}", i);
+        let repair_ssrc = infos
+            .iter()
+            .find(|r| r.repairs == Some(i.ssrc))
+            .map(|r| r.ssrc);
+
+        // If remote communicated a main a=ssrc, but no RTX, we will not send nacks.
+        let midrid = MidRid(media.mid(), None);
+        let suppress_nack = repair_ssrc.is_none();
+        streams.expect_stream_rx(i.ssrc, repair_ssrc, midrid, suppress_nack);
     }
 }
 
@@ -1291,18 +1313,13 @@ impl AsSdpMediaLine for Media {
             }
         }
 
-        let count = ssrcs_tx.len();
-        #[allow(clippy::comparison_chain)]
-        if count == 1 {
-            let (ssrc, ssrc_rtx) = &ssrcs_tx[0];
+        for (ssrc, ssrc_rtx) in ssrcs_tx {
             if let Some(ssrc_rtx) = ssrc_rtx {
                 attrs.push(MediaAttribute::SsrcGroup {
                     semantics: "FID".to_string(),
                     ssrcs: vec![*ssrc, *ssrc_rtx],
                 });
             }
-        } else {
-            // TODO: handle simulcast
         }
 
         MediaLine {
@@ -1549,7 +1566,10 @@ impl Change {
 
 #[cfg(test)]
 mod test {
+    use sdp::RestrictionId;
+
     use crate::format::Codec;
+    use crate::media::Simulcast;
     use crate::sdp::RtpMap;
 
     use super::*;
@@ -1595,11 +1615,11 @@ mod test {
 
         let mut rtc = Rtc::new();
         let mut changes = rtc.sdp_api();
-        changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None);
+        changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None, None);
         let (offer, pending) = changes.apply().unwrap();
 
         let mut changes = rtc.sdp_api();
-        changes.add_media(MediaKind::Video, Direction::SendOnly, None, None);
+        changes.add_media(MediaKind::Video, Direction::SendOnly, None, None, None);
         changes.merge(pending);
         let (new_offer, _) = changes.apply().unwrap();
 
@@ -1624,7 +1644,7 @@ mod test {
             .build();
 
         let mut change1 = rtc1.sdp_api();
-        change1.add_media(MediaKind::Video, Direction::SendOnly, None, None);
+        change1.add_media(MediaKind::Video, Direction::SendOnly, None, None, None);
         let (offer1, _) = change1.apply().unwrap();
 
         let answer = rtc2.sdp_api().accept_offer(offer1).unwrap();
@@ -1651,5 +1671,74 @@ mod test {
             !vp9_unsupported,
             "VP9 was not offered, so it should not be present in the answer"
         );
+    }
+
+    #[test]
+    fn simulcast_ssrc_allocation() {
+        crate::init_crypto_default();
+
+        let mut rtc1 = Rtc::new();
+
+        let mut change = rtc1.sdp_api();
+        change.add_media(
+            MediaKind::Video,
+            Direction::SendOnly,
+            None,
+            None,
+            Some(Simulcast {
+                send: vec!["m".into(), "h".into(), "l".into()],
+                recv: vec![],
+            }),
+        );
+
+        let Change::AddMedia(am) = &change.changes[0] else {
+            panic!("Not AddMedia?!");
+        };
+
+        // these should be organized in order: m, h, l
+        let pending_ssrcs = am.ssrcs.clone();
+        assert_eq!(pending_ssrcs.len(), 3);
+
+        for p in &pending_ssrcs {
+            assert!(p.1.is_some()); // all should have rtx
+        }
+
+        let (offer, _) = change.apply().unwrap();
+        let sdp = offer.into_inner();
+        let line = &sdp.media_lines[0];
+
+        assert_eq!(
+            line.simulcast().unwrap().send,
+            SimulcastGroups(vec![
+                RestrictionId("m".into(), true),
+                RestrictionId("h".into(), true),
+                RestrictionId("l".into(), true),
+            ])
+        );
+
+        // Each SSRC, both regular and RTX get their own a=ssrc line.
+        assert_eq!(line.ssrc_info().len(), pending_ssrcs.len() * 2);
+
+        let fids: Vec<_> = line
+            .attrs
+            .iter()
+            .filter_map(|a| {
+                if let MediaAttribute::SsrcGroup { semantics, ssrcs } = a {
+                    // We don't have any other semantics right now.
+                    assert_eq!(semantics, "FID");
+                    assert_eq!(ssrcs.len(), 2);
+                    Some((ssrcs[0], ssrcs[1]))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert_eq!(fids.len(), pending_ssrcs.len());
+
+        for (a, b) in fids.iter().zip(pending_ssrcs.iter()) {
+            assert_eq!(a.0, b.0);
+            assert_eq!(Some(a.1), b.1);
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@
 //! let mut change = rtc.sdp_api();
 //!
 //! // Do some change. A valid OFFER needs at least one "m-line" (media).
-//! let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None);
+//! let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
 //!
 //! // Get the offer.
 //! let (offer, pending) = change.apply().unwrap();
@@ -1281,8 +1281,8 @@ impl Rtc {
     /// let mut rtc = Rtc::new();
     ///
     /// let mut changes = rtc.sdp_api();
-    /// let mid_audio = changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None);
-    /// let mid_video = changes.add_media(MediaKind::Video, Direction::SendOnly, None, None);
+    /// let mid_audio = changes.add_media(MediaKind::Audio, Direction::SendOnly, None, None, None);
+    /// let mid_video = changes.add_media(MediaKind::Video, Direction::SendOnly, None, None, None);
     ///
     /// let (offer, pending) = changes.apply().unwrap();
     /// let json = serde_json::to_vec(&offer).unwrap();
@@ -1335,6 +1335,8 @@ impl Rtc {
             panic!("In rtp_mode use direct_api().stream_tx().write_rtp()");
         }
 
+        // This does not catch potential RIDs required to send simulcast, but
+        // it's a good start. An error might arise later on RID mismatch.
         self.session.media_by_mid_mut(mid)?;
 
         Some(Writer::new(&mut self.session, mid))

--- a/src/media/event.rs
+++ b/src/media/event.rs
@@ -59,12 +59,32 @@ pub struct MediaChanged {
 /// The [full spec][1] covers many cases that are not used by simple simulcast.
 ///
 /// [1]: https://datatracker.ietf.org/doc/html/draft-ietf-mmusic-sdp-simulcast-14
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Simulcast {
     /// The RID used for sending simulcast.
     pub send: Vec<Rid>,
     /// The RID used for receiving simulcast.
     pub recv: Vec<Rid>,
+}
+
+impl Simulcast {
+    pub(crate) fn into_sdp(self) -> SdpSimulcast {
+        SdpSimulcast {
+            send: crate::sdp::SimulcastGroups(
+                self.send
+                    .into_iter()
+                    .map(|r| crate::sdp::RestrictionId::new_active(r.to_string()))
+                    .collect(),
+            ),
+            recv: crate::sdp::SimulcastGroups(
+                self.recv
+                    .into_iter()
+                    .map(|r| crate::sdp::RestrictionId::new_active(r.to_string()))
+                    .collect(),
+            ),
+            is_munged: false,
+        }
+    }
 }
 
 /// Video or audio data from the remote peer.

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -49,6 +49,11 @@ pub struct Media {
     /// RTP level.
     rids_rx: Rids,
 
+    /// Rid that we can send using the [`Writer`].
+    ///
+    /// RTP level.
+    rids_tx: Rids,
+
     // ========================================= SDP level =========================================
     //
     /// The index of this media line in the Session::media Vec.
@@ -120,8 +125,10 @@ pub struct Media {
 }
 
 #[derive(Debug)]
-/// Config value for [`Media::rids_rx()`]
+/// Config value for [`Media::rids_rx()`] and [`Media::rids_tx()`]
 pub enum Rids {
+    /// No rid is allowed.
+    None,
     /// Any Rid is allowed.
     ///
     /// This is the default value for direct API.
@@ -133,8 +140,9 @@ pub enum Rids {
 }
 
 impl Rids {
-    pub(crate) fn expects(&self, rid: Rid) -> bool {
+    pub(crate) fn contains(&self, rid: Rid) -> bool {
         match self {
+            Rids::None => false,
             Rids::Any => true,
             Rids::Specific(v) => v.contains(&rid),
         }
@@ -142,6 +150,22 @@ impl Rids {
 
     pub(crate) fn is_specific(&self) -> bool {
         matches!(self, Rids::Specific(_))
+    }
+
+    fn add(&mut self, rid: Rid) {
+        match self {
+            Rids::None | Rids::Any => {
+                *self = Rids::Specific(vec![rid]);
+            }
+            Rids::Specific(vec) if !vec.contains(&rid) => vec.push(rid),
+            Rids::Specific(_) => {}
+        }
+    }
+}
+
+impl<I: AsRef<[Rid]>> From<I> for Rids {
+    fn from(value: I) -> Self {
+        Rids::Specific(value.as_ref().to_vec())
     }
 }
 
@@ -180,14 +204,8 @@ impl Media {
     /// a mid/rid combination in the RTP header extensions.
     ///
     /// RTP level.
-    pub fn expect_rid(&mut self, rid: Rid) {
-        match &mut self.rids_rx {
-            rids @ Rids::Any => {
-                *rids = Rids::Specific(vec![rid]);
-            }
-            Rids::Specific(v) if !v.contains(&rid) => v.push(rid),
-            _ => {}
-        }
+    pub fn expect_rid_rx(&mut self, rid: Rid) {
+        self.rids_rx.add(rid);
     }
 
     /// Rids we are expecting to see on incoming RTP packets that map to this mid.
@@ -198,6 +216,16 @@ impl Media {
     /// RTP level.
     pub fn rids_rx(&self) -> &Rids {
         &self.rids_rx
+    }
+
+    /// Rids we are can send via the [`Writer`].
+    ///
+    /// By default this is set to [`Rids::None`], which changes to [`Rids::Specific`] via SDP negotiation
+    /// that configures Simulcast where specific rids are expected.
+    ///
+    /// RTP level.
+    pub fn rids_tx(&self) -> &Rids {
+        &self.rids_tx
     }
 
     pub(crate) fn index(&self) -> usize {
@@ -467,6 +495,18 @@ impl Media {
         // Simply remove the depayloader, it will be re-created on the next RTP packet.
         self.depayloaders.remove(&(payload_type, rid));
     }
+
+    pub(crate) fn set_rid_rx(&mut self, rids: Rids) {
+        self.rids_rx = rids;
+    }
+
+    pub(crate) fn set_rid_tx(&mut self, rids: Rids) {
+        self.rids_tx = rids;
+    }
+
+    pub(crate) fn add_to_rid_tx(&mut self, rid: Rid) {
+        self.rids_tx.add(rid)
+    }
 }
 
 impl Default for Media {
@@ -484,6 +524,7 @@ impl Default for Media {
             dir: Direction::SendRecv,
             simulcast: None,
             rids_rx: Rids::Any,
+            rids_tx: Rids::None,
             payloaders: HashMap::new(),
             depayloaders: HashMap::new(),
             to_payload: VecDeque::default(),
@@ -528,6 +569,7 @@ impl Media {
             remote_pts: a.pts,
             remote_exts: a.exts,
             remote_created: false,
+            simulcast: a.simulcast.map(|s| s.into_sdp()),
             ..Default::default()
         }
     }

--- a/src/media/writer.rs
+++ b/src/media/writer.rs
@@ -129,7 +129,7 @@ impl<'a> Writer<'a> {
         }
 
         if let Some(rid) = self.rid {
-            if !media.rids_rx().expects(rid) && media.rids_rx().is_specific() {
+            if !media.rids_tx().contains(rid) {
                 return Err(RtcError::UnknownRid(rid));
             }
         }

--- a/src/sdp/mod.rs
+++ b/src/sdp/mod.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 mod data;
 pub(crate) use data::{FormatParam, Sdp, Session, SessionAttribute, Setup};
 pub(crate) use data::{MediaAttribute, MediaLine, MediaType, Msid, Proto};
-pub(crate) use data::{Simulcast, SimulcastGroups};
+pub(crate) use data::{RestrictionId, Simulcast, SimulcastGroups};
 pub(crate) use parser::parse_candidate;
 
 #[cfg(test)]
@@ -41,6 +41,11 @@ impl SdpOffer {
     /// Turns this offer into an SDP string, without any JSON wrapping.
     pub fn to_sdp_string(&self) -> String {
         self.0.to_string()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn into_inner(self) -> Sdp {
+        self.0
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -249,11 +249,9 @@ impl Session {
             return;
         };
 
-        let midrid = MidRid(padding_request.mid, None);
-
         let stream = self
             .streams
-            .stream_tx_by_midrid(midrid)
+            .stream_tx_by_midrid(padding_request.midrid)
             .expect("pacer to use an existing stream");
 
         stream.generate_padding(padding_request.padding);
@@ -696,17 +694,17 @@ impl Session {
         let srtp_tx = self.srtp_tx.as_mut()?;
 
         // Figure out which, if any, queue to poll
-        let mid = self.pacer.poll_queue()?;
+        let midrid = self.pacer.poll_queue()?;
         let media = self
             .medias
             .iter()
-            .find(|m| m.mid() == mid)
+            .find(|m| m.mid() == midrid.mid())
             .expect("index is media");
 
         let buf = &mut self.poll_packet_buf;
         let twcc_seq = self.twcc;
 
-        let stream = self.streams.stream_tx_by_midrid(MidRid(mid, None))?;
+        let stream = self.streams.stream_tx_by_midrid(midrid)?;
 
         let params = &self.codec_config;
         let exts = media.remote_extmap();
@@ -734,7 +732,7 @@ impl Session {
             crate::log_stat!("PACKET_SENT", header.ssrc, payload_size, kind);
         }
 
-        self.pacer.register_send(now, payload_size.into(), mid);
+        self.pacer.register_send(now, payload_size.into(), midrid);
 
         if let Some(raw_packets) = &mut self.raw_packets {
             raw_packets.push_back(Box::new(RawPacket::RtpTx(header.clone(), buf.clone())));

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -193,7 +193,7 @@ impl Streams {
             .expect("map_dynamic_by_rid to be called with Rid");
 
         // Check if the mid/rid combo is not expected
-        if !media.rids_rx().expects(rid) {
+        if !media.rids_rx().contains(rid) {
             trace!("Mid does not expect rid: {} {}", midrid.mid(), rid);
             return;
         }

--- a/tests/bidirectional.rs
+++ b/tests/bidirectional.rs
@@ -23,7 +23,7 @@ pub fn bidirectional_same_m_line() -> Result<(), RtcError> {
     r.add_local_candidate(host2);
 
     let mut change = l.sdp_api();
-    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None);
+    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
     let (offer, pending) = change.apply().unwrap();
 
     let answer = r.rtc.sdp_api().accept_offer(offer)?;

--- a/tests/contiguous.rs
+++ b/tests/contiguous.rs
@@ -158,7 +158,7 @@ impl Server {
 
         // The change is on the L (sending side) with Direction::SendRecv.
         let mut change = l.sdp_api();
-        let mid = change.add_media(MediaKind::Video, Direction::SendOnly, None, None);
+        let mid = change.add_media(MediaKind::Video, Direction::SendOnly, None, None, None);
         let (offer, pending) = change.apply().unwrap();
 
         let answer = r.rtc.sdp_api().accept_offer(offer)?;

--- a/tests/keyframes.rs
+++ b/tests/keyframes.rs
@@ -25,7 +25,7 @@ pub fn test_vp8_keyframes_detection() -> Result<(), RtcError> {
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();
-    let mid = change.add_media(MediaKind::Video, Direction::SendOnly, None, None);
+    let mid = change.add_media(MediaKind::Video, Direction::SendOnly, None, None, None);
     let (offer, pending) = change.apply().unwrap();
 
     let answer = r.rtc.sdp_api().accept_offer(offer)?;
@@ -117,7 +117,7 @@ pub fn test_vp9_keyframes_detection() -> Result<(), RtcError> {
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();
-    let mid = change.add_media(MediaKind::Video, Direction::SendOnly, None, None);
+    let mid = change.add_media(MediaKind::Video, Direction::SendOnly, None, None, None);
     let (offer, pending) = change.apply().unwrap();
 
     let answer = r.rtc.sdp_api().accept_offer(offer)?;
@@ -210,7 +210,7 @@ pub fn test_h264_keyframes_detection() -> Result<(), RtcError> {
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();
-    let mid = change.add_media(MediaKind::Video, Direction::SendOnly, None, None);
+    let mid = change.add_media(MediaKind::Video, Direction::SendOnly, None, None, None);
     let (offer, pending) = change.apply().unwrap();
 
     let answer = r.rtc.sdp_api().accept_offer(offer)?;

--- a/tests/remb.rs
+++ b/tests/remb.rs
@@ -26,7 +26,7 @@ pub fn remb() -> Result<(), RtcError> {
     r.add_local_candidate(host2);
 
     let mid = negotiate(&mut l, &mut r, |change| {
-        change.add_media(MediaKind::Video, Direction::SendOnly, None, None)
+        change.add_media(MediaKind::Video, Direction::SendOnly, None, None, None)
     });
 
     loop {

--- a/tests/rtp-direct-mid-rid.rs
+++ b/tests/rtp-direct-mid-rid.rs
@@ -29,7 +29,7 @@ pub fn rtp_direct_mid_rid() -> Result<(), RtcError> {
 
     r.direct_api()
         .declare_media(mid, MediaKind::Audio)
-        .expect_rid(rid);
+        .expect_rid_rx(rid);
 
     let max = l.last.max(r.last);
     l.last = max;

--- a/tests/rtx-cache-0.rs
+++ b/tests/rtx-cache-0.rs
@@ -32,7 +32,7 @@ pub fn rtx_cache_0() -> Result<(), RtcError> {
 
     r.direct_api()
         .declare_media(mid, MediaKind::Audio)
-        .expect_rid(rid);
+        .expect_rid_rx(rid);
 
     let max = l.last.max(r.last);
     l.last = max;

--- a/tests/sdp-negotiation.rs
+++ b/tests/sdp-negotiation.rs
@@ -172,7 +172,7 @@ pub fn answer_different_pt_to_offer() {
     assert_eq!(&[vp8(96)], &**r.codec_config());
 
     let mut change = r.sdp_api();
-    change.add_media(MediaKind::Video, Direction::SendOnly, None, None);
+    change.add_media(MediaKind::Video, Direction::SendOnly, None, None, None);
     let (offer, _pending) = change.apply().unwrap();
 
     let sdp = offer.to_sdp_string();
@@ -332,7 +332,7 @@ fn non_media_creator_cannot_change_inactive_to_recvonly() {
     );
 
     negotiate(&mut l, &mut r, |change| {
-        change.add_media(MediaKind::Video, Direction::Inactive, None, None);
+        change.add_media(MediaKind::Video, Direction::Inactive, None, None, None);
     });
     let mid = r._mids()[0];
     let m_r = r.media(mid).unwrap();
@@ -367,7 +367,7 @@ fn media_creator_can_change_inactive_to_recvonly() {
     );
 
     negotiate(&mut l, &mut r, |change| {
-        change.add_media(MediaKind::Video, Direction::Inactive, None, None);
+        change.add_media(MediaKind::Video, Direction::Inactive, None, None, None);
     });
     let mid = r._mids()[0];
     let m_r = r.media(mid).unwrap();
@@ -400,7 +400,7 @@ fn with_params(
         .unwrap_or(MediaKind::Audio);
 
     negotiate(&mut l, &mut r, |change| {
-        change.add_media(kind, Direction::SendRecv, None, None);
+        change.add_media(kind, Direction::SendRecv, None, None, None);
     });
 
     (l, r)
@@ -411,7 +411,7 @@ fn with_exts(exts_l: ExtensionMap, exts_r: ExtensionMap) -> (TestRtc, TestRtc) {
     let mut r = build_exts(info_span!("R"), exts_r);
 
     negotiate(&mut l, &mut r, |change| {
-        change.add_media(MediaKind::Video, Direction::SendRecv, None, None);
+        change.add_media(MediaKind::Video, Direction::SendRecv, None, None, None);
     });
 
     (l, r)

--- a/tests/stats.rs
+++ b/tests/stats.rs
@@ -27,7 +27,7 @@ pub fn stats() -> Result<(), RtcError> {
     r.add_local_candidate(host2);
 
     let mut change = l.sdp_api();
-    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None);
+    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
     let (offer, pending) = change.apply().unwrap();
 
     let answer = r.rtc.sdp_api().accept_offer(offer)?;

--- a/tests/twcc.rs
+++ b/tests/twcc.rs
@@ -27,7 +27,7 @@ pub fn twcc() -> Result<(), RtcError> {
     r.add_local_candidate(host2);
 
     let mid = negotiate(&mut l, &mut r, |change| {
-        change.add_media(MediaKind::Video, Direction::SendOnly, None, None)
+        change.add_media(MediaKind::Video, Direction::SendOnly, None, None, None)
     });
 
     loop {

--- a/tests/unidirectional-r-create-media.rs
+++ b/tests/unidirectional-r-create-media.rs
@@ -25,7 +25,7 @@ pub fn unidirectional_r_create_media() -> Result<(), RtcError> {
 
     // The change is on the R (not sending side) with Direction::RecvOnly.
     let mut change = r.sdp_api();
-    let mid = change.add_media(MediaKind::Audio, Direction::RecvOnly, None, None);
+    let mid = change.add_media(MediaKind::Audio, Direction::RecvOnly, None, None, None);
     let (offer, pending) = change.apply().unwrap();
 
     // str0m always produces a=ssrc lines, also for RecvOnly (since direction can change).

--- a/tests/unidirectional.rs
+++ b/tests/unidirectional.rs
@@ -24,7 +24,7 @@ pub fn unidirectional() -> Result<(), RtcError> {
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();
-    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None);
+    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
     let (offer, pending) = change.apply().unwrap();
 
     let answer = r.rtc.sdp_api().accept_offer(offer)?;

--- a/tests/user-rtp-header-extension.rs
+++ b/tests/user-rtp-header-extension.rs
@@ -89,7 +89,7 @@ pub fn user_rtp_header_extension() -> Result<(), RtcError> {
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();
-    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None);
+    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
     let (offer, pending) = change.apply().unwrap();
     let offer_str = offer.to_sdp_string();
     let offer_parsed =
@@ -232,7 +232,7 @@ pub fn user_rtp_header_extension_two_byte_form() -> Result<(), RtcError> {
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();
-    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None);
+    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
     let (offer, pending) = change.apply().unwrap();
 
     let answer = r.rtc.sdp_api().accept_offer(offer)?;


### PR DESCRIPTION
Adds support for specifying the RID when writing packets to str0m as well as for serialization of the VLA extended header.

There are a couple points that need to be resolved:
* Carrying the active/inactive state of streams from simulcast specification (adding the media) to when the SDP is created
* A couple of the VLA tests I wasn't sure about. Specifically the one that I did convert add the bidirectional serialization to (it says 3 active streams but it has no active spatial layers, which would end up being condensed to the shared bitmask)