### PR TITLE
Add DTLS cipher suite configuration to RtcConfig

### DIFF
--- a/crates/proto/src/crypto/mod.rs
+++ b/crates/proto/src/crypto/mod.rs
@@ -1,9 +1,8 @@
 mod provider;
 pub use provider::{AeadAes128Gcm, AeadAes128GcmCipher, AeadAes256Gcm, AeadAes256GcmCipher};
 pub use provider::{Aes128CmSha1_80, Aes128CmSha1_80Cipher, CryptoProvider, CryptoSafe};
-pub use provider::{
-    Dtls12CipherSuite, Dtls13CipherSuite, DtlsConfig, DtlsVersion, Sha1HmacProvider, Sha256Provider,
-};
+pub use provider::{Dtls12CipherSuite, Dtls13CipherSuite, DtlsConfig, DtlsVersion};
+pub use provider::{Sha1HmacProvider, Sha256Provider};
 pub use provider::{SrtpProvider, SupportedAeadAes128Gcm};
 pub use provider::{SupportedAeadAes256Gcm, SupportedAes128CmSha1_80};
 

--- a/crates/proto/src/crypto/mod.rs
+++ b/crates/proto/src/crypto/mod.rs
@@ -1,7 +1,10 @@
 mod provider;
 pub use provider::{AeadAes128Gcm, AeadAes128GcmCipher, AeadAes256Gcm, AeadAes256GcmCipher};
 pub use provider::{Aes128CmSha1_80, Aes128CmSha1_80Cipher, CryptoProvider, CryptoSafe};
-pub use provider::{DtlsVersion, Sha1HmacProvider, Sha256Provider};
+pub use provider::{
+    Dtls12CipherSuite, Dtls13CipherSuite, DtlsConfig, DtlsVersion, Sha1HmacProvider,
+    Sha256Provider,
+};
 pub use provider::{SrtpProvider, SupportedAeadAes128Gcm};
 pub use provider::{SupportedAeadAes256Gcm, SupportedAes128CmSha1_80};
 

--- a/crates/proto/src/crypto/mod.rs
+++ b/crates/proto/src/crypto/mod.rs
@@ -2,8 +2,7 @@ mod provider;
 pub use provider::{AeadAes128Gcm, AeadAes128GcmCipher, AeadAes256Gcm, AeadAes256GcmCipher};
 pub use provider::{Aes128CmSha1_80, Aes128CmSha1_80Cipher, CryptoProvider, CryptoSafe};
 pub use provider::{
-    Dtls12CipherSuite, Dtls13CipherSuite, DtlsConfig, DtlsVersion, Sha1HmacProvider,
-    Sha256Provider,
+    Dtls12CipherSuite, Dtls13CipherSuite, DtlsConfig, DtlsVersion, Sha1HmacProvider, Sha256Provider,
 };
 pub use provider::{SrtpProvider, SupportedAeadAes128Gcm};
 pub use provider::{SupportedAeadAes256Gcm, SupportedAes128CmSha1_80};

--- a/crates/proto/src/crypto/provider.rs
+++ b/crates/proto/src/crypto/provider.rs
@@ -138,6 +138,88 @@ impl fmt::Display for DtlsVersion {
     }
 }
 
+// ============================================================================
+// DTLS Cipher Suites
+// ============================================================================
+
+/// DTLS 1.2 cipher suites.
+///
+/// These are the TLS 1.2 cipher suites used in DTLS, which specify the
+/// full combination of key exchange, authentication, encryption, and hash.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+#[allow(non_camel_case_types)]
+pub enum Dtls12CipherSuite {
+    /// TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 (0xC02B).
+    ECDHE_ECDSA_AES128_GCM_SHA256,
+    /// TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 (0xC02C).
+    ECDHE_ECDSA_AES256_GCM_SHA384,
+    /// TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 (0xCCA9).
+    ECDHE_ECDSA_CHACHA20_POLY1305_SHA256,
+}
+
+#[cfg(feature = "dtls")]
+impl Dtls12CipherSuite {
+    /// Convert to the corresponding dimpl cipher suite.
+    pub fn into_dimpl(self) -> dimpl::crypto::Dtls12CipherSuite {
+        use dimpl::crypto::Dtls12CipherSuite as D;
+        match self {
+            Self::ECDHE_ECDSA_AES128_GCM_SHA256 => D::ECDHE_ECDSA_AES128_GCM_SHA256,
+            Self::ECDHE_ECDSA_AES256_GCM_SHA384 => D::ECDHE_ECDSA_AES256_GCM_SHA384,
+            Self::ECDHE_ECDSA_CHACHA20_POLY1305_SHA256 => D::ECDHE_ECDSA_CHACHA20_POLY1305_SHA256,
+        }
+    }
+}
+
+/// DTLS 1.3 cipher suites.
+///
+/// Unlike DTLS 1.2, TLS 1.3 cipher suites only specify the AEAD algorithm
+/// and hash function. Key exchange is negotiated separately.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+#[allow(non_camel_case_types)]
+pub enum Dtls13CipherSuite {
+    /// TLS_AES_128_GCM_SHA256 (0x1301).
+    AES_128_GCM_SHA256,
+    /// TLS_AES_256_GCM_SHA384 (0x1302).
+    AES_256_GCM_SHA384,
+    /// TLS_CHACHA20_POLY1305_SHA256 (0x1303).
+    CHACHA20_POLY1305_SHA256,
+}
+
+#[cfg(feature = "dtls")]
+impl Dtls13CipherSuite {
+    /// Convert to the corresponding dimpl cipher suite.
+    pub fn into_dimpl(self) -> dimpl::crypto::Dtls13CipherSuite {
+        use dimpl::crypto::Dtls13CipherSuite as D;
+        match self {
+            Self::AES_128_GCM_SHA256 => D::AES_128_GCM_SHA256,
+            Self::AES_256_GCM_SHA384 => D::AES_256_GCM_SHA384,
+            Self::CHACHA20_POLY1305_SHA256 => D::CHACHA20_POLY1305_SHA256,
+        }
+    }
+}
+
+// ============================================================================
+// DTLS Config
+// ============================================================================
+
+/// Configuration for the DTLS handshake.
+///
+/// Bundles the DTLS version with optional cipher suite preferences.
+/// When cipher suite lists are `None`, all provider-supported suites are used.
+/// When set to `Some`, only the listed suites are offered/accepted (allow-list).
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct DtlsConfig {
+    /// Which DTLS version to use.
+    pub version: DtlsVersion,
+    /// Allowed DTLS 1.2 cipher suites. `None` means all provider-supported suites.
+    pub dtls12_cipher_suites: Option<Vec<Dtls12CipherSuite>>,
+    /// Allowed DTLS 1.3 cipher suites. `None` means all provider-supported suites.
+    pub dtls13_cipher_suites: Option<Vec<Dtls13CipherSuite>>,
+}
+
 /// Factory for DTLS instances and certificates.
 pub trait DtlsProvider: CryptoSafe {
     /// Generate a new self-signed DTLS certificate.
@@ -146,12 +228,12 @@ pub trait DtlsProvider: CryptoSafe {
     /// In that case, the user must supply a certificate via `RtcConfig::set_dtls_cert`.
     fn generate_certificate(&self) -> Option<DtlsCert>;
 
-    /// Create a new DTLS instance with the given certificate.
+    /// Create a new DTLS instance with the given certificate and configuration.
     fn new_dtls(
         &self,
         cert: &DtlsCert,
         now: Instant,
-        dtls_version: DtlsVersion,
+        dtls_config: &DtlsConfig,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError>;
 
     /// Whether the provider is used in a test context.

--- a/crypto/apple-crypto/src/dtls.rs
+++ b/crypto/apple-crypto/src/dtls.rs
@@ -124,7 +124,8 @@ impl DtlsProvider for AppleCryptoDtlsProvider {
             DtlsVersion::Auto => Dtls::new_auto(config, dimpl_cert, now),
             _ => {
                 return Err(CryptoError::Other(format!(
-                    "Unsupported DTLS version: {}", dtls_config.version
+                    "Unsupported DTLS version: {}",
+                    dtls_config.version
                 )));
             }
         };

--- a/crypto/apple-crypto/src/dtls.rs
+++ b/crypto/apple-crypto/src/dtls.rs
@@ -6,8 +6,8 @@ use security_framework::key::{GenerateKeyOptions, KeyType, SecKey};
 use std::sync::Arc;
 use std::time::Instant;
 use str0m_proto::crypto::CryptoError;
-use str0m_proto::crypto::DtlsVersion;
 use str0m_proto::crypto::dtls::{DtlsCert, DtlsImplError, DtlsInstance, DtlsOutput, DtlsProvider};
+use str0m_proto::crypto::{DtlsConfig, DtlsVersion};
 
 // Certificate Generation
 
@@ -88,7 +88,7 @@ impl DtlsProvider for AppleCryptoDtlsProvider {
         &self,
         cert: &DtlsCert,
         now: Instant,
-        dtls_version: DtlsVersion,
+        dtls_config: &DtlsConfig,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         let dimpl_cert = DtlsCertificate {
             certificate: cert.certificate.clone(),
@@ -103,19 +103,28 @@ impl DtlsProvider for AppleCryptoDtlsProvider {
             builder = builder.dangerously_set_rng_seed(42);
         }
 
+        if let Some(suites) = &dtls_config.dtls12_cipher_suites {
+            let mapped: Vec<_> = suites.iter().map(|s| s.into_dimpl()).collect();
+            builder = builder.dtls12_cipher_suites(&mapped);
+        }
+        if let Some(suites) = &dtls_config.dtls13_cipher_suites {
+            let mapped: Vec<_> = suites.iter().map(|s| s.into_dimpl()).collect();
+            builder = builder.dtls13_cipher_suites(&mapped);
+        }
+
         let config = builder
             .with_crypto_provider(crate::dimpl_provider::default_provider())
             .build()
             .map_err(|e| CryptoError::Other(format!("dimpl config creation failed: {e}")))?;
 
         let config = Arc::new(config);
-        let dtls = match dtls_version {
+        let dtls = match dtls_config.version {
             DtlsVersion::Dtls12 => Dtls::new_12(config, dimpl_cert, now),
             DtlsVersion::Dtls13 => Dtls::new_13(config, dimpl_cert, now),
             DtlsVersion::Auto => Dtls::new_auto(config, dimpl_cert, now),
             _ => {
                 return Err(CryptoError::Other(format!(
-                    "Unsupported DTLS version: {dtls_version}"
+                    "Unsupported DTLS version: {}", dtls_config.version
                 )));
             }
         };

--- a/crypto/aws-lc-rs/src/dtls.rs
+++ b/crypto/aws-lc-rs/src/dtls.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use str0m_proto::crypto::CryptoError;
-use str0m_proto::crypto::DtlsVersion;
 use str0m_proto::crypto::dtls::{DtlsCert, DtlsImplError, DtlsInstance, DtlsOutput, DtlsProvider};
+use str0m_proto::crypto::{DtlsConfig, DtlsVersion};
 
 // ============================================================================
 // DTLS Provider Implementation
@@ -29,7 +29,7 @@ impl DtlsProvider for AwsLcRsDtlsProvider {
         &self,
         cert: &DtlsCert,
         now: Instant,
-        dtls_version: DtlsVersion,
+        dtls_config: &DtlsConfig,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         let dimpl_cert = dimpl::DtlsCertificate {
             certificate: cert.certificate.clone(),
@@ -44,18 +44,27 @@ impl DtlsProvider for AwsLcRsDtlsProvider {
             builder = builder.dangerously_set_rng_seed(42);
         }
 
+        if let Some(suites) = &dtls_config.dtls12_cipher_suites {
+            let mapped: Vec<_> = suites.iter().map(|s| s.into_dimpl()).collect();
+            builder = builder.dtls12_cipher_suites(&mapped);
+        }
+        if let Some(suites) = &dtls_config.dtls13_cipher_suites {
+            let mapped: Vec<_> = suites.iter().map(|s| s.into_dimpl()).collect();
+            builder = builder.dtls13_cipher_suites(&mapped);
+        }
+
         let config = builder
             .build()
             .map_err(|e| CryptoError::Other(format!("dimpl config creation failed: {}", e)))?;
 
         let config = Arc::new(config);
-        let dtls = match dtls_version {
+        let dtls = match dtls_config.version {
             DtlsVersion::Dtls12 => dimpl::Dtls::new_12(config, dimpl_cert, now),
             DtlsVersion::Dtls13 => dimpl::Dtls::new_13(config, dimpl_cert, now),
             DtlsVersion::Auto => dimpl::Dtls::new_auto(config, dimpl_cert, now),
             _ => {
                 return Err(CryptoError::Other(format!(
-                    "Unsupported DTLS version: {dtls_version}"
+                    "Unsupported DTLS version: {}", dtls_config.version
                 )));
             }
         };

--- a/crypto/aws-lc-rs/src/dtls.rs
+++ b/crypto/aws-lc-rs/src/dtls.rs
@@ -64,7 +64,8 @@ impl DtlsProvider for AwsLcRsDtlsProvider {
             DtlsVersion::Auto => dimpl::Dtls::new_auto(config, dimpl_cert, now),
             _ => {
                 return Err(CryptoError::Other(format!(
-                    "Unsupported DTLS version: {}", dtls_config.version
+                    "Unsupported DTLS version: {}",
+                    dtls_config.version
                 )));
             }
         };

--- a/crypto/openssl/src/dtls_dimpl.rs
+++ b/crypto/openssl/src/dtls_dimpl.rs
@@ -63,7 +63,8 @@ impl DtlsProvider for OsslDtlsProvider {
             DtlsVersion::Auto => dimpl::Dtls::new_auto(config, dimpl_cert, now),
             _ => {
                 return Err(CryptoError::Other(format!(
-                    "Unknown DTLS version: {}", dtls_config.version
+                    "Unknown DTLS version: {}",
+                    dtls_config.version
                 )));
             }
         };

--- a/crypto/openssl/src/dtls_dimpl.rs
+++ b/crypto/openssl/src/dtls_dimpl.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use str0m_proto::crypto::dtls::DtlsImplError;
 use str0m_proto::crypto::dtls::{DtlsCert, DtlsInstance, DtlsOutput, DtlsProvider};
-use str0m_proto::crypto::{CryptoError, DtlsVersion};
+use str0m_proto::crypto::{CryptoError, DtlsConfig, DtlsVersion};
 
 // ============================================================================
 // DTLS Provider Implementation
@@ -28,7 +28,7 @@ impl DtlsProvider for OsslDtlsProvider {
         &self,
         cert: &DtlsCert,
         now: Instant,
-        dtls_version: DtlsVersion,
+        dtls_config: &DtlsConfig,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         let dimpl_cert = dimpl::DtlsCertificate {
             certificate: cert.certificate.clone(),
@@ -42,19 +42,28 @@ impl DtlsProvider for OsslDtlsProvider {
             builder = builder.dangerously_set_rng_seed(42);
         }
 
+        if let Some(suites) = &dtls_config.dtls12_cipher_suites {
+            let mapped: Vec<_> = suites.iter().map(|s| s.into_dimpl()).collect();
+            builder = builder.dtls12_cipher_suites(&mapped);
+        }
+        if let Some(suites) = &dtls_config.dtls13_cipher_suites {
+            let mapped: Vec<_> = suites.iter().map(|s| s.into_dimpl()).collect();
+            builder = builder.dtls13_cipher_suites(&mapped);
+        }
+
         let config = builder
             .with_crypto_provider(crate::dimpl_provider::default_provider())
             .build()
             .map_err(|e| CryptoError::Other(format!("dimpl config creation failed: {e}")))?;
 
         let config = Arc::new(config);
-        let dtls = match dtls_version {
+        let dtls = match dtls_config.version {
             DtlsVersion::Dtls12 => dimpl::Dtls::new_12(config, dimpl_cert, now),
             DtlsVersion::Dtls13 => dimpl::Dtls::new_13(config, dimpl_cert, now),
             DtlsVersion::Auto => dimpl::Dtls::new_auto(config, dimpl_cert, now),
             _ => {
                 return Err(CryptoError::Other(format!(
-                    "Unknown DTLS version: {dtls_version}"
+                    "Unknown DTLS version: {}", dtls_config.version
                 )));
             }
         };

--- a/crypto/openssl/src/dtls_ossl.rs
+++ b/crypto/openssl/src/dtls_ossl.rs
@@ -14,7 +14,7 @@ use openssl::x509::X509;
 
 use str0m_proto::crypto::dtls::{DtlsCert, KeyingMaterial, SrtpProfile};
 use str0m_proto::crypto::dtls::{DtlsImplError, DtlsInstance, DtlsOutput, DtlsProvider};
-use str0m_proto::crypto::{CryptoError, DtlsVersion};
+use str0m_proto::crypto::{CryptoError, DtlsConfig, DtlsVersion};
 use str0m_proto::{DATAGRAM_MTU, DATAGRAM_MTU_WARN};
 
 // ============================================================================
@@ -637,9 +637,9 @@ impl DtlsProvider for OsslDtlsProvider {
         &self,
         cert: &DtlsCert,
         _now: Instant,
-        dtls_version: DtlsVersion,
+        dtls_config: &DtlsConfig,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
-        match dtls_version {
+        match dtls_config.version {
             DtlsVersion::Dtls12 => Ok(Box::new(OsslDtlsInstance::new(cert)?)),
             _ => Err(CryptoError::Other(
                 "OpenSSL DTLS provider only supports DTLS 1.2 without dimpl. \

--- a/crypto/rust-crypto/src/dtls.rs
+++ b/crypto/rust-crypto/src/dtls.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use str0m_proto::crypto::CryptoError;
-use str0m_proto::crypto::DtlsVersion;
 use str0m_proto::crypto::dtls::{DtlsCert, DtlsImplError, DtlsInstance, DtlsOutput, DtlsProvider};
+use str0m_proto::crypto::{DtlsConfig, DtlsVersion};
 
 // ============================================================================
 // DTLS Provider Implementation
@@ -29,7 +29,7 @@ impl DtlsProvider for RustCryptoDtlsProvider {
         &self,
         cert: &DtlsCert,
         now: Instant,
-        dtls_version: DtlsVersion,
+        dtls_config: &DtlsConfig,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         let dimpl_cert = dimpl::DtlsCertificate {
             certificate: cert.certificate.clone(),
@@ -44,18 +44,27 @@ impl DtlsProvider for RustCryptoDtlsProvider {
             builder = builder.dangerously_set_rng_seed(42);
         }
 
+        if let Some(suites) = &dtls_config.dtls12_cipher_suites {
+            let mapped: Vec<_> = suites.iter().map(|s| s.into_dimpl()).collect();
+            builder = builder.dtls12_cipher_suites(&mapped);
+        }
+        if let Some(suites) = &dtls_config.dtls13_cipher_suites {
+            let mapped: Vec<_> = suites.iter().map(|s| s.into_dimpl()).collect();
+            builder = builder.dtls13_cipher_suites(&mapped);
+        }
+
         let config = builder
             .build()
             .map_err(|e| CryptoError::Other(format!("dimpl config creation failed: {}", e)))?;
 
         let config = Arc::new(config);
-        let dtls = match dtls_version {
+        let dtls = match dtls_config.version {
             DtlsVersion::Dtls12 => dimpl::Dtls::new_12(config, dimpl_cert, now),
             DtlsVersion::Dtls13 => dimpl::Dtls::new_13(config, dimpl_cert, now),
             DtlsVersion::Auto => dimpl::Dtls::new_auto(config, dimpl_cert, now),
             _ => {
                 return Err(CryptoError::Other(format!(
-                    "Unsupported DTLS version: {dtls_version}"
+                    "Unsupported DTLS version: {}", dtls_config.version
                 )));
             }
         };

--- a/crypto/rust-crypto/src/dtls.rs
+++ b/crypto/rust-crypto/src/dtls.rs
@@ -64,7 +64,8 @@ impl DtlsProvider for RustCryptoDtlsProvider {
             DtlsVersion::Auto => dimpl::Dtls::new_auto(config, dimpl_cert, now),
             _ => {
                 return Err(CryptoError::Other(format!(
-                    "Unsupported DTLS version: {}", dtls_config.version
+                    "Unsupported DTLS version: {}",
+                    dtls_config.version
                 )));
             }
         };

--- a/crypto/wincrypto/src/dtls_dimpl.rs
+++ b/crypto/wincrypto/src/dtls_dimpl.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use str0m_proto::crypto::CryptoError;
-use str0m_proto::crypto::DtlsVersion;
 use str0m_proto::crypto::dtls::{DtlsCert, DtlsImplError, DtlsInstance, DtlsOutput, DtlsProvider};
+use str0m_proto::crypto::{DtlsConfig, DtlsVersion};
 
 use dimpl::{Config, Dtls, DtlsCertificate};
 
@@ -25,7 +25,7 @@ impl DtlsProvider for WinCryptoDtlsProvider {
         &self,
         cert: &DtlsCert,
         now: Instant,
-        dtls_version: DtlsVersion,
+        dtls_config: &DtlsConfig,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         let dimpl_cert = DtlsCertificate {
             certificate: cert.certificate.clone(),
@@ -38,19 +38,28 @@ impl DtlsProvider for WinCryptoDtlsProvider {
             builder = builder.dangerously_set_rng_seed(42);
         }
 
+        if let Some(suites) = &dtls_config.dtls12_cipher_suites {
+            let mapped: Vec<_> = suites.iter().map(|s| s.into_dimpl()).collect();
+            builder = builder.dtls12_cipher_suites(&mapped);
+        }
+        if let Some(suites) = &dtls_config.dtls13_cipher_suites {
+            let mapped: Vec<_> = suites.iter().map(|s| s.into_dimpl()).collect();
+            builder = builder.dtls13_cipher_suites(&mapped);
+        }
+
         let config = builder
             .with_crypto_provider(crate::dimpl_provider::default_provider())
             .build()
             .map_err(|e| CryptoError::Other(format!("dimpl config creation failed: {e}")))?;
 
         let config = Arc::new(config);
-        let dtls = match dtls_version {
+        let dtls = match dtls_config.version {
             DtlsVersion::Dtls12 => Dtls::new_12(config, dimpl_cert, now),
             DtlsVersion::Dtls13 => Dtls::new_13(config, dimpl_cert, now),
             DtlsVersion::Auto => Dtls::new_auto(config, dimpl_cert, now),
             _ => {
                 return Err(CryptoError::Other(format!(
-                    "Unsupported DTLS version: {dtls_version}"
+                    "Unsupported DTLS version: {}", dtls_config.version
                 )));
             }
         };

--- a/crypto/wincrypto/src/dtls_dimpl.rs
+++ b/crypto/wincrypto/src/dtls_dimpl.rs
@@ -59,7 +59,8 @@ impl DtlsProvider for WinCryptoDtlsProvider {
             DtlsVersion::Auto => Dtls::new_auto(config, dimpl_cert, now),
             _ => {
                 return Err(CryptoError::Other(format!(
-                    "Unsupported DTLS version: {}", dtls_config.version
+                    "Unsupported DTLS version: {}",
+                    dtls_config.version
                 )));
             }
         };

--- a/crypto/wincrypto/src/dtls_schannel.rs
+++ b/crypto/wincrypto/src/dtls_schannel.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, Instant};
 use str0m_proto::crypto::dtls::{DtlsCert, DtlsImplError, DtlsInstance, DtlsOutput, DtlsProvider};
 use str0m_proto::crypto::dtls::{KeyingMaterial, SrtpProfile};
-use str0m_proto::crypto::{CryptoError, DtlsVersion};
+use str0m_proto::crypto::{CryptoError, DtlsConfig, DtlsVersion};
 
 use crate::sys::{Certificate, Dtls, DtlsEvent};
 
@@ -42,9 +42,9 @@ impl DtlsProvider for WinCryptoDtlsProvider {
         &self,
         cert: &DtlsCert,
         _now: Instant,
-        dtls_version: DtlsVersion,
+        dtls_config: &DtlsConfig,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
-        if !matches!(dtls_version, DtlsVersion::Dtls12 | DtlsVersion::Auto) {
+        if !matches!(dtls_config.version, DtlsVersion::Dtls12 | DtlsVersion::Auto) {
             return Err(CryptoError::Other(
                 "WinCrypto DTLS provider only supports DTLS 1.2 without dimpl. \
                  Enable the str0m-wincrypto-dimpl feature for DTLS 1.3/Auto."

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 use crate::Rtc;
 use crate::config::DtlsCert;
 use crate::crypto::CryptoProvider;
-use crate::crypto::dtls::DtlsVersion;
+use crate::crypto::dtls::{Dtls12CipherSuite, Dtls13CipherSuite, DtlsConfig, DtlsVersion};
 use crate::format::CodecConfig;
 use crate::format::Vp9PacketizerMode;
 use crate::ice::IceCreds;
@@ -44,7 +44,7 @@ pub struct RtcConfig {
     pub(crate) send_buffer_video: usize,
     pub(crate) rtp_mode: bool,
     pub(crate) enable_raw_packets: bool,
-    pub(crate) dtls_version: DtlsVersion,
+    pub(crate) dtls_config: DtlsConfig,
     pub(crate) vp9_packetizer_mode: Vp9PacketizerMode,
     pub(crate) snap_enabled: bool,
 }
@@ -572,13 +572,41 @@ impl RtcConfig {
     ///
     /// Defaults to [`DtlsVersion::Dtls12`].
     pub fn set_dtls_version(mut self, version: DtlsVersion) -> Self {
-        self.dtls_version = version;
+        self.dtls_config.version = version;
         self
     }
 
     /// Get the configured DTLS version.
     pub fn dtls_version(&self) -> DtlsVersion {
-        self.dtls_version
+        self.dtls_config.version
+    }
+
+    /// Restrict which DTLS 1.2 cipher suites are offered and accepted.
+    ///
+    /// Only cipher suites present in both this list and the provider will
+    /// be used. By default all provider-supported DTLS 1.2 cipher suites are used.
+    pub fn set_dtls12_cipher_suites(mut self, suites: &[Dtls12CipherSuite]) -> Self {
+        self.dtls_config.dtls12_cipher_suites = Some(suites.to_vec());
+        self
+    }
+
+    /// Get the configured DTLS 1.2 cipher suite allow-list, if set.
+    pub fn dtls12_cipher_suites(&self) -> Option<&[Dtls12CipherSuite]> {
+        self.dtls_config.dtls12_cipher_suites.as_deref()
+    }
+
+    /// Restrict which DTLS 1.3 cipher suites are offered and accepted.
+    ///
+    /// Only cipher suites present in both this list and the provider will
+    /// be used. By default all provider-supported DTLS 1.3 cipher suites are used.
+    pub fn set_dtls13_cipher_suites(mut self, suites: &[Dtls13CipherSuite]) -> Self {
+        self.dtls_config.dtls13_cipher_suites = Some(suites.to_vec());
+        self
+    }
+
+    /// Get the configured DTLS 1.3 cipher suite allow-list, if set.
+    pub fn dtls13_cipher_suites(&self) -> Option<&[Dtls13CipherSuite]> {
+        self.dtls_config.dtls13_cipher_suites.as_deref()
     }
 
     /// Set the VP9 packetizer mode.
@@ -641,7 +669,7 @@ impl Default for RtcConfig {
             send_buffer_video: 1000,
             rtp_mode: false,
             enable_raw_packets: false,
-            dtls_version: DtlsVersion::Dtls12,
+            dtls_config: DtlsConfig::default(),
             vp9_packetizer_mode: Vp9PacketizerMode::default(),
             snap_enabled: false,
         }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -14,9 +14,7 @@ pub mod dtls {
     pub use dimpl::KeyingMaterial;
     pub use dimpl::SrtpProfile;
     // Note: dimpl::Error is renamed to DtlsImplError to avoid conflict with str0m's DtlsError
-    pub use super::provider::{
-        Dtls12CipherSuite, Dtls13CipherSuite, DtlsConfig, DtlsVersion,
-    };
+    pub use super::provider::{Dtls12CipherSuite, Dtls13CipherSuite, DtlsConfig, DtlsVersion};
     pub use dimpl::{Error as DtlsImplError, Output as DtlsOutput};
 }
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -14,7 +14,9 @@ pub mod dtls {
     pub use dimpl::KeyingMaterial;
     pub use dimpl::SrtpProfile;
     // Note: dimpl::Error is renamed to DtlsImplError to avoid conflict with str0m's DtlsError
-    pub use super::provider::DtlsVersion;
+    pub use super::provider::{
+        Dtls12CipherSuite, Dtls13CipherSuite, DtlsConfig, DtlsVersion,
+    };
     pub use dimpl::{Error as DtlsImplError, Output as DtlsOutput};
 }
 

--- a/src/dtls.rs
+++ b/src/dtls.rs
@@ -5,8 +5,8 @@ use std::time::Instant;
 
 use crate::crypto::Fingerprint;
 use crate::crypto::Sha256Provider;
-use crate::crypto::dtls::{DtlsCert, DtlsOutput};
-use crate::crypto::dtls::{DtlsInstance, DtlsProvider, DtlsVersion};
+use crate::crypto::dtls::{DtlsCert, DtlsConfig, DtlsOutput};
+use crate::crypto::dtls::{DtlsInstance, DtlsProvider};
 use crate::crypto::{CryptoError, DtlsError};
 use crate::io::DatagramSend;
 use crate::util::already_happened;
@@ -53,10 +53,10 @@ impl Dtls {
         dtls_provider: &dyn DtlsProvider,
         sha256_provider: &dyn Sha256Provider,
         now: Instant,
-        dtls_version: DtlsVersion,
+        dtls_config: &DtlsConfig,
     ) -> Result<Self, DtlsError> {
         let instance = dtls_provider
-            .new_dtls(cert, now, dtls_version)
+            .new_dtls(cert, now, dtls_config)
             .map_err(DtlsError::CryptoError)?;
 
         // Compute fingerprint from the certificate DER bytes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1158,7 +1158,7 @@ impl Rtc {
                 crypto_provider.dtls_provider,
                 crypto_provider.sha256_provider,
                 start,
-                config.dtls_version,
+                &config.dtls_config,
             )
             .expect("DTLS to init without problem"),
             dtls_connected: false,


### PR DESCRIPTION
## Summary
- Add `Dtls12CipherSuite` and `Dtls13CipherSuite` enums (provider-agnostic, defined in str0m-proto)
- Add `DtlsConfig` struct bundling DTLS version + optional cipher suite allow-lists
- Add `RtcConfig::set_dtls12_cipher_suites()` and `set_dtls13_cipher_suites()` methods
- Update `DtlsProvider::new_dtls()` trait method to accept `&DtlsConfig`
- All 5 dimpl backends forward cipher preferences to dimpl's `Config` builder
- Native backends (OpenSSL, SChannel) accept but ignore cipher suite fields

Existing `set_dtls_version()` / `dtls_version()` continue to work, delegating to the `DtlsConfig` struct.

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (all 56 tests)
- [x] `cargo test --test handshake-direct` passes (all 9 handshake tests)
- [ ] Test with restricted cipher suites in a real handshake scenario

Generated with [Claude Code](https://claude.com/claude-code)