### PR TITLE
test(ice): roundtrip remote candidate via SDP format

### DIFF
--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -1087,6 +1087,12 @@ mod test {
                 .clone()
         }
 
+        fn add_remote_candidate(&mut self, c: Candidate) {
+            let c = Candidate::from_sdp_string(&c.to_sdp_string()).unwrap(); // Round-trip via SDP to simulate signalling protocol.
+
+            self.span.in_scope(|| self.agent.add_remote_candidate(c))
+        }
+
         /// Simulate STUN to the given server and returned the server-reflexive candidate.
         ///
         /// Unlike [`TestAgent::add_host_candidate`] and [`TestAgent::add_relay_candidate`],


### PR DESCRIPTION
To better simulate that we are adding a remote candidate, roundtrip it via SDP. This e.g. removes the `base` from server-reflexive candidates.