### PR TITLE
fix: TWCC last sequence number in empty queue should be None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  * Fix bug when TWCC sequence starts above 32768 #717
+
 # 0.11.1
 
   * stun: stricter string parsing #712

--- a/src/session.rs
+++ b/src/session.rs
@@ -439,7 +439,7 @@ impl Session {
         // Mark as received for TWCC purposes
         if let Some(transport_cc) = header.ext_vals.transport_cc {
             let prev = self.twcc_rx_register.max_seq();
-            let extended = extend_u16(Some(*prev), transport_cc);
+            let extended = extend_u16(prev.map(|s| *s), transport_cc);
             self.twcc_rx_register.update_seq(extended.into(), now);
         }
 


### PR DESCRIPTION
TWCC last sequence number in empty queue should be None - prevents underflow.

Addresses #716 