### PR TITLE
fix(ice): bust cached timeout values on timing config change

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -333,6 +333,8 @@ impl IceAgent {
         self.timing_config.initial_rto = timeout;
 
         tracing::debug!("initial_rto = {timeout:?}");
+
+        self.bust_candidate_pair_timeout_caches();
     }
 
     /// Sets the maximum STUN **R**etransmission **T**ime**O**ut.
@@ -346,6 +348,8 @@ impl IceAgent {
         self.timing_config.max_rto = timeout;
 
         tracing::debug!("max_rto = {timeout:?}");
+
+        self.bust_candidate_pair_timeout_caches();
     }
 
     /// Sets the maximum number of retransmits for STUN messages.
@@ -355,6 +359,12 @@ impl IceAgent {
         self.timing_config.max_retransmits = num;
 
         tracing::debug!("max_retransmits = {num}");
+    }
+
+    fn bust_candidate_pair_timeout_caches(&mut self) {
+        for pair in self.candidate_pairs.iter_mut() {
+            pair.cached_next_attempt_time = None;
+        }
     }
 
     /// How long we at most tolerate missing replies for a candidate pair before considering it failed.

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -331,6 +331,8 @@ impl IceAgent {
     /// Defaults to 250ms.
     pub fn set_initial_stun_rto(&mut self, timeout: Duration) {
         self.timing_config.initial_rto = timeout;
+
+        tracing::debug!("initial_rto = {timeout:?}");
     }
 
     /// Sets the maximum STUN **R**etransmission **T**ime**O**ut.
@@ -342,6 +344,8 @@ impl IceAgent {
     /// Defaults to 3000ms.
     pub fn set_max_stun_rto(&mut self, timeout: Duration) {
         self.timing_config.max_rto = timeout;
+
+        tracing::debug!("max_rto = {timeout:?}");
     }
 
     /// Sets the maximum number of retransmits for STUN messages.
@@ -349,6 +353,8 @@ impl IceAgent {
     /// Defaults to 9.
     pub fn set_max_stun_retransmits(&mut self, num: usize) {
         self.timing_config.max_retransmits = num;
+
+        tracing::debug!("max_retransmits = {num}");
     }
 
     /// How long we at most tolerate missing replies for a candidate pair before considering it failed.

--- a/src/ice/pair.rs
+++ b/src/ice/pair.rs
@@ -37,7 +37,7 @@ pub struct CandidatePair {
 
     /// The next time we are to do a binding attempt, cached, since we
     /// potentially recalculate this many times per second otherwise.
-    cached_next_attempt_time: Option<Instant>,
+    pub(crate) cached_next_attempt_time: Option<Instant>,
 
     /// Number of remote binding requests we seen for this pair.
     pub(crate) remote_binding_requests: u64,


### PR DESCRIPTION
In Firezone, we dynamically update the timing config of the `IceAgent` to move into a "low-power" mode when we are idling. As soon as we see packets that we need to tunnel, we reset the timing config to ensure we detect connectivity problems in a timely manner.

At present, str0m caches when it needs to next send a binding request and these caches are not cleared when the timing config changes. As such, it may take up to how ever long MAX RTO was set to before str0m actually sends another STUN binding.