### PR TITLE
Drop feedback until ICE is established

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1586,6 +1586,9 @@ impl Rtc {
                 };
                 return Ok(Output::Transmit(t));
             }
+        } else {
+            // Don't allow accumulated feedback to build up indefinitely
+            self.session.clear_feedback();
         }
 
         let stats = self.stats.as_mut();

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -606,7 +606,7 @@ mod test {
         }
 
         fn is_partition_tail(&self, _marker: bool, packet: &[u8]) -> bool {
-            !packet.is_empty() && packet.iter().any(|v| *v == 9)
+            !packet.is_empty() && packet.contains(&9)
         }
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -657,6 +657,13 @@ impl Session {
         x
     }
 
+    /// To be called in lieu of [`Self::poll_datagram`] when the owner is not in a position to transmit any
+    /// generated feedback, and thus such feedback should be dropped.
+    pub fn clear_feedback(&mut self) {
+        self.feedback_rx.clear();
+        self.feedback_tx.clear();
+    }
+
     fn poll_feedback(&mut self) -> Option<net::DatagramSend> {
         if self.feedback_tx.is_empty() {
             return None;

--- a/tests/no-pre-ice-feedback.rs
+++ b/tests/no-pre-ice-feedback.rs
@@ -1,0 +1,72 @@
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+use str0m::media::{Direction, MediaKind};
+use str0m::rtp::RawPacket;
+use str0m::{Rtc, RtcError};
+use tracing::info_span;
+
+mod common;
+use common::{init_crypto_default, init_log, negotiate, progress, TestRtc};
+
+#[test]
+pub fn no_pre_ice_feedback() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let l_rtc = Rtc::builder().enable_raw_packets(true).build();
+    let r_rtc = Rtc::builder().enable_raw_packets(true).build();
+
+    let mut l = TestRtc::new_with_rtc(info_span!("L"), l_rtc);
+    let mut r = TestRtc::new_with_rtc(info_span!("R"), r_rtc);
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    negotiate(&mut l, &mut r, |change| {
+        change.add_media(MediaKind::Video, Direction::SendOnly, None, None, None)
+    });
+
+    // Before ICE is established, introduce a large time delta that spans at least one sender/receiver report
+    // interval
+    let mut t = l.last;
+    l.handle_input(str0m::Input::Timeout(t))?;
+    t += Duration::from_secs(10);
+    l.handle_input(str0m::Input::Timeout(t))?;
+
+    /// Some things are gated not only on DTLS being connected, i.e. `Rtc.is_connected()`, but on that
+    /// connected event being propagated internally. This includes the outputting of raw packets sometimes.
+    fn is_fully_connected(rtc: &TestRtc) -> bool {
+        rtc.events
+            .iter()
+            .any(|(_, e)| matches!(e, str0m::Event::Connected))
+    }
+
+    loop {
+        if is_fully_connected(&l) && is_fully_connected(&r) {
+            break;
+        }
+
+        progress(&mut l, &mut r)?;
+    }
+
+    for (_, event) in l.events.iter() {
+        if let Some(RawPacket::RtcpTx(tx)) = event.as_raw_packet() {
+            panic!(
+                "Sender should not have generated feedback before ICE, but it output {:?}",
+                tx
+            );
+        }
+    }
+
+    for (_, event) in r.events.iter() {
+        if let Some(RawPacket::RtcpRx(rx)) = event.as_raw_packet() {
+            panic!(
+                "Receiver should not have generated feedback before ICE, but it output {:?}",
+                rx
+            );
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Potential solution to https://github.com/algesten/str0m/issues/635.

Quite simply, it just clears any generated feedback if ICE has not yet been established. This prevents it from buffering indefinitely if ICE just never establishes at all.

I thought this might be a simpler solution than trying to have extra logic to gate generating that feedback in the first place.