### PR TITLE
Simulcast Layer API v2

### DIFF
--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -1603,7 +1603,7 @@ mod test {
     use sdp::SimulcastLayer as SdpSimulcastLayer;
 
     use crate::format::Codec;
-    use crate::media::Simulcast;
+    use crate::media::{Simulcast, SimulcastLayer};
     use crate::sdp::RtpMap;
 
     use super::*;
@@ -1755,11 +1755,11 @@ mod test {
 
         let mut rtc1 = Rtc::new();
 
-        let simulcast = Simulcast::builder()
-            .add_send_layer("h")
-            .add_send_layer("m")
-            .add_send_layer("l")
-            .build();
+        let mut simulcast = Simulcast::new();
+
+        simulcast.add_send_layer(SimulcastLayer::new("h"));
+        simulcast.add_send_layer(SimulcastLayer::new("m"));
+        simulcast.add_send_layer(SimulcastLayer::new("l"));
 
         let mut change = rtc1.sdp_api();
         change.add_media(
@@ -1843,42 +1843,49 @@ mod test {
 
         let mut rtc1 = Rtc::new();
 
-        let simulcast_builder = Simulcast::builder()
-            // High layer
-            .add_send_layer_with_attributes("high")
-            .max_width(1280)
-            .max_height(720)
-            .max_br(1100000)
-            .max_br(1300000)
-            .max_br(1500000) // the last one wins
-            .max_fps(30)
-            .finish()
-            // Medium layer
-            .add_send_layer_with_attributes("medium")
-            .max_width(640)
-            .max_height(360)
-            .max_br(600000)
-            // No max_fps
-            .finish()
-            // Low layer
-            .add_send_layer_with_attributes("low")
-            // No max_width
-            .max_height(180)
-            .max_br(200000)
-            .max_fps(15)
-            .finish()
-            // Custom attribute
-            .add_send_layer_with_attributes("custom")
-            .custom("foo", "bar")
-            .finish();
+        let mut simulcast = Simulcast::new();
 
-        // Make sure we can add layers one at a time, e.g. in a loop in a user's application
-        let simulcast = simulcast_builder
-            // No attributes
-            .add_send_layer_with_attributes("no_attrs")
-            .finish()
-            // Build the simulcast itself
-            .build();
+        // High layer
+        simulcast.add_send_layer(
+            SimulcastLayer::new_with_attributes("high")
+                .max_width(1280)
+                .max_height(720)
+                .max_br(1100000)
+                .max_br(1300000)
+                .max_br(1500000) // the last one wins
+                .max_fps(30)
+                .build(),
+        );
+
+        // Medium layer
+        simulcast.add_send_layer(
+            SimulcastLayer::new_with_attributes("medium")
+                .max_width(640)
+                .max_height(360)
+                .max_br(600000)
+                // No max_fps
+                .build(),
+        );
+
+        // Low layer
+        simulcast.add_send_layer(
+            SimulcastLayer::new_with_attributes("low")
+                // No max_width
+                .max_height(180)
+                .max_br(200000)
+                .max_fps(15)
+                .build(),
+        );
+
+        // Custom attribute
+        simulcast.add_send_layer(
+            SimulcastLayer::new_with_attributes("custom")
+                .custom("foo", "bar")
+                .build(),
+        );
+
+        // No attributes
+        simulcast.add_send_layer(SimulcastLayer::new_with_attributes("no_attrs").build());
 
         let mut change = rtc1.sdp_api();
         change.add_media(


### PR DESCRIPTION
Per discussion here - https://github.com/algesten/str0m/issues/783

The new "mixed fluent / procedural" API is going to be easier for applications to use (I can tell from updating our code at Amazon to 0.13.0).

The changes were discussed in the issue linked above, and also apparent in the diff.

Looks like this:

```rust
let mut simulcast = Simulcast::new();

// High layer
simulcast.add_send_layer(
    SimulcastLayer::new_with_attributes("high")
        .max_width(1280)
        .max_height(720)
        .max_br(1100000)
        .max_br(1300000)
        .max_br(1500000) // the last one wins
        .max_fps(30)
        .build(),
);

// Medium layer
simulcast.add_send_layer(
    SimulcastLayer::new_with_attributes("medium")
        .max_width(640)
        .max_height(360)
        .max_br(600000)
        // No max_fps
        .build(),
);
```

