### PR TITLE
feat(ice): print candidate kind as part of pair

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -735,7 +735,7 @@ impl IceAgent {
     fn form_pairs(&mut self, local_idxs: &[usize], remote_idxs: &[usize]) {
         // Ensure to first update the kinds so any log statements are up-to-date.
         for pair in &mut self.candidate_pairs {
-            pair.update_cached_kinds(&self.local_candidates, &self.remote_candidates);
+            pair.update_kinds(&self.local_candidates, &self.remote_candidates);
         }
 
         for local_idx in local_idxs {

--- a/src/ice/pair.rs
+++ b/src/ice/pair.rs
@@ -452,7 +452,9 @@ impl fmt::Debug for CandidatePair {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "CandidatePair({}-{} ({}-{}) prio={} state={:?} attempts={} unanswered={} remote={} last={:?} nom={:?})",
+            "CandidatePair(\
+                {}-{} ({}-{}) prio={} state={:?} attempts={} unanswered={} remote={} last={:?} nom={:?}\
+            )",
             self.local_idx,
             self.remote_idx,
             self.cached_local_kind,

--- a/src/ice/pair.rs
+++ b/src/ice/pair.rs
@@ -17,11 +17,11 @@ pub struct CandidatePair {
 
     /// Index into the local_candidates list in IceAgent.
     local_idx: usize,
-    cached_local_kind: CandidateKind,
+    local_kind: CandidateKind,
 
     /// Index into the remote_candidates list in IceAgent.
     remote_idx: usize,
-    cached_remote_kind: CandidateKind,
+    remote_kind: CandidateKind,
 
     /// Index into local_candidates for the last successful
     /// response. This forms the "valid pair" logic in the spec.
@@ -127,9 +127,9 @@ impl CandidatePair {
     ) -> Self {
         CandidatePair {
             local_idx,
-            cached_local_kind: local_kind,
+            local_kind,
             remote_idx,
-            cached_remote_kind: remote_kind,
+            remote_kind,
             prio,
             binding_attempts: VecDeque::with_capacity(DEFAULT_MAX_RETRANSMITS * 2),
             id: Default::default(),
@@ -394,13 +394,13 @@ impl CandidatePair {
         self.remote_binding_request_time = other.remote_binding_request_time;
     }
 
-    pub(crate) fn update_cached_kinds(
+    pub(crate) fn update_kinds(
         &mut self,
         local_candidates: &[Candidate],
         remote_candidates: &[Candidate],
     ) {
-        self.cached_local_kind = local_candidates[self.local_idx].kind();
-        self.cached_remote_kind = remote_candidates[self.remote_idx].kind();
+        self.local_kind = local_candidates[self.local_idx].kind();
+        self.remote_kind = remote_candidates[self.remote_idx].kind();
     }
 
     pub(crate) fn reset_cached_next_attempt_time(&mut self) {
@@ -457,8 +457,8 @@ impl fmt::Debug for CandidatePair {
             )",
             self.local_idx,
             self.remote_idx,
-            self.cached_local_kind,
-            self.cached_remote_kind,
+            self.local_kind,
+            self.remote_kind,
             self.prio,
             self.state,
             self.binding_attempts.len(),


### PR DESCRIPTION
When debugging ICE connectivity, it is useful to know, which _kinds_ of candidates got nominated without having to trace back the indices the candidates are referring to. The candidate that a pair is referring to can change if it was first created through a peer-reflexive candidate. Hence, we need to make sure this "cache" is up-to-date every time we form pairs.

As an example, the output from one of our tests now looks like this:

```
2025-07-31T02:03:03.819285Z DEBUG R: str0m::ice_::agent: Created local peer reflexive candidate for mapped address: 6.6.6.6:1000
2025-07-31T02:03:03.819325Z DEBUG R: str0m::ice_::agent: Created peer reflexive remote candidate from STUN request: Candidate(prflx=5.5.5.5:62292/udp prio=1862270719)
2025-07-31T02:03:03.819332Z DEBUG R: str0m::ice_::agent: Created new pair for STUN request: CandidatePair(1-3 (relay-prflx) prio=162128486503284223 state=Waiting attempts=0 unanswered=0 remote=0 last=None nom=None)
2025-07-31T02:03:03.819358Z DEBUG L: str0m::ice_::agent: Created local peer reflexive candidate for mapped address: 5.5.5.5:62292
2025-07-31T02:03:03.819364Z DEBUG L: str0m::ice_::pair: Nominated pair: CandidatePair(0-2 (host-relay) prio=162128487040155134 state=Succeeded attempts=1 unanswered=0 remote=0 last=None nom=Nominated)
2025-07-31T02:03:03.819376Z DEBUG L: str0m::ice_::agent: State change (got nomination, still trying others): Checking -> Connected
2025-07-31T02:03:03.819421Z DEBUG L: str0m::ice_::pair: Nominated attempt STUN binding: CandidatePair(0-2 (host-relay) prio=162128487040155134 state=Succeeded attempts=1 unanswered=0 remote=0 last=None nom=Nominated)
2025-07-31T02:03:03.819449Z DEBUG R: str0m::ice_::pair: Nominated pair: CandidatePair(1-3 (relay-prflx) prio=162128486503284223 state=Waiting attempts=0 unanswered=0 remote=2 last=Some(Instant { tv_sec: 12869, tv_nsec: 796367358 }) nom=Nominated)
2025-07-31T02:03:03.819475Z DEBUG L: str0m::ice_::pair: Nomination success: CandidatePair(0-2 (host-relay) prio=162128487040155134 state=Succeeded attempts=2 unanswered=0 remote=0 last=None nom=Success)
2025-07-31T02:03:03.819485Z DEBUG R: str0m::ice_::agent: State change (got nomination, still trying others): Checking -> Connected
```