### PR TITLE
Sdpapi stop media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Add `SdpApi::stop_media()` to stop an existing m-line #941
   * Always use ActPass when sending an SDP offer (RFC 8842 Section 5.2/5.5) #893
   * Fix frame drops in Firefox due missing RTX SSRC #940
   * Drop stale depacketizer state on stream pause and restore paused timestamp repair #929

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
   * Add `SdpApi::stop_media()` to stop an existing m-line #941
   * Update chat example to use `SdpApi::stop_media()` when clients are removed #941
+  * Accept recycled m-line indexes when the previous m-line was stopped #941
   * Always use ActPass when sending an SDP offer (RFC 8842 Section 5.2/5.5) #893
   * Fix frame drops in Firefox due missing RTX SSRC #940
   * Drop stale depacketizer state on stream pause and restore paused timestamp repair #929

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
   * Add `SdpApi::stop_media()` to stop an existing m-line #941
+  * Update chat example to use `SdpApi::stop_media()` when clients are removed #941
   * Always use ActPass when sending an SDP offer (RFC 8842 Section 5.2/5.5) #893
   * Fix frame drops in Firefox due missing RTX SSRC #940
   * Drop stale depacketizer state on stream pause and restore paused timestamp repair #929

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -309,13 +309,18 @@ enum TrackOutState {
     ToOpen,
     Negotiating(Mid),
     Open(Mid),
+    ToInactivate(Mid),
+    Inactive(Mid),
 }
 
 impl TrackOut {
     fn mid(&self) -> Option<Mid> {
         match self.state {
             TrackOutState::ToOpen => None,
-            TrackOutState::Negotiating(m) | TrackOutState::Open(m) => Some(m),
+            TrackOutState::Negotiating(m)
+            | TrackOutState::Open(m)
+            | TrackOutState::ToInactivate(m)
+            | TrackOutState::Inactive(m) => Some(m),
         }
     }
 }
@@ -491,21 +496,38 @@ impl Client {
             return false;
         }
 
+        // An Open track whose origin client disconnected needs its m-line
+        // transitioned to Inactive so the remote peer can see this change
+        for track in &mut self.tracks_out {
+            if let TrackOutState::Open(m) = track.state {
+                if track.track_in.upgrade().is_none() {
+                    track.state = TrackOutState::ToInactivate(m);
+                }
+            }
+        }
+
         let mut change = self.rtc.sdp_api();
 
         for track in &mut self.tracks_out {
-            if let TrackOutState::ToOpen = track.state {
-                if let Some(track_in) = track.track_in.upgrade() {
-                    let stream_id = track_in.origin.to_string();
-                    let mid = change.add_media(
-                        track_in.kind,
-                        Direction::SendOnly,
-                        Some(stream_id),
-                        None,
-                        None,
-                    );
-                    track.state = TrackOutState::Negotiating(mid);
+            match track.state {
+                TrackOutState::ToOpen => {
+                    if let Some(track_in) = track.track_in.upgrade() {
+                        let stream_id = track_in.origin.to_string();
+                        let mid = change.add_media(
+                            track_in.kind,
+                            Direction::SendOnly,
+                            Some(stream_id),
+                            None,
+                            None,
+                        );
+                        track.state = TrackOutState::Negotiating(mid);
+                    }
                 }
+                TrackOutState::ToInactivate(mid) => {
+                    change.set_direction(mid, Direction::Inactive);
+                    track.state = TrackOutState::Inactive(mid);
+                }
+                _ => {}
             }
         }
 

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -309,8 +309,8 @@ enum TrackOutState {
     ToOpen,
     Negotiating(Mid),
     Open(Mid),
-    ToInactivate(Mid),
-    Inactive(Mid),
+    ToStop(Mid),
+    NegotiatingStop(Mid),
 }
 
 impl TrackOut {
@@ -319,8 +319,8 @@ impl TrackOut {
             TrackOutState::ToOpen => None,
             TrackOutState::Negotiating(m)
             | TrackOutState::Open(m)
-            | TrackOutState::ToInactivate(m)
-            | TrackOutState::Inactive(m) => Some(m),
+            | TrackOutState::ToStop(m)
+            | TrackOutState::NegotiatingStop(m) => Some(m),
         }
     }
 }
@@ -497,11 +497,12 @@ impl Client {
         }
 
         // An Open track whose origin client disconnected needs its m-line
-        // transitioned to Inactive so the remote peer can see this change
+        // stopped so the remote transceiver transitions to "stopped" and
+        // releases its inbound-rtp stats entry.
         for track in &mut self.tracks_out {
             if let TrackOutState::Open(m) = track.state {
                 if track.track_in.upgrade().is_none() {
-                    track.state = TrackOutState::ToInactivate(m);
+                    track.state = TrackOutState::ToStop(m);
                 }
             }
         }
@@ -523,9 +524,9 @@ impl Client {
                         track.state = TrackOutState::Negotiating(mid);
                     }
                 }
-                TrackOutState::ToInactivate(mid) => {
-                    change.set_direction(mid, Direction::Inactive);
-                    track.state = TrackOutState::Inactive(mid);
+                TrackOutState::ToStop(mid) => {
+                    change.stop_media(mid);
+                    track.state = TrackOutState::NegotiatingStop(mid);
                 }
                 _ => {}
             }
@@ -573,8 +574,12 @@ impl Client {
         // Keep local track state in sync, cancelling any pending negotiation
         // so we can redo it after this offer is handled.
         for track in &mut self.tracks_out {
-            if let TrackOutState::Negotiating(_) = track.state {
-                track.state = TrackOutState::ToOpen;
+            match track.state {
+                TrackOutState::Negotiating(_) => track.state = TrackOutState::ToOpen,
+                TrackOutState::NegotiatingStop(m) => {
+                    track.state = TrackOutState::ToStop(m);
+                }
+                _ => {}
             }
         }
 
@@ -601,6 +606,11 @@ impl Client {
                     track.state = TrackOutState::Open(m);
                 }
             }
+
+            // Drop tracks whose stop negotiation completed. The m-line is
+            // now port=0 and eligible for recycling by a later add_media.
+            self.tracks_out
+                .retain(|t| !matches!(t.state, TrackOutState::NegotiatingStop(_)));
         }
     }
 

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -355,6 +355,30 @@ impl<'a> SdpApi<'a> {
         }
     }
 
+    /// Stop an already existing media.
+    ///
+    /// The next generated offer emits the m-line with port 0 and excludes
+    /// it from the BUNDLE group, per [RFC 8843] §7.5.3. The remote
+    /// transceiver transitions to the "stopped" state and the m-line slot
+    /// becomes eligible for recycling.
+    ///
+    /// Unlike [`SdpApi::set_direction()`] with [`Direction::Inactive`],
+    /// a stopped m-line cannot be reactivated.
+    ///
+    /// If the media doesn't exist, or is already stopped, [`SdpApi::apply()`]
+    /// will not require a negotiation.
+    ///
+    /// [RFC 8843]: https://datatracker.ietf.org/doc/html/rfc8843#section-7.5.3
+    pub fn stop_media(&mut self, mid: Mid) {
+        let changed = self.rtc.session.stop_media(mid);
+
+        if changed {
+            self.changes
+                .0
+                .push(Change::Direction(mid, Direction::Inactive));
+        }
+    }
+
     /// Add a new reliable ordered data channel and get the `id` that will be used.
     ///
     /// Use `add_channel_with_config` when unreliable or unordered data channels are preferred.
@@ -1219,7 +1243,7 @@ fn update_media(
                 media.mid()
             );
         }
-        media.mark_disabled();
+        media.mark_stopped();
         media.set_direction(Direction::Inactive);
         return;
     }

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -1078,8 +1078,14 @@ fn add_pending_changes(session: &mut Session, pending: Changes) {
 /// Compares m-lines in Sdp with that already in the session.
 ///
 /// * Existing m-lines can apply changes (such as direction change).
-/// * New m-lines are returned to the caller.
-fn sync_medias<'a>(session: &mut Session, sdp: &'a Sdp) -> Result<Vec<&'a MediaLine>, String> {
+/// * New m-lines are returned to the caller paired with the session
+///   index they should occupy. The index is normally the next free slot,
+///   but can be a recycled slot (RFC 8829 §5.2.2) when the remote has
+///   replaced a previously disabled Media with a new mid.
+fn sync_medias<'a>(
+    session: &mut Session,
+    sdp: &'a Sdp,
+) -> Result<Vec<(usize, &'a MediaLine)>, String> {
     let mut new_lines = Vec::with_capacity(sdp.media_lines.len());
     let bundle_mids = sdp.bundle_mids();
 
@@ -1111,6 +1117,19 @@ fn sync_medias<'a>(session: &mut Session, sdp: &'a Sdp) -> Result<Vec<&'a MediaL
 
                     continue;
                 }
+
+                // Unknown mid at an index held by a disabled Media means
+                // the remote has recycled the slot (RFC 8829 §5.2.2).
+                // Retire the disabled Media so the replacement takes its
+                // place at the same index.
+                if let Some(pos) = session.medias.iter().position(|l| l.index() == idx) {
+                    if !session.medias[pos].disabled() {
+                        return index_err(m.mid());
+                    }
+                    let retired_mid = session.medias[pos].mid();
+                    session.medias.swap_remove(pos);
+                    session.streams.remove_streams_by_mid(retired_mid);
+                }
             }
             _ => {
                 continue;
@@ -1118,7 +1137,7 @@ fn sync_medias<'a>(session: &mut Session, sdp: &'a Sdp) -> Result<Vec<&'a MediaL
         }
 
         // Second, discover new m-lines.
-        new_lines.push(m);
+        new_lines.push((idx, m));
     }
 
     fn index_err<T>(mid: Mid) -> Result<T, String> {
@@ -1129,14 +1148,17 @@ fn sync_medias<'a>(session: &mut Session, sdp: &'a Sdp) -> Result<Vec<&'a MediaL
 }
 
 /// Adds new m-lines as found in an offer or answer.
+///
+/// Each entry in `new_lines` pairs an m-line with the session index it
+/// should occupy.
 fn add_new_lines(
     session: &mut Session,
-    new_lines: &[&MediaLine],
+    new_lines: &[(usize, &MediaLine)],
     is_offer: bool,
     bundle_mids: Option<&[Mid]>,
 ) -> Result<(), String> {
-    for m in new_lines {
-        let idx = session.line_count();
+    for (idx, m) in new_lines {
+        let idx = *idx;
 
         if m.typ.is_media() {
             let mut media = Media::from_remote_media_line(m, idx, is_offer);
@@ -1657,7 +1679,7 @@ impl Changes {
     }
 
     /// Tests the given lines (from answer) corresponds to changes.
-    fn ensure_correct_answer(&self, lines: &[&MediaLine]) -> Option<String> {
+    fn ensure_correct_answer(&self, lines: &[(usize, &MediaLine)]) -> Option<String> {
         if self.count_new_medias() != lines.len() {
             return Some(format!(
                 "Differing m-line count in offer vs answer: {} != {}",
@@ -1666,7 +1688,7 @@ impl Changes {
             ));
         }
 
-        'next: for l in lines {
+        'next: for (_, l) in lines {
             let mid = l.mid();
 
             for m in &self.0 {

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -102,6 +102,13 @@ pub struct Media {
     /// If this is empty, the m-line is disabled/rejected (port=0 in SDP).
     remote_pts: Vec<Pt>,
 
+    /// Set when this m-line has been stopped via
+    /// [`SdpApi::stop_media`](crate::change::SdpApi::stop_media) or
+    /// rejected by the remote peer. Independent of `remote_pts` so that
+    /// an explicit stop preserves the negotiated PT list in SDP output
+    /// (the SDP grammar requires at least one fmt on a port=0 m-line).
+    stopped: bool,
+
     /// Remote extmaps negotiated for this media.
     ///
     /// The corresponding entries must exist in Session::codec_config.
@@ -282,16 +289,29 @@ impl Media {
 
     /// Whether this m-line is disabled/rejected (port=0 in SDP).
     ///
-    /// An m-line is disabled if there are no negotiated codecs,
-    /// either because no codecs matched or because the remote rejected the m-line.
+    /// An m-line is disabled if it has been stopped (via
+    /// [`SdpApi::stop_media`](crate::change::SdpApi::stop_media) or by the
+    /// remote peer), or if no codecs matched during negotiation.
     ///
     /// SDP level property.
     pub fn disabled(&self) -> bool {
-        self.remote_pts.is_empty()
+        self.stopped || self.remote_pts.is_empty()
     }
 
-    pub(crate) fn mark_disabled(&mut self) {
-        self.remote_pts.clear();
+    /// Whether this m-line has been stopped.
+    ///
+    /// Unlike [`disabled`](Self::disabled) this does not include the "no
+    /// codecs matched" case - only explicit stop via
+    /// [`SdpApi::stop_media`](crate::change::SdpApi::stop_media) or a
+    /// port=0 m-line received from the remote peer. A stopped m-line
+    /// cannot be reactivated; its slot can however be recycled by a
+    /// subsequent new m-line (RFC 8829 §5.2.2).
+    pub fn stopped(&self) -> bool {
+        self.stopped
+    }
+
+    pub(crate) fn mark_stopped(&mut self) {
+        self.stopped = true;
     }
 
     pub(crate) fn simulcast(&self) -> Option<&SdpSimulcast> {
@@ -558,6 +578,7 @@ impl Default for Media {
             msid: Msid::random(),
             kind: MediaKind::Video,
             remote_pts: vec![],
+            stopped: false,
             remote_exts: ExtensionMap::empty(),
             remote_created: false,
             dir: Direction::SendRecv,

--- a/src/session.rs
+++ b/src/session.rs
@@ -956,6 +956,7 @@ impl Session {
         }
     }
 
+    #[allow(dead_code)]
     pub fn line_count(&self) -> usize {
         self.medias.len() + if self.app.is_some() { 1 } else { 0 }
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1044,6 +1044,20 @@ impl Session {
         true
     }
 
+    pub fn stop_media(&mut self, mid: Mid) -> bool {
+        let Some(media) = self.media_by_mid_mut(mid) else {
+            return false;
+        };
+        if media.disabled() {
+            return false;
+        }
+
+        media.mark_stopped();
+        self.set_direction(mid, Direction::Inactive);
+
+        true
+    }
+
     pub fn is_request_keyframe_possible(&self, kind: KeyframeRequestKind) -> bool {
         // TODO: It's possible to have different set of feedback enabled for different
         // payload types. I.e. we could have FIR enabled for H264, but not for VP8.

--- a/tests/sdp-negotiation.rs
+++ b/tests/sdp-negotiation.rs
@@ -17,6 +17,7 @@ use str0m::format::PayloadParams;
 use str0m::media::Direction;
 use str0m::media::Frequency;
 use str0m::media::MediaKind;
+use str0m::media::Pt;
 use str0m::rtp::{Extension, ExtensionMap};
 use str0m::{Event, RtcError};
 use tracing::Span;
@@ -183,6 +184,90 @@ pub fn answer_no_match() {
     assert!(!r.codec_config()[0]._is_locked());
     // No remote PTs.
     assert_eq!(r.media(mid).unwrap().remote_pts(), &[]);
+}
+
+#[test]
+pub fn stop_media() {
+    init_log();
+    init_crypto_default();
+
+    // L and R negotiate a video m-line, then L stops it. The next offer
+    // must emit port 0 and leave the m-line out of the BUNDLE group.
+    let (mut l, mut r) = with_params(
+        //
+        info_span!("L"),
+        &[vp8(100)],
+        info_span!("R"),
+        &[vp8(100)],
+    );
+
+    let mid = l._mids()[0];
+
+    assert!(!l.media(mid).unwrap().stopped());
+    assert_eq!(l.media(mid).unwrap().direction(), Direction::SendRecv);
+
+    // Stop and create a subsequent offer from L
+    let (offer, pending) = l.span.in_scope(|| {
+        let mut change = l.rtc.sdp_api();
+        change.stop_media(mid);
+        change.apply().unwrap()
+    });
+
+    // Stopping an already-stopped m-line is a no-op
+    l.span.in_scope(|| {
+        let mut change = l.rtc.sdp_api();
+        change.stop_media(mid);
+        assert!(change.apply().is_none());
+    });
+
+    // Check that the offer SDP has port 0 and drops the mid from BUNDLE.
+    // The PT list is preserved so the m-line satisfies the SDP grammar
+    // (RFC 4566 §5.14 requires at least one fmt).
+    let offer_sdp = offer.to_sdp_string();
+    assert!(
+        offer_sdp.contains("m=video 0 UDP/TLS/RTP/SAVPF 100\r\n"),
+        "Expected stopped m-line with port 0 and PT 100, got:\n{}",
+        offer_sdp
+    );
+    assert!(
+        !offer_sdp.contains(&format!("a=group:BUNDLE {mid}")),
+        "Stopped m-line should not be in BUNDLE group:\n{}",
+        offer_sdp
+    );
+
+    // Test left side. Stopped, direction Inactive, PTs preserved.
+    assert!(l.media(mid).unwrap().stopped());
+    assert_eq!(l.media(mid).unwrap().direction(), Direction::Inactive);
+    assert_eq!(
+        l.media(mid).unwrap().remote_pts(),
+        &[Pt::new_with_value(100)]
+    );
+
+    // R accepts the offer and generates an answer
+    let answer = r
+        .span
+        .in_scope(|| r.rtc.sdp_api().accept_offer(offer).unwrap());
+
+    // The answer also has port 0 (with preserved PT list) for the stopped m-line
+    let answer_sdp = answer.to_sdp_string();
+    assert!(
+        answer_sdp.contains("m=video 0 UDP/TLS/RTP/SAVPF 100\r\n"),
+        "Expected stopped m-line with port 0 and PT 100 in answer, got:\n{}",
+        answer_sdp
+    );
+
+    // L accepts the answer
+    l.span.in_scope(|| {
+        l.rtc.sdp_api().accept_answer(pending, answer).unwrap();
+    });
+
+    // Test right side. Same stopped state as L.
+    assert!(r.media(mid).unwrap().stopped());
+    assert_eq!(r.media(mid).unwrap().direction(), Direction::Inactive);
+    assert_eq!(
+        r.media(mid).unwrap().remote_pts(),
+        &[Pt::new_with_value(100)]
+    );
 }
 
 #[test]

--- a/tests/sdp-negotiation.rs
+++ b/tests/sdp-negotiation.rs
@@ -17,6 +17,7 @@ use str0m::format::PayloadParams;
 use str0m::media::Direction;
 use str0m::media::Frequency;
 use str0m::media::MediaKind;
+use str0m::media::Mid;
 use str0m::media::Pt;
 use str0m::rtp::{Extension, ExtensionMap};
 use str0m::{Event, RtcError};
@@ -268,6 +269,172 @@ pub fn stop_media() {
         r.media(mid).unwrap().remote_pts(),
         &[Pt::new_with_value(100)]
     );
+}
+
+#[test]
+pub fn stop_media_then_remote_recycles_slot() {
+    init_log();
+    init_crypto_default();
+
+    // L stops its video m-line, then receives an offer that recycles the
+    // resulting port=0 slot with a new mid (RFC 8829 §5.2.2).
+    let (mut l, mut r) = with_params(info_span!("L"), &[vp8(100)], info_span!("R"), &[vp8(100)]);
+
+    let old_mid = l._mids()[0];
+
+    negotiate(&mut l, &mut r, |change| {
+        change.stop_media(old_mid);
+    });
+
+    assert!(l.media(old_mid).unwrap().stopped());
+    assert!(r.media(old_mid).unwrap().stopped());
+
+    // str0m's own SdpApi doesn't produce recycling offers, so take an
+    // offer from R (which appends a new m-line) and rewrite it so the
+    // new m-line lives at the index of the stopped one - what a browser
+    // would emit per RFC 8829 §5.2.2.
+    let offer_from_r = r
+        .span
+        .in_scope(|| {
+            let mut change = r.rtc.sdp_api();
+            change.add_media(MediaKind::Video, Direction::SendOnly, None, None, None);
+            change.apply()
+        })
+        .expect("R has a change to apply");
+
+    let offer_sdp = offer_from_r.0.to_sdp_string();
+    let recycled_offer_sdp = rewrite_offer_to_recycle_stopped_slot(&offer_sdp, old_mid);
+
+    let recycled_offer =
+        SdpOffer::from_sdp_string(&recycled_offer_sdp).expect("recycled offer parses");
+
+    let answer = l.span.in_scope(|| {
+        l.rtc
+            .sdp_api()
+            .accept_offer(recycled_offer)
+            .expect("accept")
+    });
+
+    let answer_sdp = answer.to_sdp_string();
+
+    // RFC 3264 §6: the answer must have the same m-line count as the
+    // offer. Without recycling, str0m appends a second m-line and the
+    // answer is invalid.
+    let count_m_lines = |s: &str| s.lines().filter(|l| l.starts_with("m=")).count();
+    let offer_m_lines = count_m_lines(&recycled_offer_sdp);
+    let answer_m_lines = count_m_lines(&answer_sdp);
+    assert_eq!(
+        answer_m_lines, offer_m_lines,
+        "answer m-line count ({answer_m_lines}) differs from offer m-line count ({offer_m_lines})\n\n\
+         rewritten offer:\n{recycled_offer_sdp}\n\nanswer:\n{answer_sdp}",
+    );
+}
+
+#[test]
+pub fn recycling_rejected_for_non_stopped_slot() {
+    init_log();
+    init_crypto_default();
+
+    // L holds an active video m-line. An offer arrives that tries to
+    // recycle that active slot with a new mid (no prior stop). str0m must
+    // refuse rather than install a second Media at the same index.
+    let (mut l, mut r) = with_params(info_span!("L"), &[vp8(100)], info_span!("R"), &[vp8(100)]);
+
+    let active_mid = l._mids()[0];
+
+    // Sanity: the mid is active, not stopped.
+    assert!(!l.media(active_mid).unwrap().stopped());
+    assert!(!l.media(active_mid).unwrap().disabled());
+
+    // Take an ordinary offer from R adding a new m-line, then rewrite it
+    // so the new m-line squats the slot of L's active mid.
+    let offer_from_r = r
+        .span
+        .in_scope(|| {
+            let mut change = r.rtc.sdp_api();
+            change.add_media(MediaKind::Video, Direction::SendOnly, None, None, None);
+            change.apply()
+        })
+        .expect("R has a change to apply");
+
+    let offer_sdp = offer_from_r.0.to_sdp_string();
+    let bad_offer_sdp = rewrite_offer_to_recycle_stopped_slot(&offer_sdp, active_mid);
+    let bad_offer = SdpOffer::from_sdp_string(&bad_offer_sdp).expect("offer parses");
+
+    let result = l.span.in_scope(|| l.rtc.sdp_api().accept_offer(bad_offer));
+
+    assert!(
+        result.is_err(),
+        "accept_offer must reject a recycling attempt against a non-stopped slot, got Ok:\n{}",
+        bad_offer_sdp
+    );
+}
+
+/// Moves the trailing (newly added) m-line into the slot occupied by the
+/// m-line for `old_mid`, and updates the BUNDLE group accordingly. When
+/// `old_mid` belongs to a stopped m-line (port=0) this produces the offer
+/// shape a browser emits when recycling the slot per RFC 8829 §5.2.2.
+fn rewrite_offer_to_recycle_stopped_slot(sdp: &str, old_mid: Mid) -> String {
+    // Split into sections, each starting with "m=". The first section is
+    // the session-level block before any m-line.
+    let mut sections: Vec<String> = Vec::new();
+    let mut current = String::new();
+    for line in sdp.split_inclusive("\r\n") {
+        if line.starts_with("m=") && !current.is_empty() {
+            sections.push(std::mem::take(&mut current));
+        }
+        current.push_str(line);
+    }
+    if !current.is_empty() {
+        sections.push(current);
+    }
+
+    let session_block = sections.remove(0);
+
+    // Find the stopped section and the trailing new section.
+    let old_mid_attr = format!("a=mid:{old_mid}\r\n");
+    let stopped_idx = sections
+        .iter()
+        .position(|s| s.contains(&old_mid_attr))
+        .expect("stopped section present");
+    let new_section = sections.pop().expect("new section present");
+
+    sections[stopped_idx] = new_section;
+
+    // Parse the new mid so we can rewrite the BUNDLE group.
+    let new_mid = sections[stopped_idx]
+        .lines()
+        .find_map(|l| l.strip_prefix("a=mid:"))
+        .expect("new section has a=mid:")
+        .trim()
+        .to_string();
+
+    let old_mid_str = old_mid.to_string();
+    let session_block = session_block
+        .lines()
+        .map(|l| {
+            if let Some(rest) = l.strip_prefix("a=group:BUNDLE ") {
+                let mut mids: Vec<&str> = rest
+                    .split_whitespace()
+                    .filter(|m| *m != old_mid_str)
+                    .collect();
+                if !mids.contains(&new_mid.as_str()) {
+                    mids.push(new_mid.as_str());
+                }
+                format!("a=group:BUNDLE {}", mids.join(" "))
+            } else {
+                l.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\r\n")
+        + "\r\n";
+
+    let mut out = session_block;
+    for s in sections {
+        out.push_str(&s);
+    }
+    out
 }
 
 #[test]


### PR DESCRIPTION
I found that with the current SDP Api, it did not seem possible to completely disable media lines in a way that allowed the browser to completely release them.

1. To demonstrate: check out the first commit in this PR (a483369), this sets media lines to Inactive when a user leaves
2. Run the chat example
3. Connect a user
4. Open chrome://webrtc-internals and observe that there are no inbound-rtp entries
5. Connect a second user and start cam & mic
6. Refresh webrtc-internals for the first user and observer that there is one inbound-rtp (kind=video) and one inbound-rtp (kind=audio) - expected result
7. Close the tab of the second user and wait about 30s to ensure RTP has timed out
8. Refresh webrtc-internals and observe that there is still one inbound-rtp (kind=audio) entry
9. Repeat steps 5 - 8, you will see that each time the audio media line is stranded in the stats and not fully released

It is apparently a quirk of Chrome that the video media line is automatically closed when no packets are being received, but audio media lines remain opened and stats tracked (though frozen).

To fix this, implement `disable_media()` for the `SdpApi` that will set the direction to Inactive and also set `port=0` (which indicates `stopped` per RFCs and browser standards).

This did require some refactoring in how tracks are determined to be disabled. Previously, this was true if `self.remote_pts.is_empty()`. However, an offer will be rejected if the `remote_pts` contains no entries (this is only valid in answers to indicate rejection).

The third commit updates the chat example to instead use this new method to disable the media lines instead of just setting them to inactive. You can re-run the test above to see that the inbound-rtp entries are now properly released by the browser. I kept the chat changes separate so they can be removed if you don't actually want them to be included, however I think it is a fine change to keep in the example.