### PR TITLE
dtls: fix dropped handshake resend

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1494,6 +1494,16 @@ impl Rtc {
             }
         }
 
+        // Handle DTLS timeout before polling output so any retransmit packets
+        // queued by dimpl and the re-armed flight timer are picked up by the
+        // poll loop below in the same iteration.
+        if let Some(timeout) = self.next_dtls_timeout {
+            if timeout <= self.last_now {
+                let _ = self.dtls.handle_timeout(self.last_now);
+                self.next_dtls_timeout = None;
+            }
+        }
+
         // Poll DTLS output - collect packets, handle events
         let mut just_connected = false;
         loop {
@@ -1657,14 +1667,6 @@ impl Rtc {
         }
 
         let stats = self.stats.as_mut();
-
-        // Handle DTLS timeout
-        if let Some(timeout) = self.next_dtls_timeout {
-            if timeout <= self.last_now {
-                let _ = self.dtls.handle_timeout(self.last_now);
-                self.next_dtls_timeout = None;
-            }
-        }
 
         let time_and_reason = (None, Reason::NotHappening)
             .soonest((self.next_dtls_timeout, Reason::DTLS))

--- a/tests/dtls-retransmit.rs
+++ b/tests/dtls-retransmit.rs
@@ -27,6 +27,7 @@
 use std::net::Ipv4Addr;
 use std::time::{Duration, Instant};
 
+use netem::{NetemConfig, Probability, RandomLoss};
 use str0m::{Candidate, Input, Output, Reason, Rtc};
 use tracing::info_span;
 
@@ -101,4 +102,66 @@ fn dtls_retransmit_emitted_in_same_poll_pass() {
         got_transmit,
         "poll_output should emit the DTLS retransmit in the same pass that runs handle_timeout"
     );
+}
+
+/// End-to-end: a DTLS handshake between two peers must complete even
+/// when the link drops packets. Before the fix, dropped handshake
+/// packets stalled for seconds at a time because each lost flight's
+/// retransmit was deferred to the next unrelated wake-up — on a lossy
+/// link the handshake could miss its connect deadline entirely.
+#[test]
+fn dtls_handshake_completes_under_packet_loss() {
+    init_crypto_default();
+
+    let now = Instant::now();
+    let mut l = TestRtc::new_with_rtc(info_span!("L"), Rtc::new(now));
+    let mut r = TestRtc::new_with_rtc(info_span!("R"), Rtc::new(now));
+
+    // 30% random loss in both directions from the very first packet.
+    let lossy = NetemConfig::new()
+        .loss(RandomLoss::new(Probability::new(0.3)))
+        .seed(1);
+    l.set_netem(lossy.clone());
+    r.set_netem(lossy);
+
+    let host_l = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp").unwrap();
+    let host_r = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp").unwrap();
+    l.add_local_candidate(host_l.clone());
+    l.add_remote_candidate(host_r.clone());
+    r.add_local_candidate(host_r);
+    r.add_remote_candidate(host_l);
+
+    let finger_l = l.direct_api().local_dtls_fingerprint().clone();
+    let finger_r = r.direct_api().local_dtls_fingerprint().clone();
+    l.direct_api().set_remote_fingerprint(finger_r);
+    r.direct_api().set_remote_fingerprint(finger_l);
+
+    let creds_l = l.direct_api().local_ice_credentials();
+    let creds_r = r.direct_api().local_ice_credentials();
+    l.direct_api().set_remote_ice_credentials(creds_r);
+    r.direct_api().set_remote_ice_credentials(creds_l);
+
+    l.direct_api().set_ice_controlling(true);
+    r.direct_api().set_ice_controlling(false);
+
+    l.direct_api().start_dtls(true).unwrap();
+    r.direct_api().start_dtls(false).unwrap();
+    l.direct_api().start_sctp(true);
+    r.direct_api().start_sctp(false);
+
+    // Drive both sides forward. The DTLS default connect timeout is 10s,
+    // so a bounded iteration cap that allows well past that is enough to
+    // tell whether the handshake is making progress at all.
+    let mut iterations = 0;
+    while !(l.is_connected() && r.is_connected()) {
+        progress(&mut l, &mut r).unwrap();
+        iterations += 1;
+        assert!(
+            iterations < 5000,
+            "DTLS handshake did not complete under 30% packet loss \
+             (l_connected={}, r_connected={})",
+            l.is_connected(),
+            r.is_connected()
+        );
+    }
 }

--- a/tests/dtls-retransmit.rs
+++ b/tests/dtls-retransmit.rs
@@ -14,6 +14,16 @@
 //! that a single `poll_output` pass emits the retransmit as a `Transmit`.
 //! Without the fix, the pass instead returns `Timeout` and the retransmit
 //! is stranded.
+//!
+//! The scenario asserted here is specific to dimpl's tx-queue semantics,
+//! so the test is compiled only under dimpl-backed crypto providers.
+#![cfg(any(
+    feature = "aws-lc-rs",
+    feature = "rust-crypto",
+    feature = "openssl-dimpl",
+    feature = "wincrypto-dimpl",
+    feature = "apple-crypto",
+))]
 use std::net::Ipv4Addr;
 use std::time::{Duration, Instant};
 

--- a/tests/dtls-retransmit.rs
+++ b/tests/dtls-retransmit.rs
@@ -1,0 +1,94 @@
+//! Regression test for the DTLS retransmit bug fixed in PR #943 (refs #932).
+//!
+//! When a DTLS flight timeout elapses, dimpl's `handle_timeout` re-arms the
+//! flight timer and queues the retransmit packet. Previously str0m ran
+//! `handle_timeout` at the end of `do_poll_output`, after both the DTLS
+//! `poll_output` loop and `dtls.poll_packet()` had already run — so the
+//! freshly queued retransmit was left sitting in dimpl's tx queue until
+//! some unrelated subsystem (typically an ICE consent check) woke the
+//! caller for another poll pass.
+//!
+//! This test drives two peers to the mid-handshake state (L has sent
+//! ClientHello, R ignores DTLS so never replies), advances L's clock past
+//! the flight deadline with a single `handle_input(Timeout)`, then asserts
+//! that a single `poll_output` pass emits the retransmit as a `Transmit`.
+//! Without the fix, the pass instead returns `Timeout` and the retransmit
+//! is stranded.
+use std::net::Ipv4Addr;
+use std::time::{Duration, Instant};
+
+use str0m::{Candidate, Input, Output, Reason, Rtc};
+use tracing::info_span;
+
+mod common;
+use common::{TestRtc, init_crypto_default, progress};
+
+#[test]
+fn dtls_retransmit_emitted_in_same_poll_pass() {
+    init_crypto_default();
+
+    let now = Instant::now();
+    let mut l = TestRtc::new_with_rtc(info_span!("L"), Rtc::new(now));
+    let mut r = TestRtc::new_with_rtc(info_span!("R"), Rtc::new(now));
+
+    let host_l = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp").unwrap();
+    let host_r = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp").unwrap();
+    l.add_local_candidate(host_l.clone());
+    l.add_remote_candidate(host_r.clone());
+    r.add_local_candidate(host_r);
+    r.add_remote_candidate(host_l);
+
+    let finger_l = l.direct_api().local_dtls_fingerprint().clone();
+    let finger_r = r.direct_api().local_dtls_fingerprint().clone();
+    l.direct_api().set_remote_fingerprint(finger_r);
+    r.direct_api().set_remote_fingerprint(finger_l);
+
+    let creds_l = l.direct_api().local_ice_credentials();
+    let creds_r = r.direct_api().local_ice_credentials();
+    l.direct_api().set_remote_ice_credentials(creds_r);
+    r.direct_api().set_remote_ice_credentials(creds_l);
+
+    l.direct_api().set_ice_controlling(true);
+    r.direct_api().set_ice_controlling(false);
+
+    // Only L starts DTLS. R receives L's ClientHello but ignores it
+    // (active_state is None in dtls::handle_receive), so L never gets a
+    // ServerHello and must retransmit.
+    l.direct_api().start_dtls(true).unwrap();
+
+    // Drive both sides until L is awaiting the DTLS flight deadline.
+    let mut steps = 0;
+    while l.rtc.last_timeout_reason() != Reason::DTLS {
+        progress(&mut l, &mut r).unwrap();
+        steps += 1;
+        assert!(
+            steps < 200,
+            "failed to reach DTLS-awaiting state (last reason: {:?})",
+            l.rtc.last_timeout_reason()
+        );
+    }
+
+    // Advance past the flight deadline in one step with no network input.
+    // The fix causes the following poll_output pass to emit the queued
+    // retransmit. Without the fix, it returns Output::Timeout and the
+    // retransmit stays stranded in dimpl.
+    let deadline = l.last + Duration::from_millis(1500);
+    l.rtc.handle_input(Input::Timeout(deadline)).unwrap();
+
+    let mut got_transmit = false;
+    loop {
+        match l.rtc.poll_output().unwrap() {
+            Output::Timeout(_) => break,
+            Output::Transmit(_) => {
+                got_transmit = true;
+                break;
+            }
+            Output::Event(_) => continue,
+        }
+    }
+
+    assert!(
+        got_transmit,
+        "poll_output should emit the DTLS retransmit in the same pass that runs handle_timeout"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes a latent issue where DTLS flight retransmits are delayed (sometimes by many seconds) because `handle_timeout` runs at the end of `do_poll_output` — after both `dtls.poll_packet()` and the DTLS `poll_output` loop have already been consulted.

When a flight timeout elapses, dimpl's `handle_timeout` re-arms the flight timer and queues the retransmit packet in its tx queue. With the previous ordering:

- `dtls.poll_packet()` already ran earlier and returned `None`
- `next_dtls_timeout` is cleared to `None` after `handle_timeout`, so the computed `Output::Timeout` does not reflect the new flight deadline
- The queued retransmit sits until some unrelated subsystem (typically ICE consent checks) wakes the caller

Moving the `handle_timeout` check to run before the DTLS `poll_output` loop lets the loop pick up the retransmit into `pending_packets` and record the refreshed flight timer, and the existing `poll_packet()` call emits the `Transmit` in the same iteration.

Refs #932.

## Test plan

- [x] `cargo build --all-features`
- [x] `cargo test --all-features`
- [ ] Reporter to re-test the multi-client SFU scenario
