### PR TITLE
minor tweak

### DIFF
--- a/crypto/wincrypto/src/sys/srtp.rs
+++ b/crypto/wincrypto/src/sys/srtp.rs
@@ -96,7 +96,7 @@ pub fn srtp_aes_128_cm(
 ) -> Result<usize, WinCryptoError> {
     // First, we'll make a copy of the IV with a countered as many times as
     // needed into a new countered_iv.
-    let mut iv = iv.to_vec();
+    let mut iv = *iv;
     let mut countered_iv = [0u8; MAX_BUFFER_SIZE];
     let mut offset = 0;
     while offset <= input.len() {


### PR DESCRIPTION
Small optimization, where CTR mode was allocating a fixed size 16byte vector on the heap, when it can jsut be on a [u8;16] on the stack.