### PR TITLE
feat: introduce `created_via` parameter to `Candidate::relayed`

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1942,14 +1942,14 @@ mod test {
 
         // we expect:
         // (host/udp host/udp) - (0, 1)
-        // (host/udp rflx/udp) - (0, 1)
         // (rflx/udp host/udp) - (1, 1)
+        // (host/udp rflx/udp) - (0, 0)
         // (rflx/udp rflx/udp) - (1, 0)
         // (host/tcp host/tcp) - (2, 2)
 
         assert_eq!(
             agent.pair_indexes(),
-            [(0, 1), (0, 0), (1, 1), (1, 0), (2, 2)]
+            [(0, 1), (1, 1), (0, 0), (1, 0), (2, 2)]
         );
     }
 

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -550,22 +550,7 @@ impl IceAgent {
             .filter(|v| v.addr().is_ipv6() == ip.is_ipv6())
             .count() as u32;
 
-        // For relayed candidates, we add a "punishment" to the local preference
-        // if the base address differs in the IP version from the allocated address
-        // of the candidate.
-        // This punishment ensures that we prefer relayed within the same IP version,
-        // e.g. IPv4 <> IPv4 over ones that translate between IP version, e.g. IPv4 <> IPv6.
-        let relay_across_ip_version_punishment = if c.kind() == CandidateKind::Relayed {
-            if c.base().is_ipv4() != ip.is_ipv4() {
-                1000
-            } else {
-                0
-            }
-        } else {
-            0
-        };
-
-        let pref = same_kind * 2 - relay_across_ip_version_punishment;
+        let pref = same_kind * 2;
         trace!("Calculated local preference adjustment: {}", pref);
 
         c.local_preference_mut().sub_assign(pref);

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -380,7 +380,7 @@ impl Candidate {
         //     (2^8)*(local preference) +
         //     (2^0)*(256 - component ID)
         let prio =
-            type_preference << 24 | self.local_preference() << 8 | (256 - self.component_id as u32);
+            type_preference << 24 | self.local_preference << 8 | (256 - self.component_id as u32);
 
         // https://datatracker.ietf.org/doc/html/rfc8445#section-5.1.2
         // MUST be a positive integer between 1 and (2**31 - 1)
@@ -389,6 +389,7 @@ impl Candidate {
         prio
     }
 
+    #[cfg(test)]
     pub(crate) fn local_preference(&self) -> u32 {
         self.local_preference
     }

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -718,7 +718,7 @@ mod tests {
         let candidate = Candidate::relayed(socket_addr, created_via, Protocol::SslTcp).unwrap();
         assert_eq!(
             no_hash(candidate.to_string()),
-            "candidate:--- 1 ssltcp 16776959 1.2.3.4 9876 typ relay raddr 0.0.0.0 rport 0"
+            "candidate:--- 1 ssltcp 4194047 1.2.3.4 9876 typ relay raddr 0.0.0.0 rport 0"
         );
     }
 

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -114,6 +114,7 @@ impl Candidate {
         kind: CandidateKind,
         raddr: Option<SocketAddr>,
         ufrag: Option<String>,
+        local_preference_adjustment: u32,
     ) -> Self {
         let local_preference = {
             use CandidateKind::*;
@@ -123,7 +124,7 @@ impl Candidate {
                 ServerReflexive => 32_767,
                 Relayed => 16_383,
             };
-            x - if addr.is_ipv6() { 0 } else { 1 }
+            x - if addr.is_ipv6() { 0 } else { 1 } - local_preference_adjustment
         };
 
         Candidate {
@@ -162,6 +163,7 @@ impl Candidate {
             kind,
             raddr,
             ufrag,
+            0,
         )
     }
 
@@ -183,6 +185,7 @@ impl Candidate {
             CandidateKind::Host,
             None,
             None,
+            0,
         ))
     }
 
@@ -210,6 +213,7 @@ impl Candidate {
             CandidateKind::ServerReflexive,
             Some(Self::arbitrary_raddr(addr)),
             None,
+            0,
         ))
     }
 
@@ -236,6 +240,7 @@ impl Candidate {
             CandidateKind::Relayed,
             Some(Self::arbitrary_raddr(addr)),
             None,
+            0,
         ))
     }
 
@@ -267,6 +272,7 @@ impl Candidate {
             CandidateKind::PeerReflexive,
             None,
             Some(ufrag),
+            0,
         )
     }
 
@@ -305,6 +311,7 @@ impl Candidate {
             CandidateKind::PeerReflexive,
             None,
             None,
+            0,
         )
     }
 

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -76,7 +76,7 @@ pub struct Candidate {
 
     /// The ice agent might assign a local preference if we have multiple candidates
     /// that are the same type.
-    local_preference: Option<u32>,
+    local_preference: u32,
 
     /// If we discarded this candidate (for example due to being redundant
     /// against another candidate).
@@ -125,7 +125,7 @@ impl Candidate {
             kind,
             raddr,
             ufrag,
-            local_preference: None,
+            local_preference: if addr.is_ipv6() { 65_535 } else { 65_534 },
             discarded: false,
         }
     }
@@ -391,7 +391,6 @@ impl Candidate {
 
     pub(crate) fn local_preference(&self) -> u32 {
         self.local_preference
-            .unwrap_or_else(|| if self.addr.is_ipv6() { 65_535 } else { 65_534 })
     }
 
     pub(crate) fn component_id(&self) -> u16 {
@@ -433,7 +432,7 @@ impl Candidate {
     }
 
     pub(crate) fn set_local_preference(&mut self, v: u32) {
-        self.local_preference = Some(v);
+        self.local_preference = v;
     }
 
     pub(crate) fn set_discarded(&mut self, discarded: bool) {

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -95,8 +95,12 @@ mod test {
         Candidate::server_reflexive(sock(s), sock(base), proto).unwrap()
     }
 
-    pub fn relay(s: impl Into<String>, proto: impl TryInto<Protocol>) -> Candidate {
-        Candidate::relayed(sock(s), proto).unwrap()
+    pub fn relay(
+        s: impl Into<String>,
+        created_via: impl Into<String>,
+        proto: impl TryInto<Protocol>,
+    ) -> Candidate {
+        Candidate::relayed(sock(s), sock(created_via), proto).unwrap()
     }
 
     /// Transform the socket to rig different test scenarios.
@@ -676,7 +680,7 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
 
         let c1 = a1
-            .add_local_candidate(relay("1.1.1.1:1000", "udp"))
+            .add_local_candidate(relay("1.1.1.1:1000", "2.2.2.2:1000", "udp"))
             .unwrap()
             .clone();
         a2.add_remote_candidate(c1);
@@ -701,7 +705,7 @@ mod test {
         }
 
         let c4 = a1
-            .add_local_candidate(relay("1.1.1.1:1001", "udp"))
+            .add_local_candidate(relay("1.1.1.1:1001", "2.2.2.2:1001", "udp"))
             .unwrap()
             .clone();
         a2.add_remote_candidate(c4);
@@ -734,13 +738,13 @@ mod test {
         // Both agents know their local candidates
         let c1 = a1.add_host_candidate("1.1.1.1:1000");
         let c3 = a1
-            .add_local_candidate(relay("2.2.2.2:1000", "udp"))
+            .add_local_candidate(relay("2.2.2.2:1000", "1.1.1.1:1000", "udp"))
             .unwrap()
             .clone();
 
         let c2 = a2.add_host_candidate("1.1.1.1:1001");
         let c4 = a2
-            .add_local_candidate(relay("2.2.2.2:1001", "udp"))
+            .add_local_candidate(relay("2.2.2.2:1001", "1.1.1.1:1001", "udp"))
             .unwrap()
             .clone();
 

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -700,9 +700,11 @@ mod test {
             progress(&mut a1, &mut a2);
         }
 
-        a1.add_local_candidate(relay("1.1.1.1:1001", "udp"))
-            .unwrap();
-        a2.add_remote_candidate(relay("1.1.1.1:1001", "udp"));
+        let c4 = a1
+            .add_local_candidate(relay("1.1.1.1:1001", "udp"))
+            .unwrap()
+            .clone();
+        a2.add_remote_candidate(c4);
 
         loop {
             if a2.has_event(|e| {

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -811,80 +811,80 @@ mod test {
         assert_eq!(a2.num_candidate_pairs(), 1);
     }
 
-    // // In general, ICE prefers IPv6 over IPv4.
-    // // However, in case our only IPv6 connectivity is via a relay that we are talking to over IPv4,
-    // // we want to prefer the IPv4 code path.
-    // #[test]
-    // fn prefers_ipv4_ipv4_relay_candidate_over_ipv4_ipv6_controlling() {
-    //     let _guard = tracing_subscriber::fmt()
-    //         .with_env_filter("debug")
-    //         .with_test_writer()
-    //         .set_default();
+    // In general, ICE prefers IPv6 over IPv4.
+    // However, in case our only IPv6 connectivity is via a relay that we are talking to over IPv4,
+    // we want to prefer the IPv4 code path.
+    #[test]
+    fn prefers_ipv4_ipv4_relay_candidate_over_ipv4_ipv6_controlling() {
+        let _guard = tracing_subscriber::fmt()
+            .with_env_filter("debug")
+            .with_test_writer()
+            .set_default();
 
-    //     let mut a1 = TestAgent::new(info_span!("L"));
-    //     let mut a2 = TestAgent::new(info_span!("R"));
+        let mut a1 = TestAgent::new(info_span!("L"));
+        let mut a2 = TestAgent::new(info_span!("R"));
 
-    //     a1.set_controlling(true);
-    //     a2.set_controlling(false);
+        a1.set_controlling(true);
+        a2.set_controlling(false);
 
-    //     prefer_ipv4_candidate_over_ipv6_candidate(&mut a1, &mut a2);
-    // }
+        prefer_ipv4_candidate_over_ipv6_candidate(&mut a1, &mut a2);
+    }
 
-    // // In general, ICE prefers IPv6 over IPv4.
-    // // However, in case our only IPv6 connectivity is via a relay that we are talking to over IPv4,
-    // // we want to prefer the IPv4 code path.
-    // #[test]
-    // fn prefers_ipv4_ipv4_relay_candidate_over_ipv4_ipv6_controlled() {
-    //     let _guard = tracing_subscriber::fmt()
-    //         .with_env_filter("debug")
-    //         .with_test_writer()
-    //         .set_default();
+    // In general, ICE prefers IPv6 over IPv4.
+    // However, in case our only IPv6 connectivity is via a relay that we are talking to over IPv4,
+    // we want to prefer the IPv4 code path.
+    #[test]
+    fn prefers_ipv4_ipv4_relay_candidate_over_ipv4_ipv6_controlled() {
+        let _guard = tracing_subscriber::fmt()
+            .with_env_filter("debug")
+            .with_test_writer()
+            .set_default();
 
-    //     let mut a1 = TestAgent::new(info_span!("L"));
-    //     let mut a2 = TestAgent::new(info_span!("R"));
+        let mut a1 = TestAgent::new(info_span!("L"));
+        let mut a2 = TestAgent::new(info_span!("R"));
 
-    //     a1.set_controlling(false);
-    //     a2.set_controlling(true);
+        a1.set_controlling(false);
+        a2.set_controlling(true);
 
-    //     prefer_ipv4_candidate_over_ipv6_candidate(&mut a1, &mut a2);
-    // }
+        prefer_ipv4_candidate_over_ipv6_candidate(&mut a1, &mut a2);
+    }
 
-    // fn prefer_ipv4_candidate_over_ipv6_candidate(a1: &mut TestAgent, a2: &mut TestAgent) {
-    //     // Agent 1 only has IPv4 connectivity to a relay but allocates both IPv4 and IPv6 addresses.
-    //     // Agent 2 has no relay but has full IPv4 and IPv6 connectivity.
-    //     let relay_ipv4_ipv4 = a1
-    //         .add_local_candidate(relay("7.7.7.7:5000", "udp"))
-    //         .unwrap()
-    //         .clone();
-    //     let relay_ipv6_ipv4 = a1
-    //         .add_local_candidate(relay("[::7]:5000", "udp"))
-    //         .unwrap()
-    //         .clone();
-    //     a2.add_remote_candidate(relay_ipv4_ipv4);
-    //     a2.add_remote_candidate(relay_ipv6_ipv4);
+    fn prefer_ipv4_candidate_over_ipv6_candidate(a1: &mut TestAgent, a2: &mut TestAgent) {
+        // Agent 1 only has IPv4 connectivity to a relay but allocates both IPv4 and IPv6 addresses.
+        // Agent 2 has no relay but has full IPv4 and IPv6 connectivity.
+        let relay_ipv4_ipv4 = a1
+            .add_local_candidate(relay("7.7.7.7:5000", "5.5.5.5:3000", "udp"))
+            .unwrap()
+            .clone();
+        let relay_ipv6_ipv4 = a1
+            .add_local_candidate(relay("[::7]:5000", "5.5.5.5:3000", "udp"))
+            .unwrap()
+            .clone();
+        a2.add_remote_candidate(relay_ipv4_ipv4);
+        a2.add_remote_candidate(relay_ipv6_ipv4);
 
-    //     let host_ipv4 = a2.add_host_candidate("5.5.5.5:3000");
-    //     let host_ipv6 = a2.add_host_candidate("[::2]:3000");
-    //     a1.add_remote_candidate(host_ipv4);
-    //     a1.add_remote_candidate(host_ipv6);
+        let host_ipv4 = a2.add_host_candidate("5.5.5.5:3000");
+        let host_ipv6 = a2.add_host_candidate("[::2]:3000");
+        a1.add_remote_candidate(host_ipv4);
+        a1.add_remote_candidate(host_ipv6);
 
-    //     // loop until we're connected.
-    //     loop {
-    //         if a1.state().is_connected() && a2.state().is_connected() {
-    //             break;
-    //         }
-    //         progress(a1, a2);
-    //     }
+        // loop until we're connected.
+        loop {
+            if a1.state().is_connected() && a2.state().is_connected() {
+                break;
+            }
+            progress(a1, a2);
+        }
 
-    //     assert!(a1.has_event(|e| {
-    //                 matches!(e, IceAgentEvent::NominatedSend { source, destination, .. }
-    //                      if source == &sock("7.7.7.7:5000") && destination == &sock("5.5.5.5:3000"))
-    //             }));
-    //     assert!(a2.has_event(|e| {
-    //                 matches!(e, IceAgentEvent::NominatedSend { source, destination, .. }
-    //                      if source == &sock("5.5.5.5:3000") && destination == &sock("7.7.7.7:5000"))
-    //             }));
-    // }
+        assert!(a1.has_event(|e| {
+            matches!(e, IceAgentEvent::NominatedSend { source, destination, .. }
+                         if source == &sock("7.7.7.7:5000") && destination == &sock("5.5.5.5:3000"))
+        }));
+        assert!(a2.has_event(|e| {
+            matches!(e, IceAgentEvent::NominatedSend { source, destination, .. }
+                         if source == &sock("5.5.5.5:3000") && destination == &sock("7.7.7.7:5000"))
+        }));
+    }
 
     #[test]
     fn changed_timing_config_takes_effect_immediately() {


### PR DESCRIPTION
This PR is a follow-up to #665 that re-enables the feature of computing the preference of a relay candidate such that we stay within the same IP version. To achieve this without adding additional fields to `Candidate`, almost all of the preference calculation is moved into `Candidate` except for the adjustment based on the number of already added candidates of the same type. This information is only present in the `IceAgent`.

Instead of allowing to simply set the local preference, `Candidate` now exposes a narrower API that accepts a delta that is applied to the preference.