### PR TITLE
Pii newtype to redact pii data as feature

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -46,6 +46,21 @@ jobs:
         with:
           check_diff: true
 
+  pii:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --test pii --features pii
+
   test_wincrypto:
     strategy:
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,6 +1125,7 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "pcap-file",
+ "regex",
  "rouille",
  "sctp-proto",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ sha1 = ["dep:sha1"]
 # openssl and sha1.
 wincrypto = ["dep:str0m-wincrypto"]
 
+# Redacts personally identifiable information (PII) from logs debug and above
+pii = []
+
 _internal_dont_use_log_stats = []
 _internal_test_exports = []
 
@@ -72,6 +75,7 @@ serde_json = "1.0"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "std"] }
 systemstat = "0.2.2"
 pcap-file = "2.0.0"
+regex = "1.11.1"
 
 # dummy package that enables "_internal_test_exports"
 _str0m_test = { path = "_str0m_test" }

--- a/src/ice/pair.rs
+++ b/src/ice/pair.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, Instant};
 
 use crate::io::{Id, StunTiming, TransId, DEFAULT_MAX_RETRANSMITS};
 use crate::Candidate;
+use crate::Pii;
 
 // When running ice-lite we need a cutoff when we consider the remote definitely gone.
 const RECENT_BINDING_REQUEST: Duration = Duration::from_secs(15);
@@ -199,10 +200,10 @@ impl CandidatePair {
         assert!(self.nomination_state == NominationState::None);
         if force_success {
             self.nomination_state = NominationState::Success;
-            debug!("Force success nominated pair {:?}", self);
+            debug!("Force success nominated pair {:?}", Pii(&self));
         } else {
             self.nomination_state = NominationState::Nominated;
-            debug!("Nominated pair: {:?}", self);
+            debug!("Nominated pair: {:?}", Pii(&self));
         }
     }
 
@@ -226,7 +227,7 @@ impl CandidatePair {
         self.cached_next_attempt_time = None;
 
         if matches!(self.nomination_state, NominationState::Nominated) {
-            debug!("Nominated attempt STUN binding: {:?}", self);
+            debug!("Nominated attempt STUN binding: {:?}", Pii(&self));
             self.nomination_state = NominationState::Attempt;
         }
 
@@ -283,7 +284,7 @@ impl CandidatePair {
 
         if attempt.nominated && self.nomination_state == NominationState::Attempt {
             self.nomination_state = NominationState::Success;
-            debug!("Nomination success: {:?}", self);
+            debug!("Nomination success: {:?}", Pii(&self));
         }
 
         if self.state == CheckState::InProgress {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -621,7 +621,7 @@ use std::time::{Duration, Instant};
 use streams::RtpPacket;
 use streams::StreamPaused;
 use thiserror::Error;
-use util::InstantExt;
+use util::{InstantExt, Pii};
 
 mod crypto;
 use crypto::CryptoProvider;
@@ -1444,7 +1444,7 @@ impl Rtc {
                     return Ok(Output::Event(Event::IceConnectionStateChange(v)))
                 }
                 IceAgentEvent::DiscoveredRecv { proto, source } => {
-                    info!("ICE remote address: {:?}/{:?}", source, proto);
+                    info!("ICE remote address: {:?}/{:?}", Pii(source), proto);
                     self.remote_addrs.push(source);
                     while self.remote_addrs.len() > 20 {
                         self.remote_addrs.remove(0);
@@ -1457,7 +1457,9 @@ impl Rtc {
                 } => {
                     info!(
                         "ICE nominated send from: {:?} to: {:?} with protocol {:?}",
-                        source, destination, proto,
+                        Pii(source),
+                        Pii(destination),
+                        proto,
                     );
                     self.send_addr = Some(SendAddr {
                         proto,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -4,6 +4,10 @@ mod bit_pattern;
 
 pub(crate) use bit_pattern::BitPattern;
 
+mod pii;
+
+pub(crate) use pii::Pii;
+
 pub(crate) mod value_history;
 
 mod time_tricks;

--- a/src/util/pii.rs
+++ b/src/util/pii.rs
@@ -1,0 +1,87 @@
+//! PII-safe wrapper for sensitive values.
+//!
+//! The `Pii<T>` type is a generic wrapper for any value that may contain
+//! personally identifiable information (PII) or other sensitive data.
+//! When the `pii` feature is enabled, any value wrapped in `Pii` will be
+//! redacted (displayed as `REDACTED`) when formatted with `Display`.
+//! Otherwise, the inner value is shown as normal. This helps prevent
+//! accidental leakage of sensitive information in logs or user-facing
+//! output.
+//!
+//! Logging or displaying sensitive data such as IP addresses, user IDs, or
+//! authentication tokens can lead to privacy violations or security
+//! incidents.
+//!
+//! This wrapper should be used for debug, info, warn, and error logs.
+//! It is not intended for trace-level logs, as trace logs are typically
+//! disabled in production environments.
+
+use core::fmt;
+use core::ops::Deref;
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Pii<T>(pub T);
+
+impl<T: fmt::Display> fmt::Display for Pii<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[cfg(feature = "pii")]
+        {
+            write!(f, "{{REDACTED}}")
+        }
+        #[cfg(not(feature = "pii"))]
+        {
+            write!(f, "{}", self.0)
+        }
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Pii<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[cfg(feature = "pii")]
+        {
+            write!(f, "{{REDACTED}}")
+        }
+        #[cfg(not(feature = "pii"))]
+        {
+            write!(f, "{:?}", self.0)
+        }
+    }
+}
+
+impl<T> Deref for Pii<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    #[test]
+    fn socket_addr_display() {
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+        let pii_addr = Pii(addr);
+
+        #[cfg(feature = "pii")]
+        assert_eq!(pii_addr.to_string(), "{REDACTED}");
+
+        #[cfg(not(feature = "pii"))]
+        assert_eq!(pii_addr.to_string(), "127.0.0.1:8080");
+    }
+
+    #[test]
+    fn string_display() {
+        let sensitive = String::from("sensitive data");
+        let pii_string = Pii(sensitive);
+
+        #[cfg(feature = "pii")]
+        assert_eq!(pii_string.to_string(), "{REDACTED}");
+
+        #[cfg(not(feature = "pii"))]
+        assert_eq!(pii_string.to_string(), "sensitive data");
+    }
+}

--- a/tests/pii.rs
+++ b/tests/pii.rs
@@ -1,0 +1,183 @@
+//! If this test fails, it indicates that an IP address or other personally
+//! identifiable information (PII) was logged. Ensure that sensitive values
+//! checked by this test are wrapped using the `Pii` wrapper.
+//! Run this test with:
+//! ```shell
+//! cargo test --test pii --features pii
+//! ```
+
+mod common;
+#[cfg(feature = "pii")]
+mod pii_log_redaction {
+    use common::{connect_l_r, init_crypto_default, progress};
+    use std::collections::VecDeque;
+    use std::time::Duration;
+
+    use str0m::format::Codec;
+    use str0m::media::MediaKind;
+    use str0m::rtp::{ExtensionValues, Ssrc};
+    use str0m::{Event, RtcError};
+
+    use super::*;
+    use regex::Regex;
+    use std::sync::Once;
+    use tracing::{Event as TracingEvent, Subscriber};
+    use tracing_subscriber::prelude::*;
+    use tracing_subscriber::{layer::Context, Layer, Registry};
+
+    static INIT: Once = Once::new();
+
+    struct AssertNoIpLayer {
+        ipv4: Regex,
+        ipv6: Regex,
+    }
+
+    impl<S: Subscriber> Layer<S> for AssertNoIpLayer {
+        fn on_event(&self, event: &TracingEvent<'_>, _ctx: Context<'_, S>) {
+            let mut visitor = StringVisitor::default();
+            event.record(&mut visitor);
+            let msg = visitor.0;
+            if self.ipv4.is_match(&msg) {
+                panic!("IPv4 address found in log: {}", msg);
+            }
+            if self.ipv6.is_match(&msg) {
+                panic!("IPv6 address found in log: {}", msg);
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct StringVisitor(String);
+    impl tracing::field::Visit for StringVisitor {
+        fn record_debug(&mut self, _field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            use std::fmt::Write;
+            let _ = write!(&mut self.0, "{:?}", value);
+        }
+        fn record_str(&mut self, _field: &tracing::field::Field, value: &str) {
+            self.0.push_str(value);
+        }
+    }
+
+    fn install_assert_no_ip_layer() {
+        INIT.call_once(|| {
+            let ipv4 = Regex::new(r"\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b").unwrap();
+            let ipv6 = Regex::new(r"\b([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}\b").unwrap();
+            let layer = AssertNoIpLayer { ipv4, ipv6 }
+                .with_filter(tracing_subscriber::filter::LevelFilter::DEBUG);
+            let subscriber = Registry::default().with(layer);
+            tracing::subscriber::set_global_default(subscriber).expect("set global subscriber");
+        });
+    }
+
+    #[test]
+    fn pii_test() -> Result<(), RtcError> {
+        install_assert_no_ip_layer();
+        init_crypto_default();
+
+        let (mut l, mut r) = connect_l_r();
+
+        let mid = "aud".into();
+
+        // In this example we are using MID only (no RID) to identify the incoming media.
+        let ssrc_tx: Ssrc = 42.into();
+
+        l.direct_api().declare_media(mid, MediaKind::Audio);
+
+        l.direct_api().declare_stream_tx(ssrc_tx, None, mid, None);
+
+        r.direct_api().declare_media(mid, MediaKind::Audio);
+
+        let max = l.last.max(r.last);
+        l.last = max;
+        r.last = max;
+
+        let params = l.params_opus();
+        let ssrc = l.direct_api().stream_tx_by_mid(mid, None).unwrap().ssrc();
+        assert_eq!(params.spec().codec, Codec::Opus);
+        let pt = params.pt();
+
+        let to_write: Vec<&[u8]> = vec![
+            // 1
+            &[0x1, 0x2, 0x3, 0x4],
+            // 3
+            &[0x9, 0xa, 0xb, 0xc],
+            // 2
+            &[0x5, 0x6, 0x7, 0x8],
+        ];
+
+        let mut to_write: VecDeque<_> = to_write.into();
+
+        let mut write_at = l.last + Duration::from_millis(300);
+
+        let mut counts: Vec<u64> = vec![0, 3, 1];
+
+        loop {
+            if l.start + l.duration() > write_at {
+                write_at = l.last + Duration::from_millis(300);
+                if let Some(packet) = to_write.pop_front() {
+                    let wallclock = l.start + l.duration();
+
+                    let mut direct = l.direct_api();
+                    let stream = direct.stream_tx(&ssrc).unwrap();
+
+                    let count = counts.remove(0);
+                    let time = (count * 1000 + 47_000_000) as u32;
+                    let seq_no = (47_000 + count).into();
+
+                    let exts = ExtensionValues {
+                        audio_level: Some(-42 - count as i8),
+                        voice_activity: Some(false),
+                        ..Default::default()
+                    };
+
+                    stream
+                        .write_rtp(
+                            pt,
+                            seq_no,
+                            time,
+                            wallclock,
+                            false,
+                            exts,
+                            false,
+                            packet.to_vec(),
+                        )
+                        .expect("clean write");
+                }
+            }
+
+            progress(&mut l, &mut r)?;
+
+            if l.duration() > Duration::from_secs(10) {
+                break;
+            }
+        }
+
+        let media: Vec<_> = r
+            .events
+            .iter()
+            .filter_map(|(_, e)| {
+                if let Event::RtpPacket(v) = e {
+                    Some(v)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert_eq!(media.len(), 3);
+
+        assert!(l.media(mid).is_some());
+        assert!(l.direct_api().stream_tx_by_mid(mid, None).is_some());
+        l.direct_api().remove_media(mid);
+        assert!(l.media(mid).is_none());
+        assert!(l.direct_api().stream_tx_by_mid(mid, None).is_none());
+
+        assert!(r.media(mid).is_some());
+        assert!(r.direct_api().stream_rx_by_mid(mid, None).is_some());
+        r.direct_api().remove_media(mid);
+        assert!(r.media(mid).is_none());
+        assert!(r.direct_api().stream_rx_by_mid(mid, None).is_none());
+
+        Ok(())
+    }
+}

--- a/wincrypto/Cargo.toml
+++ b/wincrypto/Cargo.toml
@@ -14,4 +14,9 @@ description = "Supporting crate for str0m"
 [dependencies]
 thiserror = { version = "1.0.38" }
 tracing = "0.1.37"
-windows = { version = "0.58", features = ["Win32_Security_Cryptography", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_System_Rpc"] }
+windows = { version = "0.58", features = [
+    "Win32_Security_Cryptography",
+    "Win32_Security_Authentication_Identity",
+    "Win32_Security_Credentials",
+    "Win32_System_Rpc",
+] }


### PR DESCRIPTION
**This is an opt-in feature flag and will be disabled by default to not change current behavior.**

It is important to be able to avoid logging PII (Personally Identifiable Information) because improper handling or exposure of such data can lead to privacy violations, regulatory penalties, reputational damage, and loss of customer trust.

IP is a clear example of PII, and this has been the focus of this PR. However there might be other information that we also want to put under PII such as ufrag, mids etc but that can be done in a follow up PR in an iterative manner.

- Introduced a new `Pii<T>` wrapper type in pii.rs that, when the `pii` feature is enabled, redacts sensitive values (shows `{REDACTED}` for `Display`/`Debug`).
- Updated logging throughout the codebase (notably in ICE and DTLS modules) to wrap sensitive values (such as credentials, candidates, addresses, and events) in `Pii`, ensuring they are redacted in logs when the `pii` feature is enabled.
- Added pii.rs with a test that:
  - Only runs if the `pii` feature is enabled.
  - Installs a custom tracing subscriber that panics if any IPv4 or IPv6 address is found in logs (using the `regex` crate).
  - Runs a media session and asserts that no IP addresses are leaked in logs.
