### PR TITLE
Add some remote stats from SR/RR stats into Ingress/EgressStats

### DIFF
--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -877,7 +877,7 @@ impl StreamTx {
     }
 
     pub(crate) fn visit_stats(&mut self, snapshot: &mut StatsSnapshot, now: Instant) {
-        self.stats.fill(snapshot, self.midrid, now);
+        self.stats.fill(snapshot, self.midrid, self.seq_no, now);
     }
 
     pub(crate) fn queue_state(&mut self, now: Instant) -> QueueState {


### PR DESCRIPTION
Fill in RemoteIngressStats, and RemoteEgressStats using the most recent RR or SR respectively.

I made the naming within the remote stats structs consistent with the local stats, so renamed "bytes_tx" to "bytes" .. since we don't differentiate that way in MediaIngressStats or MediaEgressStats.

Did not pass the ntp/rtp time values in the SR nor the last SR time + delay in RR. Not sure if we feel they're needed or not, figure they can be added when needed.
