### PR TITLE
feat(is): expose `Protocol`

### DIFF
--- a/crates/is/src/lib.rs
+++ b/crates/is/src/lib.rs
@@ -119,7 +119,7 @@ mod parse;
 mod hmac_provider;
 #[cfg(feature = "sha1")]
 pub use hmac_provider::DefaultSha1HmacProvider;
-pub use str0m_proto::Sha1HmacProvider;
+pub use str0m_proto::{Protocol, Sha1HmacProvider};
 
 #[cfg(test)]
 pub(crate) mod test {


### PR DESCRIPTION
This is needed to use `Protocol` without having to depend on `str0m_proto`.