### PR TITLE
Add PsfbApp (RTCP PSFB FMT=15 PT=206) support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -709,6 +709,7 @@ pub mod rtp {
         pub use crate::rtp_::{Dlrr, NackEntry, ReceptionReport, ReportBlock};
         pub use crate::rtp_::{FirEntry, ReceiverReport, SenderInfo, SenderReport, Twcc};
         pub use crate::rtp_::{ReportList, Rrtr, Rtcp, Sdes, SdesType};
+        pub use crate::rtp_::PsfbApp;
     }
     use self::rtcp::Rtcp;
 
@@ -942,6 +943,11 @@ pub enum Event {
 
     /// Incoming RTP data.
     RtpPacket(RtpPacket),
+
+    /// Incoming RTCP Payload-Specific Feedback Application Layer message (PSFB FMT=15, PT=206).
+    ///
+    /// Used for application-specific feedback such as VSR (Video Source Request).
+    PsfbApp(rtp::rtcp::PsfbApp),
 
     /// Debug output of incoming and outgoing RTCP/RTP packets.
     ///
@@ -1932,6 +1938,13 @@ impl Rtc {
         let n = self.change_counter;
         self.change_counter += 1;
         n
+    }
+
+    /// Enqueue a PsfbApp (RTCP PSFB FMT=15, PT=206) message for transmission.
+    ///
+    /// Used for application-specific feedback such as VSR (Video Source Request).
+    pub fn send_psfb_app(&mut self, psfb: rtp::rtcp::PsfbApp) {
+        self.session.send_psfb_app(psfb);
     }
 
     /// The codec configs for sending/receiving data.

--- a/src/rtp/rtcp/mod.rs
+++ b/src/rtp/rtcp/mod.rs
@@ -43,7 +43,9 @@ mod rtcpfb;
 pub use rtcpfb::RtcpFb;
 
 mod remb;
+mod psfbapp;
 pub use remb::Remb;
+pub use psfbapp::PsfbApp;
 
 use super::SeqNo;
 use super::Ssrc;
@@ -88,6 +90,9 @@ pub enum Rtcp {
     Twcc(Twcc),
     /// Receiver Estimated Maximum Bitrate. Feedback to the sender about the maximum bitrate.
     Remb(Remb),
+    /// Payload-Specific Feedback Application Layer (FMT=15, PT=206) that is not REMB.
+    /// Used for application-specific feedback such as VSR (Video Source Request).
+    PsfbApp(PsfbApp),
 }
 
 impl Rtcp {
@@ -236,6 +241,7 @@ impl Rtcp {
             Rtcp::Fir(v) => v.reports.is_full(),
             Rtcp::Twcc(_) => true,
             Rtcp::Remb(_) => true,
+            Rtcp::PsfbApp(_) => true,
         }
     }
 
@@ -263,6 +269,8 @@ impl Rtcp {
             Rtcp::Twcc(_) => false,
             // A REMB report is never empty.
             Rtcp::Remb(_) => false,
+            // A PsfbApp report is never empty.
+            Rtcp::PsfbApp(_) => false,
         }
     }
 
@@ -340,6 +348,7 @@ impl Rtcp {
             Fir(_) => 5,
             Twcc(_) => 6,
             Remb(_) => 7,
+            PsfbApp(_) => 8,
             ExtendedReport(_) => 10,
 
             // Goodbye last since they remove stuff.
@@ -361,6 +370,7 @@ impl RtcpPacket for Rtcp {
             Rtcp::Fir(v) => v.header(),
             Rtcp::Twcc(v) => v.header(),
             Rtcp::Remb(v) => v.header(),
+            Rtcp::PsfbApp(v) => v.header(),
         }
     }
 
@@ -376,6 +386,7 @@ impl RtcpPacket for Rtcp {
             Rtcp::Fir(v) => v.length_words(),
             Rtcp::Twcc(v) => v.length_words(),
             Rtcp::Remb(v) => v.length_words(),
+            Rtcp::PsfbApp(v) => v.length_words(),
         }
     }
 
@@ -391,6 +402,7 @@ impl RtcpPacket for Rtcp {
             Rtcp::Fir(v) => v.write_to(buf),
             Rtcp::Twcc(v) => v.write_to(buf),
             Rtcp::Remb(v) => v.write_to(buf),
+            Rtcp::PsfbApp(v) => v.write_to(buf),
         }
     }
 }
@@ -440,6 +452,10 @@ impl<'a> TryFrom<&'a [u8]> for Rtcp {
                         if header.rtcp_type() == RtcpType::PayloadSpecificFeedback {
                             if let Ok(remb) = Remb::try_from(buf) {
                                 return Ok(Rtcp::Remb(remb));
+                            }
+                            // Not REMB — parse as generic PsfbApp
+                            if let Ok(psfbapp) = PsfbApp::try_from(buf) {
+                                return Ok(Rtcp::PsfbApp(psfbapp));
                             }
                         }
                         return Err("Ignore PayloadType: ApplicationLayer");

--- a/src/rtp/rtcp/psfbapp.rs
+++ b/src/rtp/rtcp/psfbapp.rs
@@ -1,0 +1,122 @@
+use crate::rtp::Ssrc;
+
+use super::RtcpType;
+use super::{FeedbackMessageType, PayloadType, RtcpHeader, RtcpPacket};
+
+/*
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |V=2|P| FMT=15  |   PT=206      |             length            |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                  SSRC of packet sender                        |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                  SSRC of media source                         |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                  Application-dependent data                   |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+*/
+
+/// Payload-Specific Feedback Application Layer message (PSFB FMT=15, PT=206).
+///
+/// This is a catch-all for FMT=15 RTCP PSFB messages that are not REMB.
+/// Used by Teams for VSR (Video Source Request) among other things.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PsfbApp {
+    /// SSRC of the sender of this feedback message.
+    pub sender_ssrc: Ssrc,
+    /// SSRC of the media source this feedback relates to.
+    pub media_ssrc: Ssrc,
+    /// Application-dependent payload (after sender_ssrc and media_ssrc).
+    pub payload: Vec<u8>,
+}
+
+impl RtcpPacket for PsfbApp {
+    fn header(&self) -> RtcpHeader {
+        RtcpHeader {
+            rtcp_type: RtcpType::PayloadSpecificFeedback,
+            feedback_message_type: FeedbackMessageType::PayloadFeedback(
+                PayloadType::ApplicationLayer,
+            ),
+            words_less_one: (self.length_words() - 1) as u16,
+        }
+    }
+
+    fn length_words(&self) -> usize {
+        // 1 (RTCP header) + 2 (sender_ssrc + media_ssrc) + payload words
+        let payload_words = (self.payload.len() + 3) / 4;
+        1 + 2 + payload_words
+    }
+
+    fn write_to(&self, buf: &mut [u8]) -> usize {
+        self.header().write_to(&mut buf[..4]);
+        buf[4..8].copy_from_slice(&self.sender_ssrc.to_be_bytes());
+        buf[8..12].copy_from_slice(&self.media_ssrc.to_be_bytes());
+
+        let payload_len = self.payload.len();
+        buf[12..12 + payload_len].copy_from_slice(&self.payload);
+
+        // Pad to 4-byte boundary
+        let padded_payload_len = (payload_len + 3) / 4 * 4;
+        for b in &mut buf[12 + payload_len..12 + padded_payload_len] {
+            *b = 0;
+        }
+
+        12 + padded_payload_len
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for PsfbApp {
+    type Error = &'static str;
+
+    fn try_from(buf: &'a [u8]) -> Result<Self, Self::Error> {
+        if buf.len() < 8 {
+            return Err("PsfbApp less than 8 bytes");
+        }
+
+        let sender_ssrc = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]).into();
+        let media_ssrc = u32::from_be_bytes([buf[4], buf[5], buf[6], buf[7]]).into();
+        let payload = buf[8..].to_vec();
+
+        Ok(PsfbApp {
+            sender_ssrc,
+            media_ssrc,
+            payload,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_psfbapp_round_trip() {
+        let input = PsfbApp {
+            sender_ssrc: 1.into(),
+            media_ssrc: 2.into(),
+            payload: vec![0x01, 0x00, 0x00, 0x44, 0xAA, 0xBB, 0xCC, 0xDD],
+        };
+
+        let mut buf = [0u8; 256];
+        let written = input.write_to(&mut buf);
+
+        // Parse back (skip 4-byte RTCP header)
+        let parsed = PsfbApp::try_from(&buf[4..written]).unwrap();
+        assert_eq!(input.sender_ssrc, parsed.sender_ssrc);
+        assert_eq!(input.media_ssrc, parsed.media_ssrc);
+        assert_eq!(input.payload, parsed.payload);
+    }
+
+    #[test]
+    fn test_psfbapp_header() {
+        let psfbapp = PsfbApp {
+            sender_ssrc: 0.into(),
+            media_ssrc: 0.into(),
+            payload: vec![1, 2, 3, 4],
+        };
+
+        let header = psfbapp.header();
+        assert_eq!(header.rtcp_type, RtcpType::PayloadSpecificFeedback);
+    }
+}

--- a/src/rtp/rtcp/psfbapp.rs
+++ b/src/rtp/rtcp/psfbapp.rs
@@ -3,24 +3,11 @@ use crate::rtp::Ssrc;
 use super::RtcpType;
 use super::{FeedbackMessageType, PayloadType, RtcpHeader, RtcpPacket};
 
-/*
-    0                   1                   2                   3
-    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |V=2|P| FMT=15  |   PT=206      |             length            |
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |                  SSRC of packet sender                        |
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |                  SSRC of media source                         |
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |                  Application-dependent data                   |
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-*/
-
 /// Payload-Specific Feedback Application Layer message (PSFB FMT=15, PT=206).
 ///
-/// This is a catch-all for FMT=15 RTCP PSFB messages that are not REMB.
-/// Used by Teams for VSR (Video Source Request) among other things.
+/// Generic container for FMT=15 RTCP PSFB messages that are not REMB.
+/// Carries an opaque application-dependent payload after the standard
+/// sender and media SSRC fields (RFC 4585 Section 6.4).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PsfbApp {
     /// SSRC of the sender of this feedback message.
@@ -118,5 +105,53 @@ mod tests {
 
         let header = psfbapp.header();
         assert_eq!(header.rtcp_type, RtcpType::PayloadSpecificFeedback);
+    }
+
+    #[test]
+    fn test_psfbapp_non_aligned_payload() {
+        // Payload not aligned to 4 bytes — should still round-trip
+        let input = PsfbApp {
+            sender_ssrc: 100.into(),
+            media_ssrc: 200.into(),
+            payload: vec![0xAA, 0xBB, 0xCC], // 3 bytes, needs 1 byte padding
+        };
+
+        let mut buf = [0u8; 256];
+        let written = input.write_to(&mut buf);
+
+        // Total should be 4 (header) + 4 (sender) + 4 (media) + 4 (padded payload) = 16
+        assert_eq!(written, 16);
+
+        let parsed = PsfbApp::try_from(&buf[4..written]).unwrap();
+        assert_eq!(parsed.sender_ssrc, input.sender_ssrc);
+        assert_eq!(parsed.media_ssrc, input.media_ssrc);
+        // Parsed payload includes padding byte
+        assert_eq!(parsed.payload.len(), 4);
+        assert_eq!(&parsed.payload[..3], &[0xAA, 0xBB, 0xCC]);
+        assert_eq!(parsed.payload[3], 0); // padding
+    }
+
+    #[test]
+    fn test_psfbapp_empty_payload() {
+        let input = PsfbApp {
+            sender_ssrc: 1.into(),
+            media_ssrc: 2.into(),
+            payload: vec![],
+        };
+
+        let mut buf = [0u8; 256];
+        let written = input.write_to(&mut buf);
+        assert_eq!(written, 12); // header + sender + media, no payload
+
+        let parsed = PsfbApp::try_from(&buf[4..written]).unwrap();
+        assert_eq!(parsed.sender_ssrc, input.sender_ssrc);
+        assert_eq!(parsed.media_ssrc, input.media_ssrc);
+        assert!(parsed.payload.is_empty());
+    }
+
+    #[test]
+    fn test_psfbapp_too_short_rejected() {
+        let buf = [0u8; 7]; // Less than 8 bytes
+        assert!(PsfbApp::try_from(&buf[..]).is_err());
     }
 }

--- a/src/rtp/rtcp/rtcpfb.rs
+++ b/src/rtp/rtcp/rtcpfb.rs
@@ -1,4 +1,4 @@
-use super::{DlrrItem, FirEntry, NackEntry, ReceptionReport, Remb, ReportBlock, ReportList};
+use super::{DlrrItem, FirEntry, NackEntry, PsfbApp, ReceptionReport, Remb, ReportBlock, ReportList};
 use super::{Rrtr, Rtcp, Sdes, SenderInfo, Ssrc, Twcc};
 
 /// Normalization of [`Rtcp`] so we can deal with one SSRC at a time.
@@ -16,6 +16,7 @@ pub enum RtcpFb {
     Fir(FirEntry),                     // rx -> tx
     Twcc(Twcc),                        // rx -> tx
     Remb(Remb),                        // rx -> tx
+    PsfbApp(PsfbApp),                  // rx -> tx
 }
 
 impl RtcpFb {
@@ -72,6 +73,9 @@ impl RtcpFb {
                 Rtcp::Remb(v) => {
                     q.push(RtcpFb::Remb(v));
                 }
+                Rtcp::PsfbApp(v) => {
+                    q.push(RtcpFb::PsfbApp(v));
+                }
             }
         }
         q.into_iter()
@@ -90,6 +94,7 @@ impl RtcpFb {
             RtcpFb::Fir(v) => v.ssrc,
             RtcpFb::Twcc(v) => v.ssrc,
             RtcpFb::Remb(v) => v.ssrcs.first().map(|ssrc| (*ssrc).into()).unwrap_or(v.ssrc),
+            RtcpFb::PsfbApp(v) => v.media_ssrc,
         }
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -109,6 +109,9 @@ pub(crate) struct Session {
 
     raw_packets: Option<VecDeque<Box<RawPacket>>>,
 
+    // Pending PsfbApp (PSFB FMT=15) messages to emit as events.
+    pending_psfb_apps: VecDeque<crate::rtp_::PsfbApp>,
+
     #[cfg(feature = "_internal_test_exports")]
     pending_probe: Option<crate::bwe_::ProbeClusterConfig>,
 }
@@ -173,6 +176,7 @@ impl Session {
             } else {
                 None
             },
+            pending_psfb_apps: VecDeque::new(),
             #[cfg(feature = "_internal_test_exports")]
             pending_probe: None,
         }
@@ -303,6 +307,11 @@ impl Session {
         trace!("Created feedback TWCC: {:?}", twcc);
         self.feedback_tx.push_front(Rtcp::Twcc(twcc));
         Some(())
+    }
+
+    /// Enqueue a PsfbApp (PSFB FMT=15) message for transmission.
+    pub fn send_psfb_app(&mut self, psfb: crate::rtp_::PsfbApp) {
+        self.feedback_tx.push_back(Rtcp::PsfbApp(psfb));
     }
 
     pub fn handle_rtp_receive(&mut self, now: Instant, message: &[u8]) {
@@ -603,6 +612,11 @@ impl Session {
                 continue;
             }
 
+            if let RtcpFb::PsfbApp(psfb) = fb {
+                self.pending_psfb_apps.push_back(psfb);
+                continue;
+            }
+
             if fb.is_for_rx() {
                 let Some(stream) = self.streams.stream_rx(&fb.ssrc()) else {
                     continue;
@@ -648,6 +662,10 @@ impl Session {
             if let Some(p) = raw_packets.pop_front() {
                 return Some(Event::RawPacket(p));
             }
+        }
+
+        if let Some(psfb) = self.pending_psfb_apps.pop_front() {
+            return Some(Event::PsfbApp(psfb));
         }
 
         // This must be before pending_packet.take() since we need to emit the unpaused event


### PR DESCRIPTION
## Summary

- Add `PsfbApp` struct for Payload-Specific Feedback Application Layer messages (RTCP PT=206, FMT=15)
- Wire into `Rtcp` enum, `RtcpFb` normalization, `Session` API (`send_psfb_app`), and `Event::PsfbApp`
- Full serialization/deserialization with 4-byte alignment padding
- Comprehensive tests including edge cases (empty payload, non-aligned, too-short rejection)

Generic container for FMT=15 RTCP PSFB messages that are not REMB. Carries an opaque application-dependent payload after the standard sender and media SSRC fields (RFC 4585 Section 6.4).

## Test plan

- [x] Round-trip serialization test
- [x] Header type validation
- [x] Non-aligned payload padding
- [x] Empty payload handling
- [x] Too-short buffer rejection