### PR TITLE
Fix RIDs bug on updating non-simulcast media

### DIFF
--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -163,12 +163,6 @@ impl Rids {
     }
 }
 
-impl<I: AsRef<[Rid]>> From<I> for Rids {
-    fn from(value: I) -> Self {
-        Rids::Specific(value.as_ref().to_vec())
-    }
-}
-
 #[derive(Debug)]
 pub(crate) struct ToPayload {
     pub pt: Pt,


### PR DESCRIPTION
Fixes https://github.com/algesten/str0m/issues/611

https://github.com/algesten/str0m/commit/425a851a2de2d3af378c15b55d7e9ed16ca6a1b7 added a `From` impl that converted from a slice of RIDs into a `Rids` instance, and unconditionally used it when updating media via SDP. However, this impl did not take into account empty slices, which are naturally produced when simulcast is not in play. This caused non-simulcast tracks to start reporting `Rids::Specific(vec![])` once they were updated by e.g. a direction change.

As the correct `Rids` value on an empty slice depends on whether you're sending or receiving, this PR removes the `From` impl entirely and replaces it with manual conversion while updating media via SDP.