### PR TITLE
Optional integrity on STUN messages

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -917,7 +917,7 @@ impl IceAgent {
 
         let do_integrity_check = |is_request: bool| -> bool {
             let (_, password) = self.stun_credentials(is_request);
-            let integrity_passed = message.check_integrity(&password);
+            let integrity_passed = message.verify(password.as_bytes());
 
             // The integrity is always the last thing we check
             if integrity_passed {
@@ -1449,7 +1449,7 @@ impl IceAgent {
         let mut buf = vec![0_u8; DATAGRAM_MTU];
 
         let n = reply
-            .to_bytes(&password, &mut buf)
+            .to_bytes(Some(password.as_bytes()), &mut buf)
             .expect("IO error writing STUN reply");
         buf.truncate(n);
 
@@ -1496,7 +1496,7 @@ impl IceAgent {
         let mut buf = vec![0_u8; DATAGRAM_MTU];
 
         let n = binding
-            .to_bytes(&password, &mut buf)
+            .to_bytes(Some(password.as_bytes()), &mut buf)
             .expect("IO error writing STUN reply");
         buf.truncate(n);
 
@@ -2172,7 +2172,7 @@ mod test {
         let mut buf = vec![0_u8; DATAGRAM_MTU];
 
         let n = msg
-            .to_bytes(password, &mut buf)
+            .to_bytes(Some(password.as_bytes()), &mut buf)
             .expect("IO error writing STUN message");
         buf.truncate(n);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -606,6 +606,7 @@
 #![allow(clippy::get_first)]
 #![allow(clippy::needless_lifetimes)]
 #![allow(clippy::precedence)]
+#![allow(clippy::doc_overindented_list_items)]
 #![deny(missing_docs)]
 
 #[macro_use]


### PR DESCRIPTION
In some situations, for example before TURN allocation it's not possible to construct a valid `MESSAGE-INTEGRITY` attribute, therefore we need to make this possible.

Designwise I've initially made the password optional on `to_bytes`, but an alternate approach that I prefer is

```rust
    pub fn to_bytes(self, password: &str, buf: &mut [u8]) -> Result<usize, StunError> {
      self.to_bytes_internal(Some(password), buf)
    }

    pub fn to_bytes_no_auth(buf: &mut [u8]) -> Result<usize, StunError> {
      self.to_bytes_internal(Some(password), buf)
    }
```

The detailed example section from the TURN RFC is useful as an example of the flow https://datatracker.ietf.org/doc/html/rfc5766#autoid-55