### PR TITLE
Fix the fuzz crash due to multiplication overflow

### DIFF
--- a/src/packet/av1.rs
+++ b/src/packet/av1.rs
@@ -344,7 +344,7 @@ impl Depacketizer for Av1Depacketizer {
         let mut reader = (packet, 0);
 
         self.parse_aggregation_header(packet[0]);
-        reader.consume(1);
+        reader.skip_bytes(1);
 
         // if packet does not start with a continuation of an obu fragment
         // from the previous packet new obu starts
@@ -367,14 +367,14 @@ impl Depacketizer for Av1Depacketizer {
         *codec_extra = CodecExtra::Av1(Av1CodecExtra { is_keyframe });
 
         let mut obu_idx = 0;
-        while reader.remaining() > 0 {
+        while reader.remaining_bits() > 0 {
             let is_first_obu = obu_idx == 0;
             let mut is_last_obu = self.obu_count != 0 && obu_idx == (self.obu_count - 1);
 
             // Read the length of obu
             let fragment_obu_length = if self.obu_count == 0 || !is_last_obu {
                 let len = reader
-                    .get_variant()
+                    .get_leb128()
                     .ok_or(PacketError::ErrAv1CorruptedPacket)?;
 
                 if self.obu_count == 0 && len == reader.remaining_bytes() {
@@ -390,8 +390,8 @@ impl Depacketizer for Av1Depacketizer {
             if fragment_obu_length == 0 {
                 return Err(PacketError::ErrAv1CorruptedPacket);
             }
-            if reader.get_offset() > packet.len()
-                || fragment_obu_length > packet.len() - reader.get_offset()
+            if reader.byte_offset() > packet.len()
+                || fragment_obu_length > packet.len() - reader.byte_offset()
             {
                 return Err(PacketError::ErrAv1CorruptedPacket);
             }
@@ -399,16 +399,16 @@ impl Depacketizer for Av1Depacketizer {
             if is_first_obu && self.z {
                 // the previous fragment is lost, drop the buffer
                 if self.obu_buffer.is_empty() {
-                    reader.consume(fragment_obu_length);
+                    reader.skip_bytes(fragment_obu_length);
                     obu_idx = 1;
                     continue;
                 }
             }
 
-            let offset = reader.get_offset();
+            let offset = reader.byte_offset();
             self.obu_buffer
                 .extend_from_slice(&packet[offset..offset + fragment_obu_length]);
-            reader.consume(fragment_obu_length);
+            reader.skip_bytes(fragment_obu_length);
 
             if is_last_obu && self.y {
                 self.obu_length += fragment_obu_length;
@@ -591,7 +591,7 @@ fn parse_obus(payload: &[u8], parsed_obus: &mut Vec<Obu>) -> Result<(), PacketEr
     let mut reader = (payload, 0);
     let mut obu_idx = 0;
 
-    while reader.remaining() > 0 {
+    while reader.remaining_bits() > 0 {
         // Reuse existing Obu entry if available, otherwise grow the Vec
         if obu_idx >= parsed_obus.len() {
             parsed_obus.push(Obu::default());
@@ -612,8 +612,11 @@ fn parse_obus(payload: &[u8], parsed_obus: &mut Vec<Obu>) -> Result<(), PacketEr
 
         if obu.has_size() {
             let obu_size = reader
-                .get_variant()
+                .get_leb128()
                 .ok_or(PacketError::ErrAv1CorruptedPacket)?;
+            if obu_size > reader.remaining_bytes() {
+                return Err(PacketError::ErrAv1CorruptedPacket);
+            }
             let bytes = reader
                 .get_bytes(obu_size)
                 .ok_or(PacketError::ErrAv1CorruptedPacket)?;

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -156,36 +156,36 @@ pub use error::PacketError;
 
 /// Helper to replace Bytes. Provides get_u8 and get_u16 over some buffer of bytes.
 pub(crate) trait BitRead {
-    fn remaining(&self) -> usize;
+    fn remaining_bits(&self) -> usize;
     fn remaining_bytes(&self) -> usize;
-    fn get_offset(&self) -> usize;
+    fn byte_offset(&self) -> usize;
     fn get_u8(&mut self) -> Option<u8>;
     fn get_u16(&mut self) -> Option<u16>;
     fn get_remaining(&mut self) -> &[u8];
-    fn get_bytes(&mut self, size: usize) -> Option<&[u8]>;
-    fn get_variant(&mut self) -> Option<usize>;
-    fn consume(&mut self, bytes: usize);
+    fn get_bytes(&mut self, count: usize) -> Option<&[u8]>;
+    fn get_leb128(&mut self) -> Option<usize>;
+    fn skip_bytes(&mut self, count: usize);
 }
 
 impl BitRead for (&[u8], usize) {
     #[inline(always)]
-    fn remaining(&self) -> usize {
+    fn remaining_bits(&self) -> usize {
         (self.0.len() * 8).saturating_sub(self.1)
     }
 
     #[inline(always)]
     fn remaining_bytes(&self) -> usize {
-        self.remaining() / 8
+        self.remaining_bits() / 8
     }
 
     #[inline(always)]
-    fn get_offset(&self) -> usize {
+    fn byte_offset(&self) -> usize {
         self.1 / 8
     }
 
     #[inline(always)]
     fn get_u8(&mut self) -> Option<u8> {
-        if self.remaining() < 8 {
+        if self.remaining_bits() < 8 {
             return None;
         }
 
@@ -204,7 +204,7 @@ impl BitRead for (&[u8], usize) {
     }
 
     fn get_u16(&mut self) -> Option<u16> {
-        if self.remaining() < 16 {
+        if self.remaining_bits() < 16 {
             return None;
         }
         Some(u16::from_be_bytes([self.get_u8()?, self.get_u8()?]))
@@ -216,20 +216,21 @@ impl BitRead for (&[u8], usize) {
         &self.0[offset..]
     }
 
-    fn get_bytes(&mut self, size: usize) -> Option<&[u8]> {
-        if self.remaining() < (size * 8) {
+    fn get_bytes(&mut self, count: usize) -> Option<&[u8]> {
+        let count_bits = count.saturating_mul(8);
+        if self.remaining_bits() < count_bits {
             return None;
         }
         let offset = self.1 / 8;
-        self.1 += size * 8;
-        Some(&self.0[offset..offset + size])
+        self.1 += count_bits;
+        Some(&self.0[offset..offset + count])
     }
 
-    fn get_variant(&mut self) -> Option<usize> {
+    fn get_leb128(&mut self) -> Option<usize> {
         let mut temp_value: usize = 0;
 
         for i in (0..64).step_by(7) {
-            if self.remaining() < 8 {
+            if self.remaining_bits() < 8 {
                 return None;
             }
             let byte = self.get_u8().unwrap();
@@ -243,12 +244,13 @@ impl BitRead for (&[u8], usize) {
         None
     }
 
-    fn consume(&mut self, bytes: usize) {
-        if self.remaining() < bytes * 8 {
+    fn skip_bytes(&mut self, count: usize) {
+        let bits = count.saturating_mul(8);
+        if self.remaining_bits() < bits {
             return;
         }
 
-        self.1 += bytes * 8;
+        self.1 += bits;
     }
 }
 

--- a/src/packet/vp9.rs
+++ b/src/packet/vp9.rs
@@ -603,14 +603,14 @@ impl Vp9Depacketizer {
         reader: &mut dyn BitRead,
         mut payload_index: usize,
     ) -> Result<usize, PacketError> {
-        if reader.remaining() == 0 {
+        if reader.remaining_bits() == 0 {
             return Err(PacketError::ErrShortPacket);
         }
         let b = reader.get_u8().ok_or(PacketError::ErrShortPacket)?;
         payload_index += 1;
         // PID present?
         if (b & 0x80) != 0 {
-            if reader.remaining() == 0 {
+            if reader.remaining_bits() == 0 {
                 return Err(PacketError::ErrShortPacket);
             }
             // M == 1, PID is 15bit
@@ -649,7 +649,7 @@ impl Vp9Depacketizer {
         reader: &mut dyn BitRead,
         mut payload_index: usize,
     ) -> Result<usize, PacketError> {
-        if reader.remaining() == 0 {
+        if reader.remaining_bits() == 0 {
             return Err(PacketError::ErrShortPacket);
         }
         let b = reader.get_u8().ok_or(PacketError::ErrShortPacket)?;
@@ -680,7 +680,7 @@ impl Vp9Depacketizer {
         reader: &mut dyn BitRead,
         mut payload_index: usize,
     ) -> Result<usize, PacketError> {
-        if reader.remaining() == 0 {
+        if reader.remaining_bits() == 0 {
             return Err(PacketError::ErrShortPacket);
         }
         self.tl0picidx = reader.get_u8().ok_or(PacketError::ErrShortPacket)?;
@@ -707,7 +707,7 @@ impl Vp9Depacketizer {
                 return Err(PacketError::ErrTooManyPDiff);
             }
 
-            if reader.remaining() == 0 {
+            if reader.remaining_bits() == 0 {
                 return Err(PacketError::ErrShortPacket);
             }
             b = reader.get_u8().ok_or(PacketError::ErrShortPacket)?;
@@ -745,7 +745,7 @@ impl Vp9Depacketizer {
         reader: &mut dyn BitRead,
         mut payload_index: usize,
     ) -> Result<usize, PacketError> {
-        if reader.remaining() == 0 {
+        if reader.remaining_bits() == 0 {
             return Err(PacketError::ErrShortPacket);
         }
 
@@ -764,7 +764,7 @@ impl Vp9Depacketizer {
         }
 
         if self.y {
-            if reader.remaining() < 4 * ns {
+            if reader.remaining_bits() < 4 * ns {
                 return Err(PacketError::ErrShortPacket);
             }
 
@@ -776,7 +776,7 @@ impl Vp9Depacketizer {
         }
 
         if self.g {
-            if reader.remaining() == 0 {
+            if reader.remaining_bits() == 0 {
                 return Err(PacketError::ErrShortPacket);
             }
 
@@ -785,7 +785,7 @@ impl Vp9Depacketizer {
         }
 
         for i in 0..self.ng as usize {
-            if reader.remaining() == 0 {
+            if reader.remaining_bits() == 0 {
                 return Err(PacketError::ErrShortPacket);
             }
             let b = reader.get_u8().ok_or(PacketError::ErrShortPacket)?;
@@ -795,7 +795,7 @@ impl Vp9Depacketizer {
             self.pgu.push(b & 0x10 != 0);
 
             let r = ((b >> 2) & 0x3) as usize;
-            if reader.remaining() < r {
+            if reader.remaining_bits() < r {
                 return Err(PacketError::ErrShortPacket);
             }
 


### PR DESCRIPTION
Fix for the https://github.com/algesten/str0m/issues/895

Apparently Claude decided the overflow check was optional in the latest [PR](https://github.com/algesten/str0m/pull/889/changes#diff-a148bdc2d256ce7e39e50b7177cf124fa3cbd8021559b05dc2765347e85967f1L606)… and I missed it

@xnorpx, please review