### PR TITLE
Restore disabling DTLS fingerprint verification, and decoding STUN username attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  * Tweak DirectAPI fingerprint() calls (breaking) #711
+  * Restore disabling RtcConfig.fingerprint_verification #711
   * Fix panic width incorrect STUN packet #709
 
 # 0.11.0

--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -77,13 +77,13 @@ impl<'a> DirectApi<'a> {
     ///
     /// The DTLS fingerprint is a hash of the local SSL/TLS certificate used to authenticate the
     /// peer connection and establish a secure communication channel between the peers.
-    pub fn local_dtls_fingerprint(&self) -> Fingerprint {
-        self.rtc.dtls.local_fingerprint().clone()
+    pub fn local_dtls_fingerprint(&self) -> &Fingerprint {
+        self.rtc.dtls.local_fingerprint()
     }
 
     /// Returns a reference to the remote DTLS fingerprint used by this peer connection.
-    pub fn remote_dtls_fingerprint(&self) -> Option<Fingerprint> {
-        self.rtc.dtls.remote_fingerprint().clone()
+    pub fn remote_dtls_fingerprint(&self) -> Option<&Fingerprint> {
+        self.rtc.dtls.remote_fingerprint()
     }
 
     /// Sets the remote DTLS fingerprint.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -793,6 +793,7 @@ pub struct Rtc {
     change_counter: usize,
     last_timeout_reason: Reason,
     crypto_provider: CryptoProvider,
+    fingerprint_verification: bool,
 }
 
 struct SendAddr {
@@ -1092,6 +1093,7 @@ impl Rtc {
             change_counter: 0,
             last_timeout_reason: Reason::NotHappening,
             crypto_provider,
+            fingerprint_verification: config.fingerprint_verification,
         }
     }
 
@@ -1411,7 +1413,9 @@ impl Rtc {
                 DtlsEvent::RemoteFingerprint(v1) => {
                     debug!("DTLS verify remote fingerprint");
                     if let Some(v2) = &self.remote_fingerprint {
-                        if v1 != *v2 {
+                        if !self.fingerprint_verification {
+                            debug!("DTLS fingerprint verification disabled");
+                        } else if v1 != *v2 {
                             self.disconnect();
                             return Err(RtcError::RemoteSdp("remote fingerprint no match".into()));
                         }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -252,8 +252,8 @@ pub fn connect_l_r_with_rtc(rtc1: Rtc, rtc2: Rtc) -> (TestRtc, TestRtc) {
     r.add_local_candidate(host2);
     r.add_remote_candidate(host1);
 
-    let finger_l = l.direct_api().local_dtls_fingerprint();
-    let finger_r = r.direct_api().local_dtls_fingerprint();
+    let finger_l = l.direct_api().local_dtls_fingerprint().clone();
+    let finger_r = r.direct_api().local_dtls_fingerprint().clone();
 
     l.direct_api().set_remote_fingerprint(finger_r);
     r.direct_api().set_remote_fingerprint(finger_l);

--- a/tests/data-channel-direct.rs
+++ b/tests/data-channel-direct.rs
@@ -25,8 +25,8 @@ pub fn data_channel_direct() -> Result<(), RtcError> {
     r.add_local_candidate(host2).unwrap();
     r.add_remote_candidate(host1);
 
-    let finger_l = l.direct_api().local_dtls_fingerprint();
-    let finger_r = r.direct_api().local_dtls_fingerprint();
+    let finger_l = l.direct_api().local_dtls_fingerprint().clone();
+    let finger_r = r.direct_api().local_dtls_fingerprint().clone();
 
     l.direct_api().set_remote_fingerprint(finger_r);
     r.direct_api().set_remote_fingerprint(finger_l);


### PR DESCRIPTION
## Changes

- Restores disabling DTLS remote fingerprint verification using `RtcConfig.set_fingerprint_verification`.
  - closes #549 
- Fixes decoding username attribute of STUN message
- Sets the remote fingerprint on `Dtls` type handshake is completed


