### PR TITLE
Use DATAGRAM_MTU in OpenSSL

### DIFF
--- a/crypto/openssl/src/dtls.rs
+++ b/crypto/openssl/src/dtls.rs
@@ -406,6 +406,8 @@ fn dtls_create_ctx(cert: &DtlsCert) -> Result<SslContext, CryptoError> {
     let mut options = SslOptions::empty();
     options.insert(SslOptions::SINGLE_ECDH_USE);
     options.insert(SslOptions::NO_DTLSV1);
+    // Use the MTU we set via set_mtu() instead of querying
+    options.insert(SslOptions::NO_QUERY_MTU);
     ctx.set_options(options);
 
     Ok(ctx.build())


### PR DESCRIPTION
I noticed that OpenSSL split up fragments into 256 sized packets. To reduce server complexity I think we should have it honor the MTU size we set. This change does this.