### PR TITLE
Remove needless &mut T references

### DIFF
--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -951,7 +951,7 @@ fn sync_medias<'a>(session: &mut Session, sdp: &'a Sdp) -> Result<Vec<&'a MediaL
                     update_media(
                         media,
                         m,
-                        &mut session.codec_config,
+                        &session.codec_config,
                         &session.exts,
                         &mut session.streams,
                     );
@@ -999,7 +999,7 @@ fn add_new_lines(
             update_media(
                 &mut media,
                 m,
-                &mut session.codec_config,
+                &session.codec_config,
                 &session.exts,
                 &mut session.streams,
             );
@@ -1057,7 +1057,7 @@ fn as_media_lines(session: &Session) -> Vec<&dyn AsSdpMediaLine> {
 fn update_media(
     media: &mut Media,
     m: &MediaLine,
-    config: &mut CodecConfig,
+    config: &CodecConfig,
     exts: &ExtensionMap,
     streams: &mut Streams,
 ) {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -251,7 +251,7 @@ impl ChannelHandler {
     }
 
     // Do automatic allocations of sctp stream id.
-    fn do_allocations(&mut self, sctp: &mut RtcSctp) {
+    fn do_allocations(&mut self, sctp: &RtcSctp) {
         if !self.need_allocation() {
             return;
         }
@@ -326,7 +326,8 @@ impl ChannelHandler {
         }
     }
 
-    pub fn close_channel(&mut self, id: ChannelId, sctp: &mut RtcSctp) {
+    // NB: Maybe this should still be &mut self or even `self` to prove singular ownership
+    pub fn close_channel(&self, id: ChannelId, sctp: &mut RtcSctp) {
         if let Some(sctp_stream_id) = self
             .allocations
             .iter()

--- a/src/crypto/dtls.rs
+++ b/src/crypto/dtls.rs
@@ -330,7 +330,7 @@ impl DummyDtlsImpl {
         crypto_backend_not_available(self.0)
     }
 
-    fn handle_handshake(&self, o: &mut VecDeque<DtlsEvent>) -> Result<bool, CryptoError> {
+    fn handle_handshake(&self, o: &VecDeque<DtlsEvent>) -> Result<bool, CryptoError> {
         crypto_backend_not_available(self.0)
     }
 
@@ -338,7 +338,7 @@ impl DummyDtlsImpl {
         crypto_backend_not_available(self.0)
     }
 
-    fn handle_receive(&self, m: &[u8], o: &mut VecDeque<DtlsEvent>) -> Result<(), CryptoError> {
+    fn handle_receive(&self, m: &[u8], o: &VecDeque<DtlsEvent>) -> Result<(), CryptoError> {
         crypto_backend_not_available(self.0)
     }
 

--- a/src/crypto/ossl/stream.rs
+++ b/src/crypto/ossl/stream.rs
@@ -158,7 +158,7 @@ where
 }
 
 fn export_srtp_keying_material<S>(
-    stream: &mut SslStream<S>,
+    stream: &SslStream<S>,
 ) -> Result<(KeyingMaterial, SrtpProfile, Fingerprint), io::Error> {
     let ssl = stream.ssl();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -618,6 +618,7 @@
 #![allow(clippy::doc_overindented_list_items)]
 #![allow(clippy::uninlined_format_args)]
 #![allow(mismatched_lifetime_syntaxes)]
+#![deny(clippy::needless_pass_by_ref_mut)]
 #![deny(missing_docs)]
 
 #[macro_use]

--- a/src/packet/bwe/loss_controller.rs
+++ b/src/packet/bwe/loss_controller.rs
@@ -636,7 +636,7 @@ impl LossController {
         bias_factor * (diff / self.config.bandwidth_preference_smoothing_factor + diff.abs())
     }
 
-    fn calculate_instant_upper_bound(&mut self) -> Bitrate {
+    fn calculate_instant_upper_bound(&self) -> Bitrate {
         // this requires someone to set the max bitrate from outside
         let mut instant_limit = self.max_bitrate;
 

--- a/src/packet/vp9.rs
+++ b/src/packet/vp9.rs
@@ -350,7 +350,7 @@ impl Vp9Depacketizer {
     /// Updates provided [`CodecExtra`].
     /// __MUST__ be called after the all transformations of `payload_index`.
     fn update_extra(
-        &mut self,
+        &self,
         extra: &mut CodecExtra,
         out_len: usize,
         packet_len: usize,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -295,7 +295,7 @@ impl Stats {
     /// Poll for the next time to call [`Stats::wants_timeout`] and [`Stats::do_handle_timeout`].
     ///
     /// NOTE: we only need Option<_> to conform to .soonest() (see caller)
-    pub fn poll_timeout(&mut self) -> Option<Instant> {
+    pub fn poll_timeout(&self) -> Option<Instant> {
         let last_now = self.last_now?;
         Some(last_now + self.interval)
     }

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -536,7 +536,7 @@ impl Streams {
         }
     }
 
-    pub fn new_ssrc_pair(&mut self) -> (Ssrc, Ssrc) {
+    pub fn new_ssrc_pair(&self) -> (Ssrc, Ssrc) {
         let ssrc = self.new_ssrc();
 
         let rtx = loop {
@@ -675,7 +675,7 @@ impl Streams {
         self.any_nack_active.unwrap()
     }
 
-    fn rx_lookup_at(&mut self) -> Instant {
+    fn rx_lookup_at(&self) -> Instant {
         self.last_rx_lookup_cleanup + RX_LOOKUP_CLEANUP_INTERVAL
     }
 }

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -644,7 +644,7 @@ impl StreamRx {
         Some(())
     }
 
-    pub(crate) fn visit_stats(&mut self, snapshot: &mut StatsSnapshot, now: Instant) {
+    pub(crate) fn visit_stats(&self, snapshot: &mut StatsSnapshot, now: Instant) {
         self.stats
             .fill(snapshot, self.midrid, self.sender_info.as_ref(), now);
     }
@@ -764,7 +764,7 @@ impl StreamRxStats {
     }
 
     pub(crate) fn fill(
-        &mut self,
+        &self,
         snapshot: &mut StatsSnapshot,
         midrid: MidRid,
         sender_info: Option<&(Instant, SenderInfo)>,


### PR DESCRIPTION
I'm not sure if any of these are intentional to enforce single ownership, if so let's change them back. We can keep the lint and ignore it any such locations with a comment explaining why