### PR TITLE
fix(ice): transition to `Checking` on `recreate_candidate_pairs`

### DIFF
--- a/crates/is/src/agent.rs
+++ b/crates/is/src/agent.rs
@@ -988,6 +988,7 @@ impl IceAgent {
             .collect();
 
         self.form_pairs(&local_idxs, &remote_idxs);
+        self.set_connection_state(IceConnectionState::Checking, "recreate candidate pairs");
     }
 
     /// Discard candidate pairs that contain the candidate identified by a local index.


### PR DESCRIPTION
Explicitly transitioning to `Checking` allows us to specify a more accurate reason as to why we are now in `Checking`. Without this, the next call to `handle_timeout` transitions our state to `Checking` with the reason of `got new possible` which isn't really accurate.