### PR TITLE
Check for empty packet in av1

### DIFF
--- a/src/packet/av1.rs
+++ b/src/packet/av1.rs
@@ -318,6 +318,10 @@ impl Depacketizer for AV1Depacketizer {
         out: &mut Vec<u8>,
         codec_extra: &mut super::CodecExtra,
     ) -> Result<(), PacketError> {
+        if packet.is_empty() {
+            return Err(PacketError::ErrShortPacket);
+        }
+
         let mut reader = (packet, 0);
 
         self.parse_aggregation_header(packet[0]);


### PR DESCRIPTION
Found by fuzzer: passing an empty packet to AV1Depacketizer::depacketize caused a panic on packet[0] index access. Now returns ErrShortPacket.