### PR TITLE
Ensure Keypair is trivially accessible in apple-cryptokit

### DIFF
--- a/crypto/apple-crypto/src/dtls.rs
+++ b/crypto/apple-crypto/src/dtls.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 use std::time::Instant;
 
+use security_framework::access_control::SecAccessControl;
 use security_framework::key::{GenerateKeyOptions, KeyType, SecKey};
 
 use str0m_proto::crypto::dtls::{DtlsCert, DtlsImplError, DtlsInstance, DtlsOutput, DtlsProvider};
@@ -15,6 +16,9 @@ fn generate_certificate_impl() -> Result<DtlsCert, CryptoError> {
     let mut options = GenerateKeyOptions::default();
     options.set_key_type(KeyType::ec());
     options.set_size_in_bits(256);
+    let access_control = SecAccessControl::create_with_flags(0)
+        .map_err(|e| CryptoError::Other(format!("Failed to create access control: {e}")))?;
+    options.set_access_control(access_control);
 
     let private_key = SecKey::new(&options)
         .map_err(|e| CryptoError::Other(format!("Failed to generate key pair: {e}")))?;


### PR DESCRIPTION
We use SecurityFramework to generate a keypair for our certificate. Without this setting, our tests were taking 1000x longer in dev than in release, and profiling showed it was releated the KeyChain access.

Since we immediately export the private key as a DER, there is no value restricting access to key data. The key is ephemeral and not actually in the keychain, but I believe Security framework can restrict program access to the key, and allows you to pass the key by references to other system APIs, preventing the private key from ever being accessed directly by the application. Still, as I stated, we immediately export the key anyways, so removing access restrictions here doesn't make us any less secure.