### PR TITLE
Make local preference calculation pluggable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  * Make ICE agent local preference pluggable #668
+  * Fix Candidate::relay() base (breaking) #668 #665
   * Simplified serde of SDP #664
   * SR/RR stats in Ingress/EgressStats #661 #662
 

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -565,7 +565,7 @@ impl IceAgent {
         // This punishment ensures that we prefer relayed within the same IP version,
         // e.g. IPv4 <> IPv4 over ones that translate between IP version, e.g. IPv4 <> IPv6.
         let relay_across_ip_version_punishment = if c.kind() == CandidateKind::Relayed {
-            if c.base().is_ipv4() != ip.is_ipv4() {
+            if c.local().is_ipv4() != ip.is_ipv4() {
                 1000
             } else {
                 0

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -397,6 +397,13 @@ impl IceAgent {
         debug!("max_retransmits = {num}");
     }
 
+    /// Sets the local preference calculation.
+    ///
+    /// This must be used before adding any local candidates.
+    pub fn set_local_preference(&mut self, p: impl LocalPreference) {
+        self.local_preference = LocalPreferenceHolder(Arc::new(p));
+    }
+
     fn bust_candidate_pair_timeout_caches(&mut self) {
         for pair in self.candidate_pairs.iter_mut() {
             pair.reset_cached_next_attempt_time();
@@ -1430,7 +1437,7 @@ impl IceAgent {
 
         let local = pair.local_candidate(&self.local_candidates);
         let proto = local.proto();
-        let local_addr = local.source_addr();
+        let local_addr = local.base();
         let remote = pair.remote_candidate(&self.remote_candidates);
         let remote_addr = remote.addr();
 
@@ -1516,7 +1523,7 @@ impl IceAgent {
 
         let trans = Transmit {
             proto: local.proto(),
-            source: local.source_addr(),
+            source: local.base(),
             destination: remote.addr(),
             contents: buf.into(),
         };
@@ -1672,7 +1679,7 @@ impl IceAgent {
             self.nominated_send = Some(best_prio.id());
             self.emit_event(IceAgentEvent::NominatedSend {
                 proto: local.proto(),
-                source: local.source_addr(),
+                source: local.base(),
                 destination: remote.addr(),
             })
         }

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1,9 +1,13 @@
 use std::collections::{HashSet, VecDeque};
+use std::fmt;
 use std::net::SocketAddr;
+use std::panic::RefUnwindSafe;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
+use crate::ice_::preference::default_local_preference;
 use crate::io::{Id, StunClass, StunMethod, StunTiming, DATAGRAM_MTU_WARN};
 use crate::io::{Protocol, StunPacket};
 use crate::io::{StunMessage, TransId};
@@ -96,6 +100,33 @@ pub struct IceAgent {
 
     /// The timing configuration for STUN bindings.
     timing_config: StunTiming,
+
+    /// Pluggable calculation of local preference.
+    local_preference: LocalPreferenceHolder,
+}
+
+// Stupid holder to implement fmt::Debug
+struct LocalPreferenceHolder(Arc<dyn LocalPreference>);
+
+/// Trait for pluggable LocalPreference calculation
+pub trait LocalPreference: RefUnwindSafe + Send + Sync + 'static {
+    /// Calculate the local preference for a candidate.
+    ///
+    /// The `same_kind` parameter is the number of candidates of the same IP version that
+    /// have already been added to the agent.
+    ///
+    /// The `c` parameter is the candidate to calculate the preference for.
+    fn calculate(&self, c: &Candidate, same_kind: usize) -> u32;
+}
+
+/// Blanket impl for functions that look like preference calculations.
+impl<F> LocalPreference for F
+where
+    F: Fn(&Candidate, usize) -> u32 + RefUnwindSafe + Send + Sync + 'static,
+{
+    fn calculate(&self, c: &Candidate, same_kind: usize) -> u32 {
+        (self)(c, same_kind)
+    }
 }
 
 #[derive(Debug)]
@@ -275,6 +306,7 @@ impl IceAgent {
             stats: IceAgentStats::default(),
             timing_advance: Duration::from_millis(50),
             timing_config: StunTiming::default(),
+            local_preference: LocalPreferenceHolder(Arc::new(default_local_preference)),
         }
     }
 
@@ -502,84 +534,20 @@ impl IceAgent {
             }
         }
 
-        // "Adopt" any incoming candidate by setting our current ufrag.
-        c.set_ufrag(&self.local_credentials.ufrag);
-
-        // https://datatracker.ietf.org/doc/html/rfc8445#section-5.1.2.1
-        // The local preference MUST be an integer from 0 (lowest preference) to
-        // 65535 (highest preference) inclusive.  When there is only a single IP
-        // address, this value SHOULD be set to 65535.  If there are multiple
-        // candidates for a particular component for a particular data stream
-        // that have the same type, the local preference MUST be unique for each
-        // one.
-        // ...
-        // If an ICE agent is multihomed and has multiple IP addresses, the
-        // recommendations in [RFC8421] SHOULD be followed.  If multiple TURN
-        // servers are used, local priorities for the candidates obtained from
-        // the TURN servers are chosen in a similar fashion as for multihomed
-        // local candidates: the local preference value is used to indicate a
-        // preference among different servers, but the preference MUST be unique
-        // for each one.
-        // ================
-        //
-        // The above presupposes that we know all the candidates when we start
-        // the ice agent. That doesn't work for us, so we deliberately do not
-        // follow spec. We assign the following intervals for the different
-        // types of candidates:
-        //
-        // 0     - 16384 => relay
-        // 16384 - 32768 => srflx
-        // 32768 - 49152 => prflx
-        // 49152 - 65536 => host
-        //
-        // And furthermore we subdivide these to interleave IPv6 with IPv4
-        // so that odd numbers are ipv6 and even are ipv4.
-        //
-        // For host candidates this means:
-        // 65535 - first ipv6
-        // 65534 - first ipv4
-        // 65533 - second ipv6
-        // 65432 - second ipv4
-        let counter_start: u32 = {
-            use CandidateKind::*;
-            let x = match c.kind() {
-                Host => 65_535,
-                PeerReflexive => 49_151,
-                ServerReflexive => 32_767,
-                Relayed => 16_383,
-            };
-            x - if ip.is_ipv6() { 0 } else { 1 }
-        };
-
         // Count the number of existing candidates of the same kind.
         let same_kind = self
             .local_candidates
             .iter()
             .filter(|v| v.kind() == c.kind())
             .filter(|v| v.addr().is_ipv6() == ip.is_ipv6())
-            .count() as u32;
+            .count();
 
-        // For relayed candidates, we add a "punishment" to the local preference
-        // if the base address differs in the IP version from the allocated address
-        // of the candidate.
-        // This punishment ensures that we prefer relayed within the same IP version,
-        // e.g. IPv4 <> IPv4 over ones that translate between IP version, e.g. IPv4 <> IPv6.
-        let relay_across_ip_version_punishment = if c.kind() == CandidateKind::Relayed {
-            if c.local().is_ipv4() != ip.is_ipv4() {
-                1000
-            } else {
-                0
-            }
-        } else {
-            0
-        };
-
-        let pref = counter_start - same_kind * 2 - relay_across_ip_version_punishment;
+        // Delegate local preference calculation to pluggable algo.
+        let pref = self.local_preference.0.calculate(&c, same_kind);
         trace!("Calculated local preference: {}", pref);
-
         c.set_local_preference(pref);
 
-        // Tie this ufrag to this ICE-session.
+        // "Adopt" any incoming candidate by setting our current ufrag.
         c.set_ufrag(&self.local_credentials.ufrag);
 
         // A candidate is redundant if and only if its transport address and base equal those
@@ -1793,6 +1761,12 @@ impl IceAgent {
 
     pub(crate) fn remote_credentials(&self) -> Option<&IceCreds> {
         self.remote_credentials.as_ref()
+    }
+}
+
+impl fmt::Debug for LocalPreferenceHolder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("LocalPreferenceHolder").finish()
     }
 }
 

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -46,11 +46,15 @@ pub struct Candidate {
     /// The actual address to use. This might be a host address, server reflex, relay etc.
     addr: SocketAddr, // ip/port
 
-    /// The base on the local host.
+    /// The base address
     ///
     /// "Base" refers to the address an agent sends from for a
     /// particular candidate.  Thus, as a degenerate case, host candidates
     /// also have a base, but it's the same as the host candidate.
+    ///
+    /// * host - same as `addr`, i.e the local interface address
+    /// * peer/server reflexive - the local interface address
+    /// * relay - same as `addr`, the allocation on the TURN server
     base: Option<SocketAddr>, // the "base" used for local candidates.
 
     /// Type of candidate.
@@ -440,16 +444,6 @@ impl Candidate {
 
     pub(crate) fn base(&self) -> SocketAddr {
         self.base.unwrap_or(self.addr)
-    }
-
-    pub(crate) fn source_addr(&self) -> SocketAddr {
-        if self.kind == CandidateKind::Relayed {
-            // For relayed candidates, the source address the allocated address on the TURN server.
-            self.addr
-        } else {
-            // For non-relayed, the local interface address is what we need to send from.
-            self.local()
-        }
     }
 
     pub(crate) fn raddr(&self) -> Option<SocketAddr> {

--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -443,12 +443,12 @@ impl Candidate {
     }
 
     pub(crate) fn source_addr(&self) -> SocketAddr {
-        // For relayed candidates, the source address the allocated address on the TURN server.
-        // The base is the local address.
         if self.kind == CandidateKind::Relayed {
+            // For relayed candidates, the source address the allocated address on the TURN server.
             self.addr
         } else {
-            self.base()
+            // For non-relayed, the local interface address is what we need to send from.
+            self.local()
         }
     }
 

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -809,80 +809,80 @@ mod test {
         assert_eq!(a2.num_candidate_pairs(), 1);
     }
 
-    // // In general, ICE prefers IPv6 over IPv4.
-    // // However, in case our only IPv6 connectivity is via a relay that we are talking to over IPv4,
-    // // we want to prefer the IPv4 code path.
-    // #[test]
-    // fn prefers_ipv4_ipv4_relay_candidate_over_ipv4_ipv6_controlling() {
-    //     let _guard = tracing_subscriber::fmt()
-    //         .with_env_filter("debug")
-    //         .with_test_writer()
-    //         .set_default();
+    // In general, ICE prefers IPv6 over IPv4.
+    // However, in case our only IPv6 connectivity is via a relay that we are talking to over IPv4,
+    // we want to prefer the IPv4 code path.
+    #[test]
+    fn prefers_ipv4_ipv4_relay_candidate_over_ipv4_ipv6_controlling() {
+        let _guard = tracing_subscriber::fmt()
+            .with_env_filter("debug")
+            .with_test_writer()
+            .set_default();
 
-    //     let mut a1 = TestAgent::new(info_span!("L"));
-    //     let mut a2 = TestAgent::new(info_span!("R"));
+        let mut a1 = TestAgent::new(info_span!("L"));
+        let mut a2 = TestAgent::new(info_span!("R"));
 
-    //     a1.set_controlling(true);
-    //     a2.set_controlling(false);
+        a1.set_controlling(true);
+        a2.set_controlling(false);
 
-    //     prefer_ipv4_candidate_over_ipv6_candidate(&mut a1, &mut a2);
-    // }
+        prefer_ipv4_candidate_over_ipv6_candidate(&mut a1, &mut a2);
+    }
 
-    // // In general, ICE prefers IPv6 over IPv4.
-    // // However, in case our only IPv6 connectivity is via a relay that we are talking to over IPv4,
-    // // we want to prefer the IPv4 code path.
-    // #[test]
-    // fn prefers_ipv4_ipv4_relay_candidate_over_ipv4_ipv6_controlled() {
-    //     let _guard = tracing_subscriber::fmt()
-    //         .with_env_filter("debug")
-    //         .with_test_writer()
-    //         .set_default();
+    // In general, ICE prefers IPv6 over IPv4.
+    // However, in case our only IPv6 connectivity is via a relay that we are talking to over IPv4,
+    // we want to prefer the IPv4 code path.
+    #[test]
+    fn prefers_ipv4_ipv4_relay_candidate_over_ipv4_ipv6_controlled() {
+        let _guard = tracing_subscriber::fmt()
+            .with_env_filter("debug")
+            .with_test_writer()
+            .set_default();
 
-    //     let mut a1 = TestAgent::new(info_span!("L"));
-    //     let mut a2 = TestAgent::new(info_span!("R"));
+        let mut a1 = TestAgent::new(info_span!("L"));
+        let mut a2 = TestAgent::new(info_span!("R"));
 
-    //     a1.set_controlling(false);
-    //     a2.set_controlling(true);
+        a1.set_controlling(false);
+        a2.set_controlling(true);
 
-    //     prefer_ipv4_candidate_over_ipv6_candidate(&mut a1, &mut a2);
-    // }
+        prefer_ipv4_candidate_over_ipv6_candidate(&mut a1, &mut a2);
+    }
 
-    // fn prefer_ipv4_candidate_over_ipv6_candidate(a1: &mut TestAgent, a2: &mut TestAgent) {
-    //     // Agent 1 only has IPv4 connectivity to a relay but allocates both IPv4 and IPv6 addresses.
-    //     // Agent 2 has no relay but has full IPv4 and IPv6 connectivity.
-    //     let relay_ipv4_ipv4 = a1
-    //         .add_local_candidate(relay("7.7.7.7:5000", "udp"))
-    //         .unwrap()
-    //         .clone();
-    //     let relay_ipv6_ipv4 = a1
-    //         .add_local_candidate(relay("[::7]:5000", "udp"))
-    //         .unwrap()
-    //         .clone();
-    //     a2.add_remote_candidate(relay_ipv4_ipv4);
-    //     a2.add_remote_candidate(relay_ipv6_ipv4);
+    fn prefer_ipv4_candidate_over_ipv6_candidate(a1: &mut TestAgent, a2: &mut TestAgent) {
+        // Agent 1 only has IPv4 connectivity to a relay but allocates both IPv4 and IPv6 addresses.
+        // Agent 2 has no relay but has full IPv4 and IPv6 connectivity.
+        let relay_ipv4_ipv4 = a1
+            .add_local_candidate(relay("7.7.7.7:5000", "udp", "1.1.1.1:5000"))
+            .unwrap()
+            .clone();
+        let relay_ipv6_ipv4 = a1
+            .add_local_candidate(relay("[::7]:5000", "udp", "1.1.1.1:5000"))
+            .unwrap()
+            .clone();
+        a2.add_remote_candidate(relay_ipv4_ipv4);
+        a2.add_remote_candidate(relay_ipv6_ipv4);
 
-    //     let host_ipv4 = a2.add_host_candidate("5.5.5.5:3000");
-    //     let host_ipv6 = a2.add_host_candidate("[::2]:3000");
-    //     a1.add_remote_candidate(host_ipv4);
-    //     a1.add_remote_candidate(host_ipv6);
+        let host_ipv4 = a2.add_host_candidate("5.5.5.5:3000");
+        let host_ipv6 = a2.add_host_candidate("[::2]:3000");
+        a1.add_remote_candidate(host_ipv4);
+        a1.add_remote_candidate(host_ipv6);
 
-    //     // loop until we're connected.
-    //     loop {
-    //         if a1.state().is_connected() && a2.state().is_connected() {
-    //             break;
-    //         }
-    //         progress(a1, a2);
-    //     }
+        // loop until we're connected.
+        loop {
+            if a1.state().is_connected() && a2.state().is_connected() {
+                break;
+            }
+            progress(a1, a2);
+        }
 
-    //     assert!(a1.has_event(|e| {
-    //                 matches!(e, IceAgentEvent::NominatedSend { source, destination, .. }
-    //                      if source == &sock("7.7.7.7:5000") && destination == &sock("5.5.5.5:3000"))
-    //             }));
-    //     assert!(a2.has_event(|e| {
-    //                 matches!(e, IceAgentEvent::NominatedSend { source, destination, .. }
-    //                      if source == &sock("5.5.5.5:3000") && destination == &sock("7.7.7.7:5000"))
-    //             }));
-    // }
+        assert!(a1.has_event(|e| {
+            matches!(e, IceAgentEvent::NominatedSend { source, destination, .. }
+                         if source == &sock("7.7.7.7:5000") && destination == &sock("5.5.5.5:3000"))
+        }));
+        assert!(a2.has_event(|e| {
+            matches!(e, IceAgentEvent::NominatedSend { source, destination, .. }
+                         if source == &sock("5.5.5.5:3000") && destination == &sock("7.7.7.7:5000"))
+        }));
+    }
 
     #[test]
     fn changed_timing_config_takes_effect_immediately() {

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -4,12 +4,15 @@
 use thiserror::Error;
 
 mod agent;
-pub use agent::{IceAgent, IceAgentEvent, IceConnectionState, IceCreds};
+pub use agent::{IceAgent, IceAgentEvent, IceConnectionState, IceCreds, LocalPreference};
 
 mod candidate;
 pub use candidate::{Candidate, CandidateKind};
 
 mod pair;
+
+mod preference;
+pub use preference::default_local_preference;
 
 /// Errors from the ICE agent.
 #[allow(missing_docs)]

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -95,8 +95,12 @@ mod test {
         Candidate::server_reflexive(sock(s), sock(base), proto).unwrap()
     }
 
-    pub fn relay(s: impl Into<String>, proto: impl TryInto<Protocol>) -> Candidate {
-        Candidate::relayed(sock(s), proto).unwrap()
+    pub fn relay(
+        s: impl Into<String>,
+        proto: impl TryInto<Protocol>,
+        l: impl Into<String>,
+    ) -> Candidate {
+        Candidate::relayed(sock(s), proto, sock(l)).unwrap()
     }
 
     /// Transform the socket to rig different test scenarios.
@@ -676,7 +680,7 @@ mod test {
         let mut a2 = TestAgent::new(info_span!("R"));
 
         let c1 = a1
-            .add_local_candidate(relay("1.1.1.1:1000", "udp"))
+            .add_local_candidate(relay("1.1.1.1:1000", "udp", "9.9.9.9:2000"))
             .unwrap()
             .clone();
         a2.add_remote_candidate(c1);
@@ -700,9 +704,9 @@ mod test {
             progress(&mut a1, &mut a2);
         }
 
-        a1.add_local_candidate(relay("1.1.1.1:1001", "udp"))
+        a1.add_local_candidate(relay("1.1.1.1:1001", "udp", "9.9.9.9:2000"))
             .unwrap();
-        a2.add_remote_candidate(relay("1.1.1.1:1001", "udp"));
+        a2.add_remote_candidate(relay("1.1.1.1:1001", "udp", "9.9.9.9:2000"));
 
         loop {
             if a2.has_event(|e| {
@@ -732,13 +736,13 @@ mod test {
         // Both agents know their local candidates
         let c1 = a1.add_host_candidate("1.1.1.1:1000");
         let c3 = a1
-            .add_local_candidate(relay("2.2.2.2:1000", "udp"))
+            .add_local_candidate(relay("2.2.2.2:1000", "udp", "9.9.9.9:2000"))
             .unwrap()
             .clone();
 
         let c2 = a2.add_host_candidate("1.1.1.1:1001");
         let c4 = a2
-            .add_local_candidate(relay("2.2.2.2:1001", "udp"))
+            .add_local_candidate(relay("2.2.2.2:1001", "udp", "9.9.9.9:2000"))
             .unwrap()
             .clone();
 

--- a/src/ice/preference.rs
+++ b/src/ice/preference.rs
@@ -1,0 +1,378 @@
+use crate::Candidate;
+
+use super::CandidateKind;
+
+/// Standard local preference calculation for a candidate.
+///
+/// This is the default local preference calculation for a candidate.
+///
+/// It is used to determine the preference of a candidate when there are multiple candidates
+/// for a particular component for a particular data stream.
+///
+/// The preference is calculated based on the candidate type, the IP version of the candidate,
+/// and the same_kind counter.
+pub fn default_local_preference(c: &Candidate, same_kind: usize) -> u32 {
+    let ip = c.addr();
+
+    // https://datatracker.ietf.org/doc/html/rfc8445#section-5.1.2.1
+    // The local preference MUST be an integer from 0 (lowest preference) to
+    // 65535 (highest preference) inclusive.  When there is only a single IP
+    // address, this value SHOULD be set to 65535.  If there are multiple
+    // candidates for a particular component for a particular data stream
+    // that have the same type, the local preference MUST be unique for each
+    // one.
+    // ...
+    // If an ICE agent is multihomed and has multiple IP addresses, the
+    // recommendations in [RFC8421] SHOULD be followed.  If multiple TURN
+    // servers are used, local priorities for the candidates obtained from
+    // the TURN servers are chosen in a similar fashion as for multihomed
+    // local candidates: the local preference value is used to indicate a
+    // preference among different servers, but the preference MUST be unique
+    // for each one.
+    // ================
+    //
+    // The above presupposes that we know all the candidates when we start
+    // the ice agent. That doesn't work for us, so we deliberately do not
+    // follow spec. We assign the following intervals for the different
+    // types of candidates:
+    //
+    // 0     - 16384 => relay
+    // 16384 - 32768 => srflx
+    // 32768 - 49152 => prflx
+    // 49152 - 65536 => host
+    //
+    // And furthermore we subdivide these to interleave IPv6 with IPv4
+    // so that odd numbers are ipv6 and even are ipv4.
+    //
+    // For host candidates this means:
+    // 65535 - first ipv6
+    // 65534 - first ipv4
+    // 65533 - second ipv6
+    // 65432 - second ipv4
+    let counter_start: u32 = {
+        use CandidateKind::*;
+        let x = match c.kind() {
+            Host => 65_535,
+            PeerReflexive => 49_151,
+            ServerReflexive => 32_767,
+            Relayed => 16_383,
+        };
+        x - if ip.is_ipv6() { 0 } else { 1 }
+    };
+
+    // For relayed candidates, we add a "punishment" to the local preference
+    // if the base address differs in the IP version from the allocated address
+    // of the candidate.
+    // This punishment ensures that we prefer relayed within the same IP version,
+    // e.g. IPv4 <> IPv4 over ones that translate between IP version, e.g. IPv4 <> IPv6.
+    let relay_across_ip_version_punishment = if c.kind() == CandidateKind::Relayed {
+        if c.local().is_ipv4() != ip.is_ipv4() {
+            1000
+        } else {
+            0
+        }
+    } else {
+        0
+    };
+
+    counter_start - same_kind as u32 * 2 - relay_across_ip_version_punishment
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Candidate;
+    use std::net::SocketAddr;
+
+    fn ipv4_addr(ip: &str) -> SocketAddr {
+        format!("{}:1234", ip).parse().unwrap()
+    }
+
+    fn ipv6_addr(ip: &str) -> SocketAddr {
+        format!("[{}]:1234", ip).parse().unwrap()
+    }
+
+    #[test]
+    fn test_host_candidates_ipv4() {
+        let addr = ipv4_addr("192.168.1.1");
+        let candidate = Candidate::host(addr, "udp").unwrap();
+
+        // First host candidate (same_kind = 0)
+        let pref = default_local_preference(&candidate, 0);
+        assert_eq!(pref, 65534); // 65535 - 1 (IPv4) - 0 * 2
+
+        // Second host candidate (same_kind = 1)
+        let pref = default_local_preference(&candidate, 1);
+        assert_eq!(pref, 65532); // 65535 - 1 (IPv4) - 1 * 2
+
+        // Third host candidate (same_kind = 2)
+        let pref = default_local_preference(&candidate, 2);
+        assert_eq!(pref, 65530); // 65535 - 1 (IPv4) - 2 * 2
+    }
+
+    #[test]
+    fn test_host_candidates_ipv6() {
+        let addr = ipv6_addr("2001:db8::1");
+        let candidate = Candidate::host(addr, "udp").unwrap();
+
+        // First host candidate (same_kind = 0)
+        let pref = default_local_preference(&candidate, 0);
+        assert_eq!(pref, 65535); // 65535 - 0 (IPv6) - 0 * 2
+
+        // Second host candidate (same_kind = 1)
+        let pref = default_local_preference(&candidate, 1);
+        assert_eq!(pref, 65533); // 65535 - 0 (IPv6) - 1 * 2
+
+        // Third host candidate (same_kind = 2)
+        let pref = default_local_preference(&candidate, 2);
+        assert_eq!(pref, 65531); // 65535 - 0 (IPv6) - 2 * 2
+    }
+
+    #[test]
+    fn test_server_reflexive_candidates_ipv4() {
+        let addr = ipv4_addr("203.0.113.1");
+        let base = ipv4_addr("192.168.1.1");
+        let candidate = Candidate::server_reflexive(addr, base, "udp").unwrap();
+
+        // First srflx candidate (same_kind = 0)
+        let pref = default_local_preference(&candidate, 0);
+        assert_eq!(pref, 32766); // 32767 - 1 (IPv4) - 0 * 2
+
+        // Second srflx candidate (same_kind = 1)
+        let pref = default_local_preference(&candidate, 1);
+        assert_eq!(pref, 32764); // 32767 - 1 (IPv4) - 1 * 2
+    }
+
+    #[test]
+    fn test_server_reflexive_candidates_ipv6() {
+        let addr = ipv6_addr("2001:db8::100");
+        let base = ipv6_addr("2001:db8::1");
+        let candidate = Candidate::server_reflexive(addr, base, "udp").unwrap();
+
+        // First srflx candidate (same_kind = 0)
+        let pref = default_local_preference(&candidate, 0);
+        assert_eq!(pref, 32767); // 32767 - 0 (IPv6) - 0 * 2
+
+        // Second srflx candidate (same_kind = 1)
+        let pref = default_local_preference(&candidate, 1);
+        assert_eq!(pref, 32765); // 32767 - 0 (IPv6) - 1 * 2
+    }
+
+    #[test]
+    fn test_peer_reflexive_candidates_ipv4() {
+        let addr = ipv4_addr("198.51.100.1");
+        let base = ipv4_addr("192.168.1.1");
+        let candidate = Candidate::test_peer_rflx(addr, base, "udp");
+
+        // First prflx candidate (same_kind = 0)
+        let pref = default_local_preference(&candidate, 0);
+        assert_eq!(pref, 49150); // 49151 - 1 (IPv4) - 0 * 2
+
+        // Second prflx candidate (same_kind = 1)
+        let pref = default_local_preference(&candidate, 1);
+        assert_eq!(pref, 49148); // 49151 - 1 (IPv4) - 1 * 2
+    }
+
+    #[test]
+    fn test_peer_reflexive_candidates_ipv6() {
+        let addr = ipv6_addr("2001:db8::200");
+        let base = ipv6_addr("2001:db8::1");
+        let candidate = Candidate::test_peer_rflx(addr, base, "udp");
+
+        // First prflx candidate (same_kind = 0)
+        let pref = default_local_preference(&candidate, 0);
+        assert_eq!(pref, 49151); // 49151 - 0 (IPv6) - 0 * 2
+
+        // Second prflx candidate (same_kind = 1)
+        let pref = default_local_preference(&candidate, 1);
+        assert_eq!(pref, 49149); // 49151 - 0 (IPv6) - 1 * 2
+    }
+
+    #[test]
+    fn test_relayed_candidates_ipv4_same_ip_version() {
+        let addr = ipv4_addr("192.0.2.1");
+        let local = ipv4_addr("192.168.1.1");
+        let candidate = Candidate::relayed(addr, "udp", local).unwrap();
+
+        // First relay candidate (same_kind = 0, no IP version punishment)
+        let pref = default_local_preference(&candidate, 0);
+        assert_eq!(pref, 16382); // 16383 - 1 (IPv4) - 0 * 2 - 0 (no punishment)
+
+        // Second relay candidate (same_kind = 1, no IP version punishment)
+        let pref = default_local_preference(&candidate, 1);
+        assert_eq!(pref, 16380); // 16383 - 1 (IPv4) - 1 * 2 - 0 (no punishment)
+    }
+
+    #[test]
+    fn test_relayed_candidates_ipv6_same_ip_version() {
+        let addr = ipv6_addr("2001:db8::300");
+        let local = ipv6_addr("2001:db8::1");
+        let candidate = Candidate::relayed(addr, "udp", local).unwrap();
+
+        // First relay candidate (same_kind = 0, no IP version punishment)
+        let pref = default_local_preference(&candidate, 0);
+        assert_eq!(pref, 16383); // 16383 - 0 (IPv6) - 0 * 2 - 0 (no punishment)
+
+        // Second relay candidate (same_kind = 1, no IP version punishment)
+        let pref = default_local_preference(&candidate, 1);
+        assert_eq!(pref, 16381); // 16383 - 0 (IPv6) - 1 * 2 - 0 (no punishment)
+    }
+
+    #[test]
+    fn test_relayed_candidates_cross_ip_version_punishment() {
+        // IPv4 allocated address with IPv6 local address
+        let addr = ipv4_addr("192.0.2.1");
+        let local = ipv6_addr("2001:db8::1");
+        let candidate = Candidate::relayed(addr, "udp", local).unwrap();
+
+        // First relay candidate with IP version punishment
+        let pref = default_local_preference(&candidate, 0);
+        assert_eq!(pref, 15382); // 16383 - 1 (IPv4) - 0 * 2 - 1000 (punishment)
+
+        // Second relay candidate with IP version punishment
+        let pref = default_local_preference(&candidate, 1);
+        assert_eq!(pref, 15380); // 16383 - 1 (IPv4) - 1 * 2 - 1000 (punishment)
+    }
+
+    #[test]
+    fn test_relayed_candidates_cross_ip_version_punishment_reverse() {
+        // IPv6 allocated address with IPv4 local address
+        let addr = ipv6_addr("2001:db8::300");
+        let local = ipv4_addr("192.168.1.1");
+        let candidate = Candidate::relayed(addr, "udp", local).unwrap();
+
+        // First relay candidate with IP version punishment
+        let pref = default_local_preference(&candidate, 0);
+        assert_eq!(pref, 15383); // 16383 - 0 (IPv6) - 0 * 2 - 1000 (punishment)
+
+        // Second relay candidate with IP version punishment
+        let pref = default_local_preference(&candidate, 1);
+        assert_eq!(pref, 15381); // 16383 - 0 (IPv6) - 1 * 2 - 1000 (punishment)
+    }
+
+    #[test]
+    fn test_candidate_type_ordering() {
+        // Test that different candidate types maintain proper ordering
+        let ipv4_addr = ipv4_addr("192.168.1.1");
+        let ipv6_addr = ipv6_addr("2001:db8::1");
+        let local = ipv4_addr;
+
+        let host_ipv4 = Candidate::host(ipv4_addr, "udp").unwrap();
+        let host_ipv6 = Candidate::host(ipv6_addr, "udp").unwrap();
+        let srflx_ipv4 = Candidate::server_reflexive(ipv4_addr, local, "udp").unwrap();
+        let srflx_ipv6 = Candidate::server_reflexive(ipv6_addr, ipv6_addr, "udp").unwrap();
+        let prflx_ipv4 = Candidate::test_peer_rflx(ipv4_addr, local, "udp");
+        let prflx_ipv6 = Candidate::test_peer_rflx(ipv6_addr, ipv6_addr, "udp");
+        let relay_ipv4 = Candidate::relayed(ipv4_addr, "udp", local).unwrap();
+        let relay_ipv6 = Candidate::relayed(ipv6_addr, "udp", ipv6_addr).unwrap();
+
+        let same_kind = 0;
+
+        let host_ipv4_pref = default_local_preference(&host_ipv4, same_kind);
+        let host_ipv6_pref = default_local_preference(&host_ipv6, same_kind);
+        let srflx_ipv4_pref = default_local_preference(&srflx_ipv4, same_kind);
+        let srflx_ipv6_pref = default_local_preference(&srflx_ipv6, same_kind);
+        let prflx_ipv4_pref = default_local_preference(&prflx_ipv4, same_kind);
+        let prflx_ipv6_pref = default_local_preference(&prflx_ipv6, same_kind);
+        let relay_ipv4_pref = default_local_preference(&relay_ipv4, same_kind);
+        let relay_ipv6_pref = default_local_preference(&relay_ipv6, same_kind);
+
+        // Host candidates should have highest preference
+        assert!(host_ipv4_pref > srflx_ipv4_pref);
+        assert!(host_ipv6_pref > srflx_ipv6_pref);
+        assert!(host_ipv4_pref > prflx_ipv4_pref);
+        assert!(host_ipv6_pref > prflx_ipv6_pref);
+        assert!(host_ipv4_pref > relay_ipv4_pref);
+        assert!(host_ipv6_pref > relay_ipv6_pref);
+
+        // Peer reflexive candidates should have higher preference than server reflexive
+        assert!(prflx_ipv4_pref > srflx_ipv4_pref);
+        assert!(prflx_ipv6_pref > srflx_ipv6_pref);
+
+        // Server reflexive candidates should have higher preference than relayed
+        assert!(srflx_ipv4_pref > relay_ipv4_pref);
+        assert!(srflx_ipv6_pref > relay_ipv6_pref);
+
+        // Peer reflexive candidates should have higher preference than relayed
+        assert!(prflx_ipv4_pref > relay_ipv4_pref);
+        assert!(prflx_ipv6_pref > relay_ipv6_pref);
+
+        // IPv6 should have higher preference than IPv4 within the same type
+        assert!(host_ipv6_pref > host_ipv4_pref);
+        assert!(srflx_ipv6_pref > srflx_ipv4_pref);
+        assert!(prflx_ipv6_pref > prflx_ipv4_pref);
+        assert!(relay_ipv6_pref > relay_ipv4_pref);
+    }
+
+    #[test]
+    fn test_ipv4_ipv6_interleaving() {
+        // Test that IPv6 gets odd numbers and IPv4 gets even numbers
+        let ipv4_addr = ipv4_addr("192.168.1.1");
+        let ipv6_addr = ipv6_addr("2001:db8::1");
+
+        let host_ipv4 = Candidate::host(ipv4_addr, "udp").unwrap();
+        let host_ipv6 = Candidate::host(ipv6_addr, "udp").unwrap();
+
+        let ipv4_pref = default_local_preference(&host_ipv4, 0);
+        let ipv6_pref = default_local_preference(&host_ipv6, 0);
+
+        // IPv4 should get even number (65534), IPv6 should get odd number (65535)
+        assert_eq!(ipv4_pref % 2, 0, "IPv4 preference should be even");
+        assert_eq!(ipv6_pref % 2, 1, "IPv6 preference should be odd");
+        assert_eq!(
+            ipv6_pref - ipv4_pref,
+            1,
+            "IPv6 should be exactly 1 higher than IPv4"
+        );
+    }
+
+    #[test]
+    fn test_same_kind_counter_effect() {
+        let addr = ipv4_addr("192.168.1.1");
+        let candidate = Candidate::host(addr, "udp").unwrap();
+
+        // Test that same_kind counter decreases preference by 2 each time
+        let pref0 = default_local_preference(&candidate, 0);
+        let pref1 = default_local_preference(&candidate, 1);
+        let pref2 = default_local_preference(&candidate, 2);
+        let pref3 = default_local_preference(&candidate, 3);
+
+        assert_eq!(
+            pref0 - pref1,
+            2,
+            "Preference should decrease by 2 for each same_kind increment"
+        );
+        assert_eq!(
+            pref1 - pref2,
+            2,
+            "Preference should decrease by 2 for each same_kind increment"
+        );
+        assert_eq!(
+            pref2 - pref3,
+            2,
+            "Preference should decrease by 2 for each same_kind increment"
+        );
+    }
+
+    #[test]
+    fn test_no_punishment_for_non_relayed_candidates() {
+        // Test that cross-IP version scenarios don't apply punishment to non-relayed candidates
+        let ipv4_addr = ipv4_addr("192.168.1.1");
+        let ipv6_base = ipv6_addr("2001:db8::1");
+
+        // Server reflexive candidate with different IP version base (should not be punished)
+        let srflx = Candidate::server_reflexive(ipv4_addr, ipv6_base, "udp").unwrap();
+        let srflx_pref = default_local_preference(&srflx, 0);
+
+        // Compare with same IP version scenario
+        let ipv4_base = ipv4_addr;
+        let srflx_same_ip = Candidate::server_reflexive(ipv4_addr, ipv4_base, "udp").unwrap();
+        let srflx_same_ip_pref = default_local_preference(&srflx_same_ip, 0);
+
+        // Both should have the same preference (no punishment for cross-IP version in non-relayed)
+        assert_eq!(
+            srflx_pref, srflx_same_ip_pref,
+            "Server reflexive candidates should not be punished for cross-IP version"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -649,6 +649,7 @@ pub mod config {
 #[doc(hidden)]
 pub mod ice {
     pub use crate::ice_::IceCreds;
+    pub use crate::ice_::{default_local_preference, LocalPreference};
     pub use crate::ice_::{IceAgent, IceAgentEvent};
     pub use crate::io::{StunMessage, StunMessageBuilder, StunPacket, TransId};
 }


### PR DESCRIPTION
- **Candidate::local to track local interface**
- **Re-enable disabled tests**
- **Candidate::source_addr to use local instead of base**
- **Make local preference calculation pluggable**
