### PR TITLE
Don't retain Receiver Report loss info when stats are disabled

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -131,7 +131,7 @@ impl Session {
         Session {
             id,
             medias: vec![],
-            streams: Streams::default(),
+            streams: Streams::new(config.stats_interval.is_some()),
             app: None,
             reordering_size_audio: config.reordering_size_audio,
             reordering_size_video: config.reordering_size_video,


### PR DESCRIPTION
Fixes https://github.com/algesten/str0m/issues/610

`StreamTxStats` cannot be `Option`'d out entirely if stats reports are disabled, because it's still used for other purposes, e.g. RTX ratio calculation. Trying to split it out into a stats-reports and non-stats-reports portion was also awkward, due to overlap.

Instead, we give it a hint that `fill()` will never be called, which will prevent it from creating a `losses` array at all. Fortunately, bad/missing loss data was already accounted for, so even if it does end up being called, the behavior will still be sane (i.e. no panics, no bogus data).

I also considered a solution that would just put an upper bound on the `losses` array instead, but that had a few downsides:
1. We'd need to decide on overflow behavior, of which I don't have a good opinion.
2. Users that don't need stats would always eat the overhead of a full array, plus overflow behavior.