### PR TITLE
fix(ice): filter out discarded candidates

### DIFF
--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -1422,7 +1422,7 @@ impl<'a, 'b> AsSdpParams<'a, 'b> {
                 // If we are performing an ICE restart and we are keeping the same
                 // candidates we need to use ufrag from the new ICE credentials
                 // in our offer.
-                let mut new_candidates = rtc.ice.local_candidates().to_vec();
+                let mut new_candidates = rtc.ice.local_candidates().collect::<Vec<_>>();
                 for c in &mut new_candidates {
                     c.set_ufrag(&new_creds.ufrag);
                 }
@@ -1434,7 +1434,7 @@ impl<'a, 'b> AsSdpParams<'a, 'b> {
         } else {
             (
                 rtc.ice.local_credentials().clone(),
-                rtc.ice.local_candidates().to_vec(),
+                rtc.ice.local_candidates().collect::<Vec<_>>(),
             )
         };
 

--- a/src/ice/mod.rs
+++ b/src/ice/mod.rs
@@ -1383,7 +1383,6 @@ mod test {
 
         let outgoing_is_from_relay = from_agent
             .local_candidates()
-            .iter()
             .any(|c| c.addr() == from && c.kind() == CandidateKind::Relayed);
 
         // If NAT is present on sending agent, apply it.
@@ -1400,7 +1399,6 @@ mod test {
 
         let incoming_is_from_relay = to_agent
             .local_candidates()
-            .iter()
             .any(|c| c.addr() == to && c.kind() == CandidateKind::Relayed);
 
         // If NAT is present on receiving agent, apply it.


### PR DESCRIPTION
When a local or remote candidate gets invalidated, str0m internally sets a `discarded` flag instead of removing the `Candidate`. This allows us to retain the indices into the `local_candidates` and `remote_candidates` lists.

Unfortunately, with the current getters of `local_candidates` and `remote_candidates`, this implementation detail leaks through because those discarded candidates still get returned there.

In order to provide a consistent view of the world to the user, we change the API to return an `Iterator` instead and filter the candidates by the `discarded` flag.