### PR TITLE
Refactor internal tuple MidRid

### DIFF
--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -1,6 +1,7 @@
 use crate::channel::ChannelId;
 use crate::crypto::Fingerprint;
 use crate::media::{Media, MediaKind};
+use crate::rtp_::MidRid;
 use crate::rtp_::{Mid, Rid, Ssrc};
 use crate::sctp::ChannelConfig;
 use crate::streams::{StreamRx, StreamTx, DEFAULT_RTX_CACHE_DURATION, DEFAULT_RTX_RATIO_CAP};
@@ -187,10 +188,12 @@ impl<'a> DirectApi<'a> {
         // By default we do not suppress nacks, this has to be called explicitly by the user of direct API.
         let suppress_nack = false;
 
+        let midrid = MidRid(mid, rid);
+
         self.rtc
             .session
             .streams
-            .expect_stream_rx(ssrc, rtx, mid, rid, suppress_nack)
+            .expect_stream_rx(ssrc, rtx, midrid, suppress_nack)
     }
 
     /// Remove the receive stream for the given SSRC.
@@ -211,7 +214,8 @@ impl<'a> DirectApi<'a> {
 
     /// Obtain a recv stream by looking it up via mid/rid.
     pub fn stream_rx_by_mid(&mut self, mid: Mid, rid: Option<Rid>) -> Option<&mut StreamRx> {
-        self.rtc.session.streams.stream_rx_by_mid_rid(mid, rid)
+        let midrid = MidRid(mid, rid);
+        self.rtc.session.streams.stream_rx_by_midrid(midrid)
     }
 
     /// Declare the intention to send data using the given SSRC.
@@ -234,11 +238,13 @@ impl<'a> DirectApi<'a> {
 
         let is_audio = media.kind().is_audio();
 
+        let midrid = MidRid(mid, rid);
+
         let stream = self
             .rtc
             .session
             .streams
-            .declare_stream_tx(ssrc, rtx, mid, rid);
+            .declare_stream_tx(ssrc, rtx, midrid);
 
         let size = if is_audio {
             self.rtc.session.send_buffer_audio
@@ -267,6 +273,7 @@ impl<'a> DirectApi<'a> {
 
     /// Obtain a send stream by looking it up via mid/rid.
     pub fn stream_tx_by_mid(&mut self, mid: Mid, rid: Option<Rid>) -> Option<&mut StreamTx> {
-        self.rtc.session.streams.stream_tx_by_mid_rid(mid, rid)
+        let midrid = MidRid(mid, rid);
+        self.rtc.session.streams.stream_tx_by_midrid(midrid)
     }
 }

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -8,6 +8,7 @@ use crate::format::CodecConfig;
 use crate::io::{Id, DATAGRAM_MTU};
 use crate::packet::{DepacketizingBuffer, Payloader, RtpMeta};
 use crate::rtp_::ExtensionMap;
+use crate::rtp_::MidRid;
 use crate::rtp_::SRTP_BLOCK_SIZE;
 use crate::rtp_::SRTP_OVERHEAD;
 use crate::RtcError;
@@ -390,7 +391,9 @@ impl Media {
 
         let is_audio = self.kind.is_audio();
 
-        let stream = streams.stream_tx_by_mid_rid(self.mid, *rid);
+        let midrid = MidRid(self.mid, *rid);
+
+        let stream = streams.stream_tx_by_midrid(midrid);
 
         let Some(stream) = stream else {
             return Err(RtcError::NoSenderSource);

--- a/src/media/writer.rs
+++ b/src/media/writer.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
 use crate::format::PayloadParams;
+use crate::rtp_::MidRid;
 use crate::rtp_::VideoOrientation;
 use crate::session::Session;
 use crate::RtcError;
@@ -204,10 +205,12 @@ impl<'a> Writer<'a> {
             return Err(RtcError::NotReceivingDirection);
         }
 
+        let midrid = MidRid(self.mid, rid);
+
         let stream = self
             .session
             .streams
-            .stream_rx_by_mid_rid(self.mid, rid)
+            .stream_rx_by_midrid(midrid)
             .ok_or_else(|| RtcError::NoReceiverSource(rid))?;
 
         stream.request_keyframe(kind);

--- a/src/packet/pacer.rs
+++ b/src/packet/pacer.rs
@@ -596,7 +596,7 @@ impl QueueSnapshot {
 mod test {
     use std::time::{Duration, Instant};
 
-    use crate::rtp_::{DataSize, RtpHeader};
+    use crate::rtp_::{DataSize, Mid, RtpHeader};
 
     use super::*;
 

--- a/src/rtp/id.rs
+++ b/src/rtp/id.rs
@@ -262,3 +262,25 @@ impl Pt {
         Pt(v)
     }
 }
+
+/// A combination of Mid/Rid
+///
+/// In many cases they go hand-in-hand.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct MidRid(pub Mid, pub Option<Rid>);
+
+impl MidRid {
+    #[inline(always)]
+    pub fn mid(&self) -> Mid {
+        self.0
+    }
+
+    #[inline(always)]
+    pub fn rid(&self) -> Option<Rid> {
+        self.1
+    }
+
+    pub fn special_equals(&self, other: &MidRid) -> bool {
+        self.0 == other.0 && (self.1.is_none() || self.1 == other.1)
+    }
+}

--- a/src/rtp/mod.rs
+++ b/src/rtp/mod.rs
@@ -3,6 +3,7 @@ use std::io;
 use thiserror::Error;
 
 mod id;
+pub(crate) use id::MidRid;
 pub use id::{Mid, Pt, Rid, SeqNo, SessionId, Ssrc};
 
 mod ext;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -5,6 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use crate::rtp_::MidRid;
 use crate::rtp_::{Mid, Rid};
 use crate::Bitrate;
 
@@ -21,8 +22,8 @@ pub(crate) struct StatsSnapshot {
     pub rx: u64,
     pub egress_loss_fraction: Option<f32>,
     pub ingress_loss_fraction: Option<f32>,
-    pub ingress: HashMap<(Mid, Option<Rid>), MediaIngressStats>,
-    pub egress: HashMap<(Mid, Option<Rid>), MediaEgressStats>,
+    pub ingress: HashMap<MidRid, MediaIngressStats>,
+    pub egress: HashMap<MidRid, MediaEgressStats>,
     pub bwe_tx: Option<Bitrate>,
     timestamp: Instant,
 }


### PR DESCRIPTION
- **Move to MidRid instead of (Mid, Option<Rid>)**
- **Move MidRid to rtp/id**
- **Turn MidRid into a tuple**
- **Use MidRid in many more places**
