### PR TITLE
increase ufrag length to 16

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -239,9 +239,7 @@ impl IceCreds {
         // checks.  The values MUST be unguessable, with at least 128 bits of
         // random number generator output used to generate the password, and
         // at least 24 bits of output to generate the username fragment.
-        //
-        // Chrome demands lengths for ufrag 4 and pass 22.
-        let ufrag = Id::<4>::random().to_string();
+        let ufrag = Id::<16>::random().to_string();
         let pass = Id::<22>::random().to_string();
         IceCreds { ufrag, pass }
     }


### PR DESCRIPTION
## Description

the motivation is to reduce ufrag collision in demuxer, allowing a very efficient simple lookup to find the related rtc instance.

16 characters because it matches with uuid4.
Google Meet uses even a larger ufrag of 28 chars, a=ice-ufrag:Ahc0x4S2M3Y5kQoKAAiKYigCIAEQ

## Extra Note

I removed the Chrome comment, I'm not sure if this is still the case. The ICE transport connected just fine with Chrome. As mentioned above, Google Meet uses even a much large ufrag. I don't have any strong preference between 16 or 28 chars, as long as it's large enough to be most likely unique per SFU life.
