### PR TITLE
Add start of talkspurt for sample writer

### DIFF
--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -169,6 +169,7 @@ pub(crate) struct ToPayload {
     pub rid: Option<Rid>,
     pub wallclock: Instant,
     pub rtp_time: MediaTime,
+    pub start_of_talk_spurt: bool,
     pub data: Vec<u8>,
     pub ext_vals: ExtensionValues,
 }

--- a/src/media/writer.rs
+++ b/src/media/writer.rs
@@ -18,6 +18,7 @@ pub struct Writer<'a> {
     session: &'a mut Session,
     mid: Mid,
     rid: Option<Rid>,
+    start_of_talkspurt: Option<bool>,
     ext_vals: ExtensionValues,
 }
 
@@ -30,6 +31,7 @@ impl<'a> Writer<'a> {
             session,
             mid,
             rid: None,
+            start_of_talkspurt: None,
             ext_vals: ExtensionValues::default(),
         }
     }
@@ -75,6 +77,16 @@ impl<'a> Writer<'a> {
     pub fn audio_level(mut self, audio_level: i8, voice_activity: bool) -> Self {
         self.ext_vals.audio_level = Some(audio_level);
         self.ext_vals.voice_activity = Some(voice_activity);
+        self
+    }
+
+    /// First packet of a talkspurt, that is the first packet after a silence period during
+    /// which packets have not been transmitted contiguously.
+    ///
+    /// For audio only when dtx or silence suppression is enabled.
+    /// This will set the marker bit in the RTP header.
+    pub fn start_of_talkspurt(mut self, start_of_talkspurt: bool) -> Self {
+        self.start_of_talkspurt = Some(start_of_talkspurt);
         self
     }
 
@@ -151,6 +163,7 @@ impl<'a> Writer<'a> {
             wallclock,
             rtp_time,
             data,
+            start_of_talk_spurt: self.start_of_talkspurt.unwrap_or(false),
             ext_vals: self.ext_vals,
         };
 

--- a/src/packet/payload.rs
+++ b/src/packet/payload.rs
@@ -32,6 +32,7 @@ impl Payloader {
             wallclock,
             rtp_time,
             data,
+            start_of_talk_spurt,
             ext_vals,
             ..
         } = to_payload;
@@ -43,7 +44,8 @@ impl Payloader {
             let last = idx == len - 1;
 
             let previous_data = stream.last_packet();
-            let marker = self.pack.is_marker(data.as_slice(), previous_data, last);
+            let marker = self.pack.is_marker(data.as_slice(), previous_data, last)
+                || (is_audio && start_of_talk_spurt);
 
             let seq_no = stream.next_seq_no();
 


### PR DESCRIPTION
This is a proposal for implementing "start of talkspurt" support in the sample writer for use with DTX (Discontinuous Transmission) or silence suppression.

**Usage:**  
When running a client with str0m and using Opus with DTX enabled, the `start_of_talkspurt` (marker bit) should be set after periods of DTX. This indicates to the receiver that the next packet marks the beginning of a new talkspurt.

This signaling is important for jitter buffers, as it allows them to detect the end of silence periods and adjust their size accordingly.