### PR TITLE
test(ice): simulate port-restricted-cone and symmetric NATs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -681,7 +693,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "quick-error",
- "rand",
+ "rand 0.8.5",
  "safemem",
  "tempfile",
  "twoway",
@@ -870,14 +882,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -887,7 +915,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -896,7 +934,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -965,7 +1012,7 @@ dependencies = [
  "filetime",
  "multipart",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1011,7 +1058,7 @@ dependencies = [
  "crc",
  "fxhash",
  "log",
- "rand",
+ "rand 0.8.5",
  "slab",
  "thiserror",
 ]
@@ -1125,6 +1172,7 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "pcap-file",
+ "rand 0.9.2",
  "regex",
  "rouille",
  "sctp-proto",
@@ -1433,6 +1481,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,6 +1720,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "write16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter", "std"] }
 systemstat = "0.2.2"
 pcap-file = "2.0.0"
 regex = "1.11.1"
+rand = "0.9.0"
 
 # dummy package that enables "_internal_test_exports"
 _str0m_test = { path = "_str0m_test" }

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -1347,24 +1347,24 @@ mod test {
             .any(|c| c.addr() == from && c.kind() == CandidateKind::Relayed);
 
         // If NAT is present on sending agent, apply it.
-        let (from, to) = if let Some(nat) = &mut from_agent.nat {
-            // If our traffic is "from" a relay candidate, the NAT does not apply.
-            if outgoing_is_from_relay {
-                (from, to)
+        let (from, to) = from_agent.span.in_scope(|| {
+            if let Some(nat) = &mut from_agent.nat {
+                // If our traffic is "from" a relay candidate, the NAT does not apply.
+                if outgoing_is_from_relay {
+                    (from, to)
+                } else {
+                    let (new_from, new_to) = nat.transform_outbound(from, to);
+
+                    debug_assert_eq!(new_to, to);
+
+                    tracing::trace!("Outbound NAT: {} => {}", from, new_from);
+
+                    (new_from, new_to)
+                }
             } else {
-                let (new_from, new_to) = nat.transform_outbound(from, to);
-
-                debug_assert_eq!(new_to, to);
-
-                from_agent
-                    .span
-                    .in_scope(|| tracing::trace!("Outbound NAT: {} => {}", from, new_from));
-
-                (new_from, new_to)
+                (from, to)
             }
-        } else {
-            (from, to)
-        };
+        });
 
         let incoming_is_from_relay = to_agent
             .local_candidates()
@@ -1372,43 +1372,39 @@ mod test {
             .any(|c| c.addr() == to && c.kind() == CandidateKind::Relayed);
 
         // If NAT is present on receiving agent, apply it.
-        if let Some(nat) = &mut to_agent.nat {
-            // If our traffic is "to" a relay candidate, the NAT does not apply.
-            if incoming_is_from_relay {
-                Some((from, to))
-            } else {
-                if nat.external_ip != to.ip() {
-                    to_agent.span.in_scope(|| {
+        to_agent.span.in_scope(|| {
+            if let Some(nat) = &mut to_agent.nat {
+                // If our traffic is "to" a relay candidate, the NAT does not apply.
+                if incoming_is_from_relay {
+                    Some((from, to))
+                } else {
+                    if nat.external_ip != to.ip() {
                         tracing::debug!(
                             external = %nat.external_ip, %to,
                             "Dropping packet: Only traffic for external IP of NAT is allowed"
                         );
-                    });
 
-                    return None;
-                }
-
-                return match nat.transform_inbound(from, to) {
-                    Some((new_from, new_to)) => {
-                        debug_assert_eq!(new_from, from);
-
-                        to_agent
-                            .span
-                            .in_scope(|| tracing::trace!("Inbound NAT: {} => {}", to, new_to));
-
-                        Some((new_from, new_to))
+                        return None;
                     }
-                    None => {
-                        to_agent.span.in_scope(|| {
+
+                    return match nat.transform_inbound(from, to) {
+                        Some((new_from, new_to)) => {
+                            debug_assert_eq!(new_from, from);
+
+                            tracing::trace!("Inbound NAT: {} => {}", to, new_to);
+
+                            Some((new_from, new_to))
+                        }
+                        None => {
                             tracing::debug!(%from, %to, "Dropping packet: No port mapping");
-                        });
 
-                        None
-                    }
-                };
+                            None
+                        }
+                    };
+                }
+            } else {
+                Some((from, to))
             }
-        } else {
-            Some((from, to))
-        }
+        })
     }
 }

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -1387,7 +1387,7 @@ mod test {
                         return None;
                     }
 
-                    return match nat.transform_inbound(from, to) {
+                    match nat.transform_inbound(from, to) {
                         Some((new_from, new_to)) => {
                             debug_assert_eq!(new_from, from);
 
@@ -1400,7 +1400,7 @@ mod test {
 
                             None
                         }
-                    };
+                    }
                 }
             } else {
                 Some((from, to))

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -1298,7 +1298,7 @@ mod test {
             to: SocketAddr,
         ) -> Option<(SocketAddr, SocketAddr)> {
             let internal_addr = match &self.nat_type {
-                // For symmetric NAT, need exact source match of from == dst and only on the outside assigned port.
+                // For symmetric NAT, need exact source match of from == dst and only on the assigned port.
                 NatType::Symmetric { mappings } => {
                     let ((src, _), _) = mappings
                         .iter()
@@ -1306,7 +1306,8 @@ mod test {
 
                     *src
                 }
-                // For restricted-cone NAT, traffic on the outside assigned port is routed back if we have previously contacted this IP + port combination.
+                // For restricted-cone NAT, traffic on the outside assigned port is routed back
+                // if we have previously contacted this IP + port combination.
                 NatType::PortRestrictedCone { mappings } => {
                     let ((src, _), _) = mappings
                         .iter()
@@ -1387,7 +1388,10 @@ mod test {
             } else {
                 if nat.external_ip != to.ip() {
                     to_agent.span.in_scope(|| {
-                        tracing::debug!(external = %nat.external_ip, %to, "Dropping packet: Only traffic for external IP of NAT is allowed");
+                        tracing::debug!(
+                            external = %nat.external_ip, %to,
+                            "Dropping packet: Only traffic for external IP of NAT is allowed"
+                        );
                     });
 
                     return None;

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -28,8 +28,9 @@ mod test {
     use super::*;
     use crate::io::{Protocol, StunMessage, StunPacket};
 
+    use std::collections::HashMap;
     use std::net::IpAddr;
-    use std::net::{Ipv4Addr, SocketAddr};
+    use std::net::SocketAddr;
     use std::ops::{Deref, DerefMut};
     use std::time::{Duration, Instant};
 
@@ -466,7 +467,7 @@ mod test {
 
     #[test]
     pub fn prflx_host() {
-        let mut a1 = TestAgent::new(info_span!("L"));
+        let mut a1 = TestAgent::new(info_span!("L")).with_restricted_nat("4.4.4.4");
         let mut a2 = TestAgent::new(info_span!("R"));
 
         // will be rewritten to 4.4.4.4
@@ -607,18 +608,13 @@ mod test {
     #[test]
     pub fn candidate_pair_of_same_kind_does_not_get_nominated() {
         let mut a1 = TestAgent::new(info_span!("L"));
-        let mut a2 = TestAgent::new(info_span!("R"));
+        let mut a2 = TestAgent::new(info_span!("R")).with_restricted_nat("4.4.4.4");
 
-        let c1 = a1
-            .add_local_candidate(relay("1.1.1.1:1000", "udp", "9.9.9.9:2000"))
-            .unwrap()
-            .clone();
+        let c1 = a1.add_relay_candidate("1.1.1.1:1000", "9.9.9.9:2000");
         a2.add_remote_candidate(c1);
 
-        let c2 = a2
-            .add_local_candidate(srflx("4.4.4.4:1000", "3.3.3.3:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c2 = a2.server_reflexive_candidate("8.8.8.8:3478", "3.3.3.3:1000");
+        let c2 = a2.add_local_candidate(c2).unwrap().clone();
         a1.add_remote_candidate(c2);
         let c3 = a2.add_host_candidate("3.3.3.3:1000");
         a1.add_remote_candidate(c3);
@@ -634,9 +630,7 @@ mod test {
             progress(&mut a1, &mut a2);
         }
 
-        a1.add_local_candidate(relay("1.1.1.1:1001", "udp", "9.9.9.9:2000"))
-            .unwrap();
-        a2.add_remote_candidate(relay("1.1.1.1:1001", "udp", "9.9.9.9:2000"));
+        a2.add_remote_candidate(a1.add_relay_candidate("1.1.1.1:1001", "9.9.9.9:2000"));
 
         loop {
             if a2.has_event(|e| {
@@ -665,16 +659,10 @@ mod test {
 
         // Both agents know their local candidates
         let c1 = a1.add_host_candidate("1.1.1.1:1000");
-        let c3 = a1
-            .add_local_candidate(relay("2.2.2.2:1000", "udp", "9.9.9.9:2000"))
-            .unwrap()
-            .clone();
+        let c3 = a1.add_relay_candidate("2.2.2.2:1000", "9.9.9.9:2000");
 
         let c2 = a2.add_host_candidate("1.1.1.1:1001");
-        let c4 = a2
-            .add_local_candidate(relay("2.2.2.2:1001", "udp", "9.9.9.9:2000"))
-            .unwrap()
-            .clone();
+        let c4 = a2.add_relay_candidate("2.2.2.2:1001", "9.9.9.9:2000");
 
         // Agent 1 also learns about the remote candidates but agent 2 doesn't (imagine signalling layer being a bit slow)
         a1.add_remote_candidate(c2);
@@ -715,10 +703,8 @@ mod test {
 
         let c1 = a1.add_host_candidate("1.1.1.1:1000");
         a2.add_remote_candidate(c1);
-        let c2 = a2
-            .add_local_candidate(srflx("2.2.2.2:1000", "2.2.2.2:1000", "udp"))
-            .unwrap()
-            .clone();
+        let c2 = a2.server_reflexive_candidate("8.8.8.8:3478", "2.2.2.2:1000");
+        let c2 = a2.add_local_candidate(c2).unwrap().clone();
         a1.add_remote_candidate(c2);
         let c3 = a2.add_host_candidate("2.2.2.2:1000");
         a1.add_remote_candidate(c3);
@@ -780,14 +766,8 @@ mod test {
     fn prefer_ipv4_candidate_over_ipv6_candidate(a1: &mut TestAgent, a2: &mut TestAgent) {
         // Agent 1 only has IPv4 connectivity to a relay but allocates both IPv4 and IPv6 addresses.
         // Agent 2 has no relay but has full IPv4 and IPv6 connectivity.
-        let relay_ipv4_ipv4 = a1
-            .add_local_candidate(relay("7.7.7.7:5000", "udp", "1.1.1.1:5000"))
-            .unwrap()
-            .clone();
-        let relay_ipv6_ipv4 = a1
-            .add_local_candidate(relay("[::7]:5000", "udp", "1.1.1.1:5000"))
-            .unwrap()
-            .clone();
+        let relay_ipv4_ipv4 = a1.add_relay_candidate("7.7.7.7:5000", "1.1.1.1:5000");
+        let relay_ipv6_ipv4 = a1.add_relay_candidate("[::7]:5000", "1.1.1.1:5000");
         a2.add_remote_candidate(relay_ipv4_ipv4);
         a2.add_remote_candidate(relay_ipv6_ipv4);
 
@@ -944,6 +924,113 @@ mod test {
         )));
     }
 
+    #[test]
+    pub fn symmetric_nat_both_sides() {
+        let _guard = tracing_subscriber::fmt()
+            .with_test_writer()
+            .with_env_filter("trace")
+            .set_default();
+
+        // Both agents are behind symmetric NAT
+        let mut a1 = TestAgent::new(info_span!("L")).with_symmetric_nat("5.5.5.5");
+        let mut a2 = TestAgent::new(info_span!("R")).with_symmetric_nat("6.6.6.6");
+
+        // Add host candidates. Those will fail behind NAT.
+        a2.add_remote_candidate(a1.add_host_candidate("1.1.1.1:1000"));
+        a1.add_remote_candidate(a2.add_host_candidate("2.2.2.2:1000"));
+
+        // Add server-reflexive candidates, those will also fail because the NAT is symmetric
+        a2.add_remote_candidate(a1.server_reflexive_candidate("8.8.8.8:3478", "1.1.1.1:1000"));
+        a1.add_remote_candidate(a2.server_reflexive_candidate("8.8.8.8:3478", "2.2.2.2:1000"));
+
+        // Add relay candidates, those will work
+        a2.add_remote_candidate(a1.add_relay_candidate("3.3.3.3:1000", "1.1.1.1:1000"));
+        a1.add_remote_candidate(a2.add_relay_candidate("4.4.4.4:1000", "2.2.2.2:1000"));
+
+        a1.set_controlling(true);
+        a2.set_controlling(false);
+
+        loop {
+            if a1.state().is_connected() && a2.state().is_connected() {
+                break;
+            }
+            progress(&mut a1, &mut a2);
+        }
+
+        // A1 sends from its host candidate with a random port getting assigned by the symmetric NAT.
+        assert!(a1.has_event(|e| {
+            matches!(e, IceAgentEvent::NominatedSend { source, destination, .. }
+                         if source == &sock("1.1.1.1:1000") && destination == &sock("4.4.4.4:1000"))
+        }));
+        // A2 sends from its relay candidate, towards the public IP of A1.
+        assert!(a2.has_event(|e| {
+            matches!(e, IceAgentEvent::NominatedSend { source, destination, .. }
+                         if source == &sock("4.4.4.4:1000") && destination.ip() == ip("5.5.5.5"))
+        }));
+    }
+
+    #[test]
+    pub fn symmetric_nat_one_side_uses_peer_reflexive_candidate() {
+        let _guard = tracing_subscriber::fmt()
+            .with_test_writer()
+            .with_env_filter("trace")
+            .set_default();
+
+        // Only one agent is behind symmetric NAT.
+        let mut a1 = TestAgent::new(info_span!("L")).with_symmetric_nat("5.5.5.5");
+        let mut a2 = TestAgent::new(info_span!("R")).with_restricted_nat("6.6.6.6");
+
+        // Add host candidates. Those will fail behind NAT.
+        a2.add_remote_candidate(a1.add_host_candidate("1.1.1.1:1000"));
+        a1.add_remote_candidate(a2.add_host_candidate("2.2.2.2:1000"));
+
+        // Add server-reflexive candidates.
+        // The one from A1 will fail but A2's is valid so we should generate a peer-reflexive candidate and make a direct connection.
+        a2.add_remote_candidate(a1.server_reflexive_candidate("8.8.8.8:3478", "1.1.1.1:1000"));
+        let a2_srflx = a2.server_reflexive_candidate("8.8.8.8:3478", "2.2.2.2:1000");
+        a1.add_remote_candidate(a2_srflx.clone());
+
+        a1.set_controlling(true);
+        a2.set_controlling(false);
+
+        loop {
+            if a1.state().is_connected() && a2.state().is_connected() {
+                break;
+            }
+            progress(&mut a1, &mut a2);
+        }
+
+        assert!(a1.has_event(|e| {
+            matches!(e, IceAgentEvent::NominatedSend { source, destination, .. }
+                         if source == &sock("1.1.1.1:1000") && destination == &a2_srflx.addr())
+        }));
+        // We don't know the destination port for A2 because A1's symmetric NAT will have assigned a random one.
+        assert!(a2.has_event(|e| {
+            matches!(e, IceAgentEvent::NominatedSend { source, destination, .. }
+                         if source == &sock("2.2.2.2:1000") && destination.ip() == ip("5.5.5.5"))
+        }));
+    }
+
+    #[test]
+    fn server_reflexive_candidate_from_different_servers_have_different_ports_on_sym_nat() {
+        let mut agent = TestAgent::new(info_span!("A")).with_symmetric_nat("4.4.4.4");
+
+        let c1 = agent.server_reflexive_candidate("8.8.8.8:3478", "1.1.1.1:1000");
+        let c2 = agent.server_reflexive_candidate("9.9.9.9:3478", "1.1.1.1:1000");
+
+        assert_ne!(c1, c2);
+    }
+
+    #[test]
+    fn server_reflexive_candidate_from_different_servers_are_equal_on_restricted_nat() {
+        let mut agent = TestAgent::new(info_span!("A")).with_restricted_nat("4.4.4.4");
+
+        let c1 = agent.server_reflexive_candidate("8.8.8.8:3478", "1.1.1.1:1000");
+        let c2 = agent.server_reflexive_candidate("9.9.9.9:3478", "1.1.1.1:1000");
+
+        assert_eq!(c1, c2);
+    }
+
     pub struct TestAgent {
         pub start_time: Instant,
         pub agent: IceAgent,
@@ -952,6 +1039,7 @@ mod test {
         pub progress_count: u64,
         pub time: Instant,
         pub drop_sent_packets: bool,
+        pub nat: Option<Nat>,
     }
 
     impl TestAgent {
@@ -965,7 +1053,18 @@ mod test {
                 progress_count: 0,
                 time: now,
                 drop_sent_packets: false,
+                nat: None,
             }
+        }
+
+        pub fn with_symmetric_nat(mut self, external_ip: &str) -> Self {
+            self.nat = Some(Nat::new_symmetric(external_ip));
+            self
+        }
+
+        pub fn with_restricted_nat(mut self, external_ip: &str) -> Self {
+            self.nat = Some(Nat::new_restricted(external_ip));
+            self
         }
 
         fn add_host_candidate(&mut self, addr: &str) -> Candidate {
@@ -973,6 +1072,52 @@ mod test {
                 .add_local_candidate(host(addr, "udp"))
                 .unwrap()
                 .clone()
+        }
+
+        fn add_relay_candidate(&mut self, addr: &str, local: &str) -> Candidate {
+            let local = local.parse().unwrap();
+            let addr = addr.parse::<SocketAddr>().unwrap();
+
+            if let Some(Nat {
+                nat_type: NatType::Symmetric { mappings },
+                ..
+            }) = self.nat.as_mut()
+            {
+                // Register an outgoing port mapping to the relay.
+                symmetric_nat_lookup(local, SocketAddr::new(addr.ip(), 3478), mappings);
+            }
+
+            self.agent
+                .add_local_candidate(Candidate::relayed(addr, local, "udp").unwrap())
+                .unwrap()
+                .clone()
+        }
+
+        fn server_reflexive_candidate(&mut self, stun_server: &str, base: &str) -> Candidate {
+            use NatType::*;
+            let base = base.parse().unwrap();
+            let stun_server = stun_server.parse().unwrap();
+
+            match self.nat.as_mut() {
+                None => Candidate::server_reflexive(base, base, "udp"),
+                Some(Nat {
+                    nat_type: RestrictedCone { .. },
+                    external_ip,
+                }) => Candidate::server_reflexive(
+                    SocketAddr::new(*external_ip, base.port()),
+                    base,
+                    "udp",
+                ),
+                Some(Nat {
+                    nat_type: Symmetric { mappings },
+                    external_ip,
+                }) => {
+                    let outside = symmetric_nat_lookup(base, stun_server, mappings);
+
+                    Candidate::server_reflexive(SocketAddr::new(*external_ip, outside), base, "udp")
+                }
+            }
+            .unwrap()
         }
 
         fn has_event(&self, predicate: impl Fn(&IceAgentEvent) -> bool) -> bool {
@@ -997,7 +1142,7 @@ mod test {
                 StunMessage::parse(&trans.contents).expect("IceAgent to only emit StunMessages");
 
             // rewrite receive with test transforms, and potentially drop the packet.
-            if let Some((source, destination)) = transform(trans.source, trans.destination) {
+            if let Some((source, destination)) = transform(trans.source, trans.destination, f, t) {
                 if f.drop_sent_packets {
                     // drop packet
                     t.span.in_scope(|| t.agent.handle_timeout(t.time));
@@ -1079,71 +1224,194 @@ mod test {
         s.parse().unwrap()
     }
 
+    pub fn ip(s: impl Into<String>) -> IpAddr {
+        let s: String = s.into();
+        s.parse().unwrap()
+    }
+
     pub fn host(s: impl Into<String>, proto: impl TryInto<Protocol>) -> Candidate {
         Candidate::host(sock(s), proto).unwrap()
     }
 
-    pub fn srflx(
-        s: impl Into<String>,
-        base: impl Into<String>,
-        proto: impl TryInto<Protocol>,
-    ) -> Candidate {
-        Candidate::server_reflexive(sock(s), sock(base), proto).unwrap()
+    #[derive(Debug, Clone)]
+    enum NatType {
+        RestrictedCone {
+            mappings: HashMap<SocketAddr, u16>,
+        },
+        Symmetric {
+            mappings: HashMap<(SocketAddr, SocketAddr), u16>,
+        },
     }
 
-    pub fn relay(
-        s: impl Into<String>,
-        proto: impl TryInto<Protocol>,
-        l: impl Into<String>,
-    ) -> Candidate {
-        Candidate::relayed(sock(s), sock(l), proto).unwrap()
+    #[derive(Debug, Clone)]
+    pub struct Nat {
+        external_ip: IpAddr,
+        nat_type: NatType,
     }
 
-    /// Transform the socket to rig different test scenarios.
-    ///
-    /// * either port 9999 -> closed (packets dropped)
-    /// * from 3.3.3.3 is rewritten to 4.4.4.4
-    /// * to 3.3.3.3 is dropped
-    /// * to 4.4.4.4 is rewritten to 3.3.3.3
-    fn transform(from: SocketAddr, to: SocketAddr) -> Option<(SocketAddr, SocketAddr)> {
+    impl Nat {
+        fn new_restricted(external_ip: &str) -> Self {
+            Self {
+                external_ip: external_ip.parse().expect("Invalid IP address"),
+                nat_type: NatType::RestrictedCone {
+                    mappings: Default::default(),
+                },
+            }
+        }
+
+        fn new_symmetric(external_ip: &str) -> Self {
+            Self {
+                external_ip: external_ip.parse().expect("Invalid IP address"),
+                nat_type: NatType::Symmetric {
+                    mappings: Default::default(),
+                },
+            }
+        }
+
+        fn transform_outbound(
+            &mut self,
+            from: SocketAddr,
+            to: SocketAddr,
+        ) -> (SocketAddr, SocketAddr) {
+            let external_port = match &mut self.nat_type {
+                NatType::Symmetric { mappings } => {
+                    // For symmetric NATs, the key is the 4-tuple of the connection.
+
+                    symmetric_nat_lookup(from, to, mappings)
+                }
+                NatType::RestrictedCone { mappings } => {
+                    // For a restricted-cone NAT, the key is just the source address.
+                    //
+                    // For simplicity, we reuse the inner port.
+                    *mappings.entry(from).or_insert(from.port())
+                }
+            };
+
+            (SocketAddr::new(self.external_ip, external_port), to)
+        }
+
+        fn transform_inbound(
+            &self,
+            from: SocketAddr,
+            to: SocketAddr,
+        ) -> Option<(SocketAddr, SocketAddr)> {
+            let internal_addr = match &self.nat_type {
+                // For symmetric NAT, need exact source match of from == dst and only on the outside assigned port.
+                NatType::Symmetric { mappings } => {
+                    let ((src, _), _) = mappings
+                        .iter()
+                        .find(|((_, dst), outside)| from == *dst && **outside == to.port())?;
+
+                    *src
+                }
+                // For restricted-code NAT, any traffic on the outside assigned port is routed back, regardless of the source.
+                NatType::RestrictedCone { mappings } => {
+                    let (src, _) = mappings
+                        .iter()
+                        .find(|(_, outside)| **outside == to.port())?;
+
+                    *src
+                }
+            };
+
+            Some((from, internal_addr))
+        }
+    }
+
+    fn symmetric_nat_lookup(
+        src: SocketAddr,
+        dst: SocketAddr,
+        mappings: &mut HashMap<(SocketAddr, SocketAddr), u16>,
+    ) -> u16 {
+        let outside_port = loop {
+            let port = rand::random();
+
+            if mappings.values().any(|p| *p == port) {
+                continue;
+            }
+
+            break port;
+        };
+
+        *mappings.entry((src, dst)).or_insert(outside_port)
+    }
+
+    /// Transform function with flexible NAT support
+    fn transform(
+        from: SocketAddr,
+        to: SocketAddr,
+        from_agent: &mut TestAgent,
+        to_agent: &mut TestAgent,
+    ) -> Option<(SocketAddr, SocketAddr)> {
         if from.port() == 9999 || to.port() == 9999 {
-            // drop packet.
             return None;
         }
 
-        const IP3333: Ipv4Addr = Ipv4Addr::new(3, 3, 3, 3);
-        const IP4444: Ipv4Addr = Ipv4Addr::new(4, 4, 4, 4);
+        let outgoing_is_from_relay = from_agent
+            .local_candidates()
+            .iter()
+            .any(|c| c.addr() == from && c.kind() == CandidateKind::Relayed);
 
-        let ip_from = match from.ip() {
-            IpAddr::V4(v) => {
-                if v == IP3333 {
-                    // rewrite 3.3.3.3 -> 4.4.4.4
-                    IpAddr::V4(IP4444)
-                } else {
-                    IpAddr::V4(v)
-                }
+        // If NAT is present on sending agent, apply it.
+        let (from, to) = if let Some(nat) = &mut from_agent.nat {
+            // If our traffic is "from" a relay candidate, the NAT does not apply.
+            if outgoing_is_from_relay {
+                (from, to)
+            } else {
+                let (new_from, new_to) = nat.transform_outbound(from, to);
+
+                debug_assert_eq!(new_to, to);
+
+                from_agent
+                    .span
+                    .in_scope(|| tracing::trace!("Outbound NAT: {} => {}", from, new_from));
+
+                (new_from, new_to)
             }
-            IpAddr::V6(v) => IpAddr::V6(v),
+        } else {
+            (from, to)
         };
 
-        let ip_to = match to.ip() {
-            IpAddr::V4(v) => {
-                if v == IP3333 {
-                    // drop packets targeted at 3.3.3.3
+        let incoming_is_from_relay = to_agent
+            .local_candidates()
+            .iter()
+            .any(|c| c.addr() == to && c.kind() == CandidateKind::Relayed);
+
+        // If NAT is present on receiving agent, apply it.
+        if let Some(nat) = &mut to_agent.nat {
+            // If our traffic is "to" a relay candidate, the NAT does not apply.
+            if incoming_is_from_relay {
+                Some((from, to))
+            } else {
+                if nat.external_ip != to.ip() {
+                    to_agent.span.in_scope(|| {
+                        tracing::debug!(external = %nat.external_ip, %to, "Dropping packet: Only traffic for external IP of NAT is allowed");
+                    });
+
                     return None;
-                } else if v == IP4444 {
-                    // rewrite 4.4.4.4 -> 3.3.3.3
-                    IpAddr::V4(IP3333)
-                } else {
-                    IpAddr::V4(v)
                 }
-            }
-            IpAddr::V6(v) => IpAddr::V6(v),
-        };
 
-        Some((
-            SocketAddr::new(ip_from, from.port()),
-            SocketAddr::new(ip_to, to.port()),
-        ))
+                return match nat.transform_inbound(from, to) {
+                    Some((new_from, new_to)) => {
+                        debug_assert_eq!(new_from, from);
+
+                        to_agent
+                            .span
+                            .in_scope(|| tracing::trace!("Inbound NAT: {} => {}", to, new_to));
+
+                        Some((new_from, new_to))
+                    }
+                    None => {
+                        to_agent.span.in_scope(|| {
+                            tracing::debug!(%from, %to, "Dropping packet: No port mapping");
+                        });
+
+                        None
+                    }
+                };
+            }
+        } else {
+            Some((from, to))
+        }
     }
 }

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -26,6 +26,15 @@ pub enum IceError {
 mod test {
     use super::agent::IceAgentStats;
     use super::*;
+    use crate::io::{Protocol, StunMessage, StunPacket};
+
+    use std::net::IpAddr;
+    use std::net::{Ipv4Addr, SocketAddr};
+    use std::ops::{Deref, DerefMut};
+    use std::time::{Duration, Instant};
+
+    use tracing::Span;
+    use tracing_subscriber::util::SubscriberInitExt;
 
     #[test]
     pub fn drop_host() {
@@ -71,15 +80,6 @@ mod test {
             }
         );
     }
-
-    use std::net::IpAddr;
-    use std::net::{Ipv4Addr, SocketAddr};
-    use std::ops::{Deref, DerefMut};
-    use std::time::{Duration, Instant};
-
-    use crate::io::{Protocol, StunMessage, StunPacket};
-    use tracing::Span;
-    use tracing_subscriber::util::SubscriberInitExt;
 
     pub fn sock(s: impl Into<String>) -> SocketAddr {
         let s: String = s.into();

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -467,7 +467,7 @@ mod test {
 
     #[test]
     pub fn prflx_host() {
-        let mut a1 = TestAgent::new(info_span!("L")).with_restricted_nat("4.4.4.4");
+        let mut a1 = TestAgent::new(info_span!("L")).with_port_restricted_nat("4.4.4.4");
         let mut a2 = TestAgent::new(info_span!("R"));
 
         // will be rewritten to 4.4.4.4
@@ -608,7 +608,7 @@ mod test {
     #[test]
     pub fn candidate_pair_of_same_kind_does_not_get_nominated() {
         let mut a1 = TestAgent::new(info_span!("L"));
-        let mut a2 = TestAgent::new(info_span!("R")).with_restricted_nat("4.4.4.4");
+        let mut a2 = TestAgent::new(info_span!("R")).with_port_restricted_nat("4.4.4.4");
 
         let c1 = a1.add_relay_candidate("1.1.1.1:1000", "9.9.9.9:2000");
         a2.add_remote_candidate(c1);
@@ -978,7 +978,7 @@ mod test {
 
         // Only one agent is behind symmetric NAT.
         let mut a1 = TestAgent::new(info_span!("L")).with_symmetric_nat("5.5.5.5");
-        let mut a2 = TestAgent::new(info_span!("R")).with_restricted_nat("6.6.6.6");
+        let mut a2 = TestAgent::new(info_span!("R")).with_port_restricted_nat("6.6.6.6");
 
         // Add host candidates. Those will fail behind NAT.
         a2.add_remote_candidate(a1.add_host_candidate("1.1.1.1:1000"));
@@ -1026,7 +1026,7 @@ mod test {
 
     #[test]
     fn server_reflexive_candidate_from_different_servers_are_equal_on_restricted_nat() {
-        let mut agent = TestAgent::new(info_span!("A")).with_restricted_nat("4.4.4.4");
+        let mut agent = TestAgent::new(info_span!("A")).with_port_restricted_nat("4.4.4.4");
 
         let c1 = agent.server_reflexive_candidate("8.8.8.8:3478", "1.1.1.1:1000");
         let c2 = agent.server_reflexive_candidate("9.9.9.9:3478", "1.1.1.1:1000");
@@ -1065,7 +1065,7 @@ mod test {
             self
         }
 
-        pub fn with_restricted_nat(mut self, external_ip: &str) -> Self {
+        pub fn with_port_restricted_nat(mut self, external_ip: &str) -> Self {
             self.nat = Some(Nat::new_port_restricted_cone(external_ip));
             self
         }

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -81,79 +81,6 @@ mod test {
         );
     }
 
-    pub fn sock(s: impl Into<String>) -> SocketAddr {
-        let s: String = s.into();
-        s.parse().unwrap()
-    }
-
-    pub fn host(s: impl Into<String>, proto: impl TryInto<Protocol>) -> Candidate {
-        Candidate::host(sock(s), proto).unwrap()
-    }
-
-    pub fn srflx(
-        s: impl Into<String>,
-        base: impl Into<String>,
-        proto: impl TryInto<Protocol>,
-    ) -> Candidate {
-        Candidate::server_reflexive(sock(s), sock(base), proto).unwrap()
-    }
-
-    pub fn relay(
-        s: impl Into<String>,
-        proto: impl TryInto<Protocol>,
-        l: impl Into<String>,
-    ) -> Candidate {
-        Candidate::relayed(sock(s), sock(l), proto).unwrap()
-    }
-
-    /// Transform the socket to rig different test scenarios.
-    ///
-    /// * either port 9999 -> closed (packets dropped)
-    /// * from 3.3.3.3 is rewritten to 4.4.4.4
-    /// * to 3.3.3.3 is dropped
-    /// * to 4.4.4.4 is rewritten to 3.3.3.3
-    fn transform(from: SocketAddr, to: SocketAddr) -> Option<(SocketAddr, SocketAddr)> {
-        if from.port() == 9999 || to.port() == 9999 {
-            // drop packet.
-            return None;
-        }
-
-        const IP3333: Ipv4Addr = Ipv4Addr::new(3, 3, 3, 3);
-        const IP4444: Ipv4Addr = Ipv4Addr::new(4, 4, 4, 4);
-
-        let ip_from = match from.ip() {
-            IpAddr::V4(v) => {
-                if v == IP3333 {
-                    // rewrite 3.3.3.3 -> 4.4.4.4
-                    IpAddr::V4(IP4444)
-                } else {
-                    IpAddr::V4(v)
-                }
-            }
-            IpAddr::V6(v) => IpAddr::V6(v),
-        };
-
-        let ip_to = match to.ip() {
-            IpAddr::V4(v) => {
-                if v == IP3333 {
-                    // drop packets targeted at 3.3.3.3
-                    return None;
-                } else if v == IP4444 {
-                    // rewrite 4.4.4.4 -> 3.3.3.3
-                    IpAddr::V4(IP3333)
-                } else {
-                    IpAddr::V4(v)
-                }
-            }
-            IpAddr::V6(v) => IpAddr::V6(v),
-        };
-
-        Some((
-            SocketAddr::new(ip_from, from.port()),
-            SocketAddr::new(ip_to, to.port()),
-        ))
-    }
-
     #[test]
     pub fn host_host_disconnect() {
         let mut a1 = TestAgent::new(info_span!("L"));
@@ -1145,5 +1072,78 @@ mod test {
         }
 
         now
+    }
+
+    pub fn sock(s: impl Into<String>) -> SocketAddr {
+        let s: String = s.into();
+        s.parse().unwrap()
+    }
+
+    pub fn host(s: impl Into<String>, proto: impl TryInto<Protocol>) -> Candidate {
+        Candidate::host(sock(s), proto).unwrap()
+    }
+
+    pub fn srflx(
+        s: impl Into<String>,
+        base: impl Into<String>,
+        proto: impl TryInto<Protocol>,
+    ) -> Candidate {
+        Candidate::server_reflexive(sock(s), sock(base), proto).unwrap()
+    }
+
+    pub fn relay(
+        s: impl Into<String>,
+        proto: impl TryInto<Protocol>,
+        l: impl Into<String>,
+    ) -> Candidate {
+        Candidate::relayed(sock(s), sock(l), proto).unwrap()
+    }
+
+    /// Transform the socket to rig different test scenarios.
+    ///
+    /// * either port 9999 -> closed (packets dropped)
+    /// * from 3.3.3.3 is rewritten to 4.4.4.4
+    /// * to 3.3.3.3 is dropped
+    /// * to 4.4.4.4 is rewritten to 3.3.3.3
+    fn transform(from: SocketAddr, to: SocketAddr) -> Option<(SocketAddr, SocketAddr)> {
+        if from.port() == 9999 || to.port() == 9999 {
+            // drop packet.
+            return None;
+        }
+
+        const IP3333: Ipv4Addr = Ipv4Addr::new(3, 3, 3, 3);
+        const IP4444: Ipv4Addr = Ipv4Addr::new(4, 4, 4, 4);
+
+        let ip_from = match from.ip() {
+            IpAddr::V4(v) => {
+                if v == IP3333 {
+                    // rewrite 3.3.3.3 -> 4.4.4.4
+                    IpAddr::V4(IP4444)
+                } else {
+                    IpAddr::V4(v)
+                }
+            }
+            IpAddr::V6(v) => IpAddr::V6(v),
+        };
+
+        let ip_to = match to.ip() {
+            IpAddr::V4(v) => {
+                if v == IP3333 {
+                    // drop packets targeted at 3.3.3.3
+                    return None;
+                } else if v == IP4444 {
+                    // rewrite 4.4.4.4 -> 3.3.3.3
+                    IpAddr::V4(IP3333)
+                } else {
+                    IpAddr::V4(v)
+                }
+            }
+            IpAddr::V6(v) => IpAddr::V6(v),
+        };
+
+        Some((
+            SocketAddr::new(ip_from, from.port()),
+            SocketAddr::new(ip_to, to.port()),
+        ))
     }
 }

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -1087,6 +1087,13 @@ mod test {
                 .clone()
         }
 
+        /// Simulate STUN to the given server and returned the server-reflexive candidate.
+        ///
+        /// Unlike [`TestAgent::add_host_candidate`] and [`TestAgent::add_relay_candidate`],
+        /// this candidate is **not** added to the agent.
+        /// Server-reflexive candidates are typically not added locally because one cannot
+        /// directly send from them.
+        /// The agent can only send from the base which is a host candidate.
         fn server_reflexive_candidate(&mut self, stun_server: &str, base: &str) -> Candidate {
             use NatType::*;
             let base = base.parse().unwrap();

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -1079,16 +1079,7 @@ mod test {
 
         fn add_relay_candidate(&mut self, addr: &str, local: &str) -> Candidate {
             let local = local.parse().unwrap();
-            let addr = addr.parse::<SocketAddr>().unwrap();
-
-            if let Some(Nat {
-                nat_type: NatType::Symmetric { mappings },
-                ..
-            }) = self.nat.as_mut()
-            {
-                // Register an outgoing port mapping to the relay.
-                symmetric_nat_lookup(local, SocketAddr::new(addr.ip(), 3478), mappings);
-            }
+            let addr = addr.parse().unwrap();
 
             self.agent
                 .add_local_candidate(Candidate::relayed(addr, local, "udp").unwrap())


### PR DESCRIPTION
I was investigating our hole-punch behaviour with different NATs and thought it would be useful to have some tests in str0m that actually simulate different kinds of NATs to see what gets nominated.