### PR TITLE
feat(streams): use bytes::Bytes for RTP packet payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,6 +1773,7 @@ version = "0.16.2"
 dependencies = [
  "_str0m_test",
  "arrayvec",
+ "bytes",
  "combine",
  "crc",
  "dimpl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ sctp-proto = "0.7.0"
 combine = "4.6.6"
 subtle = "2.0.0"
 arrayvec = "0.7.6"
+bytes = "1"
 
 # STUN
 # Pin crc to avoid 3.4 which requires rustc 1.83

--- a/src/_internal_test_exports/fuzz.rs
+++ b/src/_internal_test_exports/fuzz.rs
@@ -107,7 +107,7 @@ pub fn depack(data: &[u8]) -> Option<()> {
             };
             let len = rng.usize(1200)?;
             let data = rng.slice(len)?.to_vec();
-            depack.push(meta, data);
+            depack.push(meta, data.into());
         } else {
             depack.pop();
         }

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -3,6 +3,8 @@ use std::fmt;
 use std::ops::{Range, RangeInclusive};
 use std::time::Instant;
 
+use bytes::Bytes;
+
 use crate::rtp_::{ExtensionValues, MediaTime, RtpHeader, SenderInfo, SeqNo};
 
 use super::contiguity::Contiguity;
@@ -90,7 +92,7 @@ impl Depacketized {
 #[derive(Debug)]
 struct Entry {
     meta: RtpMeta,
-    data: Vec<u8>,
+    data: Bytes,
     head: bool,
     tail: bool,
 }
@@ -133,7 +135,7 @@ impl DepacketizingBuffer {
         }
     }
 
-    pub fn push(&mut self, meta: RtpMeta, data: Vec<u8>) {
+    pub fn push(&mut self, meta: RtpMeta, data: Bytes) {
         // We're not emitting frames in the wrong order. If we receive
         // packets that are before the last emitted, we drop.
         //
@@ -554,7 +556,7 @@ mod test {
                 },
             };
 
-            buf.push(meta, data.to_vec());
+            buf.push(meta, Bytes::from(data.to_vec()));
 
             let mut depacks = vec![];
             while let Some(res) = buf.pop() {
@@ -769,7 +771,7 @@ mod test {
 
         for input in &inputs {
             let (meta, data) = construct_input(input.clone());
-            buffer.push(meta, data);
+            buffer.push(meta, Bytes::from(data));
         }
 
         let res0before = buffer.pop().unwrap().unwrap(); // Pop PID: 23860, `contiguous_seq == true`.
@@ -783,7 +785,7 @@ mod test {
             if meta.seq_no == SeqNo::from(8689) {
                 continue; // Skip RTP packet with seq_num=8689 vp9_payload=[20, 2, 2, 2, 2, 2, 2, 2, 2].
             }
-            buffer.push(meta.clone(), data.clone());
+            buffer.push(meta.clone(), Bytes::from(data));
         }
 
         // Pop PID: 23860, `contiguous_seq == true`.
@@ -796,7 +798,7 @@ mod test {
             let (meta, data) = construct_input(input.clone());
             if meta.seq_no == SeqNo::from(8689) {
                 // Send RTP packet with seq_num=8689 vp9_payload=[20, 2, 2, 2, 2, 2, 2, 2, 2].
-                buffer.push(meta.clone(), data.clone());
+                buffer.push(meta.clone(), Bytes::from(data));
                 break;
             }
         }

--- a/src/packet/payload.rs
+++ b/src/packet/payload.rs
@@ -1,3 +1,5 @@
+use bytes::Bytes;
+
 use crate::format::CodecSpec;
 use crate::media::ToPayload;
 use crate::rtp_::Frequency;
@@ -60,7 +62,7 @@ impl Payloader {
                 marker,
                 ext_vals.clone(),
                 nackable,
-                data,
+                Bytes::from(data),
             )?;
         }
 

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -3,6 +3,8 @@ use std::fmt::{self};
 use std::time::Duration;
 use std::time::Instant;
 
+use bytes::Bytes;
+
 use crate::format::CodecConfig;
 use crate::format::PayloadParams;
 use crate::media::{KeyframeRequest, Media, SenderFeedback};
@@ -61,7 +63,10 @@ pub struct RtpPacket {
     pub header: RtpHeader,
 
     /// RTP payload. This contains no header.
-    pub payload: Vec<u8>,
+    ///
+    /// Uses `bytes::Bytes` for zero-copy forwarding: cloning is O(1) via
+    /// atomic reference counting instead of a full heap allocation + memcpy.
+    pub payload: Bytes,
 
     /// str0m server timestamp.
     ///
@@ -112,7 +117,7 @@ impl RtpPacket {
                 payload_type: BLANK_PACKET_DEFAULT_PT,
                 ..Default::default()
             },
-            payload: vec![], // This payload is never used. See RtpHeader::create_padding_packet
+            payload: Bytes::new(), // This payload is never used. See RtpHeader::create_padding_packet
             nackable: false,
             last_sender_info: None,
             timestamp: already_happened(),

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -1,6 +1,8 @@
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
+use bytes::Bytes;
+
 use crate::media::KeyframeRequestKind;
 use crate::rtp_::MidRid;
 use crate::rtp_::{extend_u32, Bitrate, DlrrItem, ExtendedReport};
@@ -467,7 +469,7 @@ impl StreamRx {
             seq_no,
             time,
             header,
-            payload: data,
+            payload: Bytes::from(data),
             nackable: false,
             last_sender_info: self.sender_info.as_ref().map(|l| l.info),
             timestamp: now,

--- a/src/streams/rtx_cache.rs
+++ b/src/streams/rtx_cache.rs
@@ -75,6 +75,8 @@ impl RtxCache {
 
 #[cfg(test)]
 mod test {
+    use bytes::Bytes;
+
     use crate::rtp_::MediaTime;
     use crate::rtp_::RtpHeader;
 
@@ -89,7 +91,7 @@ mod test {
             header: RtpHeader::default(),
             seq_no: seq_no.into(),
             time: MediaTime::from_90khz(0),
-            payload: millis.to_be_bytes().to_vec(),
+            payload: Bytes::from(millis.to_be_bytes().to_vec()),
             timestamp: after(now, millis),
             last_sender_info: None,
             nackable: true,

--- a/src/streams/send_queue.rs
+++ b/src/streams/send_queue.rs
@@ -203,6 +203,8 @@ impl TotalQueue {
 
 #[cfg(test)]
 mod test {
+    use bytes::Bytes;
+
     use crate::rtp_::MediaTime;
     use crate::rtp_::RtpHeader;
 
@@ -216,7 +218,7 @@ mod test {
             seq_no: 0.into(),
             time: MediaTime::from_90khz(10),
             header: RtpHeader::default(),
-            payload: vec![],
+            payload: Bytes::new(),
             timestamp: Instant::now(),
             last_sender_info: None,
             nackable: true,
@@ -251,7 +253,7 @@ mod test {
             seq_no: 0.into(),
             time: MediaTime::from_90khz(10),
             header: RtpHeader::default(),
-            payload: vec![42, 42],
+            payload: Bytes::from_static(&[42, 42]),
             timestamp: start,
             last_sender_info: None,
             nackable: true,
@@ -288,7 +290,7 @@ mod test {
             seq_no: 0.into(),
             time: MediaTime::from_90khz(10),
             header: RtpHeader::default(),
-            payload: vec![0; 10],
+            payload: Bytes::from_static(&[0; 10]),
             timestamp: start,
             last_sender_info: None,
             nackable: true,
@@ -297,7 +299,7 @@ mod test {
             seq_no: 1.into(),
             time: MediaTime::from_90khz(20),
             header: RtpHeader::default(),
-            payload: vec![1; 10],
+            payload: Bytes::from_static(&[1; 10]),
             timestamp: start,
             last_sender_info: None,
             nackable: true,
@@ -306,7 +308,7 @@ mod test {
             seq_no: 2.into(),
             time: MediaTime::from_90khz(20),
             header: RtpHeader::default(),
-            payload: vec![1; 10],
+            payload: Bytes::from_static(&[1; 10]),
             timestamp: start,
             last_sender_info: None,
             nackable: true,


### PR DESCRIPTION
We use str0m as an SFU and forward each incoming packet to all other participants. Cloning Vec<u8> per subscriber gets expensive in larger rooms, so this switches RtpPacket.payload to bytes::Bytes — cloning is just a refcount bump.

write_rtp() takes `impl Into<Bytes>` now so passing Vec<u8> still works as before.

This is a breaking change for anyone constructing RtpPacket directly.