### PR TITLE
Expose CSRC property in RTP Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+  
+  * Expose CSRC property in RTP Header #910
 
 # 0.17.0
 

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -634,11 +634,13 @@ mod test {
                             version: 2,
                             has_padding: false,
                             has_extension: true,
+                            csrc_count: 0,
                             marker,
                             payload_type: Pt::new_with_value(98),
                             sequence_number: seq,
                             timestamp: time,
                             ssrc: Ssrc::from(2930203832),
+                            csrc: [0; 15],
                             ext_vals: ExtensionValues {
                                 transport_cc: Some(cc),
                                 ..Default::default()

--- a/src/rtp/header.rs
+++ b/src/rtp/header.rs
@@ -12,7 +12,8 @@ pub struct RtpHeader {
     pub has_padding: bool,
     /// RTP packet has "RTP header extensions".
     pub has_extension: bool,
-    // pub csrc_count: usize, // "contributing source" (other ssrc)
+    /// Number of contributing source identifiers.
+    pub csrc_count: usize,
     /// For video, this marker signifies the end of a series of packets that
     /// together form a single video frame.
     /// For audio, it marks the beginning of a talkspurt, which is a burst of
@@ -27,7 +28,8 @@ pub struct RtpHeader {
     pub timestamp: u32,
     /// Sender source identifier.
     pub ssrc: Ssrc,
-    // pub csrc: [u32; 15],
+    /// Contributing source identifiers (CSRC). Up to 15 values per RFC 3550.
+    pub csrc: [u32; 15],
     /// The extension values parsed using the mapping via SDP.
     pub ext_vals: ExtensionValues,
     /// Length of header.
@@ -36,9 +38,11 @@ pub struct RtpHeader {
 
 impl RtpHeader {
     pub(crate) fn write_to(&self, buf: &mut [u8], exts: &ExtensionMap) -> usize {
+        assert!(self.csrc_count <= 15, "CSRC count must be <= 15");
         buf[0] = 0b10_0_0_0000
             | if self.has_padding { 1 << 5 } else { 0 }
-            | if self.has_extension { 1 << 4 } else { 0 };
+            | if self.has_extension { 1 << 4 } else { 0 }
+            | (self.csrc_count as u8);
 
         assert!(*self.payload_type <= 127);
         buf[1] = *self.payload_type & 0b0111_1111 | if self.marker { 1 << 7 } else { 0 };
@@ -47,10 +51,17 @@ impl RtpHeader {
         buf[4..8].copy_from_slice(&self.timestamp.to_be_bytes());
         buf[8..12].copy_from_slice(&self.ssrc.to_be_bytes());
 
-        let exts_form = exts.form(&self.ext_vals);
-        buf[12..14].copy_from_slice(&exts_form.serialize());
+        let csrc_len = self.csrc_count * 4;
+        for i in 0..self.csrc_count {
+            let offset = 12 + i * 4;
+            buf[offset..offset + 4].copy_from_slice(&self.csrc[i].to_be_bytes());
+        }
 
-        let ext_buf = &mut buf[16..];
+        let ext_start = 12 + csrc_len;
+        let exts_form = exts.form(&self.ext_vals);
+        buf[ext_start..ext_start + 2].copy_from_slice(&exts_form.serialize());
+
+        let ext_buf = &mut buf[ext_start + 4..];
         let mut ext_len = exts.write_to(ext_buf, &self.ext_vals, exts_form);
 
         let pad = 4 - ext_len % 4;
@@ -62,9 +73,9 @@ impl RtpHeader {
         }
 
         let bede_len = (ext_len / 4) as u16;
-        buf[14..16].copy_from_slice(&bede_len.to_be_bytes());
+        buf[ext_start + 2..ext_start + 4].copy_from_slice(&bede_len.to_be_bytes());
 
-        16 + ext_len
+        ext_start + 4 + ext_len
     }
 
     fn do_pad(buf: &mut [u8], from: usize, pad: usize) {
@@ -164,9 +175,14 @@ impl RtpHeader {
         }
 
         let mut csrc = [0_u32; 15];
-        for i in 0..csrc_count {
-            let n = u32::from_be_bytes([buf[i], buf[i + 1], buf[i + 2], buf[i + 3]]);
-            csrc[i] = n;
+        for (i, item) in csrc.iter_mut().enumerate().take(csrc_count) {
+            let offset = i * 4;
+            *item = u32::from_be_bytes([
+                buf[offset],
+                buf[offset + 1],
+                buf[offset + 2],
+                buf[offset + 3],
+            ]);
         }
 
         let buf: &[u8] = &buf[csrc_len..];
@@ -210,13 +226,13 @@ impl RtpHeader {
             version,
             has_padding,
             has_extension,
-            // csrc_count,
+            csrc_count,
             marker,
             payload_type,
             sequence_number,
             timestamp,
             ssrc: ssrc.into(),
-            // csrc,
+            csrc,
             ext_vals: ext,
             header_len,
         };
@@ -317,11 +333,13 @@ impl Default for RtpHeader {
             version: 2,
             has_padding: false,
             has_extension: true,
+            csrc_count: 0,
             marker: false,
             payload_type: 1.into(),
             sequence_number: 0,
             timestamp: 0,
             ssrc: 0.into(),
+            csrc: [0; 15],
             ext_vals: ExtensionValues::default(),
             header_len: 16,
         }
@@ -561,11 +579,13 @@ mod test {
                 version: 2,
                 has_padding: true,
                 has_extension: true,
+                csrc_count: 0,
                 marker: false,
                 payload_type: 111.into(),
                 sequence_number: 47000,
                 timestamp: 10000,
                 ssrc: 777459193.into(),
+                csrc: [0; 15],
                 ext_vals: ExtensionValues {
                     mid: Some("xYj".into()),
                     abs_send_time: Some(abs1),
@@ -587,11 +607,13 @@ mod test {
                 version: 2,
                 has_padding: true,
                 has_extension: true,
+                csrc_count: 0,
                 marker: false,
                 payload_type: 111.into(),
                 sequence_number: 47001,
                 timestamp: 12000,
                 ssrc: 777459193.into(),
+                csrc: [0; 15],
                 ext_vals: ExtensionValues {
                     mid: Some("xYj".into()),
                     abs_send_time: Some(abs2),
@@ -613,11 +635,13 @@ mod test {
                 version: 2,
                 has_padding: true,
                 has_extension: true,
+                csrc_count: 0,
                 marker: false,
                 payload_type: 111.into(),
                 sequence_number: 47002,
                 timestamp: 14000,
                 ssrc: 777459193.into(),
+                csrc: [0; 15],
                 ext_vals: ExtensionValues {
                     mid: Some("xYj".into()),
                     abs_send_time: Some(abs3),
@@ -661,11 +685,13 @@ mod test {
                 version: 2,
                 has_padding: true,
                 has_extension: true,
+                csrc_count: 0,
                 marker: false,
                 payload_type: 111.into(),
                 sequence_number: 47000,
                 timestamp: 10000,
                 ssrc: 777459193.into(),
+                csrc: [0; 15],
                 ext_vals: ExtensionValues {
                     mid: Some("xYj".into()),
                     abs_send_time: Some(abs1),
@@ -687,11 +713,13 @@ mod test {
                 version: 2,
                 has_padding: true,
                 has_extension: true,
+                csrc_count: 0,
                 marker: false,
                 payload_type: 111.into(),
                 sequence_number: 47001,
                 timestamp: 12000,
                 ssrc: 777459193.into(),
+                csrc: [0; 15],
                 ext_vals: ExtensionValues {
                     mid: Some("xYj".into()),
                     abs_send_time: Some(abs2),
@@ -713,11 +741,13 @@ mod test {
                 version: 2,
                 has_padding: true,
                 has_extension: true,
+                csrc_count: 0,
                 marker: false,
                 payload_type: 111.into(),
                 sequence_number: 47002,
                 timestamp: 14000,
                 ssrc: 777459193.into(),
+                csrc: [0; 15],
                 ext_vals: ExtensionValues {
                     mid: Some("xYj".into()),
                     abs_send_time: Some(abs3),
@@ -727,6 +757,164 @@ mod test {
                     ..Default::default()
                 },
                 header_len: 36
+            }
+        );
+    }
+
+    #[test]
+    fn test_write_rtp_headers_with_csrc() {
+        fn mk_header(csrc_count: usize, csrc: [u32; 15], exts: &ExtensionMap) -> Vec<u8> {
+            let header = RtpHeader {
+                csrc_count,
+                payload_type: 33.into(),
+                sequence_number: 47_000,
+                timestamp: 10_000,
+                ssrc: 44.into(),
+                csrc,
+                ext_vals: ExtensionValues {
+                    audio_level: Some(-42),
+                    voice_activity: Some(true),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let mut buf = vec![0; DATAGRAM_MAX_PACKET_SIZE];
+            let n = header.write_to(&mut buf[..], exts);
+            buf.truncate(n);
+            buf
+        }
+
+        let mut exts = ExtensionMap::empty();
+        exts.set(3, Extension::AudioLevel);
+
+        // 3 CSRC entries, one-byte extension form
+        let buf1 = mk_header(
+            3,
+            [
+                100,
+                0x12_34_56_78,
+                0xFFFF_FFFF,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ],
+            &exts,
+        );
+        let p1 = &[
+            147, 33, 183, 152, 0, 0, 39, 16, 0, 0, 0, 44, // fixed header (CC=3)
+            0, 0, 0, 100, 0x12, 0x34, 0x56, 0x78, 0xFF, 0xFF, 0xFF, 0xFF, // CSRC values
+            0xBE, 0xDE, 0, 1, 48, 170, 0, 0, // extension
+        ];
+        assert_eq!(&buf1, p1);
+
+        // 15 CSRC entries (maximum)
+        let buf2 = mk_header(
+            15,
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+            &exts,
+        );
+        let p2 = &[
+            159, 33, 183, 152, 0, 0, 39, 16, 0, 0, 0, 44, // fixed header (CC=15)
+            0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, // CSRC 1-4
+            0, 0, 0, 5, 0, 0, 0, 6, 0, 0, 0, 7, 0, 0, 0, 8, // CSRC 5-8
+            0, 0, 0, 9, 0, 0, 0, 10, 0, 0, 0, 11, 0, 0, 0, 12, // CSRC 9-12
+            0, 0, 0, 13, 0, 0, 0, 14, 0, 0, 0, 15, // CSRC 13-15
+            0xBE, 0xDE, 0, 1, 48, 170, 0, 0, // extension
+        ];
+        assert_eq!(&buf2, p2);
+    }
+
+    #[test]
+    fn test_parse_rtp_headers_with_csrc() {
+        let mut exts = ExtensionMap::empty();
+        exts.set(3, Extension::AudioLevel);
+
+        // 3 CSRC entries with one-byte extension form (produced by test_write_rtp_headers_with_csrc)
+        let buf1 = [
+            147, 33, 183, 152, 0, 0, 39, 16, 0, 0, 0, 44, 0, 0, 0, 100, 0x12, 0x34, 0x56, 0x78,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xBE, 0xDE, 0, 1, 48, 170, 0, 0,
+        ];
+
+        let h1 = RtpHeader::parse(&buf1, &exts).unwrap();
+
+        assert_eq!(
+            h1,
+            RtpHeader {
+                version: 2,
+                has_padding: false,
+                has_extension: true,
+                csrc_count: 3,
+                marker: false,
+                payload_type: 33.into(),
+                sequence_number: 47_000,
+                timestamp: 10_000,
+                ssrc: 44.into(),
+                csrc: [
+                    100,
+                    0x12_34_56_78,
+                    0xFFFF_FFFF,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                ],
+                ext_vals: ExtensionValues {
+                    audio_level: Some(-42),
+                    voice_activity: Some(true),
+                    ..Default::default()
+                },
+                header_len: 32,
+            }
+        );
+
+        // 15 CSRC entries (maximum)
+        let buf2 = [
+            159, 33, 183, 152, 0, 0, 39, 16, 0, 0, 0, 44, // fixed header (CC=15)
+            0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, // CSRC 1-4
+            0, 0, 0, 5, 0, 0, 0, 6, 0, 0, 0, 7, 0, 0, 0, 8, // CSRC 5-8
+            0, 0, 0, 9, 0, 0, 0, 10, 0, 0, 0, 11, 0, 0, 0, 12, // CSRC 9-12
+            0, 0, 0, 13, 0, 0, 0, 14, 0, 0, 0, 15, // CSRC 13-15
+            0xBE, 0xDE, 0, 1, 48, 170, 0, 0, // extension
+        ];
+
+        let h2 = RtpHeader::parse(&buf2, &exts).unwrap();
+
+        assert_eq!(
+            h2,
+            RtpHeader {
+                version: 2,
+                has_padding: false,
+                has_extension: true,
+                csrc_count: 15,
+                marker: false,
+                payload_type: 33.into(),
+                sequence_number: 47_000,
+                timestamp: 10_000,
+                ssrc: 44.into(),
+                csrc: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                ext_vals: ExtensionValues {
+                    audio_level: Some(-42),
+                    voice_activity: Some(true),
+                    ..Default::default()
+                },
+                header_len: 80,
             }
         );
     }

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -265,6 +265,28 @@ impl StreamTx {
         nackable: bool,
         payload: Vec<u8>,
     ) -> Result<(), PacketError> {
+        self.write_rtp_with_csrc(
+            pt, seq_no, time, wallclock, marker, ext_vals, nackable, payload, 0, [0; 15],
+        )
+    }
+
+    /// Like [`Self::write_rtp`], but with an additional `csrc` parameter for
+    /// contributing source identifiers (up to 15 per RFC 3550).
+    #[allow(clippy::too_many_arguments)]
+    pub fn write_rtp_with_csrc(
+        &mut self,
+        pt: Pt,
+        seq_no: SeqNo,
+        time: u32,
+        wallclock: Instant,
+        marker: bool,
+        ext_vals: ExtensionValues,
+        nackable: bool,
+        payload: Vec<u8>,
+        csrc_count: usize,
+        csrc: [u32; 15],
+    ) -> Result<(), PacketError> {
+        assert!(csrc_count <= 15, "CSRC count must be <= 15");
         let first_call = self.rtp_and_wallclock.is_none();
 
         if first_call && seq_no.roc() > 0 {
@@ -281,11 +303,13 @@ impl StreamTx {
         self.rtp_and_wallclock = Some((time, wallclock));
 
         let header = RtpHeader {
+            csrc_count,
             sequence_number: *seq_no as u16,
             marker,
             payload_type: pt,
             timestamp: time,
             ssrc: self.ssrc,
+            csrc,
             ext_vals,
             ..Default::default()
         };

--- a/tests/rtp-direct-csrc.rs
+++ b/tests/rtp-direct-csrc.rs
@@ -1,0 +1,209 @@
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use str0m::format::Codec;
+use str0m::media::MediaKind;
+use str0m::rtp::{ExtensionValues, Ssrc};
+use str0m::{Event, RtcError};
+
+mod common;
+use common::{connect_l_r, init_crypto_default, init_log, progress};
+
+#[test]
+pub fn rtp_direct_csrc_basic() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let (mut l, mut r) = connect_l_r();
+
+    let mid = "aud".into();
+    let ssrc: Ssrc = 1.into();
+
+    l.direct_api().declare_media(mid, MediaKind::Audio);
+    l.direct_api().declare_stream_tx(ssrc, None, mid, None);
+
+    r.direct_api().declare_media(mid, MediaKind::Audio);
+    r.direct_api().expect_stream_rx(ssrc, None, mid, None);
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    let params = l.params_opus();
+    assert_eq!(params.spec().codec, Codec::Opus);
+    let pt = params.pt();
+
+    let csrc_values: [u32; 15] = [
+        u32::MAX,
+        0x12_34_56_78,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ];
+
+    let to_write: Vec<&[u8]> = vec![&[0x1, 0x2, 0x3, 0x4]];
+    let mut to_write: VecDeque<_> = to_write.into();
+
+    let mut write_at = l.last + Duration::from_millis(300);
+
+    loop {
+        if l.start + l.duration() > write_at {
+            write_at = l.last + Duration::from_millis(300);
+            if let Some(packet) = to_write.pop_front() {
+                let wallclock = l.start + l.duration();
+
+                let mut direct = l.direct_api();
+                let stream = direct.stream_tx(&ssrc).unwrap();
+
+                let exts = ExtensionValues {
+                    audio_level: Some(-42),
+                    voice_activity: Some(false),
+                    ..Default::default()
+                };
+
+                stream
+                    .write_rtp_with_csrc(
+                        pt,
+                        47_000.into(),
+                        47_000_000,
+                        wallclock,
+                        false,
+                        exts,
+                        false,
+                        packet.to_vec(),
+                        3,
+                        csrc_values,
+                    )
+                    .expect("clean write");
+            }
+        }
+
+        progress(&mut l, &mut r)?;
+
+        if l.duration() > Duration::from_secs(10) {
+            break;
+        }
+    }
+
+    let media: Vec<_> = r
+        .events
+        .iter()
+        .filter_map(|(_, e)| {
+            if let Event::RtpPacket(v) = e {
+                Some(v)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert_eq!(media.len(), 1);
+
+    let h = &media[0].header;
+    assert_eq!(h.csrc_count, 3);
+    assert_eq!(h.csrc[0], u32::MAX);
+    assert_eq!(h.csrc[1], 0x12_34_56_78);
+    assert_eq!(h.csrc[2], 1);
+    // Remaining slots should be zero
+    for i in 3..15 {
+        assert_eq!(h.csrc[i], 0, "csrc[{i}] should be 0");
+    }
+
+    Ok(())
+}
+
+#[test]
+pub fn rtp_direct_csrc_max_entries() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let (mut l, mut r) = connect_l_r();
+
+    let mid = "aud".into();
+    let ssrc: Ssrc = 2.into();
+
+    l.direct_api().declare_media(mid, MediaKind::Audio);
+    l.direct_api().declare_stream_tx(ssrc, None, mid, None);
+
+    r.direct_api().declare_media(mid, MediaKind::Audio);
+    r.direct_api().expect_stream_rx(ssrc, None, mid, None);
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    let params = l.params_opus();
+    let pt = params.pt();
+
+    let csrc_values: [u32; 15] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+
+    let to_write: Vec<&[u8]> = vec![&[0xa, 0xb, 0xc, 0xd]];
+    let mut to_write: VecDeque<_> = to_write.into();
+
+    let mut write_at = l.last + Duration::from_millis(300);
+
+    loop {
+        if l.start + l.duration() > write_at {
+            write_at = l.last + Duration::from_millis(300);
+            if let Some(packet) = to_write.pop_front() {
+                let wallclock = l.start + l.duration();
+
+                let mut direct = l.direct_api();
+                let stream = direct.stream_tx(&ssrc).unwrap();
+
+                stream
+                    .write_rtp_with_csrc(
+                        pt,
+                        48_000.into(),
+                        48_000_000,
+                        wallclock,
+                        false,
+                        ExtensionValues::default(),
+                        false,
+                        packet.to_vec(),
+                        15,
+                        csrc_values,
+                    )
+                    .expect("clean write");
+            }
+        }
+
+        progress(&mut l, &mut r)?;
+
+        if l.duration() > Duration::from_secs(10) {
+            break;
+        }
+    }
+
+    let media: Vec<_> = r
+        .events
+        .iter()
+        .filter_map(|(_, e)| {
+            if let Event::RtpPacket(v) = e {
+                Some(v)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert_eq!(media.len(), 1);
+
+    let h = &media[0].header;
+    assert_eq!(h.csrc_count, 15);
+    for i in 0..15 {
+        assert_eq!(h.csrc[i], (i + 1) as u32, "csrc[{i}] mismatch");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Today str0m parses the CC field in the RTP fixed header but discards the CSRC values, and SendStream::write_rtp has no way to set them. 

The change:
- Add csrc_count: usize and csrc: [u32; 15] fields to RtpHeader (defaulting to 0 / empty).
- Read/write them properly in RtpHeader::parse / RtpHeader::write_to.
- Add write_rtp_with_csrc() on SendStream; the existing write_rtp() delegates to it with csrc_count: 0.
 