### PR TITLE
Implement buffered amount and buffered amount low event

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -59,6 +59,11 @@ impl<'a> Channel<'a> {
     pub fn buffered_amount(&mut self) -> Result<usize, RtcError> {
         Ok(self.rtc.sctp.buffered_amount(self.sctp_stream_id)?)
     }
+
+    /// Set the threshold to emit an [`Event::ChannelBufferedAmountLow`][crate::Event::ChannelBufferedAmountLow]
+    pub fn set_buffered_amount_low_threshold(&mut self, threshold: usize) -> Result<(), RtcError> {
+        Ok(self.rtc.sctp.set_buffered_amount_low_threshold(self.sctp_stream_id, threshold)?)
+    }
 }
 
 impl fmt::Debug for ChannelData {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -953,6 +953,9 @@ pub enum Event {
     /// A data channel has been closed.
     ChannelClose(ChannelId),
 
+    /// A data channel's buffered amount has dropped below the configured threshold.
+    ChannelBufferedAmountLow(ChannelId),
+
     // =================== Statistics and BWE related events ===================
 
     /// Statistics event for the Rtc instance
@@ -1565,6 +1568,13 @@ impl Rtc {
                     };
                     let cd = ChannelData { id, binary, data };
                     return Ok(Output::Event(Event::ChannelData(cd)));
+                }
+                SctpEvent::BufferedAmountLow { id } => {
+                    let Some(id) = self.chan.channel_id_by_stream_id(id) else {
+                        warn!("Drop BufferedAmountLow for id: {:?}", id);
+                        continue;
+                    };
+                    return Ok(Output::Event(Event::ChannelBufferedAmountLow(id)));
                 }
             }
         }


### PR DESCRIPTION
I exposed sctp-proto's buffered amount API under str0m's `Channel` struct and added a new event that fires when sctp-proto's `BufferedAmountLow` event fires.

I wasn't sure what to do when the user calls the buffered amount functions before the sctp `state` field it `Established`. I added a new variant to the SctpError enum. Let me know if changes need to be made there.