### PR TITLE
Flip parameters of `Candidate::relayed`

### DIFF
--- a/src/ice/candidate.rs
+++ b/src/ice/candidate.rs
@@ -233,13 +233,13 @@ impl Candidate {
     ///
     /// * `addr` - The TURN server's allocated address that will be used for relaying traffic.
     ///            This is the address that will be used for communication with the peer.
-    /// * `proto` - The transport protocol to use (UDP, TCP, etc.).
     /// * `local` - The local interface address that corresponds to this candidate. This is the
     ///             address from which the TURN allocation request was sent.
+    /// * `proto` - The transport protocol to use (UDP, TCP, etc.).
     pub fn relayed(
         addr: SocketAddr,
-        proto: impl TryInto<Protocol>,
         local: SocketAddr,
+        proto: impl TryInto<Protocol>,
     ) -> Result<Self, IceError> {
         if !is_valid_ip(addr.ip()) {
             return Err(IceError::BadCandidate(format!("invalid ip {}", addr.ip())));
@@ -685,7 +685,7 @@ mod tests {
 
         // let base_addr = "5.6.7.8:4321".parse().unwrap();
 
-        let candidate = Candidate::relayed(socket_addr, Protocol::SslTcp, local_addr).unwrap();
+        let candidate = Candidate::relayed(socket_addr, local_addr, Protocol::SslTcp).unwrap();
         assert_eq!(
             no_hash(candidate.to_string()),
             "candidate:--- 1 ssltcp 16776959 1.2.3.4 9876 typ relay raddr 0.0.0.0 rport 0"
@@ -713,7 +713,7 @@ mod tests {
         assert!(host.raddr().is_none());
 
         // We're not picky on the exact choice, but it must not be the private base
-        let relay = Candidate::relayed(socket_addr, Protocol::Udp, local_addr).unwrap();
+        let relay = Candidate::relayed(socket_addr, local_addr, Protocol::Udp).unwrap();
         assert!(relay.raddr().is_some());
         let srflx = Candidate::server_reflexive(socket_addr, base_addr, Protocol::Udp).unwrap();
         assert!(srflx.raddr().is_some_and(|raddr| raddr != base_addr));
@@ -768,7 +768,7 @@ mod tests {
     }
 
     fn relay(addr: &str, local: &str) -> String {
-        Candidate::relayed(addr.parse().unwrap(), "udp", local.parse().unwrap())
+        Candidate::relayed(addr.parse().unwrap(), local.parse().unwrap(), "udp")
             .unwrap()
             .to_sdp_string()
     }

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -103,7 +103,7 @@ mod test {
         proto: impl TryInto<Protocol>,
         l: impl Into<String>,
     ) -> Candidate {
-        Candidate::relayed(sock(s), proto, sock(l)).unwrap()
+        Candidate::relayed(sock(s), sock(l), proto).unwrap()
     }
 
     /// Transform the socket to rig different test scenarios.

--- a/src/ice/preference.rs
+++ b/src/ice/preference.rs
@@ -192,7 +192,7 @@ mod tests {
     fn test_relayed_candidates_ipv4_same_ip_version() {
         let addr = ipv4_addr("192.0.2.1");
         let local = ipv4_addr("192.168.1.1");
-        let candidate = Candidate::relayed(addr, "udp", local).unwrap();
+        let candidate = Candidate::relayed(addr, local, "udp").unwrap();
 
         // First relay candidate (same_kind = 0, no IP version punishment)
         let pref = default_local_preference(&candidate, 0);
@@ -207,7 +207,7 @@ mod tests {
     fn test_relayed_candidates_ipv6_same_ip_version() {
         let addr = ipv6_addr("2001:db8::300");
         let local = ipv6_addr("2001:db8::1");
-        let candidate = Candidate::relayed(addr, "udp", local).unwrap();
+        let candidate = Candidate::relayed(addr, local, "udp").unwrap();
 
         // First relay candidate (same_kind = 0, no IP version punishment)
         let pref = default_local_preference(&candidate, 0);
@@ -223,7 +223,7 @@ mod tests {
         // IPv4 allocated address with IPv6 local address
         let addr = ipv4_addr("192.0.2.1");
         let local = ipv6_addr("2001:db8::1");
-        let candidate = Candidate::relayed(addr, "udp", local).unwrap();
+        let candidate = Candidate::relayed(addr, local, "udp").unwrap();
 
         // First relay candidate with IP version punishment
         let pref = default_local_preference(&candidate, 0);
@@ -239,7 +239,7 @@ mod tests {
         // IPv6 allocated address with IPv4 local address
         let addr = ipv6_addr("2001:db8::300");
         let local = ipv4_addr("192.168.1.1");
-        let candidate = Candidate::relayed(addr, "udp", local).unwrap();
+        let candidate = Candidate::relayed(addr, local, "udp").unwrap();
 
         // First relay candidate with IP version punishment
         let pref = default_local_preference(&candidate, 0);
@@ -263,8 +263,8 @@ mod tests {
         let srflx_ipv6 = Candidate::server_reflexive(ipv6_addr, ipv6_addr, "udp").unwrap();
         let prflx_ipv4 = Candidate::test_peer_rflx(ipv4_addr, local, "udp");
         let prflx_ipv6 = Candidate::test_peer_rflx(ipv6_addr, ipv6_addr, "udp");
-        let relay_ipv4 = Candidate::relayed(ipv4_addr, "udp", local).unwrap();
-        let relay_ipv6 = Candidate::relayed(ipv6_addr, "udp", ipv6_addr).unwrap();
+        let relay_ipv4 = Candidate::relayed(ipv4_addr, local, "udp").unwrap();
+        let relay_ipv6 = Candidate::relayed(ipv6_addr, ipv6_addr, "udp").unwrap();
 
         let same_kind = 0;
 


### PR DESCRIPTION
Flips the order of these parameters to revert the breaking change from #668.