### PR TITLE
Constant stream timeout check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Constant stream timeout check #845
   * H265 Packetizer/Depacketizer #822
   * Cap amount SCTP (data channels) buffer #831
   * Fix incorrectly purged ice-lite pairs #832


### PR DESCRIPTION
I noticed a 15%-25% CPU cost (highly dependent on the load) when the pacer's rate is reduced, even with many packets already in the queue. Since untimed packets are contiguous, we can check the last packet.

<img width="2560" height="1323" alt="image" src="https://github.com/user-attachments/assets/6e63a0b9-9aab-4c1c-8874-47f450c64002" />
 