### PR TITLE
Remove base from relay candidates (follow spec)

### DIFF
--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -209,14 +209,8 @@ impl Candidate {
     ///
     /// * `addr` - The TURN server's allocated address that will be used for relaying traffic.
     ///            This is the address that will be used for communication with the peer.
-    /// * `base` - The local interface address that corresponds to this candidate. This is the
-    ///            address from which the TURN allocation request was sent.
     /// * `proto` - The transport protocol to use (UDP, TCP, etc.).
-    pub fn relayed(
-        addr: SocketAddr,
-        base: SocketAddr,
-        proto: impl TryInto<Protocol>,
-    ) -> Result<Self, IceError> {
+    pub fn relayed(addr: SocketAddr, proto: impl TryInto<Protocol>) -> Result<Self, IceError> {
         if !is_valid_ip(addr.ip()) {
             return Err(IceError::BadCandidate(format!("invalid ip {}", addr.ip())));
         }
@@ -227,7 +221,7 @@ impl Candidate {
             parse_proto(proto)?,
             None,
             addr,
-            Some(base),
+            Some(addr),
             CandidateKind::Relayed,
             Some(Self::arbitrary_raddr(addr)),
             None,
@@ -661,9 +655,9 @@ mod tests {
             no_hash(candidate.to_string()),
             "candidate:--- 1 udp 2130706175 1.2.3.4 9876 typ host raddr 5.5.5.5 rport 5555 ufrag ufrag");
 
-        let base_addr = "5.6.7.8:4321".parse().unwrap();
+        // let base_addr = "5.6.7.8:4321".parse().unwrap();
 
-        let candidate = Candidate::relayed(socket_addr, base_addr, Protocol::SslTcp).unwrap();
+        let candidate = Candidate::relayed(socket_addr, Protocol::SslTcp).unwrap();
         assert_eq!(
             no_hash(candidate.to_string()),
             "candidate:--- 1 ssltcp 16776959 1.2.3.4 9876 typ relay raddr 0.0.0.0 rport 0"
@@ -690,7 +684,7 @@ mod tests {
         assert!(host.raddr().is_none());
 
         // We're not picky on the exact choice, but it must not be the private base
-        let relay = Candidate::relayed(socket_addr, base_addr, Protocol::Udp).unwrap();
+        let relay = Candidate::relayed(socket_addr, Protocol::Udp).unwrap();
         assert!(relay.raddr().is_some());
         let srflx = Candidate::server_reflexive(socket_addr, base_addr, Protocol::Udp).unwrap();
         assert!(srflx.raddr().is_some_and(|raddr| raddr != base_addr));
@@ -719,8 +713,8 @@ mod tests {
             host("2.2.2.2:0"),
             srflx("3.3.3.3:0", "4.4.4.4:0"),
             srflx("5.5.5.5:0", "6.6.6.6:0"),
-            relay("8.8.8.8:0", "7.7.7.7:0"),
-            relay("7.7.7.7:0", "8.8.8.8:0"),
+            relay("8.8.8.8:0"),
+            relay("7.7.7.7:0"),
         ]);
         candidates.sort();
 
@@ -744,8 +738,8 @@ mod tests {
             .to_sdp_string()
     }
 
-    fn relay(addr: &str, base: &str) -> String {
-        Candidate::relayed(addr.parse().unwrap(), base.parse().unwrap(), "udp")
+    fn relay(addr: &str) -> String {
+        Candidate::relayed(addr.parse().unwrap(), "udp")
             .unwrap()
             .to_sdp_string()
     }

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -95,12 +95,8 @@ mod test {
         Candidate::server_reflexive(sock(s), sock(base), proto).unwrap()
     }
 
-    pub fn relay(
-        s: impl Into<String>,
-        base: impl Into<String>,
-        proto: impl TryInto<Protocol>,
-    ) -> Candidate {
-        Candidate::relayed(sock(s), sock(base), proto).unwrap()
+    pub fn relay(s: impl Into<String>, proto: impl TryInto<Protocol>) -> Candidate {
+        Candidate::relayed(sock(s), proto).unwrap()
     }
 
     /// Transform the socket to rig different test scenarios.
@@ -680,7 +676,7 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
 
         let c1 = a1
-            .add_local_candidate(relay("1.1.1.1:1000", "5.6.7.8:4321", "udp"))
+            .add_local_candidate(relay("1.1.1.1:1000", "udp"))
             .unwrap()
             .clone();
         a2.add_remote_candidate(c1);
@@ -704,9 +700,9 @@ mod test {
             progress(&mut a1, &mut a2);
         }
 
-        a1.add_local_candidate(relay("1.1.1.1:1001", "5.6.7.8:4321", "udp"))
+        a1.add_local_candidate(relay("1.1.1.1:1001", "udp"))
             .unwrap();
-        a2.add_remote_candidate(relay("1.1.1.1:1001", "5.6.7.8:4321", "udp"));
+        a2.add_remote_candidate(relay("1.1.1.1:1001", "udp"));
 
         loop {
             if a2.has_event(|e| {
@@ -736,13 +732,13 @@ mod test {
         // Both agents know their local candidates
         let c1 = a1.add_host_candidate("1.1.1.1:1000");
         let c3 = a1
-            .add_local_candidate(relay("2.2.2.2:1000", "5.6.7.8:4321", "udp"))
+            .add_local_candidate(relay("2.2.2.2:1000", "udp"))
             .unwrap()
             .clone();
 
         let c2 = a2.add_host_candidate("1.1.1.1:1001");
         let c4 = a2
-            .add_local_candidate(relay("2.2.2.2:1001", "5.6.7.8:4321", "udp"))
+            .add_local_candidate(relay("2.2.2.2:1001", "udp"))
             .unwrap()
             .clone();
 
@@ -809,78 +805,80 @@ mod test {
         assert_eq!(a2.num_candidate_pairs(), 1);
     }
 
-    // In general, ICE prefers IPv6 over IPv4.
-    // However, in case our only IPv6 connectivity is via a relay that we are talking to over IPv4,
-    // we want to prefer the IPv4 code path.
-    #[test]
-    fn prefers_ipv4_ipv4_relay_candidate_over_ipv4_ipv6_controlling() {
-        let _guard = tracing_subscriber::fmt()
-            .with_env_filter("debug")
-            .with_test_writer()
-            .set_default();
+    // // In general, ICE prefers IPv6 over IPv4.
+    // // However, in case our only IPv6 connectivity is via a relay that we are talking to over IPv4,
+    // // we want to prefer the IPv4 code path.
+    // #[test]
+    // fn prefers_ipv4_ipv4_relay_candidate_over_ipv4_ipv6_controlling() {
+    //     let _guard = tracing_subscriber::fmt()
+    //         .with_env_filter("debug")
+    //         .with_test_writer()
+    //         .set_default();
 
-        let mut a1 = TestAgent::new(info_span!("L"));
-        let mut a2 = TestAgent::new(info_span!("R"));
+    //     let mut a1 = TestAgent::new(info_span!("L"));
+    //     let mut a2 = TestAgent::new(info_span!("R"));
 
-        a1.set_controlling(true);
-        a2.set_controlling(false);
+    //     a1.set_controlling(true);
+    //     a2.set_controlling(false);
 
-        prefer_ipv4_candidate_over_ipv6_candidate(&mut a1, &mut a2);
-    }
+    //     prefer_ipv4_candidate_over_ipv6_candidate(&mut a1, &mut a2);
+    // }
 
-    // In general, ICE prefers IPv6 over IPv4.
-    // However, in case our only IPv6 connectivity is via a relay that we are talking to over IPv4,
-    // we want to prefer the IPv4 code path.
-    #[test]
-    fn prefers_ipv4_ipv4_relay_candidate_over_ipv4_ipv6_controlled() {
-        let _guard = tracing_subscriber::fmt()
-            .with_env_filter("debug")
-            .with_test_writer()
-            .set_default();
+    // // In general, ICE prefers IPv6 over IPv4.
+    // // However, in case our only IPv6 connectivity is via a relay that we are talking to over IPv4,
+    // // we want to prefer the IPv4 code path.
+    // #[test]
+    // fn prefers_ipv4_ipv4_relay_candidate_over_ipv4_ipv6_controlled() {
+    //     let _guard = tracing_subscriber::fmt()
+    //         .with_env_filter("debug")
+    //         .with_test_writer()
+    //         .set_default();
 
-        let mut a1 = TestAgent::new(info_span!("L"));
-        let mut a2 = TestAgent::new(info_span!("R"));
+    //     let mut a1 = TestAgent::new(info_span!("L"));
+    //     let mut a2 = TestAgent::new(info_span!("R"));
 
-        a1.set_controlling(false);
-        a2.set_controlling(true);
+    //     a1.set_controlling(false);
+    //     a2.set_controlling(true);
 
-        prefer_ipv4_candidate_over_ipv6_candidate(&mut a1, &mut a2);
-    }
+    //     prefer_ipv4_candidate_over_ipv6_candidate(&mut a1, &mut a2);
+    // }
 
-    fn prefer_ipv4_candidate_over_ipv6_candidate(a1: &mut TestAgent, a2: &mut TestAgent) {
-        // Agent 1 only has IPv4 connectivity to a relay but allocates both IPv4 and IPv6 addresses.
-        // Agent 2 has no relay but has full IPv4 and IPv6 connectivity.
-        let relay_ipv4_ipv4 = a1
-            .add_local_candidate(relay("7.7.7.7:5000", "1.1.1.1:5000", "udp"))
-            .unwrap()
-            .clone();
-        let relay_ipv6_ipv4 = a1
-            .add_local_candidate(relay("[::7]:5000", "1.1.1.1:5000", "udp"))
-            .unwrap()
-            .clone();
-        a2.add_remote_candidate(relay_ipv4_ipv4);
-        a2.add_remote_candidate(relay_ipv6_ipv4);
+    // fn prefer_ipv4_candidate_over_ipv6_candidate(a1: &mut TestAgent, a2: &mut TestAgent) {
+    //     // Agent 1 only has IPv4 connectivity to a relay but allocates both IPv4 and IPv6 addresses.
+    //     // Agent 2 has no relay but has full IPv4 and IPv6 connectivity.
+    //     let relay_ipv4_ipv4 = a1
+    //         .add_local_candidate(relay("7.7.7.7:5000", "udp"))
+    //         .unwrap()
+    //         .clone();
+    //     let relay_ipv6_ipv4 = a1
+    //         .add_local_candidate(relay("[::7]:5000", "udp"))
+    //         .unwrap()
+    //         .clone();
+    //     a2.add_remote_candidate(relay_ipv4_ipv4);
+    //     a2.add_remote_candidate(relay_ipv6_ipv4);
 
-        let host_ipv4 = a2.add_host_candidate("5.5.5.5:3000");
-        let host_ipv6 = a2.add_host_candidate("[::2]:3000");
-        a1.add_remote_candidate(host_ipv4);
-        a1.add_remote_candidate(host_ipv6);
+    //     let host_ipv4 = a2.add_host_candidate("5.5.5.5:3000");
+    //     let host_ipv6 = a2.add_host_candidate("[::2]:3000");
+    //     a1.add_remote_candidate(host_ipv4);
+    //     a1.add_remote_candidate(host_ipv6);
 
-        // loop until we're connected.
-        loop {
-            if a1.state().is_connected() && a2.state().is_connected() {
-                break;
-            }
-            progress(a1, a2);
-        }
+    //     // loop until we're connected.
+    //     loop {
+    //         if a1.state().is_connected() && a2.state().is_connected() {
+    //             break;
+    //         }
+    //         progress(a1, a2);
+    //     }
 
-        assert!(a1.has_event(|e| {
-                    matches!(e, IceAgentEvent::NominatedSend { source, destination, .. } if source == &sock("7.7.7.7:5000") && destination == &sock("5.5.5.5:3000"))
-                }));
-        assert!(a2.has_event(|e| {
-                    matches!(e, IceAgentEvent::NominatedSend { source, destination, .. } if source == &sock("5.5.5.5:3000") && destination == &sock("7.7.7.7:5000"))
-                }));
-    }
+    //     assert!(a1.has_event(|e| {
+    //                 matches!(e, IceAgentEvent::NominatedSend { source, destination, .. }
+    //                      if source == &sock("7.7.7.7:5000") && destination == &sock("5.5.5.5:3000"))
+    //             }));
+    //     assert!(a2.has_event(|e| {
+    //                 matches!(e, IceAgentEvent::NominatedSend { source, destination, .. }
+    //                      if source == &sock("5.5.5.5:3000") && destination == &sock("7.7.7.7:5000"))
+    //             }));
+    // }
 
     #[test]
     fn changed_timing_config_takes_effect_immediately() {


### PR DESCRIPTION
Relates to #663 

The ICE spec says that relay candidates should have their base set to the same as the relay address itself. This makes it impossible to preserve the behavior where the agent prefers to maintain IPv4/IPv6 between local address and relay. This needs a solution, but we are looking at a bigger refactor (see #663)