### PR TITLE
Update thiserror to 2.0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,7 @@ checksum = "1fc1f139757b058f9f37b76c48501799d12c9aa0aa4c0d4c980b062ee925d1b2"
 dependencies = [
  "byteorder_slice",
  "derive-into-owned",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1035,17 +1035,17 @@ checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "sctp-proto"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4dea4fe3384a24652f065296ac333c810dfd0c5b39b98a2214762c16aaadc3c"
+checksum = "033687d166b8ca7c2e6e7ffd5dbf730a71e60fb85a5ccb8fbf3cf8d9636d5e12"
 dependencies = [
  "bytes",
  "crc",
  "fxhash",
  "log",
- "rand 0.8.5",
+ "rand 0.9.2",
  "slab",
- "thiserror",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -1165,7 +1165,7 @@ dependencies = [
  "sha1",
  "str0m-wincrypto",
  "systemstat",
- "thiserror",
+ "thiserror 2.0.16",
  "tracing",
  "tracing-subscriber",
  "zerofrom",
@@ -1175,7 +1175,7 @@ dependencies = [
 name = "str0m-wincrypto"
 version = "0.1.0"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.16",
  "tracing",
  "windows",
 ]
@@ -1252,7 +1252,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+dependencies = [
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -1260,6 +1269,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ _internal_dont_use_log_stats = []
 _internal_test_exports = []
 
 [dependencies]
-thiserror = "1.0.69"
+thiserror = "2.0.16"
 tracing = "0.1.37"
 fastrand = "2.0.1"
 once_cell = "1.17.0" # NB: Can be dropped in MSRV 1.80 using LazyLock.
-sctp-proto = "0.3.0"
+sctp-proto = "0.4.0"
 combine = "4.6.6"
 
 # Sadly no DTLS support in rustls.

--- a/wincrypto/Cargo.lock
+++ b/wincrypto/Cargo.lock
@@ -54,18 +54,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/wincrypto/Cargo.toml
+++ b/wincrypto/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 description = "Supporting crate for str0m"
 
 [dependencies]
-thiserror = { version = "1.0.38" }
+thiserror = "2.0.16"
 tracing = "0.1.37"
 windows = { version = "0.58", features = [
     "Win32_Security_Cryptography",


### PR DESCRIPTION
To avoid duplicated crates, update thiserrror to 2.0.

I will then update sctp-proto once this change is in.