### PR TITLE
Avoid calls std::env::set_var to configure EnvFilter.

### DIFF
--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -23,16 +23,14 @@ use str0m::{net::Receive, Candidate, Event, IceConnectionState, Input, Output, R
 mod util;
 
 fn init_log() {
-    use std::env;
     use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-    if env::var("RUST_LOG").is_err() {
-        env::set_var("RUST_LOG", "chat=info,str0m=info");
-    }
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("chat=info,str0m=info"));
 
     tracing_subscriber::registry()
         .with(fmt::layer())
-        .with(EnvFilter::from_default_env())
+        .with(env_filter)
         .init();
 }
 
@@ -50,7 +48,7 @@ pub fn main() {
     // Spin up a UDP socket for the RTC. All WebRTC traffic is going to be multiplexed over this single
     // server socket. Clients are identified via their respective remote (UDP) socket address.
     let socket = UdpSocket::bind(format!("{host_addr}:0")).expect("binding a random UDP port");
-    let addr = socket.local_addr().expect("a local socket adddress");
+    let addr = socket.local_addr().expect("a local socket address");
     info!("Bound UDP port: {}", addr);
 
     // The run loop is on a separate thread to the web server.

--- a/examples/http-post.rs
+++ b/examples/http-post.rs
@@ -18,16 +18,14 @@ use str0m::{Candidate, Event, IceConnectionState, Input, Output, Rtc, RtcError};
 mod util;
 
 fn init_log() {
-    use std::env;
     use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-    if env::var("RUST_LOG").is_err() {
-        env::set_var("RUST_LOG", "http_post=debug,str0m=debug");
-    }
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("http_post=debug,str0m=debug"));
 
     tracing_subscriber::registry()
         .with(fmt::layer())
-        .with(EnvFilter::from_default_env())
+        .with(env_filter)
         .init();
 }
 
@@ -65,7 +63,7 @@ fn web_request(request: &Request) -> Response {
 
     // Spin up a UDP socket for the RTC
     let socket = UdpSocket::bind(format!("{addr}:0")).expect("binding a random UDP port");
-    let addr = socket.local_addr().expect("a local socket adddress");
+    let addr = socket.local_addr().expect("a local socket address");
     let candidate = Candidate::host(addr, "udp").expect("a host candidate");
     rtc.add_local_candidate(candidate);
 

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -576,12 +576,10 @@ mod test {
     }
 
     // pub fn init_log() {
-    //     use std::env;
     //     use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-    //     if env::var("RUST_LOG").is_err() {
-    //         env::set_var("RUST_LOG", "trace");
-    //     }
+    //     let env_filter =
+    //         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("trace"));
 
     //     tracing_subscriber::registry()
     //         .with(fmt::layer())

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -202,19 +202,16 @@ impl DerefMut for TestRtc {
 }
 
 pub fn init_log() {
-    use std::env;
     use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-    if env::var("RUST_LOG").is_err() {
-        env::set_var("RUST_LOG", "debug");
-    }
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug"));
 
     static START: Once = Once::new();
 
     START.call_once(|| {
         tracing_subscriber::registry()
             .with(fmt::layer())
-            .with(EnvFilter::from_default_env())
+            .with(env_filter)
             .init();
     });
 }


### PR DESCRIPTION
Rust 2024 treats `std::env::set_var` as unsafe function and it is possible to avoid it using direct log filter configuration API.