### PR TITLE
Reduce reallocation when depacketizing

### DIFF
--- a/src/packet/g7xx.rs
+++ b/src/packet/g7xx.rs
@@ -42,6 +42,10 @@ impl Packetizer for G7xxPacketizer {
 pub struct G711Depacketizer;
 
 impl Depacketizer for G711Depacketizer {
+    fn out_size_hint(&self, packets_size: usize) -> Option<usize> {
+        Some(packets_size)
+    }
+
     fn depacketize(
         &mut self,
         packet: &[u8],

--- a/src/packet/h264.rs
+++ b/src/packet/h264.rs
@@ -224,6 +224,12 @@ pub struct H264Depacketizer {
 }
 
 impl Depacketizer for H264Depacketizer {
+    fn out_size_hint(&self, packets_size: usize) -> Option<usize> {
+        // Roughly account for Annex B start codes or AVC length prefixes.
+        let estimated_packets = (packets_size / 1200).saturating_add(1);
+        Some(packets_size.saturating_add(4usize.saturating_mul(estimated_packets)))
+    }
+
     /// depacketize parses the passed byte slice and stores the result in the
     /// H264Packet this method is called upon
     fn depacketize(

--- a/src/packet/h265.rs
+++ b/src/packet/h265.rs
@@ -756,6 +756,10 @@ impl H265Depacketizer {
 }
 
 impl Depacketizer for H265Depacketizer {
+    fn out_size_hint(&self, packets_size: usize) -> Option<usize> {
+        Some(packets_size)
+    }
+
     /// depacketize parses the passed byte slice and stores the result
     /// in the H265Packet this method is called upon
     fn depacketize(

--- a/src/packet/null.rs
+++ b/src/packet/null.rs
@@ -17,6 +17,10 @@ impl Packetizer for NullPacketizer {
 }
 
 impl Depacketizer for NullDepacketizer {
+    fn out_size_hint(&self, packets_size: usize) -> Option<usize> {
+        Some(packets_size)
+    }
+
     fn depacketize(
         &mut self,
         packet: &[u8],

--- a/src/packet/opus.rs
+++ b/src/packet/opus.rs
@@ -43,6 +43,10 @@ impl Packetizer for OpusPacketizer {
 pub struct OpusDepacketizer;
 
 impl Depacketizer for OpusDepacketizer {
+    fn out_size_hint(&self, packets_size: usize) -> Option<usize> {
+        Some(packets_size)
+    }
+
     fn depacketize(
         &mut self,
         packet: &[u8],

--- a/src/packet/vp8.rs
+++ b/src/packet/vp8.rs
@@ -183,6 +183,10 @@ pub struct Vp8Depacketizer {
 }
 
 impl Depacketizer for Vp8Depacketizer {
+    fn out_size_hint(&self, packets_size: usize) -> Option<usize> {
+        Some(packets_size)
+    }
+
     /// depacketize parses the passed byte slice and stores the result in the
     /// VP8Packet this method is called upon
     fn depacketize(

--- a/src/packet/vp9.rs
+++ b/src/packet/vp9.rs
@@ -283,6 +283,10 @@ pub struct Vp9Depacketizer {
 }
 
 impl Depacketizer for Vp9Depacketizer {
+    fn out_size_hint(&self, packets_size: usize) -> Option<usize> {
+        Some(packets_size)
+    }
+
     /// depacketize parses the passed byte slice and stores the result
     /// in the Vp9Packet this method is called upon
     fn depacketize(


### PR DESCRIPTION
I noticed we spent a fair amount of time reallocating growing the `out` vector in `Depacketizer::depacketize`. With this change the Depacketizer can provide a hint for the total size required and avoid these reallocations.

## Before

<img width="2672" height="1552" alt="Screenshot 2025-12-12 at 15 23 59" src="https://github.com/user-attachments/assets/ffe6b7f4-3f41-43e0-a0af-f82a5891bcdd" />

## After

<img width="2672" height="1552" alt="Screenshot 2025-12-12 at 15 23 32" src="https://github.com/user-attachments/assets/24045259-78fa-487d-bf69-1ab231b7251e" />


Total number of samples in the process over 1 minute of sending video bidirectionally is reduced by ~5.5%