### PR TITLE
fix(ice): don't reject relay candidate as redundant with host

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -779,7 +779,7 @@ impl IceAgent {
                     let check_local = check.local_candidate(&self.local_candidates);
                     let check_remote = check.remote_candidate(&self.remote_candidates);
 
-                    let redundant = local.base() == check_local.base()
+                    let redundant = local.source_addr() == check_local.source_addr()
                         && remote.addr() == check_remote.addr()
                         && local.proto() == check_local.proto()
                         && remote.proto() == check_remote.proto();


### PR DESCRIPTION
In #640 and #644, we broke ICE for network setups where both peers are behind symmetric NAT because relay candidates now have a base and when we check for redundant candidate pairs, we only compare the base. Instead, I believe we need to compare the `source_addr` here as that is what we use to send packets from.

The notion of "base" is getting pretty muddied here but I also can't think of a much better model here that doesn't involve storing yet-another `SocketAddr` in the `Candidate`.

Co-authored-by: Antoine Labarussias <antoinelabarussias@gmail.com>