### PR TITLE
fix(ice): don't disconnect if we are missing local candidates

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1779,8 +1779,10 @@ impl fmt::Debug for LocalPreferenceHolder {
 
 #[cfg(test)]
 mod test {
+    use crate::ice_::test::host;
+
     use super::*;
-    use std::net::SocketAddr;
+    use std::{iter, net::SocketAddr};
 
     impl IceAgent {
         pub(crate) fn num_candidate_pairs(&self) -> usize {
@@ -2224,6 +2226,21 @@ mod test {
         );
 
         assert!(agent.poll_transmit().is_none());
+    }
+
+    #[test]
+    pub fn no_disconnect_missing_local_candidates() {
+        let mut agent = IceAgent::new();
+        agent.set_remote_credentials(IceCreds::new().clone());
+
+        agent.add_remote_candidate(host("1.1.1.1:1000", "udp"));
+        agent.handle_timeout(Instant::now());
+        agent.handle_timeout(Instant::now() + Duration::from_millis(100));
+
+        let events = iter::from_fn(|| agent.poll_event()).collect::<Vec<_>>();
+        assert!(!events.contains(&IceAgentEvent::IceConnectionStateChange(
+            IceConnectionState::Disconnected
+        )));
     }
 
     fn make_serialized_binding_request(

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1715,10 +1715,10 @@ impl IceAgent {
             }
         }
 
-        // As a special case, before the ice agent has received any add_remote_candidate() or
+        // As a special case, before the ice agent has received any candidates or
         // discovered a peer reflexive via a STUN message, the agent is still viable. This is
         // also the case for ice_restart.
-        if self.remote_candidates.is_empty() {
+        if self.remote_candidates.is_empty() || self.local_candidates.is_empty() {
             any_still_possible = true;
         }
 


### PR DESCRIPTION
It is possible that an ICE agent receives remote candidates prior to discovering its own local candidates. For example, if the agent roams networks and therefore clears all its local candidates, it first needs to e.g. communicate with TURN servers to learn its new host and server-reflexive candidates. The signalling layer may be quicker in sending across the remote candidates than the TURN servers are in responding to the STUN bindings.

In this case, `str0m` will currently report the connection immediately as "Disconnected" even though it hasn't even formed any pairs.

The code already contains a special-case for this where we don't disconnect if we don't have any remote candidates yet. The same reasoning given there is also true for the local candidates though. Therefore, we extend this check to also include local candidates.

Related: https://github.com/firezone/firezone/pull/9793