### PR TITLE
fix: panic on STUN Binding Indication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,6 +1176,7 @@ dependencies = [
  "combine",
  "crc",
  "fastrand",
+ "hex",
  "hmac",
  "idna_adapter",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ systemstat = "0.2.2"
 pcap-file = "2.0.0"
 regex = "1.11.1"
 rand = "0.9.0"
+hex = "0.4.3"
 
 # dummy package that enables "_internal_test_exports"
 _str0m_test = { path = "_str0m_test" }

--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -2176,6 +2176,34 @@ mod test {
     }
 
     #[test]
+    fn ignore_binding_indication() {
+        // STUN Binding Indication from OBS WHIP Client using Wireshark
+        //
+        // Session Traversal Utilities for NAT
+        // Message Type: 0x0011 (Binding Indication)
+        // Message Length: 8
+        // Message Cookie: 2112a442
+        // Message Transaction ID: fb9859e67da4bc991c0cab8f
+        // [STUN Network Version: RFC-5389/8489 (3)]
+        // Attributes
+        //     FINGERPRINT
+        //         Attribute Type: FINGERPRINT
+        //         Attribute Length: 4
+        //         CRC-32: 0xed80c297 [correct]
+        //         [CRC-32 Status: Good]
+        let binding_hex: String = "
+00 11 00 08 21 12 a4 42 fb 98 59 e6 7d a4 bc 99
+1c 0c ab 8f 80 28 00 04 ed 80 c2 97"
+            .split_whitespace()
+            .collect();
+        let binding_raw = hex::decode(&binding_hex).expect("Failed to decode hex string");
+        let stun_msg = StunMessage::parse(&binding_raw).unwrap();
+
+        let agent = IceAgent::new();
+        assert!(!agent.accepts_message(&stun_msg));
+    }
+
+    #[test]
     fn queues_stun_binding_before_remote_creds() {
         let mut agent = IceAgent::new();
         agent


### PR DESCRIPTION
With certain clients such as OBS WHIP, the client may send a STUN binding indication without USERNAME attribute. There's no need to process the message per
https://datatracker.ietf.org/doc/html/rfc8489#section-6.3.2.

```
Session Traversal Utilities for NAT
    Message Type: 0x0011 (Binding Indication)
    Message Length: 8
    Message Cookie: 2112a442
    Message Transaction ID: 039f587e6a860fcac95f37bc
    [STUN Network Version: RFC-5389/8489 (3)]
    Attributes
        FINGERPRINT
            Attribute Type: FINGERPRINT
            Attribute Length: 4
            CRC-32: 0xc8507de3 [correct]
            [CRC-32 Status: Good]
```