### PR TITLE
Remove use of thiserror from wincrypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,7 +1174,6 @@ dependencies = [
 name = "str0m-wincrypto"
 version = "0.1.0"
 dependencies = [
- "thiserror",
  "tracing",
  "windows",
 ]

--- a/wincrypto/Cargo.lock
+++ b/wincrypto/Cargo.lock
@@ -36,7 +36,6 @@ dependencies = [
 name = "str0m-wincrypto"
 version = "0.1.0"
 dependencies = [
- "thiserror",
  "tracing",
  "windows",
 ]
@@ -50,26 +49,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/wincrypto/Cargo.toml
+++ b/wincrypto/Cargo.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 description = "Supporting crate for str0m"
 
 [dependencies]
-thiserror = { version = "1.0.38" }
 tracing = "0.1.37"
 windows = { version = "0.58", features = [
     "Win32_Security_Cryptography",

--- a/wincrypto/src/lib.rs
+++ b/wincrypto/src/lib.rs
@@ -1,7 +1,9 @@
 #[macro_use]
 extern crate tracing;
 
-use windows::{core::Error as WindowsError, Win32::Foundation::NTSTATUS};
+use std::{error::Error, fmt};
+
+use windows::{core::{Error as WindowsError, HRESULT}, Win32::{Foundation::{NTSTATUS, WIN32_ERROR}, System::Rpc::{RPC_STATUS, RPC_S_OK}}};
 
 mod cert;
 pub use cert::*;
@@ -17,7 +19,11 @@ pub use dtls::*;
 
 #[derive(Debug)]
 pub enum WinCryptoError {
+    Generic(String),
+    Hresult(HRESULT),
     NtStatus(NTSTATUS),
+    RpcStatus(RPC_STATUS),
+    Win32Error(WIN32_ERROR),
     WindowsError(WindowsError),
 }
 
@@ -32,20 +38,36 @@ impl WinCryptoError {
             Err(Self::NtStatus(ntstatus))
         }
     }
+
+    pub fn from_rpc_status(rpc_status: RPC_STATUS) -> Result<(), Self> {
+        if rpc_status == RPC_S_OK {
+            Ok(())
+        } else {
+            Err(Self::RpcStatus(rpc_status))
+        }
+    }
 }
 
 impl fmt::Display for WinCryptoError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::NtStatus(ntstatus) => write!(f, "{}", ntstatus),
+            Self::Generic(message) => write!(f, "{}", message),
+            Self::Hresult(hresult) => write!(f, "Hresult({})", hresult.0),
+            Self::Win32Error(win32_error) => write!(f, "Win32Error({})", win32_error.0),
+            Self::RpcStatus(rpc_status) => write!(f, "RpcStatus({})", rpc_status.0),
+            Self::NtStatus(ntstatus) => write!(f, "NtStatus({})", ntstatus.0),
             Self::WindowsError(err) => write!(f, "{}", err),
         }
     }
 }
 
-impl Error for NetError {
+impl Error for WinCryptoError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
+            Self::Generic(_) => None,
+            Self::Hresult(_) => None,
+            Self::Win32Error(_) => None,
+            Self::RpcStatus(_) => None,
             Self::NtStatus(_) => None,
             Self::WindowsError(err) => Some(err),
         }
@@ -57,5 +79,37 @@ impl Error for NetError {
 impl From<WindowsError> for WinCryptoError {
     fn from(err: WindowsError) -> Self {
         Self::WindowsError(err)
+    }
+}
+
+/// Conversion from an &str to a WinCryptoError. The WinCryptoError
+/// will include the message.
+impl From<&str> for WinCryptoError {
+    fn from(msg: &str) -> Self {
+        Self::Generic(msg.to_string())
+    }
+}
+
+/// Conversion from a String to a WinCryptoError. The WinCryptoError
+/// will include the message.
+impl From<String> for WinCryptoError {
+    fn from(msg: String) -> Self {
+        Self::Generic(msg)
+    }
+}
+
+/// Conversion from a WIN32_ERROR to a WinCryptoError. The WinCryptoError
+/// will include the message.
+impl From<WIN32_ERROR> for WinCryptoError {
+    fn from(win32_error: WIN32_ERROR) -> Self {
+        Self::Win32Error(win32_error)
+    }
+}
+
+/// Conversion from a HRESULT to a WinCryptoError. The WinCryptoError
+/// will include the message.
+impl From<HRESULT> for WinCryptoError {
+    fn from(hresult: HRESULT) -> Self {
+        Self::Hresult(hresult)
     }
 }

--- a/wincrypto/src/srtp.rs
+++ b/wincrypto/src/srtp.rs
@@ -156,9 +156,7 @@ pub fn srtp_aead_aes_gcm_encrypt(
     cipher_text: &mut [u8],
 ) -> Result<usize, WinCryptoError> {
     if cipher_text.len() < plain_text.len() {
-        return Err(WinCryptoError(
-            "Cipher Text is to small to include TAG".to_string(),
-        ));
+        return Err("Cipher Text is to small to include TAG".into());
     }
 
     assert!(
@@ -207,9 +205,7 @@ pub fn srtp_aead_aes_gcm_decrypt(
     plain_text: &mut [u8],
 ) -> Result<usize, WinCryptoError> {
     if cipher_text.len() < AEAD_AES_GCM_TAG_LEN {
-        return Err(WinCryptoError(
-            "Cipher Text too short to include tag".to_string(),
-        ));
+        return Err("Cipher Text too short to include tag".into());
     }
     let (cipher_text, tag) = cipher_text.split_at(cipher_text.len() - AEAD_AES_GCM_TAG_LEN);
 


### PR DESCRIPTION
Change WinCryptoError to be an Enum with different wrapped values. Simplify most of the code emitting error from WinCrypto to just use .into() on the Windows result object or string.