### PR TITLE
Fix NullPacer forcing 0μs timeouts between every packet send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Fix hot timeout loop with null pacer #863
   * H265 to use is_irap() for keyframe detection #859
   * Fix probe estimator panic when probes accumulate #857
   * Improve H265 test coverage and organization #853

--- a/src/pacer/null.rs
+++ b/src/pacer/null.rs
@@ -57,11 +57,6 @@ impl Pacer for NullPacer {
     }
 
     fn poll_queue(&mut self) -> Option<(MidRid, Option<TwccClusterId>)> {
-        // GATE: Block if we need timeout first
-        if self.needs_timeout_before_next_poll {
-            return None;
-        }
-
         let non_empty_queues = self
             .queue_states
             .iter()


### PR DESCRIPTION
## Summary

- Remove the `poll_queue()` gate from `NullPacer` that was incorrectly copied from `LeakyBucketPacer` during the BWE V2 refactor (ab699b8)

The gate forces `handle_timeout()` between every packet send. `LeakyBucketPacer` needs this to update debt/budget calculations, but `NullPacer` has no budgets — it just does round-robin queue selection. The gate causes each packet to require a full outer-loop iteration (sleep 0μs → handle_input → poll_output) instead of allowing `poll_output()` to drain all queued packets in a tight loop before returning a single `Timeout`.

Closes #862

## Test plan

- [x] All existing tests pass (524 unit + 55 doc/integration)
- [x] Verify on embedded system that packets are batched again (e.g. "Transmit 159 packets" instead of "Transmit 1 packets")
- [x] Verify `last_timeout_reason()` no longer shows constant `Pacer(Handle)` with NullPacer

🤖 Generated with [Claude Code](https://claude.com/claude-code)