### PR TITLE
sdp: Always use ActPass when sending an offer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Always use ActPass when sending an SDP offer (RFC 8842 Section 5.2/5.5) #893
   * Fix frame drops in Firefox due missing RTX SSRC #940
   * Drop stale depacketizer state on stream pause and restore paused timestamp repair #929
 

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -1551,15 +1551,26 @@ impl<'a, 'b> AsSdpParams<'a, 'b> {
             )
         };
 
+        // RFC 8842 Section 5.2/5.5: Offerers MUST always use a=setup:actpass.
+        // Answerers use the negotiated role (active/passive).
+        // We distinguish offer vs answer by the presence of `pending` (Some = offer).
+        let setup = if pending.is_some() {
+            // This is an offer — always actpass per RFC 8842
+            Setup::ActPass
+        } else {
+            // This is an answer — use the negotiated DTLS role
+            match rtc.dtls.is_active() {
+                Some(true) => Setup::Active,
+                Some(false) => Setup::Passive,
+                None => Setup::ActPass,
+            }
+        };
+
         AsSdpParams {
             candidates,
             creds,
             fingerprint: rtc.dtls.local_fingerprint(),
-            setup: match rtc.dtls.is_active() {
-                Some(true) => Setup::Active,
-                Some(false) => Setup::Passive,
-                None => Setup::ActPass,
-            },
+            setup,
             pending,
             local_sctp_init: rtc.sctp.local_sctp_init_for_sdp(),
         }
@@ -1775,6 +1786,82 @@ mod test {
 
     fn count_lines(lines: &str, what: &str) -> usize {
         lines.lines().filter(|l| l == &what).count()
+    }
+
+    fn get_setup_from_media_line(line: &MediaLine) -> Setup {
+        line.setup().expect("Expected a=setup attribute in SDP")
+    }
+
+    /// RFC 8842 §5.2: an offer MUST use a=setup:actpass regardless of DTLS role.
+    #[test]
+    fn offer_uses_actpass() {
+        crate::init_crypto_default();
+
+        let now = Instant::now();
+        let mut rtc = Rtc::new(now);
+
+        let mut change = rtc.sdp_api();
+        change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+        let (offer, _pending) = change.apply().unwrap();
+
+        let setup = get_setup_from_media_line(&offer.media_lines[0]);
+        assert_eq!(
+            setup,
+            Setup::ActPass,
+            "Offer must use a=setup:actpass per RFC 8842 §5.2"
+        );
+    }
+
+    /// RFC 8842 §5.5: the answerer uses the negotiated DTLS role (active or passive).
+    /// When the offerer uses actpass, the answerer picks passive (DTLS server) and the
+    /// offerer becomes active (DTLS client). The answerer's SDP must reflect passive.
+    #[test]
+    fn answer_uses_negotiated_dtls_role() {
+        crate::init_crypto_default();
+
+        let now = Instant::now();
+        let mut offerer = Rtc::new(now);
+        let mut answerer = Rtc::new(now);
+
+        // Offerer creates the offer.
+        let mut change = offerer.sdp_api();
+        change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+        let (offer, pending) = change.apply().unwrap();
+
+        // Verify the offer itself is actpass.
+        assert_eq!(
+            get_setup_from_media_line(&offer.media_lines[0]),
+            Setup::ActPass,
+            "Offer must use a=setup:actpass"
+        );
+
+        // Answerer accepts and generates the answer.
+        let answer = answerer.sdp_api().accept_offer(offer).unwrap();
+
+        // When the offerer sends actpass, the answerer takes the passive DTLS role
+        // (see init_dtls: ActPass from remote → local takes Passive).
+        // The answerer's SDP must reflect that with a=setup:passive.
+        assert_eq!(
+            get_setup_from_media_line(&answer.media_lines[0]),
+            Setup::Passive,
+            "Answerer's SDP must use a=setup:passive when responding to an actpass offer"
+        );
+
+        // Complete the exchange on the offerer side.
+        offerer.sdp_api().accept_answer(pending, answer).unwrap();
+
+        // Now generate a subsequent offer from the offerer (re-offer).
+        // Even after the DTLS role is settled (offerer is now passive), a new offer
+        // must still carry a=setup:actpass per RFC 8842 §5.2.
+        let mut change = offerer.sdp_api();
+        change.add_media(MediaKind::Video, Direction::SendRecv, None, None, None);
+        let (reoffer, _) = change.apply().unwrap();
+
+        assert_eq!(
+            get_setup_from_media_line(&reoffer.media_lines[0]),
+            Setup::ActPass,
+            "Re-offer must still use a=setup:actpass even after DTLS role is settled"
+        );
     }
 
     #[test]


### PR DESCRIPTION
When I was investigating a different issue, I came across this discrepancy. I don't have a real-world issue that this is affecting, but I wanted to open the PR in case you want to align with the RFC.

The text from the RFC:

> [5.5. ](https://datatracker.ietf.org/doc/html/rfc8842#section-5.5)[Modifying the Session](https://datatracker.ietf.org/doc/html/rfc8842#name-modifying-the-session)
> When an offerer sends a subsequent offer, if the offerer wants to establish a new DTLS association, the offerer MUST insert an SDP "setup" attribute [[RFC4145](https://datatracker.ietf.org/doc/html/rfc4145)] with an "actpass" attribute value, as well as or more SDP "fingerprint" attributes according to the procedures in [[RFC8122](https://datatracker.ietf.org/doc/html/rfc8122)]. In addition, the offerer MUST insert in the offer an SDP "tls-id" attribute with a new unique attribute value.
> 
> When an offerer sends a subsequent offer and does not want to establish a new DTLS association, if a previously established DTLS association exists, the offerer MUST insert in the offer an SDP "setup" attribute with an "actpass" attribute value, and one or more SDP "fingerprint" attributes with attribute values that do not change the previously sent fingerprint set. In addition, the offerer MUST insert an SDP "tls-id" attribute with the previously assigned attribute value in the offer.
> 
> NOTE: When a new DTLS association is being established, each endpoint needs to be prepared to receive data on both the new and old DTLS associations as long as both are alive.
