### PR TITLE
Remove openssl condition

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,7 +409,6 @@
 //! To enable RTP mode
 //!
 //! ```
-//! # #[cfg(feature = "openssl")] {
 //! # use std::time::Instant;
 //! # use str0m::Rtc;
 //! let rtc = Rtc::builder()
@@ -417,7 +416,6 @@
 //!     // This disables `MediaEvent` and the `Writer::write` API.
 //!     .set_rtp_mode(true)
 //!     .build(Instant::now());
-//! # }
 //! ```
 //!
 //! RTP mode gives us some new API points.
@@ -1083,12 +1081,10 @@ impl Rtc {
     /// To configure the instance, use [`RtcConfig`].
     ///
     /// ```
-    /// # #[cfg(feature = "openssl")] {
     /// use std::time::Instant;
     /// use str0m::Rtc;
     ///
     /// let rtc = Rtc::new(Instant::now());
-    /// # }
     /// ```
     pub fn new(start: Instant) -> Self {
         let config = RtcConfig::default();
@@ -1098,13 +1094,11 @@ impl Rtc {
     /// Creates a config builder that configures an [`Rtc`] instance.
     ///
     /// ```
-    /// # #[cfg(feature = "openssl")] {
     /// # use std::time::Instant;
     /// # use str0m::Rtc;
     /// let rtc = Rtc::builder()
     ///     .set_ice_lite(true)
     ///     .build(Instant::now());
-    /// # }
     /// ```
     pub fn builder() -> RtcConfig {
         RtcConfig::new()
@@ -1192,7 +1186,6 @@ impl Rtc {
     /// The instance can be manually disconnected using [`Rtc::disconnect()`].
     ///
     /// ```
-    /// # #[cfg(feature = "openssl")] {
     /// # use std::time::Instant;
     /// # use str0m::Rtc;
     /// let mut rtc = Rtc::new(Instant::now());
@@ -1201,7 +1194,6 @@ impl Rtc {
     ///
     /// rtc.disconnect();
     /// assert!(!rtc.is_alive());
-    /// # }
     /// ```
     pub fn is_alive(&self) -> bool {
         self.alive
@@ -1213,14 +1205,12 @@ impl Rtc {
     /// produce anymore network output or events.
     ///
     /// ```
-    /// # #[cfg(feature = "openssl")] {
     /// # use std::time::Instant;
     /// # use str0m::Rtc;
     /// let mut rtc = Rtc::new(Instant::now());
     ///
     /// rtc.disconnect();
     /// assert!(!rtc.is_alive());
-    /// # }
     /// ```
     pub fn disconnect(&mut self) {
         if self.alive {
@@ -1243,7 +1233,6 @@ impl Rtc {
     /// however advisable to add at least one local candidate before starting the instance.
     ///
     /// ```
-    /// # #[cfg(feature = "openssl")] {
     /// # use std::time::Instant;
     /// # use str0m::{Rtc, Candidate};
     /// let mut rtc = Rtc::new(Instant::now());
@@ -1252,7 +1241,6 @@ impl Rtc {
     /// let c = Candidate::host(a, "udp").unwrap();
     ///
     /// rtc.add_local_candidate(c);
-    /// # }
     /// ```
     ///
     /// [1]: https://www.rfc-editor.org/rfc/rfc8838.txt
@@ -1269,7 +1257,6 @@ impl Rtc {
     /// that are "trickled" from the other side.
     ///
     /// ```
-    /// # #[cfg(feature = "openssl")] {
     /// # use std::time::Instant;
     /// # use str0m::{Rtc, Candidate};
     /// let mut rtc = Rtc::new(Instant::now());
@@ -1278,7 +1265,6 @@ impl Rtc {
     /// let c = Candidate::host(a, "udp").unwrap();
     ///
     /// rtc.add_remote_candidate(c);
-    /// }
     /// ```
     ///
     /// [1]: https://www.rfc-editor.org/rfc/rfc8838.txt
@@ -1700,20 +1686,12 @@ impl Rtc {
     /// is a timeout.
     ///
     /// ```
-    /// # #[cfg(feature = "openssl")] {
-    /// # use str0m::{Rtc, Input, Output, Reason};
+    /// # use str0m::{Rtc, Reason};
     /// # use std::time::Instant;
-    /// let mut rtc = Rtc::new(Instant::now());
+    /// let rtc = Rtc::new(Instant::now());
     ///
-    /// let output = rtc.poll_output().unwrap();
-    ///
-    /// // Reason updates every time we get an Output::Timeout
-    /// assert!(matches!(output, Output::Timeout(_)));
-    ///
-    /// // If there are no timeouts scheduled, we get NotHappening. The timeout
-    /// // value itself will be in the distant future.
-    /// assert_eq!(rtc.last_timeout_reason(), Reason::DTLS);
-    /// # }
+    /// // Before any call to poll_output(), the reason is the default.
+    /// assert_eq!(rtc.last_timeout_reason(), Reason::NotHappening);
     /// ```
     pub fn last_timeout_reason(&self) -> Reason {
         self.last_timeout_reason


### PR DESCRIPTION
Noticed when removing the Openssl dtls 1.2 impl that this doc test started failing.

So removed all openssl configs as we should work with defaults and changed the test to be predicable

This change should be done before Openssl is switching to dimpl