### PR TITLE
H265 support

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -106,8 +106,6 @@ pub struct CodecSpec {
 pub enum Codec {
     Opus,
     H264,
-    // TODO show this when we support h265.
-    #[doc(hidden)]
     H265,
     Vp8,
     Vp9,
@@ -503,6 +501,7 @@ impl CodecConfig {
         let mut c = Self::empty();
         c.enable_opus(true);
 
+        c.enable_h265(true);
         c.enable_vp8(true);
         c.enable_h264(true);
         // c.add_default_av1();
@@ -635,6 +634,23 @@ impl CodecConfig {
         for p in PARAMS {
             self.add_h264(p.0.into(), Some(p.1.into()), p.2, p.3)
         }
+    }
+
+    /// Enable H265 codec.
+    pub fn enable_h265(&mut self, enabled: bool) {
+        self.params.retain(|c| c.spec.codec != Codec::H265);
+        if !enabled {
+            return;
+        }
+
+        self.add_config(
+            116.into(),
+            Some(117.into()),
+            Codec::H265,
+            Frequency::NINETY_KHZ,
+            None,
+            FormatParams::default(),
+        );
     }
 
     // TODO: AV1 depacketizer/packetizer.

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -18,7 +18,7 @@ mod h264_profile;
 pub(crate) use h264_profile::H264ProfileLevel;
 
 mod h265;
-use h265::H265Depacketizer;
+use h265::{H265Depacketizer, H265Packetizer};
 
 mod opus;
 use opus::{OpusDepacketizer, OpusPacketizer};
@@ -188,7 +188,7 @@ pub(crate) enum CodecPacketizer {
     #[allow(unused)]
     G722(G722Packetizer),
     H264(H264Packetizer),
-    // H265() TODO
+    H265(H265Packetizer),
     Opus(OpusPacketizer),
     Vp8(Vp8Packetizer),
     Vp9(Vp9Packetizer),
@@ -214,7 +214,7 @@ impl From<Codec> for CodecPacketizer {
         match c {
             Codec::Opus => CodecPacketizer::Opus(OpusPacketizer),
             Codec::H264 => CodecPacketizer::H264(H264Packetizer::default()),
-            Codec::H265 => unimplemented!("Missing packetizer for H265"),
+            Codec::H265 => CodecPacketizer::H265(H265Packetizer::default()),
             Codec::Vp8 => CodecPacketizer::Vp8(Vp8Packetizer::default()),
             Codec::Vp9 => CodecPacketizer::Vp9(Vp9Packetizer::default()),
             Codec::Av1 => unimplemented!("Missing packetizer for AV1"),
@@ -248,6 +248,7 @@ impl Packetizer for CodecPacketizer {
             G711(v) => v.packetize(mtu, b),
             G722(v) => v.packetize(mtu, b),
             H264(v) => v.packetize(mtu, b),
+            H265(v) => v.packetize(mtu, b),
             Opus(v) => v.packetize(mtu, b),
             Vp8(v) => v.packetize(mtu, b),
             Vp9(v) => v.packetize(mtu, b),
@@ -262,6 +263,7 @@ impl Packetizer for CodecPacketizer {
             CodecPacketizer::G722(v) => v.is_marker(data, previous, last),
             CodecPacketizer::Opus(v) => v.is_marker(data, previous, last),
             CodecPacketizer::H264(v) => v.is_marker(data, previous, last),
+            CodecPacketizer::H265(v) => v.is_marker(data, previous, last),
             CodecPacketizer::Vp8(v) => v.is_marker(data, previous, last),
             CodecPacketizer::Vp9(v) => v.is_marker(data, previous, last),
             CodecPacketizer::Null(v) => v.is_marker(data, previous, last),


### PR DESCRIPTION
These commits add full support for H265.

Including tests adapted from the `pion/webrtc` project. All tests passed.