### PR TITLE
fix(ice): go to `Checking` from `Disconnected` on new candidates

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -1744,6 +1744,8 @@ impl IceAgent {
                     }
                 } else if !any_still_possible {
                     self.set_connection_state(Disconnected, "no possible pairs");
+                } else {
+                    self.set_connection_state(Checking, "got new possible");
                 }
             }
             Connected => {


### PR DESCRIPTION
I've not found anything in the RFCs as to whether it makes sense to be in "checking" first before going back to "connected". My motivation here is that I have a 2s timeout for when I act on `IceConnectionState::Disconnected`. I don't really want to make that any longer because most of the time, it will be a "real" disconnect and therefore prolongs the creation of a new connection.

If however, we are being given new candidates, I think it makes sense to try a little longer. Now, instead of implementing that myself, I thought it would be useful to just have `str0m` transition to `Checking` from `Disconnected` when it has formed new pairs and is in fact checking them.