### PR TITLE
feat(ice): expose remote ICE credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * Make STUN timers configurable on RtcConfig #674
   * ice: stricter srflx candidate checks #672
   * ice: Dont report Disconnected when no local candidates #670
+  * ice: expose remote ICE credentials #675
   * Make ICE agent local preference pluggable #668
   * Simplified serde of SDP #664
   * SR/RR stats in Ingress/EgressStats #661 #662

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -436,6 +436,11 @@ impl IceAgent {
             .any(|pair| self.remote_candidates[pair.remote_idx()].addr() == addr)
     }
 
+    /// Remote ice credentials.
+    pub fn remote_credentials(&self) -> Option<&IceCreds> {
+        self.remote_credentials.as_ref()
+    }
+
     /// Sets the remote ice credentials.
     pub fn set_remote_credentials(&mut self, r: IceCreds) {
         if self.remote_credentials.as_ref() != Some(&r) {
@@ -1764,10 +1769,6 @@ impl IceAgent {
                 }
             }
         }
-    }
-
-    pub(crate) fn remote_credentials(&self) -> Option<&IceCreds> {
-        self.remote_credentials.as_ref()
     }
 }
 


### PR DESCRIPTION
Firezone employs an idempotent signalling protocol where we don't do anything, if the ICE credentials are still the same. Currently, we decide this based on the local ICE credentials only but it would be better to also compare the remote ones. For this, the ICE agent should expose the remote credentials just like it exposes the local ones.