### PR TITLE
fix: remove version constraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,15 +52,13 @@ subtle = "2.0.0"
 arrayvec = "0.7.6"
 
 # STUN
-# Pin crc to avoid 3.4 which requires rustc 1.83
-crc = ">=3.0, <3.4"
+crc = "3.0" # Pinned with lockfile to < 3.4 which requires rustc 1.83
 serde = { version = "1.0.152", features = ["derive"] }
 
 # DTLS made for str0m (required dependency)
 dimpl = { version = "0.3.0", default-features = false }
 
-# Pin time to avoid time-core 0.1.8+ which requires edition 2024 (rustc 1.85+)
-time = ">=0.3, <0.3.37"
+time = "0.3" # Pinned with lockfile to < 0.3.37 which requires rustc 1.85
 
 str0m-proto = { version = "0.1.2", path = "proto" }
 
@@ -80,12 +78,8 @@ str0m-wincrypto = { version = "0.3.2", path = "crypto/wincrypto", optional = tru
 rouille = { version = "3.6.2", features = [] }
 str0m-rust-crypto = { version = "0.1.2", path = "crypto/rust-crypto" }
 netem = { package = "str0m-netem", version = "0.1.1", path = "netem" }
-
-# Pin tempfile to avoid getrandom 0.4.1 which requires edition 2024 (MSRV 1.85)
-tempfile = ">=3, <3.25"
-# Pin url to avoid idna 1.x / ICU crates requiring rustc 1.82+
-url = ">=2, <2.5"
-
+tempfile = "3" # Pinned with lockfile to < 3.25 which requires rustc 1.85 via `getrandom` 0.4.1
+url = "2" # Pinned with lockfile to < 2.5 which requires rustc 1.82 via idna 1.x crates
 serde_json = "1.0"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "std"] }
 systemstat = "0.2.2"


### PR DESCRIPTION
Constraining versions of dependencies via the manifest file prevents downstream users from using them, even if they have a higher MSRV requirement. For example:

```
thomas@fedora ~/s/g/f/f/rust (bump-str0m)> cargo update -p str0m
    Updating git repository `https://github.com/algesten/str0m`
    Updating crates.io index
error: failed to select a version for `time`.
    ... required by package `str0m v0.16.2 (https://github.com/algesten/str0m?branch=main#487afbe2)`
    ... which satisfies dependency `str0m = "^0.16.2"` of package `connlib-model v0.1.0 (/home/thomas/src/github.com/firezone/firezone.bump-str0m/rust/libs/connlib/model)`
    ... which satisfies path dependency `connlib-model` (locked to 0.1.0) of package `client-ffi v0.1.0 (/home/thomas/src/github.com/firezone/firezone.bump-str0m/rust/client-ffi)`
versions that meet the requirements `>=0.3, <0.3.37` are: 0.3.36, 0.3.35, 0.3.34, 0.3.33, 0.3.32, 0.3.31, 0.3.30, 0.3.29, 0.3.28, 0.3.27, 0.3.26, 0.3.25, 0.3.24, 0.3.23, 0.3.22, 0.3.21, 0.3.20, 0.3.19, 0.3.18, 0.3.17, 0.3.16, 0.3.15, 0.3.14, 0.3.13, 0.3.12, 0.3.11, 0.3.10, 0.3.9, 0.3.7, 0.3.6, 0.3.5, 0.3.4, 0.3.3, 0.3.2, 0.3.1, 0.3.0

all possible versions conflict with previously selected packages.

  previously selected package `time v0.3.46`
    ... which satisfies dependency `time = "^0.3.46"` of package `client-shared v0.1.0 (/home/thomas/src/github.com/firezone/firezone.bump-str0m/rust/libs/client-shared)`
    ... which satisfies path dependency `client-shared` (locked to 0.1.0) of package `client-ffi v0.1.0 (/home/thomas/src/github.com/firezone/firezone.bump-str0m/rust/client-ffi)`

failed to select a version for `time` which could resolve this conflict
```

There is no reason to constrain these dependencies in there, that is what the lockfile is for and CI validates that there is a set of dependencies for which we can compile on our MSRV.

This regressed in #874.