### PR TITLE
Update dimpl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,21 +158,21 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.14.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
+checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.32.3"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "107a4e9d9cab9963e04e84bb8dee0e25f2a987f9a8bad5ed054abd439caa8f8c"
+checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
 dependencies = [
- "bindgen",
  "cc",
  "cmake",
  "dunce",
@@ -157,26 +196,6 @@ name = "base64ct"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.106",
-]
 
 [[package]]
 name = "bitflags"
@@ -269,19 +288,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
 
 [[package]]
 name = "chrono"
@@ -292,7 +326,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -309,17 +343,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
+ "zeroize",
 ]
 
 [[package]]
@@ -429,6 +453,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "deflate"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +505,20 @@ dependencies = [
  "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -496,20 +566,22 @@ dependencies = [
 
 [[package]]
 name = "dimpl"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53382532e53576983721038702387751067de126c43c3150af8341962e85b456"
+checksum = "4149e82d4e48b057ea36e39cb3b2473be96a20cd5f553cf347c413a81888753b"
 dependencies = [
  "aes-gcm",
  "arrayvec",
  "aws-lc-rs",
+ "chacha20",
+ "chacha20poly1305",
  "der",
  "ecdsa",
  "generic-array",
  "hkdf",
  "hmac",
  "log",
- "nom",
+ "nom 8.0.0",
  "once_cell",
  "p256",
  "p384",
@@ -523,7 +595,19 @@ dependencies = [
  "spki",
  "subtle",
  "time",
+ "x25519-dalek",
  "x509-cert",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -545,12 +629,6 @@ dependencies = [
  "signature",
  "spki",
 ]
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -598,6 +676,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -690,12 +774,6 @@ dependencies = [
  "opaque-debug",
  "polyval",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
@@ -797,15 +875,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,16 +913,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,9 +931,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "matchers"
@@ -942,6 +1001,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,10 +1019,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -982,6 +1069,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -1117,6 +1213,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,16 +1248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -1253,13 +1350,14 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.5"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fae430c6b28f1ad601274e78b7dffa0546de0b73b4cd32f46723c0c2a16f7a5"
+checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
 dependencies = [
  "aws-lc-rs",
  "rustls-pki-types",
  "time",
+ "x509-parser",
  "yasna",
 ]
 
@@ -1369,6 +1467,24 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
+]
 
 [[package]]
 name = "rustix"
@@ -1492,6 +1608,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1761,6 +1883,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "systemstat"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1769,7 +1902,7 @@ dependencies = [
  "bytesize",
  "lazy_static",
  "libc",
- "nom",
+ "nom 7.1.3",
  "time",
  "winapi",
 ]
@@ -2208,7 +2341,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement 0.60.0",
  "windows-interface 0.59.1",
- "windows-link 0.1.3",
+ "windows-link",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
 ]
@@ -2264,12 +2397,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2284,7 +2411,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -2303,7 +2430,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -2355,7 +2482,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -2472,6 +2599,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "x509-cert"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2480,6 +2619,24 @@ dependencies = [
  "const-oid",
  "der",
  "spki",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "aws-lc-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]
@@ -2516,3 +2673,17 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ crc = ">=3.0, <3.4"
 serde = { version = "1.0.152", features = ["derive"] }
 
 # DTLS made for str0m (required dependency)
-dimpl = { version = "0.3.0", default-features = false }
+dimpl = { version = "0.4.0", default-features = false }
 
 # Pin time to avoid time-core 0.1.8+ which requires edition 2024 (rustc 1.85+)
 time = ">=0.3, <0.3.37"

--- a/crypto/apple-crypto/Cargo.lock
+++ b/crypto/apple-crypto/Cargo.lock
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "dimpl"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53382532e53576983721038702387751067de126c43c3150af8341962e85b456"
+checksum = "4149e82d4e48b057ea36e39cb3b2473be96a20cd5f553cf347c413a81888753b"
 dependencies = [
  "arrayvec",
  "log",
@@ -154,9 +154,9 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -165,19 +165,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]

--- a/crypto/apple-crypto/Cargo.toml
+++ b/crypto/apple-crypto/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.81.0"
 
 [dependencies]
 str0m-proto = { version = "0.1.2", path = "../../proto" }
-dimpl = { version = "0.3.0", default-features = false }
+dimpl = { version = "0.4.0", default-features = false }
 # Pin time to avoid time-core 0.1.8+ which requires edition 2024 (rustc 1.85+)
 time = ">=0.3, <0.3.37"
 

--- a/crypto/aws-lc-rs/Cargo.lock
+++ b/crypto/aws-lc-rs/Cargo.lock
@@ -9,20 +9,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.15.1"
+name = "asn1-rs"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5ce75405893cd713f9ab8e297d8e438f624dde7d706108285f7e17a25a180f"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
 dependencies = [
  "aws-lc-sys",
+ "untrusted",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.34.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "179c3777a8b5e70e90ea426114ffc565b2c1a9f82f6c4a0c5a34aa6ef5e781b6"
+checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
 dependencies = [
  "cc",
  "cmake",
@@ -76,6 +122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +138,20 @@ dependencies = [
  "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -110,15 +176,15 @@ dependencies = [
 
 [[package]]
 name = "dimpl"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53382532e53576983721038702387751067de126c43c3150af8341962e85b456"
+checksum = "4149e82d4e48b057ea36e39cb3b2473be96a20cd5f553cf347c413a81888753b"
 dependencies = [
  "arrayvec",
  "aws-lc-rs",
  "der",
  "log",
- "nom",
+ "nom 8.0.0",
  "once_cell",
  "pkcs8",
  "rand",
@@ -129,6 +195,17 @@ dependencies = [
  "subtle",
  "time",
  "x509-cert",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -194,6 +271,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,9 +284,9 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -228,10 +311,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
 
 [[package]]
 name = "once_cell"
@@ -328,14 +457,24 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.5"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fae430c6b28f1ad601274e78b7dffa0546de0b73b4cd32f46723c0c2a16f7a5"
+checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
 dependencies = [
  "aws-lc-rs",
  "rustls-pki-types",
  "time",
+ "x509-parser",
  "yasna",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -448,6 +587,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "time"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +661,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +696,24 @@ dependencies = [
  "const-oid",
  "der",
  "spki",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "aws-lc-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror",
+ "time",
 ]
 
 [[package]]

--- a/crypto/aws-lc-rs/Cargo.toml
+++ b/crypto/aws-lc-rs/Cargo.toml
@@ -14,6 +14,6 @@ rust-version = "1.81.0"
 [dependencies]
 str0m-proto = { version = "0.1.2", path = "../../proto" }
 aws-lc-rs = { version = "1", default-features = false, features = ["aws-lc-sys", "prebuilt-nasm"] }
-dimpl = { version = "0.3.0", default-features = false, features = ["aws-lc-rs", "rcgen"] }
+dimpl = { version = "0.4.0", default-features = false, features = ["aws-lc-rs", "rcgen"] }
 # Pin time to avoid time-core 0.1.8+ which requires edition 2024 (rustc 1.85+)
 time = ">=0.3, <0.3.37"

--- a/crypto/openssl/src/dtls.rs
+++ b/crypto/openssl/src/dtls.rs
@@ -425,6 +425,7 @@ fn srtp_profile_openssl_name(profile: SrtpProfile) -> &'static str {
         SrtpProfile::AES128_CM_SHA1_80 => "SRTP_AES128_CM_SHA1_80",
         SrtpProfile::AEAD_AES_128_GCM => "SRTP_AEAD_AES_128_GCM",
         SrtpProfile::AEAD_AES_256_GCM => "SRTP_AEAD_AES_256_GCM",
+        _ => panic!("Unexpected SRTP profile: {profile:?}"),
     }
 }
 

--- a/crypto/rust-crypto/Cargo.lock
+++ b/crypto/rust-crypto/Cargo.lock
@@ -44,20 +44,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.15.1"
+name = "asn1-rs"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5ce75405893cd713f9ab8e297d8e438f624dde7d706108285f7e17a25a180f"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
 dependencies = [
  "aws-lc-sys",
+ "untrusted",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.34.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "179c3777a8b5e70e90ea426114ffc565b2c1a9f82f6c4a0c5a34aa6ef5e781b6"
+checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
 dependencies = [
  "cc",
  "cmake",
@@ -105,6 +151,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +182,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -171,6 +242,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +284,20 @@ dependencies = [
  "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -217,20 +334,22 @@ dependencies = [
 
 [[package]]
 name = "dimpl"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53382532e53576983721038702387751067de126c43c3150af8341962e85b456"
+checksum = "4149e82d4e48b057ea36e39cb3b2473be96a20cd5f553cf347c413a81888753b"
 dependencies = [
  "aes-gcm",
  "arrayvec",
  "aws-lc-rs",
+ "chacha20",
+ "chacha20poly1305",
  "der",
  "ecdsa",
  "generic-array",
  "hkdf",
  "hmac",
  "log",
- "nom",
+ "nom 8.0.0",
  "once_cell",
  "p256",
  "p384",
@@ -244,7 +363,19 @@ dependencies = [
  "spki",
  "subtle",
  "time",
+ "x25519-dalek",
  "x509-cert",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -297,6 +428,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -415,6 +552,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,9 +565,9 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -449,10 +592,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
 
 [[package]]
 name = "once_cell"
@@ -507,6 +696,17 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -609,13 +809,14 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.5"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fae430c6b28f1ad601274e78b7dffa0546de0b73b4cd32f46723c0c2a16f7a5"
+checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
 dependencies = [
  "aws-lc-rs",
  "rustls-pki-types",
  "time",
+ "x509-parser",
  "yasna",
 ]
 
@@ -627,6 +828,24 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -653,12 +872,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -773,6 +999,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "time"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +1083,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +1116,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "x509-cert"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +1136,24 @@ dependencies = [
  "const-oid",
  "der",
  "spki",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "aws-lc-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -897,3 +1190,17 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/crypto/rust-crypto/Cargo.toml
+++ b/crypto/rust-crypto/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.81.0"
 
 [dependencies]
 str0m-proto = { version = "0.1.2", path = "../../proto" }
-dimpl = { version = "0.3.0", default-features = false, features = ["rust-crypto", "rcgen"] }
+dimpl = { version = "0.4.0", default-features = false, features = ["rust-crypto", "rcgen"] }
 # Pin time to avoid time-core 0.1.8+ which requires edition 2024 (rustc 1.85+)
 time = ">=0.3, <0.3.37"
 hmac = { version = "0.12.1" }

--- a/proto/Cargo.lock
+++ b/proto/Cargo.lock
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "dimpl"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53382532e53576983721038702387751067de126c43c3150af8341962e85b456"
+checksum = "4149e82d4e48b057ea36e39cb3b2473be96a20cd5f553cf347c413a81888753b"
 dependencies = [
  "arrayvec",
  "log",
@@ -107,9 +107,9 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -118,19 +118,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -20,7 +20,7 @@ _internal_test_exports = []
 
 [dependencies]
 # DTLS made for str0m (required dependency for types and traits)
-dimpl = { version = "0.3.0", default-features = false }
+dimpl = { version = "0.4.0", default-features = false }
 
 # Pin time to avoid time-core 0.1.8+ which requires edition 2024 (rustc 1.85+)
 time = ">=0.3, <0.3.37"

--- a/src/dtls.rs
+++ b/src/dtls.rs
@@ -137,9 +137,13 @@ impl Dtls {
 
     /// Send application data over DTLS.
     pub fn handle_input(&mut self, data: &[u8]) -> Result<(), DtlsError> {
-        self.instance
-            .send_application_data(data)
-            .map_err(|e| DtlsError::CryptoError(CryptoError::Other(format!("DTLS error: {}", e))))
+        self.instance.send_application_data(data).map_err(|e| {
+            if matches!(e, dimpl::Error::HandshakePending) {
+                DtlsError::Io(io::Error::new(io::ErrorKind::WouldBlock, e))
+            } else {
+                DtlsError::CryptoError(CryptoError::Other(format!("DTLS error: {}", e)))
+            }
+        })
     }
 
     /// Handle a timeout event.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -661,7 +661,7 @@ use crypto::Fingerprint;
 
 mod dtls;
 use crate::crypto::dtls::DtlsOutput;
-use crate::crypto::{from_feature_flags, CryptoProvider};
+use crate::crypto::{from_feature_flags, CryptoProvider, DtlsError};
 use crate::dtls::is_would_block;
 use dtls::Dtls;
 
@@ -1549,6 +1549,11 @@ impl Rtc {
                 DtlsOutput::Timeout(t) => {
                     self.next_dtls_timeout = Some(t);
                     break;
+                }
+                other => {
+                    return Err(RtcError::Dtls(DtlsError::Io(std::io::Error::other(
+                        format!("Unexpected DTLS output: {other:?}"),
+                    ))));
                 }
             }
         }

--- a/src/rtp/srtp.rs
+++ b/src/rtp/srtp.rs
@@ -90,6 +90,7 @@ impl SrtpContext {
                     sha1_hmac_provider,
                 }
             }
+            _ => panic!("Unexpected SRTP profile: {profile:?}"),
         }
     }
 

--- a/tests/handshake-direct.rs
+++ b/tests/handshake-direct.rs
@@ -4,24 +4,105 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use str0m::channel::{ChannelConfig, ChannelId, Reliability};
-use str0m::config::Fingerprint;
+use str0m::config::{DtlsVersion, Fingerprint};
 use str0m::ice::IceCreds;
 use str0m::net::{Protocol, Receive};
 use str0m::{Candidate, Event, IceConnectionState, Input, Output, Rtc, RtcConfig, RtcError};
 use tracing::{info_span, Span};
 
 mod common;
-use common::{init_crypto_default, init_log};
+use common::{init_crypto_default, init_log, Peer};
 
 /// Pre-negotiated data channel SCTP stream ID
 const DATA_CHANNEL_ID: u16 = 0;
 
+/// Set to `true` to save packet captures to `target/pcap/` for Wireshark analysis.
+const SAVE_PCAP: bool = false;
+
 #[test]
-pub fn handshake_direct_api_two_threads() -> Result<(), RtcError> {
+pub fn handshake_dtls_auto_to_12() -> Result<(), RtcError> {
+    run_handshake_test(DtlsVersion::Auto, DtlsVersion::Dtls12)
+}
+
+#[test]
+pub fn handshake_dtls_auto_to_13() -> Result<(), RtcError> {
+    run_handshake_test(DtlsVersion::Auto, DtlsVersion::Dtls13)
+}
+
+#[test]
+pub fn handshake_dtls_auto_to_auto() -> Result<(), RtcError> {
+    run_handshake_test(DtlsVersion::Auto, DtlsVersion::Auto)
+}
+
+#[test]
+pub fn handshake_dtls_12_to_auto() -> Result<(), RtcError> {
+    run_handshake_test(DtlsVersion::Dtls12, DtlsVersion::Auto)
+}
+
+#[test]
+pub fn handshake_dtls_13_to_auto() -> Result<(), RtcError> {
+    run_handshake_test(DtlsVersion::Dtls13, DtlsVersion::Auto)
+}
+
+#[test]
+pub fn handshake_dtls_12_to_12() -> Result<(), RtcError> {
+    run_handshake_test(DtlsVersion::Dtls12, DtlsVersion::Dtls12)
+}
+
+#[test]
+pub fn handshake_dtls_13_to_13() -> Result<(), RtcError> {
+    run_handshake_test(DtlsVersion::Dtls13, DtlsVersion::Dtls13)
+}
+
+/// Returns the name of the default crypto provider based on compile-time feature flags.
+/// Mirrors the priority order in `str0m::crypto::from_feature_flags()`.
+#[allow(unreachable_code)]
+fn default_crypto_name() -> &'static str {
+    #[cfg(feature = "aws-lc-rs")]
+    return "aws-lc-rs";
+    #[cfg(feature = "rust-crypto")]
+    return "rust-crypto";
+    #[cfg(feature = "openssl")]
+    return "openssl";
+    #[cfg(all(feature = "wincrypto", target_os = "windows"))]
+    return "wincrypto";
+    #[cfg(all(feature = "apple-crypto", target_vendor = "apple"))]
+    return "apple-crypto";
+    "unknown"
+}
+
+fn run_handshake_test(client_dtls: DtlsVersion, server_dtls: DtlsVersion) -> Result<(), RtcError> {
     init_log();
     init_crypto_default();
 
     let test_start = Instant::now();
+
+    let client_crypto_name =
+        std::env::var("L_CRYPTO").unwrap_or_else(|_| default_crypto_name().into());
+    let server_crypto_name =
+        std::env::var("R_CRYPTO").unwrap_or_else(|_| default_crypto_name().into());
+
+    // wincrypto and openssl only support DTLS 1.2 — skip tests requiring 1.3/Auto.
+    // Also skip Auto client → 1.2-only server: dimpl advertises X25519 in the hybrid
+    // ClientHello but its DTLS 1.2 engine can't process X25519 in ServerKeyExchange.
+    let dtls12_only = |name: &str| matches!(name, "wincrypto" | "openssl");
+    let needs_13 = |v: DtlsVersion| matches!(v, DtlsVersion::Auto | DtlsVersion::Dtls13);
+
+    if (dtls12_only(&client_crypto_name) && needs_13(client_dtls))
+        || (dtls12_only(&server_crypto_name) && needs_13(server_dtls))
+        || (matches!(client_dtls, DtlsVersion::Auto) && dtls12_only(&server_crypto_name))
+    {
+        println!(
+            "\n=== SKIPPED: client={} ({}), server={} ({}) — DTLS 1.3/Auto not supported ===",
+            client_dtls, client_crypto_name, server_dtls, server_crypto_name
+        );
+        return Ok(());
+    }
+
+    println!(
+        "\n=== Test: client={} ({}), server={} ({}) ===",
+        client_dtls, client_crypto_name, server_dtls, server_crypto_name
+    );
 
     // Channels for communication between threads
     // client -> server
@@ -32,113 +113,166 @@ pub fn handshake_direct_api_two_threads() -> Result<(), RtcError> {
     let client_addr: SocketAddr = (Ipv4Addr::new(192, 168, 1, 1), 5000).into();
     let server_addr: SocketAddr = (Ipv4Addr::new(192, 168, 1, 2), 5001).into();
 
+    // Test name for pcap files
+    let test_name = format!(
+        "handshake_dtls_{}_to_{}",
+        dtls_version_short(client_dtls),
+        dtls_version_short(server_dtls)
+    );
+
     // Spawn server thread
-    let server_handle = thread::spawn(move || -> Result<TimingReport, RtcError> {
-        let span = info_span!("SERVER");
-        let _guard = span.enter();
-        let mut timing = TimingReport::new();
+    // Returns (packets, Result) so pcap is available even on failure.
+    let server_handle = thread::spawn(
+        move || -> (Vec<PcapPacket>, Result<TimingReport, RtcError>) {
+            let span = info_span!("SERVER");
+            let _guard = span.enter();
+            let mut timing = TimingReport::new();
+            let mut packets = Vec::new();
 
-        // Initialize server (is_client = false)
-        let (mut rtc, local_creds, local_fingerprint) = init_rtc(false, server_addr)?;
+            let result = (|| -> Result<TimingReport, RtcError> {
+                // Initialize server (is_client = false)
+                let (mut rtc, local_creds, local_fingerprint) =
+                    init_rtc(false, server_addr, server_dtls, Peer::Right, &mut timing)?;
 
-        // Send server's credentials to client
-        server_tx
-            .send(Message::Credentials {
-                ice_ufrag: local_creds.ufrag.clone(),
-                ice_pwd: local_creds.pass.clone(),
-                dtls_fingerprint: local_fingerprint,
-            })
-            .expect("Failed to send server credentials");
+                // Send server's credentials to client
+                server_tx
+                    .send(Message::Credentials {
+                        ice_ufrag: local_creds.ufrag.clone(),
+                        ice_pwd: local_creds.pass.clone(),
+                        dtls_fingerprint: local_fingerprint,
+                    })
+                    .expect("Failed to send server credentials");
 
-        // Wait for client's credentials
-        let (remote_ice_ufrag, remote_ice_pwd, remote_fingerprint) =
-            match server_rx.recv_timeout(Duration::from_secs(5)) {
-                Ok(Message::Credentials {
-                    ice_ufrag,
-                    ice_pwd,
-                    dtls_fingerprint,
-                }) => {
-                    timing.got_offer = Some(Instant::now());
-                    (ice_ufrag, ice_pwd, dtls_fingerprint)
-                }
-                Ok(_) => panic!("Server expected Credentials, got something else"),
-                Err(e) => panic!("Server failed to receive credentials: {:?}", e),
-            };
+                // Wait for client's credentials
+                let (remote_ice_ufrag, remote_ice_pwd, remote_fingerprint) =
+                    match server_rx.recv_timeout(Duration::from_secs(5)) {
+                        Ok(Message::Credentials {
+                            ice_ufrag,
+                            ice_pwd,
+                            dtls_fingerprint,
+                        }) => {
+                            timing.got_offer = Some(Instant::now());
+                            (ice_ufrag, ice_pwd, dtls_fingerprint)
+                        }
+                        Ok(_) => panic!("Server expected Credentials, got something else"),
+                        Err(e) => panic!("Server failed to receive credentials: {:?}", e),
+                    };
 
-        // Configure with remote credentials (is_client = false)
-        configure_rtc(
-            &mut rtc,
-            false,
-            client_addr,
-            remote_ice_ufrag,
-            remote_ice_pwd,
-            remote_fingerprint,
-        )?;
-        timing.sent_answer = Some(Instant::now());
+                // Configure with remote credentials (is_client = false)
+                configure_rtc(
+                    &mut rtc,
+                    false,
+                    client_addr,
+                    remote_ice_ufrag,
+                    remote_ice_pwd,
+                    remote_fingerprint,
+                )?;
+                timing.sent_answer = Some(Instant::now());
 
-        // Run the event loop with message exchange
-        run_rtc_loop_with_exchange(&mut rtc, &span, &server_rx, &server_tx, &mut timing, false)?;
+                // Run the event loop with message exchange
+                run_rtc_loop_with_exchange(
+                    &mut rtc,
+                    &span,
+                    &server_rx,
+                    &server_tx,
+                    &mut timing,
+                    false,
+                    &mut packets,
+                )?;
 
-        Ok(timing)
-    });
+                Ok(timing)
+            })();
+
+            (packets, result)
+        },
+    );
 
     // Spawn client thread
-    let client_handle = thread::spawn(move || -> Result<TimingReport, RtcError> {
-        let span = info_span!("CLIENT");
-        let _guard = span.enter();
-        let mut timing = TimingReport::new();
+    // Returns (packets, Result) so pcap is available even on failure.
+    let client_handle = thread::spawn(
+        move || -> (Vec<PcapPacket>, Result<TimingReport, RtcError>) {
+            let span = info_span!("CLIENT");
+            let _guard = span.enter();
+            let mut timing = TimingReport::new();
+            let mut packets = Vec::new();
 
-        // Initialize client (is_client = true)
-        let (mut rtc, local_creds, local_fingerprint) = init_rtc(true, client_addr)?;
+            let result = (|| -> Result<TimingReport, RtcError> {
+                // Initialize client (is_client = true)
+                let (mut rtc, local_creds, local_fingerprint) =
+                    init_rtc(true, client_addr, client_dtls, Peer::Left, &mut timing)?;
 
-        // Wait for server's credentials first
-        let (remote_ice_ufrag, remote_ice_pwd, remote_fingerprint) =
-            match client_rx.recv_timeout(Duration::from_secs(5)) {
-                Ok(Message::Credentials {
-                    ice_ufrag,
-                    ice_pwd,
-                    dtls_fingerprint,
-                }) => (ice_ufrag, ice_pwd, dtls_fingerprint),
-                Ok(_) => panic!("Client expected Credentials, got something else"),
-                Err(e) => panic!("Client failed to receive server credentials: {:?}", e),
-            };
+                // Wait for server's credentials first
+                let (remote_ice_ufrag, remote_ice_pwd, remote_fingerprint) =
+                    match client_rx.recv_timeout(Duration::from_secs(5)) {
+                        Ok(Message::Credentials {
+                            ice_ufrag,
+                            ice_pwd,
+                            dtls_fingerprint,
+                        }) => (ice_ufrag, ice_pwd, dtls_fingerprint),
+                        Ok(_) => panic!("Client expected Credentials, got something else"),
+                        Err(e) => panic!("Client failed to receive server credentials: {:?}", e),
+                    };
 
-        // Send client's credentials to server
-        client_tx
-            .send(Message::Credentials {
-                ice_ufrag: local_creds.ufrag.clone(),
-                ice_pwd: local_creds.pass.clone(),
-                dtls_fingerprint: local_fingerprint,
-            })
-            .expect("Failed to send client credentials");
-        timing.sent_offer = Some(Instant::now());
+                // Send client's credentials to server
+                client_tx
+                    .send(Message::Credentials {
+                        ice_ufrag: local_creds.ufrag.clone(),
+                        ice_pwd: local_creds.pass.clone(),
+                        dtls_fingerprint: local_fingerprint,
+                    })
+                    .expect("Failed to send client credentials");
+                timing.sent_offer = Some(Instant::now());
 
-        // Configure with remote credentials (is_client = true)
-        configure_rtc(
-            &mut rtc,
-            true,
-            server_addr,
-            remote_ice_ufrag,
-            remote_ice_pwd,
-            remote_fingerprint,
-        )?;
-        timing.got_answer = Some(Instant::now());
+                // Configure with remote credentials (is_client = true)
+                configure_rtc(
+                    &mut rtc,
+                    true,
+                    server_addr,
+                    remote_ice_ufrag,
+                    remote_ice_pwd,
+                    remote_fingerprint,
+                )?;
+                timing.got_answer = Some(Instant::now());
 
-        // Run the event loop with message exchange
-        run_rtc_loop_with_exchange(&mut rtc, &span, &client_rx, &client_tx, &mut timing, true)?;
+                // Run the event loop with message exchange
+                run_rtc_loop_with_exchange(
+                    &mut rtc,
+                    &span,
+                    &client_rx,
+                    &client_tx,
+                    &mut timing,
+                    true,
+                    &mut packets,
+                )?;
 
-        Ok(timing)
-    });
+                Ok(timing)
+            })();
+
+            (packets, result)
+        },
+    );
 
     // Wait for both threads to complete
-    let server_timing = server_handle
-        .join()
-        .expect("Server thread panicked")
-        .expect("Server returned error");
-    let client_timing = client_handle
-        .join()
-        .expect("Client thread panicked")
-        .expect("Client returned error");
+    let (server_packets, server_result) = server_handle.join().expect("Server thread panicked");
+    let (client_packets, client_result) = client_handle.join().expect("Client thread panicked");
+
+    // Save pcap files BEFORE checking errors so we capture failing handshakes
+    if SAVE_PCAP {
+        let pcap_dir = std::path::Path::new("target/pcap");
+        std::fs::create_dir_all(pcap_dir).expect("Failed to create target/pcap directory");
+
+        let client_path = pcap_dir.join(format!("{test_name}_client.pcap"));
+        let server_path = pcap_dir.join(format!("{test_name}_server.pcap"));
+
+        write_pcap(&client_path, &client_packets).expect("Failed to write client pcap");
+        write_pcap(&server_path, &server_packets).expect("Failed to write server pcap");
+
+        println!("  PCAP saved: {}", client_path.display());
+        println!("  PCAP saved: {}", server_path.display());
+    }
+
+    let server_timing = server_result.expect("Server returned error");
+    let client_timing = client_result.expect("Client returned error");
 
     let total_time = test_start.elapsed();
 
@@ -175,14 +309,26 @@ pub fn handshake_direct_api_two_threads() -> Result<(), RtcError> {
 /// Initialize an Rtc instance configured for client or server role.
 ///
 /// Returns the Rtc instance and the local ICE credentials/DTLS fingerprint for exchange.
-fn init_rtc(is_client: bool, local_addr: SocketAddr) -> Result<(Rtc, IceCreds, String), RtcError> {
+fn init_rtc(
+    is_client: bool,
+    local_addr: SocketAddr,
+    dtls_version: DtlsVersion,
+    peer: Peer,
+    timing: &mut TimingReport,
+) -> Result<(Rtc, IceCreds, String), RtcError> {
     let ice_creds = IceCreds::new();
 
-    let mut rtc_config = RtcConfig::new().set_local_ice_credentials(ice_creds.clone());
+    let mut rtc_config = RtcConfig::new()
+        .set_local_ice_credentials(ice_creds.clone())
+        .set_dtls_version(dtls_version);
     if !is_client {
         rtc_config = rtc_config.set_ice_lite(true);
     }
+    if let Some(crypto) = peer.crypto_provider() {
+        rtc_config = rtc_config.set_crypto_provider(crypto);
+    }
     let mut rtc = rtc_config.build(Instant::now());
+    timing.rtc_built = Some(Instant::now());
 
     // Get DTLS fingerprint
     let fingerprint = rtc.direct_api().local_dtls_fingerprint().to_string();
@@ -274,6 +420,7 @@ enum Message {
 #[derive(Debug, Default)]
 struct TimingReport {
     start: Option<Instant>,
+    rtc_built: Option<Instant>,
     sent_offer: Option<Instant>,
     got_offer: Option<Instant>,
     sent_answer: Option<Instant>,
@@ -296,6 +443,12 @@ impl TimingReport {
     fn print(&self, name: &str) {
         let start = self.start.unwrap();
         println!("\n=== {} Timing Report ===", name);
+        if let Some(t) = self.rtc_built {
+            println!(
+                "  Rtc built:       {:>8.3}ms",
+                (t - start).as_secs_f64() * 1000.0
+            );
+        }
         if let Some(t) = self.sent_offer {
             println!(
                 "  Sent offer:      {:>8.3}ms",
@@ -370,6 +523,7 @@ fn run_rtc_loop_with_exchange(
     outgoing: &Sender<Message>,
     timing: &mut TimingReport,
     is_client: bool,
+    packets: &mut Vec<PcapPacket>,
 ) -> Result<(), RtcError> {
     let mut state = DataExchangeState::WaitingForChannelOpen;
     let mut channel_id: Option<ChannelId> = None;
@@ -392,12 +546,20 @@ fn run_rtc_loop_with_exchange(
             match span.in_scope(|| rtc.poll_output())? {
                 Output::Timeout(t) => break t,
                 Output::Transmit(t) => {
+                    let data = t.contents.to_vec();
+                    if SAVE_PCAP {
+                        packets.push(PcapPacket {
+                            src: t.source,
+                            dst: t.destination,
+                            data: data.clone(),
+                        });
+                    }
                     // Send packet to other peer
                     let _ = outgoing.send(Message::Packet {
                         proto: t.proto,
                         source: t.source,
                         destination: t.destination,
-                        contents: t.contents.to_vec(),
+                        contents: data,
                     });
                 }
                 Output::Event(e) => {
@@ -431,6 +593,13 @@ fn run_rtc_loop_with_exchange(
                 contents,
             }) => {
                 println!("[{}] Received packet ({} bytes)", role, contents.len());
+                if SAVE_PCAP {
+                    packets.push(PcapPacket {
+                        src: source,
+                        dst: destination,
+                        data: contents.clone(),
+                    });
+                }
                 let receive = Receive {
                     proto,
                     source,
@@ -535,4 +704,89 @@ fn handle_event(
         }
         _ => {}
     }
+}
+
+// --- PCAP support ---
+
+fn dtls_version_short(v: DtlsVersion) -> &'static str {
+    match v {
+        DtlsVersion::Auto => "auto",
+        DtlsVersion::Dtls12 => "12",
+        DtlsVersion::Dtls13 => "13",
+        _ => "unknown",
+    }
+}
+
+/// A captured packet for pcap output.
+struct PcapPacket {
+    src: SocketAddr,
+    dst: SocketAddr,
+    data: Vec<u8>,
+}
+
+/// Write packets to a pcap file using the standard pcap format.
+/// Uses raw IPv4 link type so Wireshark can dissect the UDP/DTLS layers.
+fn write_pcap(path: &std::path::Path, packets: &[PcapPacket]) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let mut f = std::fs::File::create(path)?;
+
+    // Global header (24 bytes)
+    // magic_number, version_major, version_minor, thiszone, sigfigs, snaplen, network
+    f.write_all(&0xa1b2c3d4u32.to_le_bytes())?; // magic
+    f.write_all(&2u16.to_le_bytes())?; // version major
+    f.write_all(&4u16.to_le_bytes())?; // version minor
+    f.write_all(&0i32.to_le_bytes())?; // thiszone
+    f.write_all(&0u32.to_le_bytes())?; // sigfigs
+    f.write_all(&65535u32.to_le_bytes())?; // snaplen
+    f.write_all(&228u32.to_le_bytes())?; // LINKTYPE_IPV4 (228 = raw IPv4)
+
+    for (i, pkt) in packets.iter().enumerate() {
+        // Build a minimal IPv4 + UDP frame around the payload
+        let udp_len = 8 + pkt.data.len();
+        let ip_total_len = 20 + udp_len;
+
+        // IPv4 header (20 bytes, no options)
+        let mut ip_header = [0u8; 20];
+        ip_header[0] = 0x45; // version=4, IHL=5
+        ip_header[1] = 0; // DSCP/ECN
+        ip_header[2..4].copy_from_slice(&(ip_total_len as u16).to_be_bytes());
+        ip_header[4..6].copy_from_slice(&(i as u16).to_be_bytes()); // identification
+        ip_header[8] = 64; // TTL
+        ip_header[9] = 17; // protocol = UDP
+                           // checksum left as 0 (Wireshark will flag but still parse)
+        match pkt.src {
+            SocketAddr::V4(a) => ip_header[12..16].copy_from_slice(&a.ip().octets()),
+            _ => {}
+        }
+        match pkt.dst {
+            SocketAddr::V4(a) => ip_header[16..20].copy_from_slice(&a.ip().octets()),
+            _ => {}
+        }
+
+        // UDP header (8 bytes)
+        let mut udp_header = [0u8; 8];
+        udp_header[0..2].copy_from_slice(&pkt.src.port().to_be_bytes());
+        udp_header[2..4].copy_from_slice(&pkt.dst.port().to_be_bytes());
+        udp_header[4..6].copy_from_slice(&(udp_len as u16).to_be_bytes());
+        // checksum left as 0
+
+        let frame_len = ip_total_len as u32;
+
+        // Packet record header (16 bytes)
+        // Use packet index as fake timestamp (1ms apart)
+        let ts_sec = i as u32;
+        let ts_usec = 0u32;
+        f.write_all(&ts_sec.to_le_bytes())?;
+        f.write_all(&ts_usec.to_le_bytes())?;
+        f.write_all(&frame_len.to_le_bytes())?; // incl_len
+        f.write_all(&frame_len.to_le_bytes())?; // orig_len
+
+        // Frame data
+        f.write_all(&ip_header)?;
+        f.write_all(&udp_header)?;
+        f.write_all(&pkt.data)?;
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
### What

Bumps the dimpl DTLS library from 0.3.0 to 0.4.0 across all crates (str0m, proto, apple-crypto, aws-lc-rs, rust-crypto) and adds DTLS 1.3 handshake test coverage.

### Key Changes

**dtls.rs** — `handle_input` now distinguishes `dimpl::Error::HandshakePending` from other errors, mapping it to `WouldBlock` so the SCTP transmit layer can push packets back and retry rather than treating it as a fatal error.

**lib.rs** — Adds a catch-all arm for `DtlsOutput` polling (required because `Output` is now `#[non_exhaustive]` in dimpl 0.4.0). Also imports `DtlsError` directly.

**srtp.rs, dtls.rs** — Add `_ => panic!()` wildcard arms for `SrtpProfile` matches (also now `#[non_exhaustive]`).

**handshake-direct.rs** — Replaces the single `handshake_direct_api_two_threads` test with 7 parameterized tests covering the DTLS version matrix:

| Client \ Server | Dtls12 | Dtls13 | Auto |
|---|---|---|---|
| **Dtls12** | `12_to_12` | — | `12_to_auto` |
| **Dtls13** | — | `13_to_13` | `13_to_auto` |
| **Auto** | `auto_to_12` | `auto_to_13` | `auto_to_auto` |

Also adds: per-peer crypto provider selection via `L_CRYPTO`/`R_CRYPTO` env vars, optional PCAP capture (`SAVE_PCAP`), `rtc_built` timing, and fault-tolerant packet capture (packets returned even on test failure).

### Gaps
**wincrypto and openssl have zero DTLS 1.3/Auto coverage** — All 5 tests involving `Auto` or `Dtls13` are silently skipped (`return Ok(())`) for these providers. That's 5 of 7 tests skipped with no `#[ignore]` annotation or CI indicator.

**Known dimpl limitation: Auto client → DTLS-1.2-only server** — Explicitly skipped with the comment that dimpl advertises X25519 in the hybrid ClientHello but can't process X25519 in `ServerKeyExchange`. This is a dimpl bug, not a str0m concern, but it means `Auto` client negotiation isn't truly auto when the server is 1.2-only.
