### PR TITLE
Fix nightly test for Intel macOS

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -163,6 +163,10 @@ jobs:
       - name: Build ${{ matrix.platform.name }}
         run: cargo +${{steps.toolchain.outputs.name}} build --target ${{ matrix.platform.target }} --no-default-features --features ${{ matrix.platform.features }}
 
+      - name: Set Swift library path for macOS Intel
+        if: matrix.platform.os == 'macos-15-intel'
+        run: echo "DYLD_LIBRARY_PATH=/usr/lib/swift${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}" >> $GITHUB_ENV
+
       - name: Test ${{ matrix.platform.name }}
         run: cargo +${{steps.toolchain.outputs.name}} test --release --target ${{ matrix.platform.target }} --no-default-features --features ${{ matrix.platform.features }} --lib --bins --tests
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ str0m-rust-crypto = { version = "0.1.1", path = "crypto/rust-crypto", optional =
 str0m-openssl = { version = "0.1.2", path = "crypto/openssl", optional = true }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
-str0m-apple-crypto = { version = "0.1.1", path = "crypto/apple-crypto", optional = true }
+str0m-apple-crypto = { version = "0.1.3", path = "crypto/apple-crypto", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 # Windows Crypto (CNG + SChannel)


### PR DESCRIPTION
Add DYLD_LIBRARY_PATH=/usr/lib/swift for macOS Intel (macos-15-intel) runner.

The apple-crypto feature uses Swift via apple-cryptokit-rs, which requires the Swift runtime libraries. On Intel macOS runners, the dynamic linker cannot find libswiftCore.dylib at runtime without this path being set. This is only needed for Intel x86_64, not ARM64 macOS.