### PR TITLE
Fix vp8 depacketize for small packets

### DIFF
--- a/src/packet/vp8.rs
+++ b/src/packet/vp8.rs
@@ -182,9 +182,9 @@ impl Depacketizer for Vp8Depacketizer {
         extra: &mut CodecExtra,
     ) -> Result<(), PacketError> {
         let payload_len = packet.len();
-        if payload_len < 4 {
-            return Err(PacketError::ErrShortPacket);
-        }
+        // VP8 Payload Descriptor
+        // https://datatracker.ietf.org/doc/html/rfc7741#section-4.2
+        //
         //    0 1 2 3 4 5 6 7                      0 1 2 3 4 5 6 7
         //    +-+-+-+-+-+-+-+-+                   +-+-+-+-+-+-+-+-+
         //    |X|R|N|S|R| PID | (REQUIRED)        |X|R|N|S|R| PID | (REQUIRED)
@@ -197,8 +197,8 @@ impl Depacketizer for Vp8Depacketizer {
         //    +-+-+-+-+-+-+-+-+                   +-+-+-+-+-+-+-+-+
         //T/K:|tid|Y| KEYIDX  | (OPTIONAL)   L:   |   tl0picidx   | (OPTIONAL)
         //    +-+-+-+-+-+-+-+-+                   +-+-+-+-+-+-+-+-+
-        //T/K:|tid|Y| KEYIDX  | (OPTIONAL)
-        //    +-+-+-+-+-+-+-+-+
+        //                                    T/K:|tid|Y| KEYIDX  | (OPTIONAL)
+        //                                        +-+-+-+-+-+-+-+-+
 
         let mut reader = (packet, 0);
         let mut payload_index = 0;

--- a/src/packet/vp8.rs
+++ b/src/packet/vp8.rs
@@ -352,14 +352,15 @@ mod test {
         let result = pck.depacketize(empty_bytes, &mut payload, &mut extra);
         assert!(result.is_err(), "Result should be err in case of error");
 
-        // Payload smaller than header size
+        // Small Payload with single octet header
         let small_bytes = &[0x00, 0x11, 0x22];
         let mut payload = Vec::new();
-        let result = pck.depacketize(small_bytes, &mut payload, &mut extra);
-        assert!(result.is_err(), "Result should be err in case of error");
+        pck.depacketize(small_bytes, &mut payload, &mut extra)
+            .expect("Small packet");
+        assert_eq!(payload, [0x11, 0x22]);
 
-        // Payload smaller than header size
-        let small_bytes = &[0x00, 0x11];
+        // Payload is header only
+        let small_bytes = &[0x00];
         let mut payload = Vec::new();
         let result = pck.depacketize(small_bytes, &mut payload, &mut extra);
         assert!(result.is_err(), "Result should be err in case of error");


### PR DESCRIPTION
# Description

I'm successfully using a GStreamer pipeline to send a VP8 encoded test pattern into str0m, but occasionally I'm seeing a `PacketError::ErrShortPacket` back from `Vp8Depacketizer.depacketize()`. Upon tracing the issue, I determined that the cause is a total packet length check at the top of the method, which I believe is incorrect.

According to the [VP8 Payload Descriptor documentation](https://datatracker.ietf.org/doc/html/rfc7741#section-4.2), there are two variations of this payload descriptor, with the more compact version only requiring a single octet. I regularly see valid packets in my tests with a length of less than four, which result in corrupted video when returned as an error instead of being processed.

I've recorded a short video demonstration of what I'm seeing with an example of the current code version with extra logging, and an example after the change has been made. In both cases, the VP8 encoder only generates keyframes on request, and both tests run for more than 5 minutes: https://www.youtube.com/watch?v=Po4v8QGKKcM

# Changes Made

The primary change is the removal of the packet length check. The rest of the code below will naturally detect a short packet if that were to occur.

Additionally, I fixed an issue with the payload descriptor comment, as the last row was offset incorrectly, and included the URL to the documentation mirroring the "VP8 Payload Header" comment found later in the code.



