### PR TITLE
Add PeerStats::rtt

### DIFF
--- a/src/rtp/rtcp/twcc.rs
+++ b/src/rtp/rtcp/twcc.rs
@@ -1267,6 +1267,11 @@ impl TwccSendRegister {
 
         Some((lost as f32) / (total as f32))
     }
+
+    /// Calculate the RTT for the most recently reported packet.
+    pub fn rtt(&self) -> Option<Duration> {
+        self.queue.iter().rev().find_map(|s| s.rtt())
+    }
 }
 
 #[derive()]

--- a/src/session.rs
+++ b/src/session.rs
@@ -824,6 +824,7 @@ impl Session {
         snapshot.bwe_tx = self.bwe.as_ref().and_then(|bwe| bwe.last_estimate());
 
         snapshot.egress_loss_fraction = self.twcc_tx_register.loss(Duration::from_secs(1), now);
+        snapshot.rtt = self.twcc_tx_register.rtt();
         snapshot.ingress_loss_fraction = self.twcc_rx_register.loss();
     }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -23,6 +23,7 @@ pub(crate) struct StatsSnapshot {
     pub rx: u64,
     pub egress_loss_fraction: Option<f32>,
     pub ingress_loss_fraction: Option<f32>,
+    pub rtt: Option<Duration>,
     pub ingress: HashMap<MidRid, MediaIngressStats>,
     pub egress: HashMap<MidRid, MediaEgressStats>,
     pub bwe_tx: Option<Bitrate>,
@@ -41,6 +42,7 @@ impl StatsSnapshot {
             ingress_loss_fraction: None,
             ingress: HashMap::new(),
             egress: HashMap::new(),
+            rtt: None,
             bwe_tx: None,
             selected_candidate_pair: None,
             timestamp,
@@ -78,6 +80,8 @@ pub struct PeerStats {
     pub egress_loss_fraction: Option<f32>,
     /// The ingress loss since the last stats event.
     pub ingress_loss_fraction: Option<f32>,
+    /// The most recent RTT since the last stats event.
+    pub rtt: Option<Duration>,
     /// The selected ICE candidate pair, if any.
     pub selected_candidate_pair: Option<CandidatePairStats>,
 }
@@ -256,6 +260,7 @@ impl Stats {
             bwe_tx: snapshot.bwe_tx,
             egress_loss_fraction: snapshot.egress_loss_fraction,
             ingress_loss_fraction: snapshot.ingress_loss_fraction,
+            rtt: snapshot.rtt,
             selected_candidate_pair: snapshot.selected_candidate_pair.clone(),
         };
 


### PR DESCRIPTION
Add RTT reporting at the `Rtc` level. This value will contain the most recent RTT based on TWCC feedback.