### PR TITLE
Fix probe estimator panic when probes accumulate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Fix probe estimator panic when probes accumulate #857
   * Improve H265 test coverage and organization #853
 
 # 0.16.1

--- a/src/bwe/mod.rs
+++ b/src/bwe/mod.rs
@@ -77,8 +77,8 @@ impl Bwe {
         result
     }
 
-    pub fn start_probe(&mut self, config: ProbeClusterConfig) {
-        self.bwe.start_probe(config);
+    pub fn start_probe(&mut self, config: ProbeClusterConfig, now: Instant) -> bool {
+        self.bwe.start_probe(config, now)
     }
 
     pub fn end_probe(&mut self, now: Instant, cluster_id: TwccClusterId) {
@@ -387,8 +387,9 @@ impl SendSideBandwidthEstimator {
     ///
     /// This should be called when the pacer starts sending a probe cluster,
     /// to tell the estimator which cluster to watch for in TWCC feedback.
-    pub fn start_probe(&mut self, config: ProbeClusterConfig) {
-        self.probe_estimator.probe_start(config);
+    /// Returns `true` if the probe was started, `false` if rejected.
+    pub fn start_probe(&mut self, config: ProbeClusterConfig, now: Instant) -> bool {
+        self.probe_estimator.probe_start(config, now)
     }
 
     /// End a probe cluster and mark it for cleanup.


### PR DESCRIPTION
## Summary

- Fixes panic at `estimator.rs:102` when probes accumulate without completing
- Adds `created_at` timestamp to track probe age
- Cleans up stale probes (>5 seconds old) when hitting the 20 probe cap
- Gracefully rejects new probes instead of panicking if still at capacity

## Problem

The `ProbeEstimator` could panic with `"Too many active probes"` when probes were started but never completed. This happened because:

1. `probe_start()` added probes with `finalize_at = not_happening()` (infinite future)
2. `end_probe()` was only called when the pacer completed the probe
3. If probes never completed (e.g., pacer couldn't send enough packets), they accumulated until hitting the 20 limit

## Test plan

- [x] Added `stale_probes_cleaned_up_at_capacity` test
- [x] Added `non_stale_probes_preserved_during_cleanup` test
- [x] All existing BWE tests pass
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)