### PR TITLE
feat(ice): prefer relayed connections within the same IP version

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -528,7 +528,7 @@ impl IceAgent {
                 ServerReflexive => 32_767,
                 Relayed => 16_383,
             };
-            x - (if ip.is_ipv6() { 0 } else { 1 })
+            x - if ip.is_ipv6() { 0 } else { 1 }
         };
 
         // Count the number of existing candidates of the same kind.

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1766,8 +1766,6 @@ impl IceAgent {
 #[cfg(test)]
 mod test {
 
-    use crate::ice_::test::relay;
-
     use super::*;
     use std::net::SocketAddr;
 
@@ -2163,38 +2161,6 @@ mod test {
         );
 
         assert!(agent.poll_transmit().is_none());
-    }
-
-    #[test]
-    fn relayed_candidates_across_ip_versions_have_lower_priority() {
-        let mut agent = IceAgent::new();
-
-        let relay_ipv4_ipv4 = relay("1.1.1.1:0", "udp", "2.2.2.2:0");
-        let relay_ipv4_ipv6 = relay("1.1.1.1:1", "udp", "[::1]:0");
-        let relay_ipv6_ipv4 = relay("[::1]:0", "udp", "1.1.1.1:0");
-        let relay_ipv6_ipv6 = relay("[::1]:1", "udp", "[::2]:0");
-
-        agent.add_local_candidate(relay_ipv4_ipv4.clone());
-        agent.add_local_candidate(relay_ipv6_ipv6.clone());
-        agent.add_local_candidate(relay_ipv4_ipv6.clone());
-        agent.add_local_candidate(relay_ipv6_ipv4.clone());
-
-        let extract_candidate = |c: &Candidate| {
-            agent
-                .local_candidates()
-                .iter()
-                .find(|cand| cand.addr() == c.addr())
-                .unwrap()
-        };
-
-        let relay_ipv4_ipv4 = extract_candidate(&relay_ipv4_ipv4);
-        let relay_ipv4_ipv6 = extract_candidate(&relay_ipv4_ipv6);
-        let relay_ipv6_ipv4 = extract_candidate(&relay_ipv6_ipv4);
-        let relay_ipv6_ipv6 = extract_candidate(&relay_ipv6_ipv6);
-
-        assert!(relay_ipv6_ipv6.prio() > relay_ipv4_ipv4.prio());
-        assert!(relay_ipv4_ipv4.prio() > relay_ipv4_ipv6.prio());
-        assert!(relay_ipv4_ipv4.prio() > relay_ipv6_ipv4.prio());
     }
 
     fn make_serialized_binding_request(

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1765,7 +1765,6 @@ impl IceAgent {
 
 #[cfg(test)]
 mod test {
-    use tracing_subscriber::util::SubscriberInitExt;
 
     use crate::ice_::test::relay;
 

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -418,10 +418,15 @@ impl Candidate {
             return local;
         }
 
-        if self.addr.is_ipv6() {
-            65_535
-        } else {
-            65_534
+        let Some(relay_base) = self.relay_base else {
+            return if self.addr.is_ipv6() { 65_535 } else { 65_534 };
+        };
+
+        match (self.addr, relay_base) {
+            (SocketAddr::V6(_), SocketAddr::V6(_)) => 60_000,
+            (SocketAddr::V4(_), SocketAddr::V4(_)) => 50_000,
+            (SocketAddr::V4(_), SocketAddr::V6(_)) => 40_000,
+            (SocketAddr::V6(_), SocketAddr::V4(_)) => 40_000,
         }
     }
 

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -227,7 +227,7 @@ impl Candidate {
     ///
     /// ICE generally prefers IPv6 over IPv4, meaning an IPv6 address sent to from an IPv4 base
     /// may be preferred over the IPv4 address on the same allocation.
-    /// In order to avoid conversions across IP versions, we take into account this `base` address
+    /// In order to avoid conversions across IP versions, we take into account this address
     /// as part of priority calculation.
     pub fn relayed(
         addr: SocketAddr,

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -745,6 +745,18 @@ mod tests {
         assert!(candidates[5].contains("host"));
     }
 
+    #[test]
+    fn relay_candidate_priorities_across_ip_versions() {
+        let relay_ipv4_ipv4 = relay_c("1.1.1.1:0", "2.2.2.2:0");
+        let relay_ipv4_ipv6 = relay_c("1.1.1.1:0", "[::1]:0");
+        let relay_ipv6_ipv4 = relay_c("[::1]:0", "1.1.1.1:0");
+        let relay_ipv6_ipv6 = relay_c("[::1]:0", "[::2]:0");
+
+        assert!(relay_ipv6_ipv6.prio() > relay_ipv4_ipv4.prio());
+        assert!(relay_ipv4_ipv4.prio() > relay_ipv4_ipv6.prio());
+        assert!(relay_ipv4_ipv4.prio() > relay_ipv6_ipv4.prio());
+    }
+
     fn host(socket: &str) -> String {
         Candidate::host(socket.parse().unwrap(), "udp")
             .unwrap()

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -57,7 +57,7 @@ pub struct Candidate {
     ///
     /// TURN allows a client to allocate IPv4 and IPv6 addresses in a single allocation.
     /// Thus, a client may send traffic over IPv4 to an IPv6 peer.
-    /// In order to avoid conversions across IP versions, we take into account this `base` address when calculating the priority.
+    /// In order to avoid conversions across IP versions, we take into account this address when calculating the priority.
     local_turn_socket: Option<SocketAddr>,
 
     /// Type of candidate.

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -383,8 +383,15 @@ impl Candidate {
     }
 
     pub(crate) fn local_preference(&self) -> u32 {
-        self.local_preference
-            .unwrap_or_else(|| if self.addr.is_ipv6() { 65_535 } else { 65_534 })
+        if let Some(local) = self.local_preference {
+            return local;
+        }
+
+        if self.addr.is_ipv6() {
+            65_535
+        } else {
+            65_534
+        }
     }
 
     pub(crate) fn component_id(&self) -> u16 {

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -688,7 +688,7 @@ mod tests {
         let candidate = Candidate::relayed(socket_addr, Protocol::SslTcp, socket_addr).unwrap();
         assert_eq!(
             no_hash(candidate.to_string()),
-            "candidate:--- 1 ssltcp 16776959 1.2.3.4 9876 typ relay raddr 0.0.0.0 rport 0"
+            "candidate:--- 1 ssltcp 7680255 1.2.3.4 9876 typ relay raddr 0.0.0.0 rport 0"
         );
     }
 

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -94,8 +94,12 @@ mod test {
         Candidate::server_reflexive(sock(s), sock(base), proto).unwrap()
     }
 
-    pub fn relay(s: impl Into<String>, proto: impl TryInto<Protocol>) -> Candidate {
-        Candidate::relayed(sock(s), proto).unwrap()
+    pub fn relay(
+        s: impl Into<String>,
+        proto: impl TryInto<Protocol>,
+        b: impl Into<String>,
+    ) -> Candidate {
+        Candidate::relayed(sock(s), proto, sock(b)).unwrap()
     }
 
     /// Transform the socket to rig different test scenarios.
@@ -677,7 +681,7 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = relay("1.1.1.1:1000", "udp");
+        let c1 = relay("1.1.1.1:1000", "udp", "2.2.2.2:1000");
         a1.add_local_candidate(c1.clone());
         a2.add_remote_candidate(c1);
         let c2 = srflx("4.4.4.4:1000", "3.3.3.3:1000", "udp");
@@ -698,8 +702,8 @@ mod test {
             progress(&mut a1, &mut a2);
         }
 
-        a1.add_local_candidate(relay("1.1.1.1:1001", "udp"));
-        a2.add_remote_candidate(relay("1.1.1.1:1001", "udp"));
+        a1.add_local_candidate(relay("1.1.1.1:1001", "udp", "5.5.5.5:1001"));
+        a2.add_remote_candidate(relay("1.1.1.1:1001", "udp", "5.5.5.5:1001"));
 
         loop {
             if a2.has_event(|e| {
@@ -728,8 +732,8 @@ mod test {
         let c2 = host("1.1.1.1:1001", "udp");
 
         // We need a 2nd pair of candidates to make sure the agent doesn't go straight into `Completed`.
-        let c3 = relay("2.2.2.2:1000", "udp");
-        let c4 = relay("2.2.2.2:1001", "udp");
+        let c3 = relay("2.2.2.2:1000", "udp", "5.5.5.5:1000");
+        let c4 = relay("2.2.2.2:1001", "udp", "5.5.5.5:1001");
 
         // Agent 1 knows all candidates ahead of time.
         a1.add_local_candidate(c1.clone());


### PR DESCRIPTION
When calculating preferences for candidates, we currently always prefer IPv6 over IPv4. This can lead to sub-optimal situations when a connection ends up using a TURN server.

TURN allows a client to allocate an IPv4 and an IPv6 address in the same allocation. This makes it possible for e.g. an IPv4-only client to connect to an IPv6-only peer as long as the TURN server runs in dual-stack AND the client requests an IPv6 address in addition to an IPv4 address with the `ADDITIONAL-ADDRESS-FAMILY` attribute.

Assume that a client sits behind symmetric NAT and therefore needs to rely on a TURN server to communicate with its peers. The TURN server as well as all the other peers operate in dual-stack mode.

The current priority calculation will yield a communication path that uses IPv4 to talk to the TURN server (as that is the only one available) but due to the preference ordering of IPv6 over IPv4, will use an IPv6 path to the peer, despite the peer also supporting IPv4.

This isn't a problem per-se but makes (our) life unnecessarily difficult. We operate a fleet of TURN servers that use eBPF to efficiently deal with TURN's channel-data messages. Channel-data messages are just UDP packets with a 4 byte header. Adding / removing that is easy enough to do within an eBPF program, allowing for much greater throughput than copying bytes from kernel space to user space and back.

This doesn't work though if we need to also convert from IPv4 to IPv6 or vice versa. It is not technically impossible but more challenging to implement because we also need to translate the IP header from one version to the other instead of just updating source and destination addresses.

This patch extends the `Candidate::relayed` constructor to also take a `local_turn_socket` address which is - similar to the `base` address of other candidate types - the address the client is sending from in order to use this candidate. In the context of relayed candidates, this is the address the client is using to talk to the TURN server. We can use this information in the candidate's priority calculation to prefer candidates that allow traffic to remain within one IP version, i.e. if the client talks to the TURN server over IPv4, the allocated IPv4 address on the TURN server will have a higher priority than the allocated IPv6 address.

In addition to this priority calculation, we also patch the `add_local_candidate`. In there, we currently compute a fixed `local_preference` which - when set on the candidate - opts out of the priority calculation within `Candidate`.

Staying within the same IP version whilst relaying traffic allows our TURN servers to use their eBPF kernel which results in a much better UX due to lower latency and higher throughput.

In general, I'd consider the ability of TURN servers to translate between IP versions as a fallback mechanism. A kind of "last resort" way of establishing a connection if all else fails. But for that to be true, we need to take into account the base address that we are using to talk to the TURN server, otherwise IPv6 network paths will always win over the IPv4 one.