### PR TITLE
Remove restriction on EC to use on ECDH exchange

### DIFF
--- a/src/crypto/ossl/dtls.rs
+++ b/src/crypto/ossl/dtls.rs
@@ -2,8 +2,6 @@ use std::collections::VecDeque;
 use std::io::{self, Read, Write};
 use std::time::{Duration, Instant};
 
-use openssl::ec::EcKey;
-use openssl::nid::Nid;
 use openssl::ssl::{Ssl, SslContext, SslContextBuilder, SslMethod, SslOptions, SslVerifyMode};
 
 use crate::crypto::dtls::DtlsInner;
@@ -15,8 +13,7 @@ use super::io_buf::IoBuffer;
 use super::stream::TlsStream;
 use super::CryptoError;
 
-const DTLS_CIPHERS: &str = "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
-const DTLS_EC_CURVE: Nid = Nid::X9_62_PRIME256V1;
+const DTLS_CIPHERS: &str = "ECDHE+AESGCM:DHE+AESGCM:ECDHE+AES256:DHE+AES256";
 
 pub struct OsslDtlsImpl {
     /// Certificate for the DTLS session.
@@ -170,9 +167,5 @@ pub fn dtls_create_ctx(cert: &OsslDtlsCert) -> Result<SslContext, CryptoError> {
 pub fn dtls_ssl_create(ctx: &SslContext) -> Result<Ssl, CryptoError> {
     let mut ssl = Ssl::new(ctx)?;
     ssl.set_mtu(DATAGRAM_MTU as u32)?;
-
-    let eckey = EcKey::from_curve_name(DTLS_EC_CURVE)?;
-    ssl.set_tmp_ecdh(&eckey)?;
-
     Ok(ssl)
 }

--- a/src/crypto/ossl/dtls.rs
+++ b/src/crypto/ossl/dtls.rs
@@ -13,6 +13,8 @@ use super::io_buf::IoBuffer;
 use super::stream::TlsStream;
 use super::CryptoError;
 
+// We restrict cipher suites to those that include ephermeral Diffie-Hellman or ephemeral
+// Elliptical Curve Diffie-Hellman AND AES-256 or AES-GCM.
 const DTLS_CIPHERS: &str = "ECDHE+AESGCM:DHE+AESGCM:ECDHE+AES256:DHE+AES256";
 
 pub struct OsslDtlsImpl {


### PR DESCRIPTION
Str0m cannot complete a DTLS handshake with a peer using a certificate signed with an secp384r1 key. The DTLS server hello indicates that that key is supported, however, Str0m (when using openssl) will reject fail the DTLS handshake. The issue is that Str0m is restricting OpenSSL to only use/accept the secp256r1 EC.

---- More details ----

set_tmp_ecdh() is deprecated in OpenSSL, and under the covers will call set_groups() with the EC group of the provided key. This restricts our session to the one given EC group (secp256r1/PRIME256V1 in the code) [See https://github.com/openssl/openssl/discussions/23070#discussioncomment-7885148]. This prevents session establishment with DTLS implementations using secp384r1 or another valid EC.

By simply removing the call, we are allowing OpenSSL to decide which ECs to support. Which is at least: x25519, secp256r1 (prime256v1), secp521r1, and secp384r1.

The upside is that we let OpenSSL manage which EC are "safe" to use. The downside is that we rely on OpenSSL maintaining the default as a safe list, should weaknesses be discovered in the ECs.