### PR TITLE
Fix InterGroupDelayDelta sorting in BWE TrendlineEstimator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
  * ice: fix panic on STUN Binding Indication #690
- * bwe: fix panic on assert in `TrendlineEstimator` caused by monotonicity breaking on packet reordering #700 
+ * bwe: fix panic on history monotonicity assert in `TrendlineEstimator` #700
 
 # 0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
  * ice: fix panic on STUN Binding Indication #690
+ * bwe: fix panic on assert in `TrendlineEstimator` caused by monotonicity breaking on packet reordering #700 
 
 # 0.10.0
 

--- a/src/packet/bwe/trendline_estimator.rs
+++ b/src/packet/bwe/trendline_estimator.rs
@@ -453,6 +453,9 @@ mod test {
             .iter()
             .zip(estimator.history.iter().skip(1))
             .all(|(a, b)| a.remote_recv_time_ms <= b.remote_recv_time_ms);
-        assert!(ordered, "history should remain sorted by remote_recv_time_ms");
+        assert!(
+            ordered,
+            "history should remain sorted by remote_recv_time_ms"
+        );
     }
 }

--- a/src/packet/bwe/trendline_estimator.rs
+++ b/src/packet/bwe/trendline_estimator.rs
@@ -414,9 +414,9 @@ mod test {
         // Test for algesten/str0m#698
         //
         // This test reproduces the scenario where a sample with a remote receive time
-        // earlier than all existing history entries is added when the window is full.
+        // earlier than all existing history entries is added.
         // Prior to the fix, this appended the smallest (negative) element to the end
-        // causing the monotonicity assert to fail.
+        // causing the monotonicity assert to fail when the window is full.
 
         let now = Instant::now();
         let zero_time_base = Instant::now();


### PR DESCRIPTION
Fixes #698

So judging from the provided panic log:

```
Timing { remote_recv_time_ms: 2474.0, ...}, 
Timing { remote_recv_time_ms: 2583.0, ... }, 
...
Timing { remote_recv_time_ms:4273.0, ... }, 
Timing { remote_recv_time_ms: -151.75, ... }]
```

`Timing.remote_recv_time_ms` is a relative to the first value observed, it being negative means that this is an out-of-order sample with a `InterGroupDelayDelta.last_remote_recv_time` being less then `TrendlineEstimator.zero_time`. It being placed at the end breaks the monotonicity assert.