### PR TITLE
chore(ice): don't log last remote binding attempt time

### DIFF
--- a/src/ice/pair.rs
+++ b/src/ice/pair.rs
@@ -455,7 +455,7 @@ impl fmt::Debug for CandidatePair {
         write!(
             f,
             "CandidatePair(\
-                {}-{} ({}-{}) prio={} state={:?} attempts={} unanswered={} remote={} last={:?} nom={:?}\
+                {}-{} ({}-{}) prio={} state={:?} attempts={} unanswered={} remote={} nom={:?}\
             )",
             self.local_idx,
             self.remote_idx,
@@ -466,7 +466,6 @@ impl fmt::Debug for CandidatePair {
             self.binding_attempts.len(),
             self.unanswered().map(|b| b.0).unwrap_or(0),
             self.remote_binding_requests,
-            self.remote_binding_request_time,
             self.nomination_state
         )
     }


### PR DESCRIPTION
A raw `Instant` isn't particularly useful because it is a platform-dependent implementation detail, what this `Instant` is relative to. Therefore, remove this from the debug output.