### PR TITLE
refactor(ice): return `Candidate` from `add_local_candidate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   * RTT in PeerStats #648
   * Fix off-by-one SDES size calculation #647
   * Increase ufrag size to 16 #646
+  * Change `Rtc::add_local_candidate` and `IceAgent::add_local_candidate` to return the candidate on success #650
 
 # 0.8.0
 

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -86,7 +86,7 @@ fn web_request(request: &Request, addr: SocketAddr, tx: SyncSender<Rtc>) -> Resp
 
     // Add the shared UDP socket as a host candidate
     let candidate = Candidate::host(addr, "udp").expect("a host candidate");
-    rtc.add_local_candidate(candidate);
+    rtc.add_local_candidate(candidate).unwrap();
 
     // Create an SDP Answer.
     let answer = rtc

--- a/examples/http-post.rs
+++ b/examples/http-post.rs
@@ -65,7 +65,7 @@ fn web_request(request: &Request) -> Response {
     let socket = UdpSocket::bind(format!("{addr}:0")).expect("binding a random UDP port");
     let addr = socket.local_addr().expect("a local socket address");
     let candidate = Candidate::host(addr, "udp").expect("a host candidate");
-    rtc.add_local_candidate(candidate);
+    rtc.add_local_candidate(candidate).unwrap();
 
     // Create an SDP Answer.
     let answer = rtc

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1824,10 +1824,18 @@ mod test {
     fn local_preference_host() {
         let mut agent = IceAgent::new();
 
-        agent.add_local_candidate(Candidate::host(ipv4_1(), "udp").unwrap());
-        agent.add_local_candidate(Candidate::host(ipv6_1(), "udp").unwrap());
-        agent.add_local_candidate(Candidate::host(ipv6_2(), "udp").unwrap());
-        agent.add_local_candidate(Candidate::host(ipv4_2(), "udp").unwrap());
+        agent
+            .add_local_candidate(Candidate::host(ipv4_1(), "udp").unwrap())
+            .unwrap();
+        agent
+            .add_local_candidate(Candidate::host(ipv6_1(), "udp").unwrap())
+            .unwrap();
+        agent
+            .add_local_candidate(Candidate::host(ipv6_2(), "udp").unwrap())
+            .unwrap();
+        agent
+            .add_local_candidate(Candidate::host(ipv4_2(), "udp").unwrap())
+            .unwrap();
 
         let v: Vec<_> = agent
             .local_candidates
@@ -1859,7 +1867,7 @@ mod test {
         let host = Candidate::host(ipv4_1(), "udp").unwrap();
         let srflx = Candidate::server_reflexive(ipv4_1(), ipv4_1(), "udp").unwrap();
 
-        agent.add_local_candidate(host.clone());
+        agent.add_local_candidate(host.clone()).unwrap();
         let invalidated = agent.invalidate_candidate(&srflx);
         assert!(!invalidated);
 
@@ -1942,11 +1950,17 @@ mod test {
         let mut agent = IceAgent::new();
 
         // local 0
-        agent.add_local_candidate(Candidate::host(ipv4_1(), "udp").unwrap());
+        agent
+            .add_local_candidate(Candidate::host(ipv4_1(), "udp").unwrap())
+            .unwrap();
         // local 1 "udp"
-        agent.add_local_candidate(Candidate::test_peer_rflx(ipv4_4(), ipv4_2(), "udp"));
+        agent
+            .add_local_candidate(Candidate::test_peer_rflx(ipv4_4(), ipv4_2(), "udp"))
+            .unwrap();
         // local 2 "tcp"
-        agent.add_local_candidate(Candidate::host(ipv4_1(), "tcp").unwrap());
+        agent
+            .add_local_candidate(Candidate::host(ipv4_1(), "tcp").unwrap())
+            .unwrap();
 
         // remote 0
         agent.add_remote_candidate(Candidate::test_peer_rflx(ipv4_4(), ipv4_3(), "udp"));
@@ -1974,18 +1988,24 @@ mod test {
 
         agent.add_remote_candidate(Candidate::host(ipv4_3(), "udp").unwrap());
         agent.add_remote_candidate(Candidate::host(ipv4_3(), "tcp").unwrap());
-        agent.add_local_candidate(Candidate::host(ipv4_1(), "udp").unwrap());
+        agent
+            .add_local_candidate(Candidate::host(ipv4_1(), "udp").unwrap())
+            .unwrap();
 
         // the UDP candidates should be pair up.
         assert_eq!(agent.pair_indexes(), [(0, 0)]);
 
         // this local UDP candidate is redundant an won't form a new pair.
-        agent.add_local_candidate(Candidate::test_peer_rflx(ipv4_2(), ipv4_1(), "udp"));
+        agent
+            .add_local_candidate(Candidate::test_peer_rflx(ipv4_2(), ipv4_1(), "udp"))
+            .unwrap();
 
         assert_eq!(agent.pair_indexes(), [(0, 0)]);
 
         // this local TCP candidate will be paired up (This is the 3rd local candidate)
-        agent.add_local_candidate(Candidate::test_peer_rflx(ipv4_2(), ipv4_1(), "tcp"));
+        agent
+            .add_local_candidate(Candidate::test_peer_rflx(ipv4_2(), ipv4_1(), "tcp"))
+            .unwrap();
 
         assert_eq!(agent.pair_indexes(), [(0, 0), (2, 1)]);
     }
@@ -1995,13 +2015,17 @@ mod test {
         let mut agent = IceAgent::new();
 
         agent.add_remote_candidate(Candidate::host(ipv4_3(), "udp").unwrap());
-        agent.add_local_candidate(Candidate::test_peer_rflx(ipv4_2(), ipv4_1(), "udp"));
+        agent
+            .add_local_candidate(Candidate::test_peer_rflx(ipv4_2(), ipv4_1(), "udp"))
+            .unwrap();
 
         assert_eq!(agent.pair_indexes(), [(0, 0)]);
 
         // this local candidate is redundant, but has higher priority than then existing pair.
         // it replaces the existing pair.
-        agent.add_local_candidate(Candidate::host(ipv4_1(), "udp").unwrap());
+        agent
+            .add_local_candidate(Candidate::host(ipv4_1(), "udp").unwrap())
+            .unwrap();
 
         assert_eq!(agent.pair_indexes(), [(1, 0)]);
     }
@@ -2022,7 +2046,9 @@ mod test {
         );
 
         agent.add_remote_candidate(c);
-        agent.add_local_candidate(Candidate::host(ipv4_1(), "udp").unwrap());
+        agent
+            .add_local_candidate(Candidate::host(ipv4_1(), "udp").unwrap())
+            .unwrap();
 
         assert_eq!(agent.pair_indexes(), [(0, 0)]);
 
@@ -2050,7 +2076,7 @@ mod test {
 
         let local = Candidate::test_peer_rflx(ipv4_2(), ipv4_1(), "udp");
 
-        agent.add_local_candidate(local.clone());
+        agent.add_local_candidate(local.clone()).unwrap();
         agent.invalidate_candidate(&local);
 
         agent.add_remote_candidate(Candidate::host(ipv4_3(), "udp").unwrap());
@@ -2068,7 +2094,9 @@ mod test {
         agent.add_remote_candidate(remote.clone());
         agent.invalidate_candidate(&remote);
 
-        agent.add_local_candidate(Candidate::test_peer_rflx(ipv4_2(), ipv4_1(), "udp"));
+        agent
+            .add_local_candidate(Candidate::test_peer_rflx(ipv4_2(), ipv4_1(), "udp"))
+            .unwrap();
 
         // There should be no pairs since we invalidated the local candidate.
         assert_eq!(agent.pair_indexes(), []);
@@ -2077,7 +2105,9 @@ mod test {
     #[test]
     fn poll_time_must_timing_advance() {
         let mut agent = IceAgent::new();
-        agent.add_local_candidate(Candidate::host(ipv4_1(), "udp").unwrap());
+        agent
+            .add_local_candidate(Candidate::host(ipv4_1(), "udp").unwrap())
+            .unwrap();
         agent.add_remote_candidate(Candidate::host(ipv4_3(), "udp").unwrap());
 
         let now1 = Instant::now();
@@ -2116,7 +2146,9 @@ mod test {
         remote_candidate.set_ufrag(&remote_creds.ufrag);
 
         agent.set_remote_credentials(remote_creds.clone());
-        agent.add_local_candidate(Candidate::host(ipv4_1(), "udp").unwrap());
+        agent
+            .add_local_candidate(Candidate::host(ipv4_1(), "udp").unwrap())
+            .unwrap();
         agent.add_remote_candidate(remote_candidate);
         agent.handle_timeout(Instant::now());
 
@@ -2135,7 +2167,9 @@ mod test {
     #[test]
     fn queues_stun_binding_before_remote_creds() {
         let mut agent = IceAgent::new();
-        agent.add_local_candidate(Candidate::host(ipv4_1(), "udp").unwrap());
+        agent
+            .add_local_candidate(Candidate::host(ipv4_1(), "udp").unwrap())
+            .unwrap();
 
         let remote_creds = IceCreds::new();
         let mut remote_candidate = Candidate::host(ipv4_3(), "udp").unwrap();

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -30,16 +30,10 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
 
         // 9999 is just dropped by propagate
-        let c1 = a1
-            .add_local_candidate(host("1.1.1.1:9999", "udp"))
-            .unwrap()
-            .clone();
+        let c1 = a1.add_host_candidate("1.1.1.1:9999");
         a2.add_remote_candidate(c1);
 
-        let c2 = a2
-            .add_local_candidate(host("2.2.2.2:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c2 = a2.add_host_candidate("2.2.2.2:1000");
         a1.add_remote_candidate(c2);
 
         a1.set_controlling(true);
@@ -162,16 +156,10 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = a1
-            .add_local_candidate(host("1.1.1.1:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c1 = a1.add_host_candidate("1.1.1.1:1000");
         a2.add_remote_candidate(c1);
 
-        let c2 = a1
-            .add_local_candidate(host("2.2.2.2:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c2 = a2.add_host_candidate("2.2.2.2:1000");
         a1.add_remote_candidate(c2);
 
         a1.set_controlling(true);
@@ -238,16 +226,10 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = a1
-            .add_local_candidate(host("1.1.1.1:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c1 = a1.add_host_candidate("1.1.1.1:1000");
         a2.add_remote_candidate(c1);
 
-        let c2 = a2
-            .add_local_candidate(host("2.2.2.2:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c2 = a2.add_host_candidate("2.2.2.2:1000");
         a1.add_remote_candidate(c2);
 
         a1.set_controlling(true);
@@ -294,16 +276,10 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
         a2.time = early_now;
 
-        let c1 = a1
-            .add_local_candidate(host("1.1.1.1:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c1 = a1.add_host_candidate("1.1.1.1:1000");
         a2.add_remote_candidate(c1);
 
-        let c2 = a2
-            .add_local_candidate(host("2.2.2.2:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c2 = a2.add_host_candidate("2.2.2.2:1000");
         a1.add_remote_candidate(c2);
 
         a1.set_controlling(true);
@@ -322,16 +298,10 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = a1
-            .add_local_candidate(host("1.1.1.1:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c1 = a1.add_host_candidate("1.1.1.1:1000");
         a2.add_remote_candidate(c1.clone());
 
-        let c2 = a2
-            .add_local_candidate(host("2.2.2.2:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c2 = a2.add_host_candidate("2.2.2.2:1000");
         a1.add_remote_candidate(c2);
 
         a1.set_controlling(true);
@@ -379,10 +349,7 @@ mod test {
         let c1 = a1.add_local_candidate(c1).unwrap().clone();
         a2.add_remote_candidate(c1.clone());
 
-        let c2 = a2
-            .add_local_candidate(host("2.2.2.2:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c2 = a2.add_host_candidate("2.2.2.2:1000");
         a1.add_remote_candidate(c2);
 
         a1.set_controlling(true);
@@ -430,16 +397,10 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = a1
-            .add_local_candidate(host("1.1.1.1:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c1 = a1.add_host_candidate("1.1.1.1:1000");
         a2.add_remote_candidate(c1.clone());
 
-        let c2 = a2
-            .add_local_candidate(host("2.2.2.2:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c2 = a2.add_host_candidate("2.2.2.2:1000");
         a1.add_remote_candidate(c2);
 
         a1.set_controlling(true);
@@ -481,16 +442,10 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = a1
-            .add_local_candidate(host("1.1.1.1:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c1 = a1.add_host_candidate("1.1.1.1:1000");
         a2.add_remote_candidate(c1);
 
-        let c2 = a2
-            .add_local_candidate(host("2.2.2.2:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c2 = a2.add_host_candidate("2.2.2.2:1000");
         a1.add_remote_candidate(c2.clone());
 
         a1.set_controlling(true);
@@ -536,16 +491,10 @@ mod test {
         a1.agent.set_ice_lite(true);
 
         // 9999 is just dropped by propagate
-        let c1 = a1
-            .add_local_candidate(host("1.1.1.1:9999", "udp"))
-            .unwrap()
-            .clone();
+        let c1 = a1.add_host_candidate("1.1.1.1:9999");
         a2.add_remote_candidate(c1);
 
-        let c2 = a2
-            .add_local_candidate(host("2.2.2.2:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c2 = a2.add_host_candidate("2.2.2.2:1000");
         a1.add_remote_candidate(c2);
 
         a1.set_controlling(true);
@@ -591,16 +540,10 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
 
         // will be rewritten to 4.4.4.4
-        let c1 = a1
-            .add_local_candidate(host("3.3.3.3:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c1 = a1.add_host_candidate("3.3.3.3:1000");
         a2.add_remote_candidate(c1);
 
-        let c2 = a2
-            .add_local_candidate(host("2.2.2.2:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c2 = a2.add_host_candidate("2.2.2.2:1000");
         a1.add_remote_candidate(c2);
 
         a1.set_controlling(true);
@@ -655,16 +598,10 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = a1
-            .add_local_candidate(host("1.1.1.1:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c1 = a1.add_host_candidate("1.1.1.1:1000");
         a2.add_remote_candidate(c1.clone());
 
-        let c2 = a2
-            .add_local_candidate(host("2.2.2.2:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c2 = a2.add_host_candidate("2.2.2.2:1000");
         a1.add_remote_candidate(c2.clone());
 
         a1.set_controlling(true);
@@ -712,16 +649,10 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
 
         // no traffic possible
-        let c1 = a1
-            .add_local_candidate(host("3.3.3.3:9999", "udp"))
-            .unwrap()
-            .clone();
+        let c1 = a1.add_host_candidate("3.3.3.3:9999");
         a2.add_remote_candidate(c1);
 
-        let c2 = a2
-            .add_local_candidate(host("2.2.2.2:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c2 = a2.add_host_candidate("2.2.2.2:1000");
         a1.add_remote_candidate(c2);
 
         a1.set_controlling(true);
@@ -733,9 +664,8 @@ mod test {
         }
 
         // "trickle" a possible candidate
-        a1.add_local_candidate(host("1.1.1.1:1000", "udp")); // possible
+        a1.add_host_candidate("1.1.1.1:1000");
 
-        // loop until we're connected.
         loop {
             if a1.state().is_connected() && a2.state().is_connected() {
                 break;
@@ -760,10 +690,7 @@ mod test {
             .unwrap()
             .clone();
         a1.add_remote_candidate(c2);
-        let c3 = a2
-            .add_local_candidate(host("3.3.3.3:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c3 = a2.add_host_candidate("3.3.3.3:1000");
         a1.add_remote_candidate(c3);
 
         a1.set_controlling(true);
@@ -806,19 +733,13 @@ mod test {
         // We need a 2nd pair of candidates to make sure the agent doesn't go straight into `Completed`.
 
         // Both agents know their local candidates
-        let c1 = a1
-            .add_local_candidate(host("1.1.1.1:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c1 = a1.add_host_candidate("1.1.1.1:1000");
         let c3 = a1
             .add_local_candidate(relay("2.2.2.2:1000", "5.6.7.8:4321", "udp"))
             .unwrap()
             .clone();
 
-        let c2 = a2
-            .add_local_candidate(host("1.1.1.1:1001", "udp"))
-            .unwrap()
-            .clone();
+        let c2 = a2.add_host_candidate("1.1.1.1:1001");
         let c4 = a2
             .add_local_candidate(relay("2.2.2.2:1001", "5.6.7.8:4321", "udp"))
             .unwrap()
@@ -861,20 +782,14 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = a1
-            .add_local_candidate(host("1.1.1.1:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c1 = a1.add_host_candidate("1.1.1.1:1000");
         a2.add_remote_candidate(c1);
         let c2 = a2
             .add_local_candidate(srflx("2.2.2.2:1000", "2.2.2.2:1000", "udp"))
             .unwrap()
             .clone();
         a1.add_remote_candidate(c2);
-        let c3 = a2
-            .add_local_candidate(host("2.2.2.2:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c3 = a2.add_host_candidate("2.2.2.2:1000");
         a1.add_remote_candidate(c3);
 
         a1.set_controlling(true);
@@ -945,14 +860,8 @@ mod test {
         a2.add_remote_candidate(relay_ipv4_ipv4);
         a2.add_remote_candidate(relay_ipv6_ipv4);
 
-        let host_ipv4 = a2
-            .add_local_candidate(host("5.5.5.5:3000", "udp"))
-            .unwrap()
-            .clone();
-        let host_ipv6 = a2
-            .add_local_candidate(host("[::2]:3000", "udp"))
-            .unwrap()
-            .clone();
+        let host_ipv4 = a2.add_host_candidate("5.5.5.5:3000");
+        let host_ipv6 = a2.add_host_candidate("[::2]:3000");
         a1.add_remote_candidate(host_ipv4);
         a1.add_remote_candidate(host_ipv6);
 
@@ -1050,6 +959,13 @@ mod test {
                 time: now,
                 drop_sent_packets: false,
             }
+        }
+
+        fn add_host_candidate(&mut self, addr: &str) -> Candidate {
+            self.agent
+                .add_local_candidate(host(addr, "udp"))
+                .unwrap()
+                .clone()
         }
 
         fn has_event(&self, predicate: impl Fn(&IceAgentEvent) -> bool) -> bool {

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -808,7 +808,7 @@ mod test {
     // However, in case our only IPv6 connectivity is via a relay that we are talking to over IPv4,
     // we want to prefer the IPv4 code path.
     #[test]
-    fn prefers_ipv4_ipv4_relay_candidate_over_ipv4_ipv6() {
+    fn prefers_ipv4_ipv4_relay_candidate_over_ipv4_ipv6_controlling() {
         let _guard = tracing_subscriber::fmt()
             .with_env_filter("debug")
             .with_test_writer()
@@ -817,6 +817,32 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
+        a1.set_controlling(true);
+        a2.set_controlling(false);
+
+        prefer_ipv4_candidate_over_ipv6_candidate(&mut a1, &mut a2);
+    }
+
+    // In general, ICE prefers IPv6 over IPv4.
+    // However, in case our only IPv6 connectivity is via a relay that we are talking to over IPv4,
+    // we want to prefer the IPv4 code path.
+    #[test]
+    fn prefers_ipv4_ipv4_relay_candidate_over_ipv4_ipv6_controlled() {
+        let _guard = tracing_subscriber::fmt()
+            .with_env_filter("debug")
+            .with_test_writer()
+            .set_default();
+
+        let mut a1 = TestAgent::new(info_span!("L"));
+        let mut a2 = TestAgent::new(info_span!("R"));
+
+        a1.set_controlling(false);
+        a2.set_controlling(true);
+
+        prefer_ipv4_candidate_over_ipv6_candidate(&mut a1, &mut a2);
+    }
+
+    fn prefer_ipv4_candidate_over_ipv6_candidate(a1: &mut TestAgent, a2: &mut TestAgent) {
         // Agent 1 only has IPv4 connectivity to a relay but allocates both IPv4 and IPv6 addresses.
         let relay_ipv4_ipv4 = relay("7.7.7.7:5000", "1.1.1.1:5000", "udp");
         let relay_ipv6_ipv4 = relay("[::7]:5000", "1.1.1.1:5000", "udp");
@@ -835,23 +861,20 @@ mod test {
         a1.add_remote_candidate(host_ipv4.clone());
         a1.add_remote_candidate(host_ipv6.clone());
 
-        a1.set_controlling(true);
-        a2.set_controlling(false);
-
         // loop until we're connected.
         loop {
             if a1.state().is_connected() && a2.state().is_connected() {
                 break;
             }
-            progress(&mut a1, &mut a2);
+            progress(a1, a2);
         }
 
         assert!(a1.has_event(|e| {
-            matches!(e, IceAgentEvent::NominatedSend { source, destination, .. } if source == &sock("7.7.7.7:5000") && destination == &sock("5.5.5.5:3000"))
-        }));
+                    matches!(e, IceAgentEvent::NominatedSend { source, destination, .. } if source == &sock("7.7.7.7:5000") && destination == &sock("5.5.5.5:3000"))
+                }));
         assert!(a2.has_event(|e| {
-            matches!(e, IceAgentEvent::NominatedSend { source, destination, .. } if source == &sock("5.5.5.5:3000") && destination == &sock("7.7.7.7:5000"))
-        }));
+                    matches!(e, IceAgentEvent::NominatedSend { source, destination, .. } if source == &sock("5.5.5.5:3000") && destination == &sock("7.7.7.7:5000"))
+                }));
     }
 
     #[test]

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -424,7 +424,7 @@ mod test {
         }
 
         // Add back the invalidated candidate
-        a1.add_local_candidate(c1);
+        a1.add_local_candidate(c1).unwrap();
 
         // progress() fails after 100 number of polls.
         a1.progress_count = 0;
@@ -704,7 +704,8 @@ mod test {
             progress(&mut a1, &mut a2);
         }
 
-        a1.add_local_candidate(relay("1.1.1.1:1001", "5.6.7.8:4321", "udp"));
+        a1.add_local_candidate(relay("1.1.1.1:1001", "5.6.7.8:4321", "udp"))
+            .unwrap();
         a2.add_remote_candidate(relay("1.1.1.1:1001", "5.6.7.8:4321", "udp"));
 
         loop {

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -350,8 +350,8 @@ mod test {
         a2.add_remote_candidate(c1.clone());
 
         let c2 = host("2.2.2.2:1000", "udp");
-        a1.add_remote_candidate(c2.clone());
-        a2.add_local_candidate(c2).unwrap();
+        let c2 = a2.add_local_candidate(c2).unwrap().clone();
+        a1.add_remote_candidate(c2);
 
         a1.set_controlling(true);
         a2.set_controlling(false);
@@ -735,15 +735,16 @@ mod test {
         let c3 = relay("2.2.2.2:1000", "5.6.7.8:4321", "udp");
         let c4 = relay("2.2.2.2:1001", "5.6.7.8:4321", "udp");
 
-        // Agent 1 knows all candidates ahead of time.
+        // Both agents know their local candidates
         let c1 = a1.add_local_candidate(c1).unwrap().clone();
-        a1.add_remote_candidate(c2.clone());
         let c3 = a1.add_local_candidate(c3).unwrap().clone();
-        a1.add_remote_candidate(c4.clone());
 
-        // Agent 2 only knows his own candidates (imagine signalling layer being a bit slow)
-        a2.add_local_candidate(c2);
-        a2.add_local_candidate(c4.clone());
+        let c2 = a2.add_local_candidate(c2).unwrap().clone();
+        let c4 = a2.add_local_candidate(c4.clone()).unwrap().clone();
+
+        // Agent 1 also learns about the remote candidates but agent 2 doesn't (imagine signalling layer being a bit slow)
+        a1.add_remote_candidate(c2);
+        a1.add_remote_candidate(c4);
 
         a1.set_controlling(true);
         a2.set_controlling(false);
@@ -851,15 +852,15 @@ mod test {
         let host_ipv4 = host("5.5.5.5:3000", "udp");
         let host_ipv6 = host("[::2]:3000", "udp");
 
-        a1.add_local_candidate(relay_ipv4_ipv4.clone());
-        a1.add_local_candidate(relay_ipv6_ipv4.clone());
-        a2.add_remote_candidate(relay_ipv4_ipv4.clone());
-        a2.add_remote_candidate(relay_ipv6_ipv4.clone());
+        let relay_ipv4_ipv4 = a1.add_local_candidate(relay_ipv4_ipv4).unwrap().clone();
+        let relay_ipv6_ipv4 = a1.add_local_candidate(relay_ipv6_ipv4).unwrap().clone();
+        a2.add_remote_candidate(relay_ipv4_ipv4);
+        a2.add_remote_candidate(relay_ipv6_ipv4);
 
-        a2.add_local_candidate(host_ipv4.clone());
-        a2.add_local_candidate(host_ipv6.clone());
-        a1.add_remote_candidate(host_ipv4.clone());
-        a1.add_remote_candidate(host_ipv6.clone());
+        let host_ipv4 = a2.add_local_candidate(host_ipv4).unwrap().clone();
+        let host_ipv6 = a2.add_local_candidate(host_ipv6).unwrap().clone();
+        a1.add_remote_candidate(host_ipv4);
+        a1.add_remote_candidate(host_ipv6);
 
         // loop until we're connected.
         loop {

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -29,12 +29,19 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = host("1.1.1.1:9999", "udp"); // 9999 is just dropped by propagate
-        let c1 = a1.add_local_candidate(c1).unwrap().clone();
+        // 9999 is just dropped by propagate
+        let c1 = a1
+            .add_local_candidate(host("1.1.1.1:9999", "udp"))
+            .unwrap()
+            .clone();
         a2.add_remote_candidate(c1);
-        let c2 = host("2.2.2.2:1000", "udp");
-        let c2 = a2.add_local_candidate(c2).unwrap().clone();
+
+        let c2 = a2
+            .add_local_candidate(host("2.2.2.2:1000", "udp"))
+            .unwrap()
+            .clone();
         a1.add_remote_candidate(c2);
+
         a1.set_controlling(true);
         a2.set_controlling(false);
 
@@ -155,11 +162,16 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = host("1.1.1.1:1000", "udp");
-        let c1 = a1.add_local_candidate(c1).unwrap().clone();
+        let c1 = a1
+            .add_local_candidate(host("1.1.1.1:1000", "udp"))
+            .unwrap()
+            .clone();
         a2.add_remote_candidate(c1);
-        let c2 = host("2.2.2.2:1000", "udp");
-        let c2 = a2.add_local_candidate(c2).unwrap().clone();
+
+        let c2 = a1
+            .add_local_candidate(host("2.2.2.2:1000", "udp"))
+            .unwrap()
+            .clone();
         a1.add_remote_candidate(c2);
 
         a1.set_controlling(true);
@@ -226,12 +238,18 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = host("1.1.1.1:1000", "udp");
-        let c1 = a1.add_local_candidate(c1).unwrap().clone();
+        let c1 = a1
+            .add_local_candidate(host("1.1.1.1:1000", "udp"))
+            .unwrap()
+            .clone();
         a2.add_remote_candidate(c1);
-        let c2 = host("2.2.2.2:1000", "udp");
-        let c2 = a2.add_local_candidate(c2).unwrap().clone();
+
+        let c2 = a2
+            .add_local_candidate(host("2.2.2.2:1000", "udp"))
+            .unwrap()
+            .clone();
         a1.add_remote_candidate(c2);
+
         a1.set_controlling(true);
         a2.set_controlling(false);
 
@@ -276,12 +294,18 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
         a2.time = early_now;
 
-        let c1 = host("1.1.1.1:1000", "udp");
-        let c1 = a1.add_local_candidate(c1).unwrap().clone();
+        let c1 = a1
+            .add_local_candidate(host("1.1.1.1:1000", "udp"))
+            .unwrap()
+            .clone();
         a2.add_remote_candidate(c1);
-        let c2 = host("2.2.2.2:1000", "udp");
-        let c2 = a2.add_local_candidate(c2).unwrap().clone();
+
+        let c2 = a2
+            .add_local_candidate(host("2.2.2.2:1000", "udp"))
+            .unwrap()
+            .clone();
         a1.add_remote_candidate(c2);
+
         a1.set_controlling(true);
         a2.set_controlling(false);
 
@@ -298,12 +322,18 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = host("1.1.1.1:1000", "udp");
-        let c1 = a1.add_local_candidate(c1).unwrap().clone();
+        let c1 = a1
+            .add_local_candidate(host("1.1.1.1:1000", "udp"))
+            .unwrap()
+            .clone();
         a2.add_remote_candidate(c1.clone());
-        let c2 = host("2.2.2.2:1000", "udp");
-        let c2 = a2.add_local_candidate(c2).unwrap().clone();
+
+        let c2 = a2
+            .add_local_candidate(host("2.2.2.2:1000", "udp"))
+            .unwrap()
+            .clone();
         a1.add_remote_candidate(c2);
+
         a1.set_controlling(true);
         a2.set_controlling(false);
 
@@ -349,8 +379,10 @@ mod test {
         let c1 = a1.add_local_candidate(c1).unwrap().clone();
         a2.add_remote_candidate(c1.clone());
 
-        let c2 = host("2.2.2.2:1000", "udp");
-        let c2 = a2.add_local_candidate(c2).unwrap().clone();
+        let c2 = a2
+            .add_local_candidate(host("2.2.2.2:1000", "udp"))
+            .unwrap()
+            .clone();
         a1.add_remote_candidate(c2);
 
         a1.set_controlling(true);
@@ -398,12 +430,18 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = host("1.1.1.1:1000", "udp");
-        let c1 = a1.add_local_candidate(c1).unwrap().clone();
+        let c1 = a1
+            .add_local_candidate(host("1.1.1.1:1000", "udp"))
+            .unwrap()
+            .clone();
         a2.add_remote_candidate(c1.clone());
-        let c2 = host("2.2.2.2:1000", "udp");
-        let c2 = a2.add_local_candidate(c2).unwrap().clone();
+
+        let c2 = a2
+            .add_local_candidate(host("2.2.2.2:1000", "udp"))
+            .unwrap()
+            .clone();
         a1.add_remote_candidate(c2);
+
         a1.set_controlling(true);
         a2.set_controlling(false);
 
@@ -443,12 +481,18 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = host("1.1.1.1:1000", "udp");
-        let c1 = a1.add_local_candidate(c1).unwrap().clone();
+        let c1 = a1
+            .add_local_candidate(host("1.1.1.1:1000", "udp"))
+            .unwrap()
+            .clone();
         a2.add_remote_candidate(c1);
-        let c2 = host("2.2.2.2:1000", "udp");
-        let c2 = a2.add_local_candidate(c2).unwrap().clone();
+
+        let c2 = a2
+            .add_local_candidate(host("2.2.2.2:1000", "udp"))
+            .unwrap()
+            .clone();
         a1.add_remote_candidate(c2.clone());
+
         a1.set_controlling(true);
         a2.set_controlling(false);
 
@@ -491,12 +535,19 @@ mod test {
         // a1 acts as "server"
         a1.agent.set_ice_lite(true);
 
-        let c1 = host("1.1.1.1:9999", "udp"); // 9999 is just dropped by propagate
-        let c1 = a1.add_local_candidate(c1).unwrap().clone();
+        // 9999 is just dropped by propagate
+        let c1 = a1
+            .add_local_candidate(host("1.1.1.1:9999", "udp"))
+            .unwrap()
+            .clone();
         a2.add_remote_candidate(c1);
-        let c2 = host("2.2.2.2:1000", "udp");
-        let c2 = a2.add_local_candidate(c2).unwrap().clone();
+
+        let c2 = a2
+            .add_local_candidate(host("2.2.2.2:1000", "udp"))
+            .unwrap()
+            .clone();
         a1.add_remote_candidate(c2);
+
         a1.set_controlling(true);
         a2.set_controlling(false);
 
@@ -539,11 +590,17 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = host("3.3.3.3:1000", "udp"); // will be rewritten to 4.4.4.4
-        let c1 = a1.add_local_candidate(c1).unwrap().clone();
+        // will be rewritten to 4.4.4.4
+        let c1 = a1
+            .add_local_candidate(host("3.3.3.3:1000", "udp"))
+            .unwrap()
+            .clone();
         a2.add_remote_candidate(c1);
-        let c2 = host("2.2.2.2:1000", "udp");
-        let c2 = a2.add_local_candidate(c2).unwrap().clone();
+
+        let c2 = a2
+            .add_local_candidate(host("2.2.2.2:1000", "udp"))
+            .unwrap()
+            .clone();
         a1.add_remote_candidate(c2);
 
         a1.set_controlling(true);
@@ -598,11 +655,16 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = host("1.1.1.1:1000", "udp");
-        let c1 = a1.add_local_candidate(c1).unwrap().clone();
+        let c1 = a1
+            .add_local_candidate(host("1.1.1.1:1000", "udp"))
+            .unwrap()
+            .clone();
         a2.add_remote_candidate(c1.clone());
-        let c2 = host("2.2.2.2:1000", "udp");
-        let c2 = a2.add_local_candidate(c2).unwrap().clone();
+
+        let c2 = a2
+            .add_local_candidate(host("2.2.2.2:1000", "udp"))
+            .unwrap()
+            .clone();
         a1.add_remote_candidate(c2.clone());
 
         a1.set_controlling(true);
@@ -649,11 +711,17 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = host("3.3.3.3:9999", "udp"); // no traffic possible
-        let c1 = a1.add_local_candidate(c1).unwrap().clone();
+        // no traffic possible
+        let c1 = a1
+            .add_local_candidate(host("3.3.3.3:9999", "udp"))
+            .unwrap()
+            .clone();
         a2.add_remote_candidate(c1);
-        let c2 = host("2.2.2.2:1000", "udp");
-        let c2 = a2.add_local_candidate(c2).unwrap().clone();
+
+        let c2 = a2
+            .add_local_candidate(host("2.2.2.2:1000", "udp"))
+            .unwrap()
+            .clone();
         a1.add_remote_candidate(c2);
 
         a1.set_controlling(true);
@@ -681,14 +749,21 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = relay("1.1.1.1:1000", "5.6.7.8:4321", "udp");
-        let c1 = a1.add_local_candidate(c1).unwrap().clone();
+        let c1 = a1
+            .add_local_candidate(relay("1.1.1.1:1000", "5.6.7.8:4321", "udp"))
+            .unwrap()
+            .clone();
         a2.add_remote_candidate(c1);
-        let c2 = srflx("4.4.4.4:1000", "3.3.3.3:1000", "udp");
-        let c3 = host("3.3.3.3:1000", "udp");
-        let c2 = a2.add_local_candidate(c2).unwrap().clone();
+
+        let c2 = a2
+            .add_local_candidate(srflx("4.4.4.4:1000", "3.3.3.3:1000", "udp"))
+            .unwrap()
+            .clone();
         a1.add_remote_candidate(c2);
-        let c3 = a2.add_local_candidate(c3).unwrap().clone();
+        let c3 = a2
+            .add_local_candidate(host("3.3.3.3:1000", "udp"))
+            .unwrap()
+            .clone();
         a1.add_remote_candidate(c3);
 
         a1.set_controlling(true);
@@ -728,19 +803,26 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = host("1.1.1.1:1000", "udp");
-        let c2 = host("1.1.1.1:1001", "udp");
-
         // We need a 2nd pair of candidates to make sure the agent doesn't go straight into `Completed`.
-        let c3 = relay("2.2.2.2:1000", "5.6.7.8:4321", "udp");
-        let c4 = relay("2.2.2.2:1001", "5.6.7.8:4321", "udp");
 
         // Both agents know their local candidates
-        let c1 = a1.add_local_candidate(c1).unwrap().clone();
-        let c3 = a1.add_local_candidate(c3).unwrap().clone();
+        let c1 = a1
+            .add_local_candidate(host("1.1.1.1:1000", "udp"))
+            .unwrap()
+            .clone();
+        let c3 = a1
+            .add_local_candidate(relay("2.2.2.2:1000", "5.6.7.8:4321", "udp"))
+            .unwrap()
+            .clone();
 
-        let c2 = a2.add_local_candidate(c2).unwrap().clone();
-        let c4 = a2.add_local_candidate(c4).unwrap().clone();
+        let c2 = a2
+            .add_local_candidate(host("1.1.1.1:1001", "udp"))
+            .unwrap()
+            .clone();
+        let c4 = a2
+            .add_local_candidate(relay("2.2.2.2:1001", "5.6.7.8:4321", "udp"))
+            .unwrap()
+            .clone();
 
         // Agent 1 also learns about the remote candidates but agent 2 doesn't (imagine signalling layer being a bit slow)
         a1.add_remote_candidate(c2);
@@ -779,14 +861,20 @@ mod test {
         let mut a1 = TestAgent::new(info_span!("L"));
         let mut a2 = TestAgent::new(info_span!("R"));
 
-        let c1 = host("1.1.1.1:1000", "udp");
-        let c1 = a1.add_local_candidate(c1).unwrap().clone();
+        let c1 = a1
+            .add_local_candidate(host("1.1.1.1:1000", "udp"))
+            .unwrap()
+            .clone();
         a2.add_remote_candidate(c1);
-        let c2 = srflx("2.2.2.2:1000", "2.2.2.2:1000", "udp");
-        let c3 = host("2.2.2.2:1000", "udp");
-        let c2 = a2.add_local_candidate(c2).unwrap().clone();
+        let c2 = a2
+            .add_local_candidate(srflx("2.2.2.2:1000", "2.2.2.2:1000", "udp"))
+            .unwrap()
+            .clone();
         a1.add_remote_candidate(c2);
-        let c3 = a2.add_local_candidate(c3).unwrap().clone();
+        let c3 = a2
+            .add_local_candidate(host("2.2.2.2:1000", "udp"))
+            .unwrap()
+            .clone();
         a1.add_remote_candidate(c3);
 
         a1.set_controlling(true);
@@ -845,20 +933,26 @@ mod test {
 
     fn prefer_ipv4_candidate_over_ipv6_candidate(a1: &mut TestAgent, a2: &mut TestAgent) {
         // Agent 1 only has IPv4 connectivity to a relay but allocates both IPv4 and IPv6 addresses.
-        let relay_ipv4_ipv4 = relay("7.7.7.7:5000", "1.1.1.1:5000", "udp");
-        let relay_ipv6_ipv4 = relay("[::7]:5000", "1.1.1.1:5000", "udp");
-
         // Agent 2 has no relay but has full IPv4 and IPv6 connectivity.
-        let host_ipv4 = host("5.5.5.5:3000", "udp");
-        let host_ipv6 = host("[::2]:3000", "udp");
-
-        let relay_ipv4_ipv4 = a1.add_local_candidate(relay_ipv4_ipv4).unwrap().clone();
-        let relay_ipv6_ipv4 = a1.add_local_candidate(relay_ipv6_ipv4).unwrap().clone();
+        let relay_ipv4_ipv4 = a1
+            .add_local_candidate(relay("7.7.7.7:5000", "1.1.1.1:5000", "udp"))
+            .unwrap()
+            .clone();
+        let relay_ipv6_ipv4 = a1
+            .add_local_candidate(relay("[::7]:5000", "1.1.1.1:5000", "udp"))
+            .unwrap()
+            .clone();
         a2.add_remote_candidate(relay_ipv4_ipv4);
         a2.add_remote_candidate(relay_ipv6_ipv4);
 
-        let host_ipv4 = a2.add_local_candidate(host_ipv4).unwrap().clone();
-        let host_ipv6 = a2.add_local_candidate(host_ipv6).unwrap().clone();
+        let host_ipv4 = a2
+            .add_local_candidate(host("5.5.5.5:3000", "udp"))
+            .unwrap()
+            .clone();
+        let host_ipv6 = a2
+            .add_local_candidate(host("[::2]:3000", "udp"))
+            .unwrap()
+            .clone();
         a1.add_remote_candidate(host_ipv4);
         a1.add_remote_candidate(host_ipv6);
 

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -740,7 +740,7 @@ mod test {
         let c3 = a1.add_local_candidate(c3).unwrap().clone();
 
         let c2 = a2.add_local_candidate(c2).unwrap().clone();
-        let c4 = a2.add_local_candidate(c4.clone()).unwrap().clone();
+        let c4 = a2.add_local_candidate(c4).unwrap().clone();
 
         // Agent 1 also learns about the remote candidates but agent 2 doesn't (imagine signalling layer being a bit slow)
         a1.add_remote_candidate(c2);

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -30,10 +30,10 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
 
         let c1 = host("1.1.1.1:9999", "udp"); // 9999 is just dropped by propagate
-        a1.add_local_candidate(c1.clone());
+        let c1 = a1.add_local_candidate(c1).unwrap().clone();
         a2.add_remote_candidate(c1);
         let c2 = host("2.2.2.2:1000", "udp");
-        a2.add_local_candidate(c2.clone());
+        let c2 = a2.add_local_candidate(c2).unwrap().clone();
         a1.add_remote_candidate(c2);
         a1.set_controlling(true);
         a2.set_controlling(false);
@@ -156,10 +156,10 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
 
         let c1 = host("1.1.1.1:1000", "udp");
-        a1.add_local_candidate(c1.clone());
+        let c1 = a1.add_local_candidate(c1).unwrap().clone();
         a2.add_remote_candidate(c1);
         let c2 = host("2.2.2.2:1000", "udp");
-        a2.add_local_candidate(c2.clone());
+        let c2 = a2.add_local_candidate(c2).unwrap().clone();
         a1.add_remote_candidate(c2);
 
         a1.set_controlling(true);
@@ -227,10 +227,10 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
 
         let c1 = host("1.1.1.1:1000", "udp");
-        a1.add_local_candidate(c1.clone());
+        let c1 = a1.add_local_candidate(c1).unwrap().clone();
         a2.add_remote_candidate(c1);
         let c2 = host("2.2.2.2:1000", "udp");
-        a2.add_local_candidate(c2.clone());
+        let c2 = a2.add_local_candidate(c2).unwrap().clone();
         a1.add_remote_candidate(c2);
         a1.set_controlling(true);
         a2.set_controlling(false);
@@ -277,10 +277,10 @@ mod test {
         a2.time = early_now;
 
         let c1 = host("1.1.1.1:1000", "udp");
-        a1.add_local_candidate(c1.clone());
+        let c1 = a1.add_local_candidate(c1).unwrap().clone();
         a2.add_remote_candidate(c1);
         let c2 = host("2.2.2.2:1000", "udp");
-        a2.add_local_candidate(c2.clone());
+        let c2 = a2.add_local_candidate(c2).unwrap().clone();
         a1.add_remote_candidate(c2);
         a1.set_controlling(true);
         a2.set_controlling(false);
@@ -299,10 +299,10 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
 
         let c1 = host("1.1.1.1:1000", "udp");
-        a1.add_local_candidate(c1.clone());
+        let c1 = a1.add_local_candidate(c1).unwrap().clone();
         a2.add_remote_candidate(c1.clone());
         let c2 = host("2.2.2.2:1000", "udp");
-        a2.add_local_candidate(c2.clone());
+        let c2 = a2.add_local_candidate(c2).unwrap().clone();
         a1.add_remote_candidate(c2);
         a1.set_controlling(true);
         a2.set_controlling(false);
@@ -346,12 +346,12 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
 
         let c1 = host("1.1.1.1:1000", "udp");
-        a1.add_local_candidate(c1.clone());
+        let c1 = a1.add_local_candidate(c1).unwrap().clone();
         a2.add_remote_candidate(c1.clone());
 
         let c2 = host("2.2.2.2:1000", "udp");
         a1.add_remote_candidate(c2.clone());
-        a2.add_local_candidate(c2.clone());
+        a2.add_local_candidate(c2).unwrap();
 
         a1.set_controlling(true);
         a2.set_controlling(false);
@@ -368,7 +368,7 @@ mod test {
         let new_sock = sock("8.8.8.8:1000");
 
         let c3 = Candidate::host(new_sock, Protocol::Udp).unwrap();
-        a1.add_local_candidate(c3.clone());
+        let c3 = a1.add_local_candidate(c3).unwrap().clone();
         a2.add_remote_candidate(c3);
 
         a1.agent.invalidate_candidate(&c1);
@@ -399,10 +399,10 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
 
         let c1 = host("1.1.1.1:1000", "udp");
-        a1.add_local_candidate(c1.clone());
+        let c1 = a1.add_local_candidate(c1).unwrap().clone();
         a2.add_remote_candidate(c1.clone());
         let c2 = host("2.2.2.2:1000", "udp");
-        a2.add_local_candidate(c2.clone());
+        let c2 = a2.add_local_candidate(c2).unwrap().clone();
         a1.add_remote_candidate(c2);
         a1.set_controlling(true);
         a2.set_controlling(false);
@@ -444,10 +444,10 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
 
         let c1 = host("1.1.1.1:1000", "udp");
-        a1.add_local_candidate(c1.clone());
+        let c1 = a1.add_local_candidate(c1).unwrap().clone();
         a2.add_remote_candidate(c1);
         let c2 = host("2.2.2.2:1000", "udp");
-        a2.add_local_candidate(c2.clone());
+        let c2 = a2.add_local_candidate(c2).unwrap().clone();
         a1.add_remote_candidate(c2.clone());
         a1.set_controlling(true);
         a2.set_controlling(false);
@@ -492,10 +492,10 @@ mod test {
         a1.agent.set_ice_lite(true);
 
         let c1 = host("1.1.1.1:9999", "udp"); // 9999 is just dropped by propagate
-        a1.add_local_candidate(c1.clone());
+        let c1 = a1.add_local_candidate(c1).unwrap().clone();
         a2.add_remote_candidate(c1);
         let c2 = host("2.2.2.2:1000", "udp");
-        a2.add_local_candidate(c2.clone());
+        let c2 = a2.add_local_candidate(c2).unwrap().clone();
         a1.add_remote_candidate(c2);
         a1.set_controlling(true);
         a2.set_controlling(false);
@@ -540,10 +540,10 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
 
         let c1 = host("3.3.3.3:1000", "udp"); // will be rewritten to 4.4.4.4
-        a1.add_local_candidate(c1.clone());
+        let c1 = a1.add_local_candidate(c1).unwrap().clone();
         a2.add_remote_candidate(c1);
         let c2 = host("2.2.2.2:1000", "udp");
-        a2.add_local_candidate(c2.clone());
+        let c2 = a2.add_local_candidate(c2).unwrap().clone();
         a1.add_remote_candidate(c2);
 
         a1.set_controlling(true);
@@ -599,10 +599,10 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
 
         let c1 = host("1.1.1.1:1000", "udp");
-        a1.add_local_candidate(c1.clone());
+        let c1 = a1.add_local_candidate(c1).unwrap().clone();
         a2.add_remote_candidate(c1.clone());
         let c2 = host("2.2.2.2:1000", "udp");
-        a2.add_local_candidate(c2.clone());
+        let c2 = a2.add_local_candidate(c2).unwrap().clone();
         a1.add_remote_candidate(c2.clone());
 
         a1.set_controlling(true);
@@ -650,10 +650,10 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
 
         let c1 = host("3.3.3.3:9999", "udp"); // no traffic possible
-        a1.add_local_candidate(c1.clone());
+        let c1 = a1.add_local_candidate(c1).unwrap().clone();
         a2.add_remote_candidate(c1);
         let c2 = host("2.2.2.2:1000", "udp");
-        a2.add_local_candidate(c2.clone());
+        let c2 = a2.add_local_candidate(c2).unwrap().clone();
         a1.add_remote_candidate(c2);
 
         a1.set_controlling(true);
@@ -682,13 +682,13 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
 
         let c1 = relay("1.1.1.1:1000", "5.6.7.8:4321", "udp");
-        a1.add_local_candidate(c1.clone());
+        let c1 = a1.add_local_candidate(c1).unwrap().clone();
         a2.add_remote_candidate(c1);
         let c2 = srflx("4.4.4.4:1000", "3.3.3.3:1000", "udp");
         let c3 = host("3.3.3.3:1000", "udp");
-        a2.add_local_candidate(c2.clone());
+        let c2 = a2.add_local_candidate(c2).unwrap().clone();
         a1.add_remote_candidate(c2);
-        a2.add_local_candidate(c3.clone());
+        let c3 = a2.add_local_candidate(c3).unwrap().clone();
         a1.add_remote_candidate(c3);
 
         a1.set_controlling(true);
@@ -736,13 +736,13 @@ mod test {
         let c4 = relay("2.2.2.2:1001", "5.6.7.8:4321", "udp");
 
         // Agent 1 knows all candidates ahead of time.
-        a1.add_local_candidate(c1.clone());
+        let c1 = a1.add_local_candidate(c1).unwrap().clone();
         a1.add_remote_candidate(c2.clone());
-        a1.add_local_candidate(c3.clone());
+        let c3 = a1.add_local_candidate(c3).unwrap().clone();
         a1.add_remote_candidate(c4.clone());
 
         // Agent 2 only knows his own candidates (imagine signalling layer being a bit slow)
-        a2.add_local_candidate(c2.clone());
+        a2.add_local_candidate(c2);
         a2.add_local_candidate(c4.clone());
 
         a1.set_controlling(true);
@@ -779,13 +779,13 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
 
         let c1 = host("1.1.1.1:1000", "udp");
-        a1.add_local_candidate(c1.clone());
+        let c1 = a1.add_local_candidate(c1).unwrap().clone();
         a2.add_remote_candidate(c1);
         let c2 = srflx("2.2.2.2:1000", "2.2.2.2:1000", "udp");
         let c3 = host("2.2.2.2:1000", "udp");
-        a2.add_local_candidate(c2.clone());
+        let c2 = a2.add_local_candidate(c2).unwrap().clone();
         a1.add_remote_candidate(c2);
-        a2.add_local_candidate(c3.clone());
+        let c3 = a2.add_local_candidate(c3).unwrap().clone();
         a1.add_remote_candidate(c3);
 
         a1.set_controlling(true);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1220,6 +1220,9 @@ impl Rtc {
     /// Add a local ICE candidate. Local candidates are socket addresses the `Rtc` instance
     /// use for communicating with the peer.
     ///
+    /// If the candidate is accepted by the `Rtc` instance, it will return `Some` with a reference
+    /// to it. You should then signal this candidate to the remote peer.
+    ///
     /// This library has no built-in discovery of local network addresses on the host
     /// or NATed addresses via a STUN server or TURN server. The user of the library
     /// is expected to add new local candidates as they are discovered.
@@ -1240,8 +1243,8 @@ impl Rtc {
     /// ```
     ///
     /// [1]: https://www.rfc-editor.org/rfc/rfc8838.txt
-    pub fn add_local_candidate(&mut self, c: Candidate) {
-        self.ice.add_local_candidate(c);
+    pub fn add_local_candidate(&mut self, c: Candidate) -> Option<&Candidate> {
+        self.ice.add_local_candidate(c)
     }
 
     /// Add a remote ICE candidate. Remote candidates are addresses of the peer.

--- a/tests/bidirectional.rs
+++ b/tests/bidirectional.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use str0m::format::Codec;
 use str0m::media::{Direction, MediaKind};
-use str0m::{Candidate, Event, RtcError};
+use str0m::{Event, RtcError};
 use tracing::info_span;
 
 mod common;
@@ -17,10 +17,8 @@ pub fn bidirectional_same_m_line() -> Result<(), RtcError> {
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1).unwrap();
-    r.add_local_candidate(host2).unwrap();
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
 
     let mut change = l.sdp_api();
     let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);

--- a/tests/bidirectional.rs
+++ b/tests/bidirectional.rs
@@ -19,8 +19,8 @@ pub fn bidirectional_same_m_line() -> Result<(), RtcError> {
 
     let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
     let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1);
-    r.add_local_candidate(host2);
+    l.add_local_candidate(host1).unwrap();
+    r.add_local_candidate(host2).unwrap();
 
     let mut change = l.sdp_api();
     let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,6 +1,6 @@
 #![allow(unused)]
 use std::io::Cursor;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::ops::{Deref, DerefMut};
 use std::sync::Once;
 use std::time::{Duration, Instant};
@@ -40,6 +40,13 @@ impl TestRtc {
             last: now,
             events: vec![],
         }
+    }
+
+    pub fn add_host_candidate(&mut self, socket: SocketAddr) -> Candidate {
+        self.rtc
+            .add_local_candidate(Candidate::host(socket, "udp").unwrap())
+            .unwrap()
+            .clone()
     }
 
     pub fn duration(&self) -> Duration {
@@ -240,9 +247,9 @@ pub fn connect_l_r_with_rtc(rtc1: Rtc, rtc2: Rtc) -> (TestRtc, TestRtc) {
 
     let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp").unwrap();
     let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp").unwrap();
-    l.add_local_candidate(host1.clone()).unwrap();
+    l.add_local_candidate(host1.clone());
     l.add_remote_candidate(host2.clone());
-    r.add_local_candidate(host2).unwrap();
+    r.add_local_candidate(host2);
     r.add_remote_candidate(host1);
 
     let finger_l = l.direct_api().local_dtls_fingerprint();

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -240,9 +240,9 @@ pub fn connect_l_r_with_rtc(rtc1: Rtc, rtc2: Rtc) -> (TestRtc, TestRtc) {
 
     let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp").unwrap();
     let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp").unwrap();
-    l.add_local_candidate(host1.clone());
+    l.add_local_candidate(host1.clone()).unwrap();
     l.add_remote_candidate(host2.clone());
-    r.add_local_candidate(host2);
+    r.add_local_candidate(host2).unwrap();
     r.add_remote_candidate(host1);
 
     let finger_l = l.direct_api().local_dtls_fingerprint();

--- a/tests/contiguous.rs
+++ b/tests/contiguous.rs
@@ -153,8 +153,8 @@ impl Server {
 
         let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
         let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-        l.add_local_candidate(host1);
-        r.add_local_candidate(host2);
+        l.add_local_candidate(host1).unwrap();
+        r.add_local_candidate(host2).unwrap();
 
         // The change is on the L (sending side) with Direction::SendRecv.
         let mut change = l.sdp_api();

--- a/tests/contiguous.rs
+++ b/tests/contiguous.rs
@@ -151,10 +151,14 @@ impl Server {
 
         let mut r = TestRtc::new_with_rtc(info_span!("R"), rtc_r);
 
-        let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
-        let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-        l.add_local_candidate(host1).unwrap();
-        r.add_local_candidate(host2).unwrap();
+        l.add_local_candidate(Candidate::host(
+            (Ipv4Addr::new(1, 1, 1, 1), 1000).into(),
+            "udp",
+        )?);
+        r.add_local_candidate(Candidate::host(
+            (Ipv4Addr::new(2, 2, 2, 2), 2000).into(),
+            "udp",
+        )?);
 
         // The change is on the L (sending side) with Direction::SendRecv.
         let mut change = l.sdp_api();

--- a/tests/data-channel-direct.rs
+++ b/tests/data-channel-direct.rs
@@ -20,9 +20,9 @@ pub fn data_channel_direct() -> Result<(), RtcError> {
 
     let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
     let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1.clone());
+    l.add_local_candidate(host1.clone()).unwrap();
     l.add_remote_candidate(host2.clone());
-    r.add_local_candidate(host2);
+    r.add_local_candidate(host2).unwrap();
     r.add_remote_candidate(host1);
 
     let finger_l = l.direct_api().local_dtls_fingerprint();

--- a/tests/data-channel.rs
+++ b/tests/data-channel.rs
@@ -17,8 +17,8 @@ pub fn data_channel() -> Result<(), RtcError> {
 
     let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
     let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1);
-    r.add_local_candidate(host2);
+    l.add_local_candidate(host1).unwrap();
+    r.add_local_candidate(host2).unwrap();
 
     let mut change = l.sdp_api();
     let cid = change.add_channel("My little channel".into());

--- a/tests/data-channel.rs
+++ b/tests/data-channel.rs
@@ -1,7 +1,7 @@
 use std::net::Ipv4Addr;
 use std::time::Duration;
 
-use str0m::{Candidate, RtcError};
+use str0m::RtcError;
 use tracing::info_span;
 
 mod common;
@@ -15,10 +15,8 @@ pub fn data_channel() -> Result<(), RtcError> {
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1).unwrap();
-    r.add_local_candidate(host2).unwrap();
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
 
     let mut change = l.sdp_api();
     let cid = change.add_channel("My little channel".into());

--- a/tests/flappy-ice-state.rs
+++ b/tests/flappy-ice-state.rs
@@ -20,8 +20,8 @@ pub fn flappy_ice_lite_state() -> Result<(), RtcError> {
 
     let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
     let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1);
-    r.add_local_candidate(host2);
+    l.add_local_candidate(host1).unwrap();
+    r.add_local_candidate(host2).unwrap();
 
     let mut change = l.sdp_api();
     let _ = change.add_channel("My little channel".into());

--- a/tests/flappy-ice-state.rs
+++ b/tests/flappy-ice-state.rs
@@ -2,7 +2,7 @@ use std::net::Ipv4Addr;
 use std::time::Duration;
 
 use str0m::RtcConfig;
-use str0m::{Candidate, Event, RtcError};
+use str0m::{Event, RtcError};
 use tracing::info_span;
 
 mod common;
@@ -18,10 +18,8 @@ pub fn flappy_ice_lite_state() -> Result<(), RtcError> {
     let rtc = RtcConfig::new().set_ice_lite(true).build();
     let mut r = TestRtc::new_with_rtc(info_span!("R"), rtc);
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1).unwrap();
-    r.add_local_candidate(host2).unwrap();
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
 
     let mut change = l.sdp_api();
     let _ = change.add_channel("My little channel".into());

--- a/tests/ice-restart.rs
+++ b/tests/ice-restart.rs
@@ -20,8 +20,8 @@ pub fn ice_restart() -> Result<(), RtcError> {
 
     let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
     let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1);
-    r.add_local_candidate(host2);
+    l.add_local_candidate(host1).unwrap();
+    r.add_local_candidate(host2).unwrap();
 
     let (offer, pending) = l.span.in_scope(|| {
         let mut change = l.rtc.sdp_api();

--- a/tests/ice-restart.rs
+++ b/tests/ice-restart.rs
@@ -2,7 +2,7 @@ use std::net::Ipv4Addr;
 use std::time::Duration;
 
 use str0m::RtcConfig;
-use str0m::{Candidate, RtcError};
+use str0m::RtcError;
 use tracing::info_span;
 
 mod common;
@@ -18,10 +18,8 @@ pub fn ice_restart() -> Result<(), RtcError> {
     let rtc = RtcConfig::new().set_ice_lite(true).build();
     let mut r = TestRtc::new_with_rtc(info_span!("R"), rtc);
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1).unwrap();
-    r.add_local_candidate(host2).unwrap();
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
 
     let (offer, pending) = l.span.in_scope(|| {
         let mut change = l.rtc.sdp_api();

--- a/tests/keyframes.rs
+++ b/tests/keyframes.rs
@@ -20,8 +20,8 @@ pub fn test_vp8_keyframes_detection() -> Result<(), RtcError> {
 
     let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
     let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1);
-    r.add_local_candidate(host2);
+    l.add_local_candidate(host1).unwrap();
+    r.add_local_candidate(host2).unwrap();
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();
@@ -112,8 +112,8 @@ pub fn test_vp9_keyframes_detection() -> Result<(), RtcError> {
 
     let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
     let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1);
-    r.add_local_candidate(host2);
+    l.add_local_candidate(host1).unwrap();
+    r.add_local_candidate(host2).unwrap();
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();
@@ -205,8 +205,8 @@ pub fn test_h264_keyframes_detection() -> Result<(), RtcError> {
 
     let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
     let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1);
-    r.add_local_candidate(host2);
+    l.add_local_candidate(host1).unwrap();
+    r.add_local_candidate(host2).unwrap();
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();

--- a/tests/keyframes.rs
+++ b/tests/keyframes.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use str0m::format::{Codec, CodecExtra};
 use str0m::media::{Direction, MediaKind};
-use str0m::{Candidate, Event, RtcError};
+use str0m::{Event, RtcError};
 use tracing::info_span;
 
 mod common;
@@ -18,10 +18,8 @@ pub fn test_vp8_keyframes_detection() -> Result<(), RtcError> {
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1).unwrap();
-    r.add_local_candidate(host2).unwrap();
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();
@@ -110,10 +108,8 @@ pub fn test_vp9_keyframes_detection() -> Result<(), RtcError> {
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1).unwrap();
-    r.add_local_candidate(host2).unwrap();
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();
@@ -203,10 +199,8 @@ pub fn test_h264_keyframes_detection() -> Result<(), RtcError> {
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1).unwrap();
-    r.add_local_candidate(host2).unwrap();
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();

--- a/tests/mediatime-backwards.rs
+++ b/tests/mediatime-backwards.rs
@@ -24,8 +24,8 @@ pub fn mediatime_backwards() -> Result<(), RtcError> {
 
     let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
     let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1);
-    r.add_local_candidate(host2);
+    l.add_local_candidate(host1).unwrap();
+    r.add_local_candidate(host2).unwrap();
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();

--- a/tests/mediatime-backwards.rs
+++ b/tests/mediatime-backwards.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use str0m::format::Codec;
 use str0m::media::{Direction, MediaKind, MediaTime};
 use str0m::rtp::RawPacket;
-use str0m::{Candidate, Event, RtcError};
+use str0m::{Event, RtcError};
 use tracing::info;
 use tracing::info_span;
 
@@ -22,10 +22,8 @@ pub fn mediatime_backwards() -> Result<(), RtcError> {
     // Enable raw packets to trace the RTP headers
     r.rtc = str0m::Rtc::builder().enable_raw_packets(true).build();
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1).unwrap();
-    r.add_local_candidate(host2).unwrap();
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();

--- a/tests/remb.rs
+++ b/tests/remb.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use str0m::bwe::{Bitrate, BweKind};
 use str0m::media::{Direction, MediaKind};
-use str0m::{Candidate, Event, Rtc, RtcError};
+use str0m::{Event, Rtc, RtcError};
 use tracing::info_span;
 
 mod common;
@@ -20,10 +20,8 @@ pub fn remb() -> Result<(), RtcError> {
     let mut l = TestRtc::new_with_rtc(info_span!("L"), l_rtc);
     let mut r = TestRtc::new_with_rtc(info_span!("R"), r_rtc);
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1).unwrap();
-    r.add_local_candidate(host2).unwrap();
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
 
     let mid = negotiate(&mut l, &mut r, |change| {
         change.add_media(MediaKind::Video, Direction::SendOnly, None, None, None)

--- a/tests/remb.rs
+++ b/tests/remb.rs
@@ -22,8 +22,8 @@ pub fn remb() -> Result<(), RtcError> {
 
     let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
     let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1);
-    r.add_local_candidate(host2);
+    l.add_local_candidate(host1).unwrap();
+    r.add_local_candidate(host2).unwrap();
 
     let mid = negotiate(&mut l, &mut r, |change| {
         change.add_media(MediaKind::Video, Direction::SendOnly, None, None, None)

--- a/tests/stats.rs
+++ b/tests/stats.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use str0m::format::Codec;
 use str0m::media::{Direction, MediaKind};
 use str0m::stats::MediaEgressStats;
-use str0m::{Candidate, Event, RtcConfig, RtcError};
+use str0m::{Event, RtcConfig, RtcError};
 use tracing::info_span;
 
 mod common;
@@ -21,10 +21,8 @@ pub fn stats() -> Result<(), RtcError> {
     let mut l = TestRtc::new_with_rtc(info_span!("L"), l_config.build());
     let mut r = TestRtc::new_with_rtc(info_span!("R"), r_config.build());
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1).unwrap();
-    r.add_local_candidate(host2).unwrap();
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
 
     let mut change = l.sdp_api();
     let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);

--- a/tests/stats.rs
+++ b/tests/stats.rs
@@ -23,8 +23,8 @@ pub fn stats() -> Result<(), RtcError> {
 
     let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
     let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1);
-    r.add_local_candidate(host2);
+    l.add_local_candidate(host1).unwrap();
+    r.add_local_candidate(host2).unwrap();
 
     let mut change = l.sdp_api();
     let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);

--- a/tests/twcc.rs
+++ b/tests/twcc.rs
@@ -23,8 +23,8 @@ pub fn twcc() -> Result<(), RtcError> {
 
     let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
     let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1);
-    r.add_local_candidate(host2);
+    l.add_local_candidate(host1).unwrap();
+    r.add_local_candidate(host2).unwrap();
 
     let mid = negotiate(&mut l, &mut r, |change| {
         change.add_media(MediaKind::Video, Direction::SendOnly, None, None, None)

--- a/tests/twcc.rs
+++ b/tests/twcc.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use str0m::format::Codec;
 use str0m::media::{Direction, MediaKind};
 use str0m::rtp::rtcp::Twcc;
-use str0m::{Candidate, Rtc, RtcError};
+use str0m::{Rtc, RtcError};
 use tracing::info_span;
 
 mod common;
@@ -21,10 +21,8 @@ pub fn twcc() -> Result<(), RtcError> {
     let mut l = TestRtc::new_with_rtc(info_span!("L"), l_rtc);
     let mut r = TestRtc::new_with_rtc(info_span!("R"), r_rtc);
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1).unwrap();
-    r.add_local_candidate(host2).unwrap();
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
 
     let mid = negotiate(&mut l, &mut r, |change| {
         change.add_media(MediaKind::Video, Direction::SendOnly, None, None, None)

--- a/tests/unidirectional-r-create-media.rs
+++ b/tests/unidirectional-r-create-media.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use str0m::change::SdpOffer;
 use str0m::format::Codec;
 use str0m::media::{Direction, MediaKind};
-use str0m::{Candidate, Event, RtcError};
+use str0m::{Event, RtcError};
 use tracing::info_span;
 
 mod common;
@@ -18,10 +18,8 @@ pub fn unidirectional_r_create_media() -> Result<(), RtcError> {
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1).unwrap();
-    r.add_local_candidate(host2).unwrap();
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
 
     // The change is on the R (not sending side) with Direction::RecvOnly.
     let mut change = r.sdp_api();

--- a/tests/unidirectional-r-create-media.rs
+++ b/tests/unidirectional-r-create-media.rs
@@ -20,8 +20,8 @@ pub fn unidirectional_r_create_media() -> Result<(), RtcError> {
 
     let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
     let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1);
-    r.add_local_candidate(host2);
+    l.add_local_candidate(host1).unwrap();
+    r.add_local_candidate(host2).unwrap();
 
     // The change is on the R (not sending side) with Direction::RecvOnly.
     let mut change = r.sdp_api();

--- a/tests/unidirectional.rs
+++ b/tests/unidirectional.rs
@@ -19,8 +19,8 @@ pub fn unidirectional() -> Result<(), RtcError> {
 
     let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
     let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1);
-    r.add_local_candidate(host2);
+    l.add_local_candidate(host1).unwrap();
+    r.add_local_candidate(host2).unwrap();
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();

--- a/tests/unidirectional.rs
+++ b/tests/unidirectional.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use str0m::format::Codec;
 use str0m::media::{Direction, MediaKind};
-use str0m::{Candidate, Event, RtcError};
+use str0m::{Event, RtcError};
 use tracing::info_span;
 
 mod common;
@@ -17,10 +17,8 @@ pub fn unidirectional() -> Result<(), RtcError> {
     let mut l = TestRtc::new(info_span!("L"));
     let mut r = TestRtc::new(info_span!("R"));
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1).unwrap();
-    r.add_local_candidate(host2).unwrap();
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();

--- a/tests/user-rtp-header-extension.rs
+++ b/tests/user-rtp-header-extension.rs
@@ -8,7 +8,7 @@ use str0m::rtp::Extension;
 use str0m::rtp::ExtensionSerializer;
 use str0m::rtp::ExtensionValues;
 use str0m::Rtc;
-use str0m::{Candidate, Event, RtcError};
+use str0m::{Event, RtcError};
 use tracing::info_span;
 
 mod common;
@@ -82,10 +82,8 @@ pub fn user_rtp_header_extension() -> Result<(), RtcError> {
     let mut l = TestRtc::new_with_rtc(info_span!("L"), rtc_l);
     let mut r = TestRtc::new_with_rtc(info_span!("R"), rtc_r);
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1).unwrap();
-    r.add_local_candidate(host2).unwrap();
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();
@@ -225,10 +223,8 @@ pub fn user_rtp_header_extension_two_byte_form() -> Result<(), RtcError> {
     let mut l = TestRtc::new_with_rtc(info_span!("L"), rtc_l);
     let mut r = TestRtc::new_with_rtc(info_span!("R"), rtc_r);
 
-    let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
-    let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1).unwrap();
-    r.add_local_candidate(host2).unwrap();
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();

--- a/tests/user-rtp-header-extension.rs
+++ b/tests/user-rtp-header-extension.rs
@@ -84,8 +84,8 @@ pub fn user_rtp_header_extension() -> Result<(), RtcError> {
 
     let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
     let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1);
-    r.add_local_candidate(host2);
+    l.add_local_candidate(host1).unwrap();
+    r.add_local_candidate(host2).unwrap();
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();
@@ -227,8 +227,8 @@ pub fn user_rtp_header_extension_two_byte_form() -> Result<(), RtcError> {
 
     let host1 = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp")?;
     let host2 = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp")?;
-    l.add_local_candidate(host1);
-    r.add_local_candidate(host2);
+    l.add_local_candidate(host1).unwrap();
+    r.add_local_candidate(host2).unwrap();
 
     // The change is on the L (sending side) with Direction::SendRecv.
     let mut change = l.sdp_api();


### PR DESCRIPTION
At present, `IceAgent::add_local_candidate` consumes the `Candidate` and returns a `bool` whether the candidate was accepted by the `IceAgent`. In most applications, one needs to test for this boolean to know, whether the candidate should be signaled to the remote party. For example, a redundant candidate doesn't need to be signaled to the remote.

The current API is sub-optimal for this usecase because one always needs to `clone` the candidate in order to have it available to sending it via the signalling layer. We therefore refactor this API to return an Option`` instead with a reference to the candidate if it got accepted.

In addition, as of #640, str0m has a feature where it computes the local preference of a `Candidate` such that relay candidates allocated via the same IP version are preferred over others: An IPv4 relay candidate allocated over an IPv4 network is preferred over the IPv6 relay candidate allocated on the same network. By returning a reference to the accepted candidate from `add_local_candidate`, this local preference is preserved and reflected accordingly in the priority communicated to the remote.

As a result, the controlling agent (even if that isn't str0m), will prefer such a candidate and nominate a network path that doesn't need any IP stack translation on the relay. Prior to this change, this would only work for the relay candidates of the controlling agent as local preferences are only computed once a candidate is added to an agent.