### PR TITLE
improvement: Use BCryptHash in SHA256 impl to avoid creating a hash instance.

### DIFF
--- a/crypto/wincrypto/src/sys/sha256.rs
+++ b/crypto/wincrypto/src/sys/sha256.rs
@@ -1,10 +1,8 @@
 //! SHA-256 implementation using Windows CNG.
 
 use crate::WinCryptoError;
-use windows::core::Owned;
-use windows::Win32::Security::Cryptography::BCRYPT_HASH_HANDLE;
+use windows::Win32::Security::Cryptography::BCryptHash;
 use windows::Win32::Security::Cryptography::BCRYPT_SHA256_ALG_HANDLE;
-use windows::Win32::Security::Cryptography::{BCryptHash, BCryptHashData};
 
 /// Compute SHA-256 hash of the given data using Windows CNG.
 pub fn sha256(data: &[u8]) -> Result<[u8; 32], WinCryptoError> {


### PR DESCRIPTION
We don't need to create a hash object for each sha256 call, and can instead call BCryptHash with the psuedo-algorithm