### PR TITLE
Allow lockfiles to have longer line length for snowflake check

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -75,7 +75,7 @@ jobs:
         uses: algesten/snowflake@v1.1.0
         with:
           check_diff: true
-          line_width_rules: 'CHANGELOG.md:120;c_cpp_properties.json:160;Cargo.toml:150;README.md:180;README.tpl:180;*.md:110;*.rs:110;*.toml:110;DEFAULT=110'
+          line_width_rules: 'CHANGELOG.md:120;c_cpp_properties.json:160;Cargo.toml:150;README.md:180;README.tpl:180;*.md:110;*.rs:110;*.toml:110;*.lock:200;DEFAULT=110'
 
   pii:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When running CI with private branches/forks refering to git. Snowflake fails due to line length.

example: https://github.com/algesten/str0m/actions/runs/20669916155/job/59348974171?pr=813

This is just frustrating when trying to get green CI so would be nice to have exception for lock files or simply allow longer width.