### PR TITLE
Fix `impl PartialEq for PayloadParams`

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -77,6 +77,7 @@ impl PartialEq for PayloadParams {
             && self.fb_nack == other.fb_nack
             && self.fb_pli == other.fb_pli
             && self.fb_fir == other.fb_fir
+            && self.fb_remb == other.fb_remb
     }
 }
 


### PR DESCRIPTION
Not sure where to ask properly, but I think here could be a valid place. I think there might be an unnoticed issue with implementation of `PartialEq` I've noticed while reading the source code. @algesten could you please have a look and confirm? Or alternatively comment about "locked" might need to be updated.