### PR TITLE
chore(ice): don't log idempotent updates

### DIFF
--- a/src/ice/agent.rs
+++ b/src/ice/agent.rs
@@ -4,7 +4,6 @@ use std::net::SocketAddr;
 use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use std::{fmt, mem};
 
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
When updating the timing config of an ICE agent to the exact values that are already being used, we can save ourselves logging a statement on DEBUG. This makes DEBUG logs just a tad less noisy.