### PR TITLE
Add PCM support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Support PCMu/PCMa #685
   * Make STUN timers configurable on RtcConfig #674
   * ice: stricter srflx candidate checks #672
   * ice: Dont report Disconnected when no local candidates #670

--- a/src/format.rs
+++ b/src/format.rs
@@ -105,6 +105,8 @@ pub struct CodecSpec {
 #[allow(missing_docs)]
 pub enum Codec {
     Opus,
+    PCMU,
+    PCMA,
     H264,
     // TODO show this when we support h265.
     #[doc(hidden)]
@@ -580,6 +582,38 @@ impl CodecConfig {
         )
     }
 
+    /// Convenience for adding a PCM u-law payload type.
+    pub fn enable_pcmu(&mut self, enabled: bool) {
+        self.params.retain(|c| c.spec.codec != Codec::PCMU);
+        if !enabled {
+            return;
+        }
+        self.add_config(
+            0.into(),
+            None,
+            Codec::PCMU,
+            Frequency::EIGHT_KHZ,
+            None,
+            Default::default(),
+        );
+    }
+
+    /// Convenience for adding a PCM a-law payload type.
+    pub fn enable_pcma(&mut self, enabled: bool) {
+        self.params.retain(|c| c.spec.codec != Codec::PCMA);
+        if !enabled {
+            return;
+        }
+        self.add_config(
+            8.into(),
+            None,
+            Codec::PCMA,
+            Frequency::EIGHT_KHZ,
+            None,
+            Default::default(),
+        );
+    }
+
     /// Add a default OPUS payload type.
     pub fn enable_opus(&mut self, enabled: bool) {
         self.params.retain(|c| c.spec.codec != Codec::Opus);
@@ -940,7 +974,7 @@ impl Codec {
     /// Tells if codec is audio.
     pub fn is_audio(&self) -> bool {
         use Codec::*;
-        matches!(self, Opus)
+        matches!(self, Opus | PCMU | PCMA)
     }
 
     /// Tells if codec is video.
@@ -964,6 +998,8 @@ impl<'a> From<&'a str> for Codec {
         let lc = v.to_ascii_lowercase();
         match &lc[..] {
             "opus" => Codec::Opus,
+            "pcmu" => Codec::PCMU,
+            "pcma" => Codec::PCMA,
             "h264" => Codec::H264,
             "h265" => Codec::H265,
             "vp8" => Codec::Vp8,
@@ -979,6 +1015,8 @@ impl fmt::Display for Codec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Codec::Opus => write!(f, "opus"),
+            Codec::PCMU => write!(f, "PCMU"),
+            Codec::PCMA => write!(f, "PCMA"),
             Codec::H264 => write!(f, "H264"),
             Codec::H265 => write!(f, "H265"),
             Codec::Vp8 => write!(f, "VP8"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2150,6 +2150,22 @@ impl RtcConfig {
         self
     }
 
+    /// Enable PCM μ-law audio codec.
+    ///
+    /// This is 14-bit audio compressed to 8-bit as specified by G.711
+    pub fn enable_pcmu(mut self, enabled: bool) -> Self {
+        self.codec_config.enable_pcmu(enabled);
+        self
+    }
+
+    /// Enable PCM a-law audio codec.
+    ///
+    /// This is 13-bit audio compressed to 8-bit as specified by G.711
+    pub fn enable_pcma(mut self, enabled: bool) -> Self {
+        self.codec_config.enable_pcma(enabled);
+        self
+    }
+
     /// Enable VP8 video codec.
     ///
     /// Enabled by default.

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -116,6 +116,7 @@ impl DepacketizingBuffer {
             | CodecDepacketizer::H265(_)
             | CodecDepacketizer::Boxed(_)
             | CodecDepacketizer::Opus(_)
+            | CodecDepacketizer::G711(_)
             | CodecDepacketizer::Null(_) => Contiguity::None,
         };
 

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -8,7 +8,7 @@ use crate::format::Codec;
 use crate::sdp::MediaType;
 
 mod g7xx;
-use g7xx::{G711Packetizer, G722Packetizer};
+use g7xx::{G711Depacketizer, G711Packetizer, G722Packetizer};
 
 mod h264;
 pub use h264::H264CodecExtra;
@@ -199,6 +199,7 @@ pub(crate) enum CodecPacketizer {
 
 #[derive(Debug)]
 pub(crate) enum CodecDepacketizer {
+    G711(G711Depacketizer),
     H264(H264Depacketizer),
     H265(H265Depacketizer),
     Opus(OpusDepacketizer),
@@ -213,6 +214,8 @@ impl From<Codec> for CodecPacketizer {
     fn from(c: Codec) -> Self {
         match c {
             Codec::Opus => CodecPacketizer::Opus(OpusPacketizer),
+            Codec::PCMU => CodecPacketizer::G711(G711Packetizer::default()),
+            Codec::PCMA => CodecPacketizer::G711(G711Packetizer::default()),
             Codec::H264 => CodecPacketizer::H264(H264Packetizer::default()),
             Codec::H265 => unimplemented!("Missing packetizer for H265"),
             Codec::Vp8 => CodecPacketizer::Vp8(Vp8Packetizer::default()),
@@ -229,6 +232,8 @@ impl From<Codec> for CodecDepacketizer {
     fn from(c: Codec) -> Self {
         match c {
             Codec::Opus => CodecDepacketizer::Opus(OpusDepacketizer),
+            Codec::PCMU => CodecDepacketizer::G711(G711Depacketizer),
+            Codec::PCMA => CodecDepacketizer::G711(G711Depacketizer),
             Codec::H264 => CodecDepacketizer::H264(H264Depacketizer::default()),
             Codec::H265 => CodecDepacketizer::H265(H265Depacketizer::default()),
             Codec::Vp8 => CodecDepacketizer::Vp8(Vp8Depacketizer::default()),
@@ -282,6 +287,7 @@ impl Depacketizer for CodecDepacketizer {
             H264(v) => v.depacketize(packet, out, extra),
             H265(v) => v.depacketize(packet, out, extra),
             Opus(v) => v.depacketize(packet, out, extra),
+            G711(v) => v.depacketize(packet, out, extra),
             Vp8(v) => v.depacketize(packet, out, extra),
             Vp9(v) => v.depacketize(packet, out, extra),
             Null(v) => v.depacketize(packet, out, extra),
@@ -295,6 +301,7 @@ impl Depacketizer for CodecDepacketizer {
             H264(v) => v.is_partition_head(packet),
             H265(v) => v.is_partition_head(packet),
             Opus(v) => v.is_partition_head(packet),
+            G711(v) => v.is_partition_head(packet),
             Vp8(v) => v.is_partition_head(packet),
             Vp9(v) => v.is_partition_head(packet),
             Null(v) => v.is_partition_head(packet),
@@ -308,6 +315,7 @@ impl Depacketizer for CodecDepacketizer {
             H264(v) => v.is_partition_tail(marker, packet),
             H265(v) => v.is_partition_tail(marker, packet),
             Opus(v) => v.is_partition_tail(marker, packet),
+            G711(v) => v.is_partition_tail(marker, packet),
             Vp8(v) => v.is_partition_tail(marker, packet),
             Vp9(v) => v.is_partition_tail(marker, packet),
             Null(v) => v.is_partition_tail(marker, packet),

--- a/src/rtp/mtime.rs
+++ b/src/rtp/mtime.rs
@@ -48,6 +48,9 @@ impl Frequency {
     /// Cycles in a second of a 48 kHz signal.
     pub const FORTY_EIGHT_KHZ: Frequency = Self::make(48_000);
 
+    /// Cycles in a second of a 8000 Hz signal.
+    pub const EIGHT_KHZ: Frequency = Self::make(8_000);
+
     /// Milliseconds in a second.
     pub const MILLIS: Frequency = Self::make(1_000);
 


### PR DESCRIPTION
Adds support for PCMU and PCMA, payload types 0 and 8. I've written the bare minimum to make this functional and I'd be happy to flesh this out if desired.