### PR TITLE
Fix panic! in stun.rs if crafted packet is small with.

### DIFF
--- a/src/io/stun.rs
+++ b/src/io/stun.rs
@@ -124,7 +124,7 @@ impl<'a> StunMessage<'a> {
         if len & 0b0000_0011 > 0 {
             return Err(StunError::Parse("len is not a multiple of 4".into()));
         }
-        if len as usize != buf.len() - 20 {
+        if (len as usize + 20) != buf.len() {
             return Err(StunError::Parse(
                 "STUN length vs UDP packet mismatch".into(),
             ));

--- a/src/io/stun.rs
+++ b/src/io/stun.rs
@@ -124,6 +124,7 @@ impl<'a> StunMessage<'a> {
         if len & 0b0000_0011 > 0 {
             return Err(StunError::Parse("len is not a multiple of 4".into()));
         }
+        // Use addition here to avoid panic! if the UDP packet is under 20 bytes long.
         if (len as usize + 20) != buf.len() {
             return Err(StunError::Parse(
                 "STUN length vs UDP packet mismatch".into(),


### PR DESCRIPTION
If you craft a valid STUN packet, and only send the first 19bytes, you'll get a panic! since the check to match udp packet len to stun len subtracts 20 from the udp length, leading to underflow.