### PR TITLE
RTC event log support (v2 format)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "apple-cryptokit-rs"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +645,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +670,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -707,6 +725,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flagset"
@@ -807,6 +831,18 @@ checksum = "95cc527b92e6029a62960ad99aa8a6660faa4555fe5f731aab13aa6a921795a2"
 dependencies = [
  "crc32fast",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -971,6 +1007,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +1038,15 @@ dependencies = [
  "subtle",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1098,6 +1153,12 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "multipart"
@@ -1318,6 +1379,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,6 +1464,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,6 +1489,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -1893,6 +2026,7 @@ dependencies = [
  "fastrand",
  "is",
  "pcap-file",
+ "prost",
  "rand 0.9.3",
  "regex",
  "rouille",
@@ -1904,6 +2038,7 @@ dependencies = [
  "str0m-netem",
  "str0m-openssl",
  "str0m-proto",
+ "str0m-rtc-event-log",
  "str0m-rust-crypto",
  "str0m-wincrypto",
  "subtle",
@@ -1975,6 +2110,14 @@ dependencies = [
  "serde",
  "subtle",
  "time",
+]
+
+[[package]]
+name = "str0m-rtc-event-log"
+version = "0.1.0"
+dependencies = [
+ "prost",
+ "prost-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
   "crates/proto",
   "crates/is",
   "crates/netem",
+  "crates/rtc-event-log",
   "crates/_str0m_test",
   "crypto/aws-lc-rs",
   "crypto/rust-crypto",
@@ -48,6 +49,7 @@ str0m-rust-crypto = { version = "0.3.0", path = "crypto/rust-crypto" }
 str0m-openssl = { version = "0.3.0", path = "crypto/openssl" }
 str0m-apple-crypto = { version = "0.3.0", path = "crypto/apple-crypto" }
 str0m-wincrypto = { version = "0.5.0", path = "crypto/wincrypto" }
+str0m-rtc-event-log = { version = "0.1.0", path = "crates/rtc-event-log" }
 _str0m_test = { path = "crates/_str0m_test" }
 
 # Core dependencies
@@ -134,6 +136,7 @@ dimpl.workspace = true
 
 str0m-proto = { workspace = true, features = ["dtls"] }
 is.workspace = true
+str0m-rtc-event-log.workspace = true
 
 # Crypto providers
 str0m-aws-lc-rs = { workspace = true, optional = true }
@@ -150,6 +153,8 @@ str0m-wincrypto = { workspace = true, optional = true }
 [dev-dependencies]
 rouille.workspace = true
 str0m-rust-crypto.workspace = true
+str0m-rtc-event-log.workspace = true
+prost = "0.13"
 tempfile.workspace = true
 url.workspace = true
 serde_json.workspace = true
@@ -171,4 +176,8 @@ required-features = ["examples"]
 
 [[example]]
 name = "http-post"
+required-features = ["examples"]
+
+[[example]]
+name = "rtc-event-log"
 required-features = ["examples"]

--- a/README.md
+++ b/README.md
@@ -286,6 +286,46 @@ A production worthy SFU probably needs an even more sophisticated
 strategy weighing in all possible time sources to get a good estimate
 of the remote wallclock for a packet.
 
+## RTC Event Logging
+
+str0m can produce WebRTC-compatible event logs in the `rtc_event_log2` (version 2)
+protobuf format used by Chrome/libWebRTC. RTC event logs can be enabled to capture 
+in-depth inpformation about sent and received packets and the internal state of 
+some WebRTC components. The logs are useful to understand network behavior and to 
+debug issues around connectivity, bandwidth estimation and audio jitter buffers 
+using existing tools in libWebRTC like `event_log_visualizer`.
+
+```rust
+use std::time::Instant;
+use str0m::{Rtc, RtcConfig, Event, Output};
+
+let mut rtc = RtcConfig::new()
+    .enable_rtc_event_log(true)
+    .build(Instant::now());
+
+// In your run loop, write event log chunks to a file:
+loop {
+    match rtc.poll_output().unwrap() {
+        Output::Event(Event::RtcEventLog(data)) => {
+            // Append `data` to your .log file
+        }
+        // ... handle other outputs ...
+        _ => break,
+    }
+}
+
+// Before dropping Rtc, stop logging to flush the EndLogEvent marker:
+rtc.stop_rtc_event_log();
+// Then drain remaining Event::RtcEventLog events from poll_output().
+```
+
+Event logging adds near-zero overhead when disabled (a single branch per packet)
+and minimal overhead when enabled (a `Vec::push()` per packet, serialization
+deferred to the flush interval). See the [`rtc-event-log`][x-rtc-event-log] example
+for a complete working setup.
+
+[x-rtc-event-log]: https://github.com/algesten/str0m/blob/main/examples/rtc-event-log.rs
+
 ## Crypto backends
 
 str0m supports multiple crypto backends via feature flags. The default is `aws-lc-rs`.

--- a/crates/rtc-event-log/Cargo.toml
+++ b/crates/rtc-event-log/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "str0m-rtc-event-log"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85.0"
+description = "WebRTC event log encoder (rtc_event_log2 v2 format) for str0m"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+prost = "0.13"
+
+[build-dependencies]
+prost-build = "0.13"

--- a/crates/rtc-event-log/build.rs
+++ b/crates/rtc-event-log/build.rs
@@ -1,0 +1,8 @@
+use std::io::Result;
+
+fn main() -> Result<()> {
+    prost_build::Config::new()
+        .btree_map(["."])
+        .compile_protos(&["proto/rtc_event_log2.proto"], &["proto/"])?;
+    Ok(())
+}

--- a/crates/rtc-event-log/proto/rtc_event_log2.proto
+++ b/crates/rtc-event-log/proto/rtc_event_log2.proto
@@ -1,0 +1,817 @@
+// THIS FILE IS EXPERIMENTAL. BREAKING CHANGES MAY BE MADE AT ANY TIME
+// WITHOUT PRIOR WARNING. THIS FILE SHOULD NOT BE USED IN PRODUCTION CODE.
+
+syntax = "proto2";
+
+option optimize_for = LITE_RUNTIME;
+package webrtc.rtclog2;
+
+// At the top level, a WebRTC event log is just an EventStream object. Note that
+// concatenating multiple EventStreams in the same file is equivalent to a
+// single EventStream object containing the same events. Hence, it is not
+// necessary to wait for the entire log to be complete before beginning to
+// write it to a file.
+// Note: For all X_deltas fields, we rely on the default value being an
+// empty string.
+message EventStream {
+  // Deprecated - Maintained for compatibility with the old event log.
+  repeated Event stream = 1 [deprecated = true];
+  repeated IncomingRtpPackets incoming_rtp_packets = 2;
+  repeated OutgoingRtpPackets outgoing_rtp_packets = 3;
+  repeated IncomingRtcpPackets incoming_rtcp_packets = 4;
+  repeated OutgoingRtcpPackets outgoing_rtcp_packets = 5;
+  repeated AudioPlayoutEvents audio_playout_events = 6;
+  repeated FrameDecodedEvents frame_decoded_events = 7;
+  // The field tags 8-15 are reserved for the most common events.
+  repeated BeginLogEvent begin_log_events = 16;
+  repeated EndLogEvent end_log_events = 17;
+  repeated LossBasedBweUpdates loss_based_bwe_updates = 18;
+  repeated DelayBasedBweUpdates delay_based_bwe_updates = 19;
+  repeated AudioNetworkAdaptations audio_network_adaptations = 20;
+  repeated BweProbeCluster probe_clusters = 21;
+  repeated BweProbeResultSuccess probe_success = 22;
+  repeated BweProbeResultFailure probe_failure = 23;
+  repeated AlrState alr_states = 24;
+  repeated IceCandidatePairConfig ice_candidate_configs = 25;
+  repeated IceCandidatePairEvent ice_candidate_events = 26;
+  repeated DtlsTransportStateEvent dtls_transport_state_events = 27;
+  repeated DtlsWritableState dtls_writable_states = 28;
+  repeated GenericPacketSent generic_packets_sent = 29 [deprecated = true];
+  repeated GenericPacketReceived generic_packets_received = 30
+      [deprecated = true];
+  repeated GenericAckReceived generic_acks_received = 31 [deprecated = true];
+  repeated RouteChange route_changes = 32;
+  repeated RemoteEstimates remote_estimates = 33;
+  repeated NetEqSetMinimumDelay neteq_set_minimum_delay = 34;
+  repeated ScreamBweUpdates scream_bwe_updates = 35;
+
+  repeated AudioRecvStreamConfig audio_recv_stream_configs = 101;
+  repeated AudioSendStreamConfig audio_send_stream_configs = 102;
+  repeated VideoRecvStreamConfig video_recv_stream_configs = 103;
+  repeated VideoSendStreamConfig video_send_stream_configs = 104;
+}
+
+// DEPRECATED.
+message Event {
+  // TODO(terelius): Do we want to preserve the old Event definition here?
+}
+
+message GenericPacketReceived {
+  // All fields are required.
+  optional int64 timestamp_ms = 1;
+  optional int64 packet_number = 2;
+  // Length of the packet in bytes.
+  optional int32 packet_length = 3;
+
+  // Provided if there are deltas in the batch.
+  optional uint32 number_of_deltas = 16;
+  optional bytes timestamp_ms_deltas = 17;
+  optional bytes packet_number_deltas = 18;
+  optional bytes packet_length_deltas = 19;
+}
+
+message GenericPacketSent {
+  // All fields are required. All lengths in bytes.
+  optional int64 timestamp_ms = 1;
+  optional int64 packet_number = 2;
+  // overhead+payload+padding length = packet_length in bytes.
+  optional int32 overhead_length = 3;
+  optional int32 payload_length = 4;
+  optional int32 padding_length = 5;
+
+  optional uint32 number_of_deltas = 16;
+  optional bytes timestamp_ms_deltas = 17;
+  optional bytes packet_number_deltas = 18;
+  optional bytes overhead_length_deltas = 19;
+  optional bytes payload_length_deltas = 20;
+  optional bytes padding_length_deltas = 21;
+}
+
+message GenericAckReceived {
+  optional int64 timestamp_ms = 1;
+
+  // ID of the received packet.
+  optional int64 packet_number = 2;
+
+  // ID of the packet that was acked.
+  optional int64 acked_packet_number = 3;
+
+  // Timestamp in ms when the packet was received by the other side.
+  optional int64 receive_acked_packet_time_ms = 4;
+
+  optional uint32 number_of_deltas = 16;
+  optional bytes timestamp_ms_deltas = 17;
+  optional bytes packet_number_deltas = 18;
+  optional bytes acked_packet_number_deltas = 19;
+  optional bytes receive_acked_packet_time_ms_deltas = 20;
+}
+
+message DependencyDescriptorsWireInfo {
+  // required
+  // Base and delta encoded B and E bits represented as two bit numbers.
+  optional uint32 start_end_bit = 1;
+  optional bytes start_end_bit_deltas = 2;
+
+  // required
+  // Base and delta encoded template IDs, represented as six bit numbers.
+  optional uint32 template_id = 3;
+  optional bytes template_id_deltas = 4;
+
+  // required
+  // Base and delta compressed frame IDs.
+  optional uint32 frame_id = 5;
+  optional bytes frame_id_deltas = 6;
+
+  // optional - set if any DD contains extended information.
+  // The extended info encoded as optional blobs.
+  optional bytes extended_infos = 7;
+}
+
+message IncomingRtpPackets {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required - RTP marker bit, used to label boundaries between video frames.
+  optional bool marker = 2;
+
+  // required - RTP payload type.
+  optional uint32 payload_type = 3;
+
+  // required - RTP sequence number.
+  optional uint32 sequence_number = 4;
+
+  // required - RTP monotonic clock timestamp (not actual time).
+  optional fixed32 rtp_timestamp = 5;
+
+  // required - Synchronization source of this packet's RTP stream.
+  optional fixed32 ssrc = 6;
+
+  // TODO(terelius/dinor): Add CSRCs. Field number 7 reserved for this purpose.
+
+  // required - The size (in bytes) of the media payload, not including
+  // RTP header or padding. The packet size is the sum of payload, header and
+  // padding.
+  optional uint32 payload_size = 8;
+
+  // required - The size (in bytes) of the RTP header.
+  optional uint32 header_size = 9;
+
+  // required - The size (in bytes) of the padding.
+  optional uint32 padding_size = 10;
+
+  // optional - required if the batch contains delta encoded events.
+  optional uint32 number_of_deltas = 11;
+
+  // Field numbers 12-14 reserved for future use.
+
+  // Optional header extensions.
+  optional uint32 transport_sequence_number = 15;
+  optional int32 transmission_time_offset = 16;
+  optional uint32 absolute_send_time = 17;
+  optional uint32 video_rotation = 18;
+  // `audio_level` and `voice_activity` are always used in conjunction.
+  optional uint32 audio_level = 19;
+  optional bool voice_activity = 20;
+  // Encodes all DD information in the batch, not just the base event.
+  optional DependencyDescriptorsWireInfo dependency_descriptor = 21;
+  // TODO(terelius): Add other header extensions like playout delay?
+
+  // optional - The RTX OSN value, only set for RTX packets.
+  optional uint32 rtx_original_sequence_number = 22;
+
+  // Delta encodings.
+  optional bytes timestamp_ms_deltas = 101;
+  optional bytes marker_deltas = 102;
+  optional bytes payload_type_deltas = 103;
+  optional bytes sequence_number_deltas = 104;
+  optional bytes rtp_timestamp_deltas = 105;
+  // Field number 107 reserved for CSRC.
+  optional bytes ssrc_deltas = 106;
+  optional bytes payload_size_deltas = 108;
+  optional bytes header_size_deltas = 109;
+  optional bytes padding_size_deltas = 110;
+  // Field number 111-114 reserved for future use.
+  optional bytes transport_sequence_number_deltas = 115;
+  optional bytes transmission_time_offset_deltas = 116;
+  optional bytes absolute_send_time_deltas = 117;
+  optional bytes video_rotation_deltas = 118;
+  // `audio_level` and `voice_activity` are always used in conjunction.
+  optional bytes audio_level_deltas = 119;
+  optional bytes voice_activity_deltas = 120;
+  optional bytes rtx_original_sequence_number_deltas = 121;
+}
+
+message OutgoingRtpPackets {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required - RTP marker bit, used to label boundaries between video frames.
+  optional bool marker = 2;
+
+  // required - RTP payload type.
+  optional uint32 payload_type = 3;
+
+  // required - RTP sequence number.
+  optional uint32 sequence_number = 4;
+
+  // required - RTP monotonic clock timestamp (not actual time).
+  optional fixed32 rtp_timestamp = 5;
+
+  // required - Synchronization source of this packet's RTP stream.
+  optional fixed32 ssrc = 6;
+
+  // TODO(terelius/dinor): Add CSRCs. Field number 7 reserved for this purpose.
+
+  // required - The size (in bytes) of the media payload, not including
+  // RTP header or padding. The packet size is the sum of payload, header and
+  // padding.
+  optional uint32 payload_size = 8;
+
+  // required - The size (in bytes) of the RTP header.
+  optional uint32 header_size = 9;
+
+  // required - The size (in bytes) of the padding.
+  optional uint32 padding_size = 10;
+
+  // optional - required if the batch contains delta encoded events.
+  optional uint32 number_of_deltas = 11;
+
+  // Field numbers 12-14 reserved for future use.
+
+  // Optional header extensions.
+  optional uint32 transport_sequence_number = 15;
+  optional int32 transmission_time_offset = 16;
+  optional uint32 absolute_send_time = 17;
+  optional uint32 video_rotation = 18;
+  // `audio_level` and `voice_activity` are always used in conjunction.
+  optional uint32 audio_level = 19;
+  optional bool voice_activity = 20;
+  // TODO(terelius): Add other header extensions like playout delay?
+  // Encodes all DD information in the batch, not just the base event.
+  optional DependencyDescriptorsWireInfo dependency_descriptor = 21;
+
+  // optional - The RTX OSN value, only set for RTX packets.
+  optional uint32 rtx_original_sequence_number = 22;
+
+  // optional - The probe cluster id, only set for packets sent as part of a
+  // BWE probe cluster.
+  optional int32 probe_cluster_id = 23;
+
+  // Delta encodings.
+  optional bytes timestamp_ms_deltas = 101;
+  optional bytes marker_deltas = 102;
+  optional bytes payload_type_deltas = 103;
+  optional bytes sequence_number_deltas = 104;
+  optional bytes rtp_timestamp_deltas = 105;
+  optional bytes ssrc_deltas = 106;
+  // Field number 107 reserved for CSRC.
+  optional bytes payload_size_deltas = 108;
+  optional bytes header_size_deltas = 109;
+  optional bytes padding_size_deltas = 110;
+  // Field number 111-114 reserved for future use.
+  optional bytes transport_sequence_number_deltas = 115;
+  optional bytes transmission_time_offset_deltas = 116;
+  optional bytes absolute_send_time_deltas = 117;
+  optional bytes video_rotation_deltas = 118;
+  // `audio_level` and `voice_activity` are always used in conjunction.
+  optional bytes audio_level_deltas = 119;
+  optional bytes voice_activity_deltas = 120;
+  optional bytes rtx_original_sequence_number_deltas = 121;
+  optional bytes probe_cluster_id_deltas = 122;
+}
+
+message IncomingRtcpPackets {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required - The whole packet including both payload and header.
+  optional bytes raw_packet = 2;
+  // TODO(terelius): Feasible to log parsed RTCP instead?
+
+  // optional - required if the batch contains delta encoded events.
+  optional uint32 number_of_deltas = 3;
+
+  // Delta/blob encodings.
+  optional bytes timestamp_ms_deltas = 101;
+  optional bytes raw_packet_blobs = 102;
+}
+
+message OutgoingRtcpPackets {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required - The whole packet including both payload and header.
+  optional bytes raw_packet = 2;
+  // TODO(terelius): Feasible to log parsed RTCP instead?
+
+  // optional - required if the batch contains delta encoded events.
+  optional uint32 number_of_deltas = 3;
+
+  // Delta/blob encodings.
+  optional bytes timestamp_ms_deltas = 101;
+  optional bytes raw_packet_blobs = 102;
+}
+
+message AudioPlayoutEvents {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required - The SSRC of the audio stream associated with the playout event.
+  optional uint32 local_ssrc = 2;
+
+  // optional - required if the batch contains delta encoded events.
+  optional uint32 number_of_deltas = 3;
+
+  // Delta encodings.
+  optional bytes timestamp_ms_deltas = 101;
+  optional bytes local_ssrc_deltas = 102;
+}
+
+message NetEqSetMinimumDelay {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required - The SSRC of the remote stream associated with the MinimumDelay
+  // event.
+  optional fixed32 remote_ssrc = 2;
+
+  // required - minimum delay passed to SetBaseMinimumDelay.
+  optional int32 minimum_delay_ms = 3;
+
+  // optional - required if the batch contains delta encoded events.
+  optional uint32 number_of_deltas = 4;
+
+  // Delta encodings.
+  optional bytes timestamp_ms_deltas = 101;
+  optional bytes remote_ssrc_deltas = 102;
+  optional bytes minimum_delay_ms_deltas = 103;
+}
+
+message FrameDecodedEvents {
+  enum Codec {
+    CODEC_UNKNOWN = 0;
+    CODEC_GENERIC = 1;
+    CODEC_VP8 = 2;
+    CODEC_VP9 = 3;
+    CODEC_AV1 = 4;
+    CODEC_H264 = 5;
+    CODEC_H265 = 6;
+  }
+
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required - The SSRC of the video stream that the frame belongs to.
+  optional fixed32 ssrc = 2;
+
+  // required - The predicted render time of the frame.
+  optional int64 render_time_ms = 3;
+
+  // required - The width (in pixels) of the frame.
+  optional int32 width = 4;
+
+  // required - The height (in pixels) of the frame.
+  optional int32 height = 5;
+
+  // required - The codec type of the frame.
+  optional Codec codec = 6;
+
+  // required - The QP (quantization parameter) of the frame. Range [0,255].
+  optional uint32 qp = 7;
+
+  // optional - required if the batch contains delta encoded events.
+  optional uint32 number_of_deltas = 15;
+
+  // Delta encodings.
+  optional bytes timestamp_ms_deltas = 101;
+  optional bytes ssrc_deltas = 102;
+  optional bytes render_time_ms_deltas = 103;
+  optional bytes width_deltas = 104;
+  optional bytes height_deltas = 105;
+  optional bytes codec_deltas = 106;
+  optional bytes qp_deltas = 107;
+}
+
+message BeginLogEvent {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required
+  optional uint32 version = 2;
+
+  // required
+  optional int64 utc_time_ms = 3;
+}
+
+message EndLogEvent {
+  // required
+  optional int64 timestamp_ms = 1;
+}
+
+message LossBasedBweUpdates {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // TODO(terelius): Update log interface to unsigned.
+  // required - Bandwidth estimate (in bps) after the update.
+  optional uint32 bitrate_bps = 2;
+
+  // required - Fraction of lost packets since last receiver report
+  // computed as floor( 256 * (#lost_packets / #total_packets) ).
+  // The possible values range from 0 to 255.
+  optional uint32 fraction_loss = 3;
+
+  // TODO(terelius): Is this really needed? Remove or make optional?
+  // TODO(terelius): Update log interface to unsigned.
+  // required - Total number of packets that the BWE update is based on.
+  optional uint32 total_packets = 4;
+
+  // optional - required if the batch contains delta encoded events.
+  optional uint32 number_of_deltas = 5;
+
+  // Delta encodings.
+  optional bytes timestamp_ms_deltas = 101;
+  optional bytes bitrate_bps_deltas = 102;
+  optional bytes fraction_loss_deltas = 103;
+  optional bytes total_packets_deltas = 104;
+}
+
+message DelayBasedBweUpdates {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required - Bandwidth estimate (in bps) after the update.
+  optional uint32 bitrate_bps = 2;
+
+  enum DetectorState {
+    BWE_UNKNOWN_STATE = 0;
+    BWE_NORMAL = 1;
+    BWE_UNDERUSING = 2;
+    BWE_OVERUSING = 3;
+  }
+  optional DetectorState detector_state = 3;
+
+  // optional - required if the batch contains delta encoded events.
+  optional uint32 number_of_deltas = 4;
+
+  // Delta encodings.
+  optional bytes timestamp_ms_deltas = 101;
+  optional bytes bitrate_bps_deltas = 102;
+  optional bytes detector_state_deltas = 103;
+}
+
+message ScreamBweUpdates {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  optional uint32 ref_window_bytes = 2;
+  optional uint32 target_rate_kbps = 3;
+  optional uint32 smoothed_rtt_ms = 4;
+  optional uint32 avg_queue_delay_ms = 5;
+  optional uint32 l4s_marked_permille = 6;
+  optional uint32 data_in_flight_bytes = 7;
+
+  // optional - required if the batch contains delta encoded events.
+  optional uint32 number_of_deltas = 15;
+
+  // Delta encodings.
+  optional bytes timestamp_ms_deltas = 101;
+  optional bytes ref_window_bytes_deltas = 102;
+  optional bytes target_rate_kbps_deltas = 103;
+  optional bytes smoothed_rtt_ms_deltas = 104;
+  optional bytes avg_queue_delay_ms_deltas = 105;
+  optional bytes l4s_marked_permille_deltas = 106;
+  optional bytes data_in_flight_bytes_deltas = 107;
+}
+
+// Maps RTP header extension names to numerical IDs.
+message RtpHeaderExtensionConfig {
+  // Optional IDs for the header extensions. Each ID is a 4-bit number that is
+  // only set if that extension is configured.
+  // TODO: Can we skip audio level?
+  optional int32 transmission_time_offset_id = 1;
+  optional int32 absolute_send_time_id = 2;
+  optional int32 transport_sequence_number_id = 3;
+  optional int32 video_rotation_id = 4;
+  optional int32 audio_level_id = 5;
+  optional int32 dependency_descriptor_id = 6;
+  // TODO(terelius): Add other header extensions like playout delay?
+}
+
+message VideoRecvStreamConfig {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required - Synchronization source (stream identifier) to be received.
+  optional uint32 remote_ssrc = 2;
+
+  // required - Sender SSRC used for sending RTCP (such as receiver reports).
+  optional uint32 local_ssrc = 3;
+
+  // optional - required if RTX is configured. SSRC for the RTX stream.
+  optional uint32 rtx_ssrc = 4;
+
+  // IDs for the header extension we care about. Only required if there are
+  // header extensions configured.
+  optional RtpHeaderExtensionConfig header_extensions = 5;
+
+  // TODO(terelius): Do we need codec-payload mapping? If so and rtx_ssrc is
+  // used, we also need a map between RTP payload type and RTX payload type.
+}
+
+message VideoSendStreamConfig {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required - Synchronization source (stream identifier) for outgoing stream.
+  // When using simulcast, a separate config should be logged for each stream.
+  optional uint32 ssrc = 2;
+
+  // optional - required if RTX is configured. SSRC for the RTX stream.
+  optional uint32 rtx_ssrc = 3;
+
+  // IDs for the header extension we care about. Only required if there are
+  // header extensions configured.
+  optional RtpHeaderExtensionConfig header_extensions = 4;
+
+  // TODO(terelius): Do we need codec-payload mapping? If so and rtx_ssrc is
+  // used, we also need a map between RTP payload type and RTX payload type.
+}
+
+message AudioRecvStreamConfig {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required - Synchronization source (stream identifier) to be received.
+  optional uint32 remote_ssrc = 2;
+
+  // required - Sender SSRC used for sending RTCP (such as receiver reports).
+  optional uint32 local_ssrc = 3;
+
+  // Field number 4 reserved for RTX SSRC.
+
+  // IDs for the header extension we care about. Only required if there are
+  // header extensions configured.
+  optional RtpHeaderExtensionConfig header_extensions = 5;
+
+  // TODO(terelius): Do we need codec-payload mapping? If so and rtx_ssrc is
+  // used, we also need a map between RTP payload type and RTX payload type.
+}
+
+message AudioSendStreamConfig {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required - Synchronization source (stream identifier) for outgoing stream.
+  optional uint32 ssrc = 2;
+
+  // Field number 3 reserved for RTX SSRC.
+
+  // IDs for the header extension we care about. Only required if there are
+  // header extensions configured.
+  optional RtpHeaderExtensionConfig header_extensions = 4;
+
+  // TODO(terelius): Do we need codec-payload mapping? If so and rtx_ssrc is
+  // used, we also need a map between RTP payload type and RTX payload type.
+}
+
+message AudioNetworkAdaptations {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // Bit rate that the audio encoder is operating at.
+  // TODO(terelius): Signed vs unsigned?
+  optional int32 bitrate_bps = 2;
+
+  // Frame length that each encoded audio packet consists of.
+  // TODO(terelius): Signed vs unsigned?
+  optional int32 frame_length_ms = 3;
+
+  // Packet loss fraction that the encoder's forward error correction (FEC) is
+  // optimized for.
+  // Instead of encoding a float, we encode a value between 0 and 16383, which
+  // if divided by 16383, will give a value close to the original float.
+  // The value 16383 (2^14 - 1) was chosen so that it would give good precision
+  // on the one hand, and would be encodable with two bytes in varint form
+  // on the other hand.
+  optional uint32 uplink_packet_loss_fraction = 4;
+
+  // Whether forward error correction (FEC) is turned on or off.
+  optional bool enable_fec = 5;
+
+  // Whether discontinuous transmission (DTX) is turned on or off.
+  optional bool enable_dtx = 6;
+
+  // Number of audio channels that each encoded packet consists of.
+  optional uint32 num_channels = 7;
+
+  // optional - required if the batch contains delta encoded events.
+  optional uint32 number_of_deltas = 8;
+
+  // Delta encodings.
+  optional bytes timestamp_ms_deltas = 101;
+  optional bytes bitrate_bps_deltas = 102;
+  optional bytes frame_length_ms_deltas = 103;
+  optional bytes uplink_packet_loss_fraction_deltas = 104;
+  optional bytes enable_fec_deltas = 105;
+  optional bytes enable_dtx_deltas = 106;
+  optional bytes num_channels_deltas = 107;
+}
+
+message BweProbeCluster {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required - The id of this probe cluster.
+  optional uint32 id = 2;
+
+  // required - The bitrate in bps that this probe cluster is meant to probe.
+  optional uint32 bitrate_bps = 3;
+
+  // required - The minimum number of packets used to probe the given bitrate.
+  optional uint32 min_packets = 4;
+
+  // required - The minimum number of bytes used to probe the given bitrate.
+  optional uint32 min_bytes = 5;
+}
+
+message BweProbeResultSuccess {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required - The id of this probe cluster.
+  optional uint32 id = 2;
+
+  // required - The resulting bitrate in bps.
+  optional uint32 bitrate_bps = 3;
+}
+
+message BweProbeResultFailure {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required - The id of this probe cluster.
+  optional uint32 id = 2;
+
+  enum FailureReason {
+    UNKNOWN = 0;
+    INVALID_SEND_RECEIVE_INTERVAL = 1;
+    INVALID_SEND_RECEIVE_RATIO = 2;
+    TIMEOUT = 3;
+  }
+
+  // required
+  optional FailureReason failure = 3;
+}
+
+message AlrState {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required - True if the send rate is application limited.
+  optional bool in_alr = 2;
+}
+
+message IceCandidatePairConfig {
+  enum IceCandidatePairConfigType {
+    UNKNOWN_CONFIG_TYPE = 0;
+    ADDED = 1;
+    UPDATED = 2;
+    DESTROYED = 3;
+    SELECTED = 4;
+  }
+
+  enum IceCandidateType {
+    UNKNOWN_CANDIDATE_TYPE = 0;
+    LOCAL = 1;
+    STUN = 2;
+    PRFLX = 3;
+    RELAY = 4;
+  }
+
+  enum Protocol {
+    UNKNOWN_PROTOCOL = 0;
+    UDP = 1;
+    TCP = 2;
+    SSLTCP = 3;
+    TLS = 4;
+  }
+
+  enum AddressFamily {
+    UNKNOWN_ADDRESS_FAMILY = 0;
+    IPV4 = 1;
+    IPV6 = 2;
+  }
+
+  enum NetworkType {
+    UNKNOWN_NETWORK_TYPE = 0;
+    ETHERNET = 1;
+    WIFI = 2;
+    CELLULAR = 3;
+    VPN = 4;
+    LOOPBACK = 5;
+  }
+
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required
+  optional IceCandidatePairConfigType config_type = 2;
+
+  // required
+  optional uint32 candidate_pair_id = 3;
+
+  // required
+  optional IceCandidateType local_candidate_type = 4;
+
+  // required
+  optional Protocol local_relay_protocol = 5;
+
+  // required
+  optional NetworkType local_network_type = 6;
+
+  // required
+  optional AddressFamily local_address_family = 7;
+
+  // required
+  optional IceCandidateType remote_candidate_type = 8;
+
+  // required
+  optional AddressFamily remote_address_family = 9;
+
+  // required
+  optional Protocol candidate_pair_protocol = 10;
+}
+
+message IceCandidatePairEvent {
+  enum IceCandidatePairEventType {
+    UNKNOWN_CHECK_TYPE = 0;
+    CHECK_SENT = 1;
+    CHECK_RECEIVED = 2;
+    CHECK_RESPONSE_SENT = 3;
+    CHECK_RESPONSE_RECEIVED = 4;
+  }
+
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required
+  optional IceCandidatePairEventType event_type = 2;
+
+  // required
+  optional uint32 candidate_pair_id = 3;
+
+  // required
+  optional uint32 transaction_id = 4;
+}
+
+message DtlsTransportStateEvent {
+  enum DtlsTransportState {
+    UNKNOWN_DTLS_TRANSPORT_STATE = 0;
+    DTLS_TRANSPORT_NEW = 1;
+    DTLS_TRANSPORT_CONNECTING = 2;
+    DTLS_TRANSPORT_CONNECTED = 3;
+    DTLS_TRANSPORT_CLOSED = 4;
+    DTLS_TRANSPORT_FAILED = 5;
+  }
+
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required
+  optional DtlsTransportState dtls_transport_state = 2;
+}
+
+message DtlsWritableState {
+  // required
+  optional int64 timestamp_ms = 1;
+
+  // required
+  optional bool writable = 2;
+}
+
+message RouteChange {
+  // required
+  optional int64 timestamp_ms = 1;
+  // required - True if the route is ready for sending packets.
+  optional bool connected = 2;
+  // required - The per packet data overhead for this route.
+  optional uint32 overhead = 3;
+}
+
+message RemoteEstimates {
+  // required
+  optional int64 timestamp_ms = 1;
+  // optional - value used as a safe measure of available capacity.
+  optional uint32 link_capacity_lower_kbps = 2;
+  // optional - value used as limit for increasing bitrate.
+  optional uint32 link_capacity_upper_kbps = 3;
+
+  // optional - required if the batch contains delta encoded events.
+  optional uint32 number_of_deltas = 4;
+
+  // Delta encodings.
+  optional bytes timestamp_ms_deltas = 101;
+  optional bytes link_capacity_lower_kbps_deltas = 102;
+  optional bytes link_capacity_upper_kbps_deltas = 103;
+}

--- a/crates/rtc-event-log/src/delta.rs
+++ b/crates/rtc-event-log/src/delta.rs
@@ -1,0 +1,504 @@
+/// Fixed-length bit-packed delta encoding compatible with WebRTC's `delta_encoding.cc`.
+///
+/// This module implements the exact same binary format as Chrome/libWebRTC's
+/// RTC event log v2 delta encoding, ensuring output files are parseable by
+/// existing WebRTC tools (`webrtc_event_log_visualizer`, `event_log_analyzer`, etc.).
+
+// -- BitWriter ----------------------------------------------------------------
+
+/// Sub-byte-aligned bit writer. Packs bits MSB-first into a byte buffer,
+/// matching WebRTC's `BitBufferWriter` which writes MSB-first.
+pub(crate) struct BitWriter {
+    buf: Vec<u8>,
+    /// Bit position within the current byte (0 = MSB, 7 = LSB).
+    bit_offset: usize,
+}
+
+impl BitWriter {
+    pub fn with_capacity(byte_count: usize) -> Self {
+        BitWriter {
+            buf: vec![0u8; byte_count],
+            bit_offset: 0,
+        }
+    }
+
+    /// Write `bit_count` bits from `val` (MSB-first).
+    pub fn write_bits(&mut self, val: u64, bit_count: usize) {
+        debug_assert!(bit_count <= 64);
+        for i in (0..bit_count).rev() {
+            let bit = ((val >> i) & 1) as u8;
+            let byte_pos = self.bit_offset / 8;
+            let bit_pos = 7 - (self.bit_offset % 8); // MSB first
+            if byte_pos >= self.buf.len() {
+                self.buf.push(0);
+            }
+            self.buf[byte_pos] |= bit << bit_pos;
+            self.bit_offset += 1;
+        }
+    }
+
+    /// Write raw bytes (8 bits per byte).
+    pub fn write_bytes(&mut self, data: &[u8]) {
+        for &b in data {
+            self.write_bits(b as u64, 8);
+        }
+    }
+
+    /// Consume the writer and return the packed bytes, truncated to the
+    /// minimum number of bytes needed.
+    pub fn finish(mut self) -> Vec<u8> {
+        let byte_len = bits_to_bytes(self.bit_offset);
+        self.buf.truncate(byte_len);
+        self.buf
+    }
+}
+
+// -- Varint -------------------------------------------------------------------
+
+/// Maximum varint length for u64.
+const MAX_VARINT_LEN: usize = 10;
+
+/// Encode a u64 as a LEB128 varint (7 bits per byte, MSB = continuation).
+/// Matches WebRTC's `EncodeVarInt`.
+pub(crate) fn encode_varint(mut value: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(MAX_VARINT_LEN);
+    loop {
+        let mut byte = (value & 0x7F) as u8;
+        value >>= 7;
+        if value > 0 {
+            byte |= 0x80;
+        }
+        out.push(byte);
+        if value == 0 {
+            break;
+        }
+    }
+    out
+}
+
+// -- Helpers ------------------------------------------------------------------
+
+fn bits_to_bytes(bits: usize) -> usize {
+    (bits + 7) / 8
+}
+
+/// Bit width needed to represent `input` as an unsigned integer.
+/// `UnsignedBitWidth(0)` = 1 (matching WebRTC's default behavior).
+fn unsigned_bit_width(input: u64) -> u64 {
+    if input == 0 {
+        return 1;
+    }
+    64 - input.leading_zeros() as u64
+}
+
+/// Bit width needed for an unsigned value, but 0 maps to width 0.
+/// Used in `SignedBitWidth` calculation.
+fn unsigned_bit_width_zero_as_zero(input: u64) -> u64 {
+    if input == 0 {
+        return 0;
+    }
+    unsigned_bit_width(input)
+}
+
+/// Bit width needed for signed deltas given max positive and max negative magnitudes.
+/// Matches WebRTC's `SignedBitWidth`.
+fn signed_bit_width(max_pos_magnitude: u64, max_neg_magnitude: u64) -> u64 {
+    let bitwidth_pos = unsigned_bit_width_zero_as_zero(max_pos_magnitude);
+    let bitwidth_neg = if max_neg_magnitude > 0 {
+        unsigned_bit_width_zero_as_zero(max_neg_magnitude - 1)
+    } else {
+        0
+    };
+    1 + std::cmp::max(bitwidth_pos, bitwidth_neg)
+}
+
+/// Maximum unsigned value for a given bit width.
+fn max_unsigned_value_of_bit_width(bit_width: u64) -> u64 {
+    debug_assert!((1..=64).contains(&bit_width));
+    if bit_width == 64 {
+        u64::MAX
+    } else {
+        (1u64 << bit_width) - 1
+    }
+}
+
+/// Compute (current - previous) with wraparound at bit_mask.
+fn unsigned_delta(previous: u64, current: u64, bit_mask: u64) -> u64 {
+    current.wrapping_sub(previous) & bit_mask
+}
+
+// -- Header constants ---------------------------------------------------------
+
+const BITS_ENCODING_TYPE: usize = 2;
+const BITS_DELTA_WIDTH: usize = 6;
+const BITS_SIGNED_DELTAS: usize = 1;
+const BITS_VALUES_OPTIONAL: usize = 1;
+const BITS_VALUE_WIDTH: usize = 6;
+
+// -- Core encoder -------------------------------------------------------------
+
+/// Encode a sequence of values using WebRTC's fixed-length bit-packed delta encoding.
+///
+/// `base` is the base value (from the proto's base field). If `None`, the field is
+/// optional and the first present value is encoded as a varint.
+///
+/// `values` contains `number_of_deltas` values (one per subsequent event in the batch).
+///
+/// `value_width_bits` is the field-specific width controlling wrapping behavior.
+/// For non-wrapping fields, pass 64.
+///
+/// Returns empty `Vec<u8>` if all values equal the base, signaling the caller
+/// should NOT set the `_deltas` proto field (parser interprets missing field as "all equal").
+pub(crate) fn encode_deltas(
+    base: Option<u64>,
+    values: &[Option<u64>],
+    value_width_bits: u64,
+) -> Vec<u8> {
+    assert!(!values.is_empty());
+    assert!((1..=64).contains(&value_width_bits));
+
+    // Special case: all values identical to base → empty output.
+    if values.iter().all(|v| *v == base) {
+        return Vec::new();
+    }
+
+    // Determine if the sequence is non-decreasing and find max value
+    let mut non_decreasing = true;
+    let mut max_value_including_base = base.unwrap_or(0);
+    let mut existent_count: usize = 0;
+    {
+        let mut previous = base.unwrap_or(0);
+        for v in values {
+            if let Some(val) = v {
+                existent_count += 1;
+                non_decreasing &= previous <= *val;
+                max_value_including_base = std::cmp::max(max_value_including_base, *val);
+                previous = *val;
+            }
+        }
+    }
+
+    // If non-decreasing, use value_width = 64 (no wrapping needed).
+    // Otherwise compute the actual width from max value.
+    let effective_value_width = if non_decreasing {
+        64
+    } else {
+        std::cmp::max(unsigned_bit_width(max_value_including_base), value_width_bits)
+    };
+
+    let value_mask = max_unsigned_value_of_bit_width(effective_value_width);
+
+    // Calculate min/max deltas
+    let (max_unsigned_d, max_pos_signed_d, min_neg_signed_d) =
+        calc_min_max_deltas(base, values, value_mask);
+
+    let delta_width_unsigned = unsigned_bit_width(max_unsigned_d);
+    let delta_width_signed = signed_bit_width(max_pos_signed_d, min_neg_signed_d);
+
+    // Prefer unsigned if same width (efficiency)
+    let signed_deltas = delta_width_signed < delta_width_unsigned;
+    let delta_width_bits = if signed_deltas {
+        delta_width_signed
+    } else {
+        delta_width_unsigned
+    };
+
+    let values_optional = !base.is_some() || existent_count < values.len();
+
+    // Compute output size
+    let header_bits = header_len_bits(signed_deltas, values_optional, effective_value_width);
+    let delta_bits =
+        encoded_deltas_len_bits(values, existent_count, base, delta_width_bits, values_optional);
+    let total_bytes = bits_to_bytes(header_bits + delta_bits);
+
+    let mut writer = BitWriter::with_capacity(total_bytes);
+    let delta_mask = max_unsigned_value_of_bit_width(delta_width_bits);
+
+    // Write header
+    encode_header(
+        &mut writer,
+        delta_width_bits,
+        signed_deltas,
+        values_optional,
+        effective_value_width,
+    );
+
+    // Write existence bitmap (if optional)
+    if values_optional {
+        for v in values {
+            writer.write_bits(if v.is_some() { 1 } else { 0 }, 1);
+        }
+    }
+
+    // Write deltas
+    let mut previous = base;
+    for v in values {
+        let Some(val) = v else {
+            continue;
+        };
+
+        if previous.is_none() {
+            // First existent value when base is None → encode as varint
+            let varint = encode_varint(*val);
+            writer.write_bytes(&varint);
+            // Pad remaining bytes of the varint allocation to maintain fixed output size
+            for _ in varint.len()..MAX_VARINT_LEN {
+                writer.write_bits(0, 8);
+            }
+        } else {
+            let prev = previous.unwrap();
+            if signed_deltas {
+                encode_signed_delta(&mut writer, prev, *val, value_mask, delta_mask, delta_width_bits);
+            } else {
+                let delta = unsigned_delta(prev, *val, value_mask);
+                writer.write_bits(delta, delta_width_bits as usize);
+            }
+        }
+
+        previous = Some(*val);
+    }
+
+    writer.finish()
+}
+
+fn calc_min_max_deltas(
+    base: Option<u64>,
+    values: &[Option<u64>],
+    bit_mask: u64,
+) -> (u64, u64, u64) {
+    let mut max_unsigned_delta = 0u64;
+    let mut max_pos_signed_delta = 0u64;
+    let mut min_neg_signed_delta = 0u64;
+
+    let mut prev: Option<u64> = base;
+    for v in values {
+        let Some(val) = v else {
+            continue;
+        };
+
+        if prev.is_none() {
+            // First existent value when base is None: encoded as varint, not delta
+            prev = Some(*val);
+            continue;
+        }
+
+        let previous = prev.unwrap();
+        let current = *val;
+
+        let forward_delta = unsigned_delta(previous, current, bit_mask);
+        let backward_delta = unsigned_delta(current, previous, bit_mask);
+
+        max_unsigned_delta = std::cmp::max(max_unsigned_delta, forward_delta);
+
+        if forward_delta < backward_delta {
+            max_pos_signed_delta = std::cmp::max(max_pos_signed_delta, forward_delta);
+        } else {
+            min_neg_signed_delta = std::cmp::max(min_neg_signed_delta, backward_delta);
+        }
+
+        prev = Some(current);
+    }
+
+    (max_unsigned_delta, max_pos_signed_delta, min_neg_signed_delta)
+}
+
+fn header_len_bits(signed_deltas: bool, values_optional: bool, value_width_bits: u64) -> usize {
+    if !signed_deltas && !values_optional && value_width_bits == 64 {
+        // Compact header: encoding_type(2) + delta_width(6) = 8 bits
+        BITS_ENCODING_TYPE + BITS_DELTA_WIDTH
+    } else {
+        // Full header: encoding_type(2) + delta_width(6) + signed(1) + optional(1) + value_width(6) = 16 bits
+        BITS_ENCODING_TYPE + BITS_DELTA_WIDTH + BITS_SIGNED_DELTAS + BITS_VALUES_OPTIONAL + BITS_VALUE_WIDTH
+    }
+}
+
+fn encoded_deltas_len_bits(
+    values: &[Option<u64>],
+    existent_count: usize,
+    base: Option<u64>,
+    delta_width_bits: u64,
+    values_optional: bool,
+) -> usize {
+    if !values_optional {
+        values.len() * delta_width_bits as usize
+    } else {
+        let existence_bitmap_bits = values.len();
+        let first_is_varint = base.is_none() && existent_count >= 1;
+        let varint_bits = if first_is_varint {
+            8 * MAX_VARINT_LEN
+        } else {
+            0
+        };
+        let delta_count = existent_count - first_is_varint as usize;
+        let delta_bits = delta_count * delta_width_bits as usize;
+        existence_bitmap_bits + varint_bits + delta_bits
+    }
+}
+
+fn encode_header(
+    writer: &mut BitWriter,
+    delta_width_bits: u64,
+    signed_deltas: bool,
+    values_optional: bool,
+    value_width_bits: u64,
+) {
+    let use_compact = !signed_deltas && !values_optional && value_width_bits == 64;
+    let encoding_type: u64 = if use_compact { 0 } else { 1 };
+
+    writer.write_bits(encoding_type, BITS_ENCODING_TYPE);
+    writer.write_bits(delta_width_bits - 1, BITS_DELTA_WIDTH);
+
+    if use_compact {
+        return;
+    }
+
+    writer.write_bits(signed_deltas as u64, BITS_SIGNED_DELTAS);
+    writer.write_bits(values_optional as u64, BITS_VALUES_OPTIONAL);
+    writer.write_bits(value_width_bits - 1, BITS_VALUE_WIDTH);
+}
+
+// -- Blob encoding (for RTCP raw packets) ------------------------------------
+
+/// Encode variable-length blobs for RTCP raw packets.
+///
+/// Format (matches WebRTC's `blob_encoding.cc`):
+///   Phase 1: For each blob, write `varint(length)`  — all lengths first
+///   Phase 2: For each blob, write raw bytes          — all data concatenated
+///
+/// The decoder knows the blob count from `number_of_deltas` in the proto.
+pub(crate) fn encode_blobs<T: AsRef<[u8]>>(blobs: &[T]) -> Vec<u8> {
+    let total_len: usize = blobs
+        .iter()
+        .map(|b| {
+            let b = b.as_ref();
+            encode_varint(b.len() as u64).len() + b.len()
+        })
+        .sum();
+    let mut out = Vec::with_capacity(total_len);
+
+    // Phase 1: all lengths as varints
+    for blob in blobs {
+        let blob = blob.as_ref();
+        out.extend(encode_varint(blob.len() as u64));
+    }
+
+    // Phase 2: all data concatenated
+    for blob in blobs {
+        out.extend_from_slice(blob.as_ref());
+    }
+
+    out
+}
+
+fn encode_signed_delta(
+    writer: &mut BitWriter,
+    previous: u64,
+    current: u64,
+    value_mask: u64,
+    delta_mask: u64,
+    delta_width_bits: u64,
+) {
+    let forward_delta = unsigned_delta(previous, current, value_mask);
+    let backward_delta = unsigned_delta(current, previous, value_mask);
+
+    let delta = if forward_delta <= backward_delta {
+        forward_delta
+    } else {
+        // Two's complement negative in delta_width space
+        delta_mask - backward_delta + 1
+    };
+
+    writer.write_bits(delta, delta_width_bits as usize);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn varint_encoding() {
+        assert_eq!(encode_varint(0), vec![0x00]);
+        assert_eq!(encode_varint(127), vec![0x7F]);
+        assert_eq!(encode_varint(128), vec![0x80, 0x01]);
+        assert_eq!(encode_varint(300), vec![0xAC, 0x02]);
+    }
+
+    #[test]
+    fn unsigned_bit_width_values() {
+        assert_eq!(unsigned_bit_width(0), 1);
+        assert_eq!(unsigned_bit_width(1), 1);
+        assert_eq!(unsigned_bit_width(2), 2);
+        assert_eq!(unsigned_bit_width(3), 2);
+        assert_eq!(unsigned_bit_width(4), 3);
+        assert_eq!(unsigned_bit_width(255), 8);
+        assert_eq!(unsigned_bit_width(256), 9);
+        assert_eq!(unsigned_bit_width(u64::MAX), 64);
+    }
+
+    #[test]
+    fn all_equal_returns_empty() {
+        let base = Some(42u64);
+        let values = vec![Some(42), Some(42), Some(42)];
+        let result = encode_deltas(base, &values, 64);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn single_value_non_decreasing() {
+        let base = Some(100u64);
+        let values = vec![Some(102)];
+        let result = encode_deltas(base, &values, 64);
+        // Should produce compact header + 1 delta
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn roundtrip_simple_increasing() {
+        // Sequence: base=100, values=[102, 104, 108]
+        // Deltas: 2, 2, 4 → max_delta=4 → 3 bits unsigned
+        let base = Some(100u64);
+        let values = vec![Some(102), Some(104), Some(108)];
+        let result = encode_deltas(base, &values, 64);
+        assert!(!result.is_empty());
+        // Non-decreasing → compact header (value_width=64)
+        // Compact header = 8 bits: [00 000010] = encoding_type=0, delta_width=3-1=2
+        // Deltas: 2 (010), 2 (010), 4 (100) = 9 bits → padded to byte boundary
+        // Total: 8 + 9 = 17 bits → 3 bytes
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn optional_values_with_none_base() {
+        let base: Option<u64> = None;
+        let values = vec![Some(42), Some(44), None, Some(50)];
+        let result = encode_deltas(base, &values, 64);
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn wrapping_sequence_number() {
+        // 16-bit sequence numbers wrapping around
+        let base = Some(65534u64);
+        let values = vec![Some(65535), Some(0), Some(1)];
+        let result = encode_deltas(base, &values, 16);
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn bit_writer_basics() {
+        let mut w = BitWriter::with_capacity(2);
+        w.write_bits(0b11, 2);
+        w.write_bits(0b000101, 6);
+        let out = w.finish();
+        assert_eq!(out, vec![0b11000101]);
+    }
+
+    #[test]
+    fn bit_writer_cross_byte() {
+        let mut w = BitWriter::with_capacity(2);
+        w.write_bits(0xFF, 8);
+        w.write_bits(0b1010, 4);
+        let out = w.finish();
+        assert_eq!(out, vec![0xFF, 0b10100000]);
+    }
+}

--- a/crates/rtc-event-log/src/encoder.rs
+++ b/crates/rtc-event-log/src/encoder.rs
@@ -1,0 +1,1512 @@
+use std::collections::BTreeMap;
+
+use prost::Message;
+
+use crate::delta::{encode_blobs, encode_deltas};
+use crate::events::{
+    AlrStateEvent, AudioRecvStreamConfig, AudioSendStreamConfig, DelayBasedBweUpdate,
+    IncomingRtcp, IncomingRtp, LossBasedBweUpdate, OutgoingRtcp, OutgoingRtp,
+    ProbeClusterCreated, ProbeClusterFailure, ProbeClusterSuccess, RtcEvent,
+    VideoRecvStreamConfig, VideoSendStreamConfig,
+};
+use crate::filter::filter_rtcp;
+use crate::proto;
+
+/// Encodes RTC events into the WebRTC event log v2 protobuf format.
+///
+/// Events are batched by type and delta-encoded for compression.
+/// The output is a sequence of serialized `EventStream` protobuf messages
+/// that can be concatenated into a single file.
+///
+/// The encoder is stateless — delta encoding is computed within each batch,
+/// not across batches.
+pub struct RtcEventLogEncoder;
+
+impl RtcEventLogEncoder {
+    pub fn new() -> Self {
+        RtcEventLogEncoder
+    }
+
+    /// Encode a BeginLogEvent as a standalone EventStream.
+    /// This must be the first bytes written to the output file.
+    pub fn encode_log_start(&self, timestamp_ms: i64, utc_time_ms: i64) -> Vec<u8> {
+        let event = proto::BeginLogEvent {
+            timestamp_ms: Some(timestamp_ms),
+            version: Some(2),
+            utc_time_ms: Some(utc_time_ms),
+        };
+
+        let stream = proto::EventStream {
+            begin_log_events: vec![event],
+            ..Default::default()
+        };
+
+        stream.encode_to_vec()
+    }
+
+    /// Encode an EndLogEvent as a standalone EventStream.
+    /// This must be the last bytes written to the output file.
+    pub fn encode_log_end(&self, timestamp_ms: i64) -> Vec<u8> {
+        let event = proto::EndLogEvent {
+            timestamp_ms: Some(timestamp_ms),
+        };
+
+        let stream = proto::EventStream {
+            end_log_events: vec![event],
+            ..Default::default()
+        };
+
+        stream.encode_to_vec()
+    }
+
+    /// Encode a batch of events into a serialized EventStream.
+    ///
+    /// Events are grouped by type. RTP events are further sub-grouped by SSRC
+    /// for effective delta compression (one proto message per SSRC).
+    pub fn encode_batch(&self, events: &[RtcEvent]) -> Vec<u8> {
+        let mut stream = proto::EventStream::default();
+
+        // Collect events by type. RTP events are sub-grouped by SSRC.
+        let mut outgoing_rtp_by_ssrc: BTreeMap<u32, Vec<&OutgoingRtp>> = BTreeMap::new();
+        let mut incoming_rtp_by_ssrc: BTreeMap<u32, Vec<&IncomingRtp>> = BTreeMap::new();
+        let mut incoming_rtcp: Vec<&IncomingRtcp> = Vec::new();
+        let mut outgoing_rtcp: Vec<&OutgoingRtcp> = Vec::new();
+        let mut loss_bwe: Vec<&LossBasedBweUpdate> = Vec::new();
+        let mut delay_bwe: Vec<&DelayBasedBweUpdate> = Vec::new();
+
+        for event in events {
+            match event {
+                RtcEvent::OutgoingRtp(rtp) => {
+                    outgoing_rtp_by_ssrc
+                        .entry(rtp.ssrc)
+                        .or_default()
+                        .push(rtp);
+                }
+                RtcEvent::IncomingRtp(rtp) => {
+                    incoming_rtp_by_ssrc
+                        .entry(rtp.ssrc)
+                        .or_default()
+                        .push(rtp);
+                }
+                RtcEvent::IncomingRtcp(rtcp) => {
+                    incoming_rtcp.push(rtcp);
+                }
+                RtcEvent::OutgoingRtcp(rtcp) => {
+                    outgoing_rtcp.push(rtcp);
+                }
+                RtcEvent::LossBasedBweUpdate(e) => {
+                    loss_bwe.push(e);
+                }
+                RtcEvent::DelayBasedBweUpdate(e) => {
+                    delay_bwe.push(e);
+                }
+                // Individually-serialized events are handled below.
+                RtcEvent::ProbeClusterCreated(e) => {
+                    stream.probe_clusters.push(encode_probe_cluster_created(e));
+                }
+                RtcEvent::ProbeClusterSuccess(e) => {
+                    stream.probe_success.push(encode_probe_success(e));
+                }
+                RtcEvent::ProbeClusterFailure(e) => {
+                    stream.probe_failure.push(encode_probe_failure(e));
+                }
+                RtcEvent::AlrStateEvent(e) => {
+                    stream.alr_states.push(encode_alr_state(e));
+                }
+                RtcEvent::AudioRecvStreamConfig(e) => {
+                    stream
+                        .audio_recv_stream_configs
+                        .push(encode_audio_recv_stream_config(e));
+                }
+                RtcEvent::AudioSendStreamConfig(e) => {
+                    stream
+                        .audio_send_stream_configs
+                        .push(encode_audio_send_stream_config(e));
+                }
+                RtcEvent::VideoRecvStreamConfig(e) => {
+                    stream
+                        .video_recv_stream_configs
+                        .push(encode_video_recv_stream_config(e));
+                }
+                RtcEvent::VideoSendStreamConfig(e) => {
+                    stream
+                        .video_send_stream_configs
+                        .push(encode_video_send_stream_config(e));
+                }
+                // BeginLog and EndLog are handled by encode_log_start/encode_log_end
+                RtcEvent::BeginLog(_) | RtcEvent::EndLog(_) => {}
+            }
+        }
+
+        // Encode each SSRC group as a separate RtpPackets message.
+        // Sort each group by timestamp to ensure correct delta encoding,
+        // even if events were recorded slightly out of order.
+        // This is O(n) for already-sorted data (common case).
+        for (_ssrc, mut group) in outgoing_rtp_by_ssrc {
+            group.sort_by_key(|e| e.timestamp_ms);
+            if let Some(msg) = encode_outgoing_rtp_batch(&group) {
+                stream.outgoing_rtp_packets.push(msg);
+            }
+        }
+
+        for (_ssrc, mut group) in incoming_rtp_by_ssrc {
+            group.sort_by_key(|e| e.timestamp_ms);
+            if let Some(msg) = encode_incoming_rtp_batch(&group) {
+                stream.incoming_rtp_packets.push(msg);
+            }
+        }
+
+        // RTCP events are batched together (not grouped by SSRC).
+        if !incoming_rtcp.is_empty() {
+            incoming_rtcp.sort_by_key(|e| e.timestamp_ms);
+            if let Some(msg) = encode_incoming_rtcp_batch(&incoming_rtcp) {
+                stream.incoming_rtcp_packets.push(msg);
+            }
+        }
+
+        if !outgoing_rtcp.is_empty() {
+            outgoing_rtcp.sort_by_key(|e| e.timestamp_ms);
+            if let Some(msg) = encode_outgoing_rtcp_batch(&outgoing_rtcp) {
+                stream.outgoing_rtcp_packets.push(msg);
+            }
+        }
+
+        // Delta-encoded BWE updates.
+        if !loss_bwe.is_empty() {
+            loss_bwe.sort_by_key(|e| e.timestamp_ms);
+            if let Some(msg) = encode_loss_bwe_batch(&loss_bwe) {
+                stream.loss_based_bwe_updates.push(msg);
+            }
+        }
+
+        if !delay_bwe.is_empty() {
+            delay_bwe.sort_by_key(|e| e.timestamp_ms);
+            if let Some(msg) = encode_delay_bwe_batch(&delay_bwe) {
+                stream.delay_based_bwe_updates.push(msg);
+            }
+        }
+
+        stream.encode_to_vec()
+    }
+}
+
+impl Default for RtcEventLogEncoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Encode a batch of OutgoingRtp events (same SSRC) into a protobuf message.
+fn encode_outgoing_rtp_batch(events: &[&OutgoingRtp]) -> Option<proto::OutgoingRtpPackets> {
+    let first = events.first()?;
+
+    let mut msg = proto::OutgoingRtpPackets {
+        // Base event fields
+        timestamp_ms: Some(first.timestamp_ms),
+        marker: Some(first.marker),
+        payload_type: Some(first.payload_type),
+        sequence_number: Some(first.sequence_number),
+        rtp_timestamp: Some(first.rtp_timestamp),
+        ssrc: Some(first.ssrc),
+        payload_size: Some(first.payload_size),
+        header_size: Some(first.header_size),
+        padding_size: Some(first.padding_size),
+        transport_sequence_number: first.transport_sequence_number,
+        transmission_time_offset: first.transmission_time_offset.map(|v| v as i32),
+        absolute_send_time: first.absolute_send_time,
+        video_rotation: first.video_rotation,
+        audio_level: first.audio_level,
+        voice_activity: first.voice_activity,
+        rtx_original_sequence_number: first.rtx_original_sequence_number,
+        probe_cluster_id: first.probe_cluster_id,
+        ..Default::default()
+    };
+
+    if events.len() <= 1 {
+        return Some(msg);
+    }
+
+    // Delta encode subsequent events
+    let number_of_deltas = (events.len() - 1) as u32;
+    msg.number_of_deltas = Some(number_of_deltas);
+
+    let rest = &events[1..];
+
+    // Each field is delta-encoded independently with its own value_width_bits.
+    // If encode_deltas returns empty, we leave the _deltas field unset (parser
+    // interprets missing field as "all values equal to base").
+
+    // timestamp_ms (value_width=64, never wraps)
+    set_deltas(
+        &mut msg.timestamp_ms_deltas,
+        Some(first.timestamp_ms as u64),
+        &collect_required(rest, |e| e.timestamp_ms as u64),
+        64,
+    );
+
+    // marker (value_width=64, boolean as u64)
+    set_deltas(
+        &mut msg.marker_deltas,
+        Some(first.marker as u64),
+        &collect_required(rest, |e| e.marker as u64),
+        64,
+    );
+
+    // payload_type (value_width=64)
+    set_deltas(
+        &mut msg.payload_type_deltas,
+        Some(first.payload_type as u64),
+        &collect_required(rest, |e| e.payload_type as u64),
+        64,
+    );
+
+    // sequence_number (value_width=16, wraps)
+    set_deltas(
+        &mut msg.sequence_number_deltas,
+        Some(first.sequence_number as u64),
+        &collect_required(rest, |e| e.sequence_number as u64),
+        16,
+    );
+
+    // rtp_timestamp (value_width=32, wraps)
+    set_deltas(
+        &mut msg.rtp_timestamp_deltas,
+        Some(first.rtp_timestamp as u64),
+        &collect_required(rest, |e| e.rtp_timestamp as u64),
+        32,
+    );
+
+    // ssrc (value_width=32) — same SSRC in batch, but encode anyway
+    set_deltas(
+        &mut msg.ssrc_deltas,
+        Some(first.ssrc as u64),
+        &collect_required(rest, |e| e.ssrc as u64),
+        32,
+    );
+
+    // payload_size (value_width=64)
+    set_deltas(
+        &mut msg.payload_size_deltas,
+        Some(first.payload_size as u64),
+        &collect_required(rest, |e| e.payload_size as u64),
+        64,
+    );
+
+    // header_size (value_width=64)
+    set_deltas(
+        &mut msg.header_size_deltas,
+        Some(first.header_size as u64),
+        &collect_required(rest, |e| e.header_size as u64),
+        64,
+    );
+
+    // padding_size (value_width=64)
+    set_deltas(
+        &mut msg.padding_size_deltas,
+        Some(first.padding_size as u64),
+        &collect_required(rest, |e| e.padding_size as u64),
+        64,
+    );
+
+    // transport_sequence_number (optional, value_width=16)
+    set_deltas(
+        &mut msg.transport_sequence_number_deltas,
+        first.transport_sequence_number.map(|v| v as u64),
+        &collect_optional(rest, |e| e.transport_sequence_number.map(|v| v as u64)),
+        16,
+    );
+
+    // transmission_time_offset (optional, value_width=32)
+    set_deltas(
+        &mut msg.transmission_time_offset_deltas,
+        first.transmission_time_offset.map(|v| v as u64),
+        &collect_optional(rest, |e| e.transmission_time_offset.map(|v| v as u64)),
+        32,
+    );
+
+    // absolute_send_time (optional, value_width=24)
+    set_deltas(
+        &mut msg.absolute_send_time_deltas,
+        first.absolute_send_time.map(|v| v as u64),
+        &collect_optional(rest, |e| e.absolute_send_time.map(|v| v as u64)),
+        24,
+    );
+
+    // video_rotation (optional, value_width=64)
+    set_deltas(
+        &mut msg.video_rotation_deltas,
+        first.video_rotation.map(|v| v as u64),
+        &collect_optional(rest, |e| e.video_rotation.map(|v| v as u64)),
+        64,
+    );
+
+    // audio_level (optional, value_width=64)
+    set_deltas(
+        &mut msg.audio_level_deltas,
+        first.audio_level.map(|v| v as u64),
+        &collect_optional(rest, |e| e.audio_level.map(|v| v as u64)),
+        64,
+    );
+
+    // voice_activity (optional, value_width=64)
+    set_deltas(
+        &mut msg.voice_activity_deltas,
+        first.voice_activity.map(|v| v as u64),
+        &collect_optional(rest, |e| e.voice_activity.map(|v| v as u64)),
+        64,
+    );
+
+    // rtx_original_sequence_number (optional, value_width=16)
+    set_deltas(
+        &mut msg.rtx_original_sequence_number_deltas,
+        first.rtx_original_sequence_number.map(|v| v as u64),
+        &collect_optional(rest, |e| {
+            e.rtx_original_sequence_number.map(|v| v as u64)
+        }),
+        16,
+    );
+
+    // probe_cluster_id (optional, value_width=64, signed stored as unsigned)
+    set_deltas(
+        &mut msg.probe_cluster_id_deltas,
+        first.probe_cluster_id.map(|v| v as u32 as u64),
+        &collect_optional(rest, |e| e.probe_cluster_id.map(|v| v as u32 as u64)),
+        64,
+    );
+
+    Some(msg)
+}
+
+/// Encode a batch of IncomingRtp events (same SSRC) into a protobuf message.
+fn encode_incoming_rtp_batch(events: &[&IncomingRtp]) -> Option<proto::IncomingRtpPackets> {
+    let first = events.first()?;
+
+    let mut msg = proto::IncomingRtpPackets {
+        timestamp_ms: Some(first.timestamp_ms),
+        marker: Some(first.marker),
+        payload_type: Some(first.payload_type),
+        sequence_number: Some(first.sequence_number),
+        rtp_timestamp: Some(first.rtp_timestamp),
+        ssrc: Some(first.ssrc),
+        payload_size: Some(first.payload_size),
+        header_size: Some(first.header_size),
+        padding_size: Some(first.padding_size),
+        transport_sequence_number: first.transport_sequence_number,
+        transmission_time_offset: first.transmission_time_offset.map(|v| v as i32),
+        absolute_send_time: first.absolute_send_time,
+        video_rotation: first.video_rotation,
+        audio_level: first.audio_level,
+        voice_activity: first.voice_activity,
+        rtx_original_sequence_number: first.rtx_original_sequence_number,
+        ..Default::default()
+    };
+
+    if events.len() <= 1 {
+        return Some(msg);
+    }
+
+    let number_of_deltas = (events.len() - 1) as u32;
+    msg.number_of_deltas = Some(number_of_deltas);
+
+    let rest = &events[1..];
+
+    set_deltas(
+        &mut msg.timestamp_ms_deltas,
+        Some(first.timestamp_ms as u64),
+        &collect_required(rest, |e| e.timestamp_ms as u64),
+        64,
+    );
+    set_deltas(
+        &mut msg.marker_deltas,
+        Some(first.marker as u64),
+        &collect_required(rest, |e| e.marker as u64),
+        64,
+    );
+    set_deltas(
+        &mut msg.payload_type_deltas,
+        Some(first.payload_type as u64),
+        &collect_required(rest, |e| e.payload_type as u64),
+        64,
+    );
+    set_deltas(
+        &mut msg.sequence_number_deltas,
+        Some(first.sequence_number as u64),
+        &collect_required(rest, |e| e.sequence_number as u64),
+        16,
+    );
+    set_deltas(
+        &mut msg.rtp_timestamp_deltas,
+        Some(first.rtp_timestamp as u64),
+        &collect_required(rest, |e| e.rtp_timestamp as u64),
+        32,
+    );
+    set_deltas(
+        &mut msg.ssrc_deltas,
+        Some(first.ssrc as u64),
+        &collect_required(rest, |e| e.ssrc as u64),
+        32,
+    );
+    set_deltas(
+        &mut msg.payload_size_deltas,
+        Some(first.payload_size as u64),
+        &collect_required(rest, |e| e.payload_size as u64),
+        64,
+    );
+    set_deltas(
+        &mut msg.header_size_deltas,
+        Some(first.header_size as u64),
+        &collect_required(rest, |e| e.header_size as u64),
+        64,
+    );
+    set_deltas(
+        &mut msg.padding_size_deltas,
+        Some(first.padding_size as u64),
+        &collect_required(rest, |e| e.padding_size as u64),
+        64,
+    );
+    set_deltas(
+        &mut msg.transport_sequence_number_deltas,
+        first.transport_sequence_number.map(|v| v as u64),
+        &collect_optional(rest, |e| e.transport_sequence_number.map(|v| v as u64)),
+        16,
+    );
+    set_deltas(
+        &mut msg.transmission_time_offset_deltas,
+        first.transmission_time_offset.map(|v| v as u64),
+        &collect_optional(rest, |e| e.transmission_time_offset.map(|v| v as u64)),
+        32,
+    );
+    set_deltas(
+        &mut msg.absolute_send_time_deltas,
+        first.absolute_send_time.map(|v| v as u64),
+        &collect_optional(rest, |e| e.absolute_send_time.map(|v| v as u64)),
+        24,
+    );
+    set_deltas(
+        &mut msg.video_rotation_deltas,
+        first.video_rotation.map(|v| v as u64),
+        &collect_optional(rest, |e| e.video_rotation.map(|v| v as u64)),
+        64,
+    );
+    set_deltas(
+        &mut msg.audio_level_deltas,
+        first.audio_level.map(|v| v as u64),
+        &collect_optional(rest, |e| e.audio_level.map(|v| v as u64)),
+        64,
+    );
+    set_deltas(
+        &mut msg.voice_activity_deltas,
+        first.voice_activity.map(|v| v as u64),
+        &collect_optional(rest, |e| e.voice_activity.map(|v| v as u64)),
+        64,
+    );
+    set_deltas(
+        &mut msg.rtx_original_sequence_number_deltas,
+        first.rtx_original_sequence_number.map(|v| v as u64),
+        &collect_optional(rest, |e| {
+            e.rtx_original_sequence_number.map(|v| v as u64)
+        }),
+        16,
+    );
+
+    Some(msg)
+}
+
+/// Encode a batch of IncomingRtcp events into a protobuf message.
+fn encode_incoming_rtcp_batch(events: &[&IncomingRtcp]) -> Option<proto::IncomingRtcpPackets> {
+    let first = events.first()?;
+
+    let filtered_first = filter_rtcp(&first.raw_packet);
+
+    let mut msg = proto::IncomingRtcpPackets {
+        timestamp_ms: Some(first.timestamp_ms),
+        raw_packet: Some(filtered_first),
+        ..Default::default()
+    };
+
+    if events.len() <= 1 {
+        return Some(msg);
+    }
+
+    let number_of_deltas = (events.len() - 1) as u32;
+    msg.number_of_deltas = Some(number_of_deltas);
+
+    let rest = &events[1..];
+
+    set_deltas(
+        &mut msg.timestamp_ms_deltas,
+        Some(first.timestamp_ms as u64),
+        &collect_required(rest, |e| e.timestamp_ms as u64),
+        64,
+    );
+
+    let filtered_rest: Vec<Vec<u8>> = rest.iter().map(|e| filter_rtcp(&e.raw_packet)).collect();
+    msg.raw_packet_blobs = Some(encode_blobs(&filtered_rest));
+
+    Some(msg)
+}
+
+/// Encode a batch of OutgoingRtcp events into a protobuf message.
+fn encode_outgoing_rtcp_batch(events: &[&OutgoingRtcp]) -> Option<proto::OutgoingRtcpPackets> {
+    let first = events.first()?;
+
+    let filtered_first = filter_rtcp(&first.raw_packet);
+
+    let mut msg = proto::OutgoingRtcpPackets {
+        timestamp_ms: Some(first.timestamp_ms),
+        raw_packet: Some(filtered_first),
+        ..Default::default()
+    };
+
+    if events.len() <= 1 {
+        return Some(msg);
+    }
+
+    let number_of_deltas = (events.len() - 1) as u32;
+    msg.number_of_deltas = Some(number_of_deltas);
+
+    let rest = &events[1..];
+
+    set_deltas(
+        &mut msg.timestamp_ms_deltas,
+        Some(first.timestamp_ms as u64),
+        &collect_required(rest, |e| e.timestamp_ms as u64),
+        64,
+    );
+
+    let filtered_rest: Vec<Vec<u8>> = rest.iter().map(|e| filter_rtcp(&e.raw_packet)).collect();
+    msg.raw_packet_blobs = Some(encode_blobs(&filtered_rest));
+
+    Some(msg)
+}
+
+/// If encoded deltas are non-empty, set the proto field.
+fn set_deltas(
+    field: &mut Option<Vec<u8>>,
+    base: Option<u64>,
+    values: &[Option<u64>],
+    value_width_bits: u64,
+) {
+    if values.is_empty() {
+        return;
+    }
+    let encoded = encode_deltas(base, values, value_width_bits);
+    if !encoded.is_empty() {
+        *field = Some(encoded);
+    }
+}
+
+/// Collect required (always-present) field values from a slice of events.
+fn collect_required<T, F>(events: &[&T], f: F) -> Vec<Option<u64>>
+where
+    F: Fn(&T) -> u64,
+{
+    events.iter().map(|e| Some(f(e))).collect()
+}
+
+/// Collect optional field values from a slice of events.
+fn collect_optional<T, F>(events: &[&T], f: F) -> Vec<Option<u64>>
+where
+    F: Fn(&T) -> Option<u64>,
+{
+    events.iter().map(|e| f(e)).collect()
+}
+
+/// Encode a batch of LossBasedBweUpdate events (delta-encoded).
+fn encode_loss_bwe_batch(events: &[&LossBasedBweUpdate]) -> Option<proto::LossBasedBweUpdates> {
+    let first = events.first()?;
+
+    let mut msg = proto::LossBasedBweUpdates {
+        timestamp_ms: Some(first.timestamp_ms),
+        bitrate_bps: Some(first.bitrate_bps),
+        fraction_loss: Some(first.fraction_loss),
+        total_packets: Some(first.total_packets),
+        ..Default::default()
+    };
+
+    if events.len() <= 1 {
+        return Some(msg);
+    }
+
+    let number_of_deltas = (events.len() - 1) as u32;
+    msg.number_of_deltas = Some(number_of_deltas);
+
+    let rest = &events[1..];
+
+    set_deltas(
+        &mut msg.timestamp_ms_deltas,
+        Some(first.timestamp_ms as u64),
+        &collect_required(rest, |e| e.timestamp_ms as u64),
+        64,
+    );
+    set_deltas(
+        &mut msg.bitrate_bps_deltas,
+        Some(first.bitrate_bps as u64),
+        &collect_required(rest, |e| e.bitrate_bps as u64),
+        64,
+    );
+    set_deltas(
+        &mut msg.fraction_loss_deltas,
+        Some(first.fraction_loss as u64),
+        &collect_required(rest, |e| e.fraction_loss as u64),
+        64,
+    );
+    set_deltas(
+        &mut msg.total_packets_deltas,
+        Some(first.total_packets as u64),
+        &collect_required(rest, |e| e.total_packets as u64),
+        64,
+    );
+
+    Some(msg)
+}
+
+/// Encode a batch of DelayBasedBweUpdate events (delta-encoded).
+fn encode_delay_bwe_batch(events: &[&DelayBasedBweUpdate]) -> Option<proto::DelayBasedBweUpdates> {
+    let first = events.first()?;
+
+    let mut msg = proto::DelayBasedBweUpdates {
+        timestamp_ms: Some(first.timestamp_ms),
+        bitrate_bps: Some(first.bitrate_bps),
+        detector_state: Some(first.detector_state as i32),
+        ..Default::default()
+    };
+
+    if events.len() <= 1 {
+        return Some(msg);
+    }
+
+    let number_of_deltas = (events.len() - 1) as u32;
+    msg.number_of_deltas = Some(number_of_deltas);
+
+    let rest = &events[1..];
+
+    set_deltas(
+        &mut msg.timestamp_ms_deltas,
+        Some(first.timestamp_ms as u64),
+        &collect_required(rest, |e| e.timestamp_ms as u64),
+        64,
+    );
+    set_deltas(
+        &mut msg.bitrate_bps_deltas,
+        Some(first.bitrate_bps as u64),
+        &collect_required(rest, |e| e.bitrate_bps as u64),
+        64,
+    );
+    set_deltas(
+        &mut msg.detector_state_deltas,
+        Some(first.detector_state as i32 as u64),
+        &collect_required(rest, |e| e.detector_state as i32 as u64),
+        64,
+    );
+
+    Some(msg)
+}
+
+/// Encode a ProbeClusterCreated event as a proto message (individually serialized).
+fn encode_probe_cluster_created(e: &ProbeClusterCreated) -> proto::BweProbeCluster {
+    proto::BweProbeCluster {
+        timestamp_ms: Some(e.timestamp_ms),
+        id: Some(e.id),
+        bitrate_bps: Some(e.bitrate_bps),
+        min_packets: Some(e.min_packets),
+        min_bytes: None, // str0m doesn't track min_bytes
+    }
+}
+
+/// Encode a ProbeClusterSuccess event as a proto message (individually serialized).
+fn encode_probe_success(e: &ProbeClusterSuccess) -> proto::BweProbeResultSuccess {
+    proto::BweProbeResultSuccess {
+        timestamp_ms: Some(e.timestamp_ms),
+        id: Some(e.id),
+        bitrate_bps: Some(e.bitrate_bps),
+    }
+}
+
+/// Encode a ProbeClusterFailure event as a proto message (individually serialized).
+fn encode_probe_failure(e: &ProbeClusterFailure) -> proto::BweProbeResultFailure {
+    proto::BweProbeResultFailure {
+        timestamp_ms: Some(e.timestamp_ms),
+        id: Some(e.id),
+        failure: Some(e.failure_reason as i32),
+    }
+}
+
+/// Encode an AlrStateEvent as a proto message (individually serialized).
+fn encode_alr_state(e: &AlrStateEvent) -> proto::AlrState {
+    proto::AlrState {
+        timestamp_ms: Some(e.timestamp_ms),
+        in_alr: Some(e.in_alr),
+    }
+}
+
+fn encode_header_extensions(
+    ext: &crate::events::RtpHeaderExtensionConfig,
+) -> proto::RtpHeaderExtensionConfig {
+    proto::RtpHeaderExtensionConfig {
+        transmission_time_offset_id: ext.transmission_time_offset_id,
+        absolute_send_time_id: ext.absolute_send_time_id,
+        transport_sequence_number_id: ext.transport_sequence_number_id,
+        video_rotation_id: ext.video_rotation_id,
+        audio_level_id: ext.audio_level_id,
+        dependency_descriptor_id: None,
+    }
+}
+
+fn encode_audio_recv_stream_config(
+    e: &AudioRecvStreamConfig,
+) -> proto::AudioRecvStreamConfig {
+    proto::AudioRecvStreamConfig {
+        timestamp_ms: Some(e.timestamp_ms),
+        remote_ssrc: Some(e.remote_ssrc),
+        local_ssrc: Some(e.local_ssrc),
+        header_extensions: Some(encode_header_extensions(&e.header_extensions)),
+    }
+}
+
+fn encode_audio_send_stream_config(
+    e: &AudioSendStreamConfig,
+) -> proto::AudioSendStreamConfig {
+    proto::AudioSendStreamConfig {
+        timestamp_ms: Some(e.timestamp_ms),
+        ssrc: Some(e.ssrc),
+        header_extensions: Some(encode_header_extensions(&e.header_extensions)),
+    }
+}
+
+fn encode_video_recv_stream_config(
+    e: &VideoRecvStreamConfig,
+) -> proto::VideoRecvStreamConfig {
+    proto::VideoRecvStreamConfig {
+        timestamp_ms: Some(e.timestamp_ms),
+        remote_ssrc: Some(e.remote_ssrc),
+        local_ssrc: Some(e.local_ssrc),
+        rtx_ssrc: e.rtx_ssrc,
+        header_extensions: Some(encode_header_extensions(&e.header_extensions)),
+    }
+}
+
+fn encode_video_send_stream_config(
+    e: &VideoSendStreamConfig,
+) -> proto::VideoSendStreamConfig {
+    proto::VideoSendStreamConfig {
+        timestamp_ms: Some(e.timestamp_ms),
+        ssrc: Some(e.ssrc),
+        rtx_ssrc: e.rtx_ssrc,
+        header_extensions: Some(encode_header_extensions(&e.header_extensions)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::OutgoingRtp;
+
+    fn make_outgoing_rtp(ts: i64, seq: u32, ssrc: u32) -> OutgoingRtp {
+        OutgoingRtp {
+            timestamp_ms: ts,
+            ssrc,
+            sequence_number: seq,
+            rtp_timestamp: (ts * 90) as u32, // 90kHz clock
+            payload_type: 111,
+            marker: false,
+            payload_size: 1000,
+            header_size: 12,
+            padding_size: 0,
+            transport_sequence_number: Some(seq),
+            absolute_send_time: None,
+            transmission_time_offset: None,
+            audio_level: None,
+            voice_activity: None,
+            video_rotation: None,
+            rtx_original_sequence_number: None,
+            probe_cluster_id: None,
+        }
+    }
+
+    #[test]
+    fn encode_begin_end() {
+        let encoder = RtcEventLogEncoder::new();
+        let start = encoder.encode_log_start(1000, 1704067200000);
+        let end = encoder.encode_log_end(5000);
+
+        // Both should be valid protobuf
+        let start_stream = proto::EventStream::decode(start.as_slice()).unwrap();
+        assert_eq!(start_stream.begin_log_events.len(), 1);
+        assert_eq!(start_stream.begin_log_events[0].version, Some(2));
+        assert_eq!(start_stream.begin_log_events[0].timestamp_ms, Some(1000));
+
+        let end_stream = proto::EventStream::decode(end.as_slice()).unwrap();
+        assert_eq!(end_stream.end_log_events.len(), 1);
+        assert_eq!(end_stream.end_log_events[0].timestamp_ms, Some(5000));
+    }
+
+    #[test]
+    fn encode_single_rtp() {
+        let encoder = RtcEventLogEncoder::new();
+        let events = vec![RtcEvent::OutgoingRtp(make_outgoing_rtp(1000, 1, 0x12345678))];
+        let data = encoder.encode_batch(&events);
+
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+        assert_eq!(stream.outgoing_rtp_packets.len(), 1);
+        let msg = &stream.outgoing_rtp_packets[0];
+        assert_eq!(msg.ssrc, Some(0x12345678));
+        assert_eq!(msg.sequence_number, Some(1));
+        assert!(msg.number_of_deltas.is_none());
+    }
+
+    #[test]
+    fn encode_batch_same_ssrc() {
+        let encoder = RtcEventLogEncoder::new();
+        let events = vec![
+            RtcEvent::OutgoingRtp(make_outgoing_rtp(1000, 1, 0xAABBCCDD)),
+            RtcEvent::OutgoingRtp(make_outgoing_rtp(1020, 2, 0xAABBCCDD)),
+            RtcEvent::OutgoingRtp(make_outgoing_rtp(1040, 3, 0xAABBCCDD)),
+        ];
+        let data = encoder.encode_batch(&events);
+
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+        assert_eq!(stream.outgoing_rtp_packets.len(), 1);
+        let msg = &stream.outgoing_rtp_packets[0];
+        assert_eq!(msg.number_of_deltas, Some(2));
+        assert!(msg.timestamp_ms_deltas.is_some());
+        assert!(msg.sequence_number_deltas.is_some());
+    }
+
+    #[test]
+    fn encode_batch_multiple_ssrc() {
+        let encoder = RtcEventLogEncoder::new();
+        let events = vec![
+            RtcEvent::OutgoingRtp(make_outgoing_rtp(1000, 1, 0x11111111)),
+            RtcEvent::OutgoingRtp(make_outgoing_rtp(1010, 1, 0x22222222)),
+            RtcEvent::OutgoingRtp(make_outgoing_rtp(1020, 2, 0x11111111)),
+        ];
+        let data = encoder.encode_batch(&events);
+
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+        // Two separate messages — one per SSRC
+        assert_eq!(stream.outgoing_rtp_packets.len(), 2);
+    }
+
+    #[test]
+    fn full_pipeline() {
+        let encoder = RtcEventLogEncoder::new();
+        let mut output = Vec::new();
+
+        // BeginLog
+        output.extend(encoder.encode_log_start(0, 1704067200000));
+
+        // Batch of packets
+        let events: Vec<RtcEvent> = (0..10)
+            .map(|i| {
+                RtcEvent::OutgoingRtp(make_outgoing_rtp(
+                    1000 + i * 20,
+                    i as u32 + 1,
+                    0xDEADBEEF,
+                ))
+            })
+            .collect();
+        output.extend(encoder.encode_batch(&events));
+
+        // EndLog
+        output.extend(encoder.encode_log_end(2000));
+
+        // The output should be parseable as concatenated EventStream messages
+        assert!(!output.is_empty());
+    }
+
+    fn make_incoming_rtp(ts: i64, seq: u32, ssrc: u32) -> IncomingRtp {
+        IncomingRtp {
+            timestamp_ms: ts,
+            ssrc,
+            sequence_number: seq,
+            rtp_timestamp: (ts * 90) as u32,
+            payload_type: 111,
+            marker: false,
+            payload_size: 1000,
+            header_size: 12,
+            padding_size: 0,
+            transport_sequence_number: Some(seq),
+            absolute_send_time: None,
+            transmission_time_offset: None,
+            audio_level: None,
+            voice_activity: None,
+            video_rotation: None,
+            rtx_original_sequence_number: None,
+        }
+    }
+
+    #[test]
+    fn encode_incoming_rtp_single() {
+        let encoder = RtcEventLogEncoder::new();
+        let events = vec![RtcEvent::IncomingRtp(make_incoming_rtp(1000, 1, 0x12345678))];
+        let data = encoder.encode_batch(&events);
+
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+        assert_eq!(stream.incoming_rtp_packets.len(), 1);
+        let msg = &stream.incoming_rtp_packets[0];
+        assert_eq!(msg.ssrc, Some(0x12345678));
+        assert_eq!(msg.sequence_number, Some(1));
+        assert!(msg.number_of_deltas.is_none());
+    }
+
+    #[test]
+    fn encode_incoming_rtp_batch() {
+        let encoder = RtcEventLogEncoder::new();
+        let events = vec![
+            RtcEvent::IncomingRtp(make_incoming_rtp(1000, 1, 0xAABBCCDD)),
+            RtcEvent::IncomingRtp(make_incoming_rtp(1020, 2, 0xAABBCCDD)),
+            RtcEvent::IncomingRtp(make_incoming_rtp(1040, 3, 0xAABBCCDD)),
+        ];
+        let data = encoder.encode_batch(&events);
+
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+        assert_eq!(stream.incoming_rtp_packets.len(), 1);
+        let msg = &stream.incoming_rtp_packets[0];
+        assert_eq!(msg.number_of_deltas, Some(2));
+        assert!(msg.timestamp_ms_deltas.is_some());
+        assert!(msg.sequence_number_deltas.is_some());
+    }
+
+    #[test]
+    fn encode_incoming_rtcp_single() {
+        let encoder = RtcEventLogEncoder::new();
+        let events = vec![RtcEvent::IncomingRtcp(IncomingRtcp {
+            timestamp_ms: 1000,
+            raw_packet: vec![0x80, 200, 0, 1, 1, 2, 3, 4],
+        })];
+        let data = encoder.encode_batch(&events);
+
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+        assert_eq!(stream.incoming_rtcp_packets.len(), 1);
+        let msg = &stream.incoming_rtcp_packets[0];
+        assert_eq!(msg.timestamp_ms, Some(1000));
+        assert_eq!(msg.raw_packet, Some(vec![0x80, 200, 0, 1, 1, 2, 3, 4]));
+        assert!(msg.number_of_deltas.is_none());
+    }
+
+    #[test]
+    fn encode_incoming_rtcp_batch_with_blobs() {
+        let encoder = RtcEventLogEncoder::new();
+        let events = vec![
+            RtcEvent::IncomingRtcp(IncomingRtcp {
+                timestamp_ms: 1000,
+                raw_packet: vec![0x80, 200, 0, 0],
+            }),
+            RtcEvent::IncomingRtcp(IncomingRtcp {
+                timestamp_ms: 1100,
+                raw_packet: vec![0x80, 201, 0, 1, 0, 0, 0, 0],
+            }),
+            RtcEvent::IncomingRtcp(IncomingRtcp {
+                timestamp_ms: 1200,
+                raw_packet: vec![0x80, 200, 0, 0],
+            }),
+        ];
+        let data = encoder.encode_batch(&events);
+
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+        assert_eq!(stream.incoming_rtcp_packets.len(), 1);
+        let msg = &stream.incoming_rtcp_packets[0];
+        assert_eq!(msg.number_of_deltas, Some(2));
+        assert!(msg.timestamp_ms_deltas.is_some());
+        assert!(msg.raw_packet_blobs.is_some());
+    }
+
+    #[test]
+    fn encode_outgoing_rtcp_batch() {
+        let encoder = RtcEventLogEncoder::new();
+        let events = vec![
+            RtcEvent::OutgoingRtcp(OutgoingRtcp {
+                timestamp_ms: 1000,
+                raw_packet: vec![0x80, 201, 0, 1, 0, 0, 0, 0],
+            }),
+            RtcEvent::OutgoingRtcp(OutgoingRtcp {
+                timestamp_ms: 1100,
+                raw_packet: vec![0x80, 201, 0, 1, 0, 0, 0, 0],
+            }),
+        ];
+        let data = encoder.encode_batch(&events);
+
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+        assert_eq!(stream.outgoing_rtcp_packets.len(), 1);
+        let msg = &stream.outgoing_rtcp_packets[0];
+        assert_eq!(msg.number_of_deltas, Some(1));
+    }
+
+    #[test]
+    fn encode_mixed_rtp_and_rtcp() {
+        let encoder = RtcEventLogEncoder::new();
+        let events = vec![
+            RtcEvent::OutgoingRtp(make_outgoing_rtp(1000, 1, 0x11111111)),
+            RtcEvent::IncomingRtp(make_incoming_rtp(1010, 1, 0x22222222)),
+            RtcEvent::IncomingRtcp(IncomingRtcp {
+                timestamp_ms: 1020,
+                raw_packet: vec![0x80, 200, 0, 0],
+            }),
+            RtcEvent::OutgoingRtcp(OutgoingRtcp {
+                timestamp_ms: 1030,
+                raw_packet: vec![0x80, 201, 0, 0],
+            }),
+        ];
+        let data = encoder.encode_batch(&events);
+
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+        assert_eq!(stream.outgoing_rtp_packets.len(), 1);
+        assert_eq!(stream.incoming_rtp_packets.len(), 1);
+        assert_eq!(stream.incoming_rtcp_packets.len(), 1);
+        assert_eq!(stream.outgoing_rtcp_packets.len(), 1);
+    }
+
+    #[test]
+    fn encode_rtcp_keeps_event_when_filtered_empty() {
+        let encoder = RtcEventLogEncoder::new();
+        // SDES-only packet: filtered output should be empty, but event must remain.
+        let events = vec![RtcEvent::IncomingRtcp(IncomingRtcp {
+            timestamp_ms: 1000,
+            raw_packet: vec![0x80, 202, 0, 0],
+        })];
+
+        let data = encoder.encode_batch(&events);
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+
+        assert_eq!(stream.incoming_rtcp_packets.len(), 1);
+        let msg = &stream.incoming_rtcp_packets[0];
+        assert_eq!(msg.timestamp_ms, Some(1000));
+        assert_eq!(msg.raw_packet, Some(Vec::new()));
+    }
+
+    #[test]
+    fn encode_delay_bwe_updates() {
+        use crate::events::DetectorState;
+
+        let encoder = RtcEventLogEncoder::new();
+        let events = vec![
+            RtcEvent::DelayBasedBweUpdate(DelayBasedBweUpdate {
+                timestamp_ms: 1000,
+                bitrate_bps: 500_000,
+                detector_state: DetectorState::Normal,
+            }),
+            RtcEvent::DelayBasedBweUpdate(DelayBasedBweUpdate {
+                timestamp_ms: 1500,
+                bitrate_bps: 600_000,
+                detector_state: DetectorState::Overusing,
+            }),
+        ];
+        let data = encoder.encode_batch(&events);
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+
+        assert_eq!(stream.delay_based_bwe_updates.len(), 1);
+        let msg = &stream.delay_based_bwe_updates[0];
+        assert_eq!(msg.timestamp_ms, Some(1000));
+        assert_eq!(msg.bitrate_bps, Some(500_000));
+        assert_eq!(msg.detector_state, Some(1)); // BWE_NORMAL
+        assert_eq!(msg.number_of_deltas, Some(1));
+    }
+
+    #[test]
+    fn encode_loss_bwe_updates() {
+        let encoder = RtcEventLogEncoder::new();
+        let events = vec![
+            RtcEvent::LossBasedBweUpdate(LossBasedBweUpdate {
+                timestamp_ms: 2000,
+                bitrate_bps: 400_000,
+                fraction_loss: 25,
+                total_packets: 100,
+            }),
+        ];
+        let data = encoder.encode_batch(&events);
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+
+        assert_eq!(stream.loss_based_bwe_updates.len(), 1);
+        let msg = &stream.loss_based_bwe_updates[0];
+        assert_eq!(msg.timestamp_ms, Some(2000));
+        assert_eq!(msg.bitrate_bps, Some(400_000));
+        assert_eq!(msg.fraction_loss, Some(25));
+        assert_eq!(msg.total_packets, Some(100));
+    }
+
+    #[test]
+    fn encode_probe_events() {
+        use crate::events::{ProbeClusterCreated, ProbeClusterSuccess, ProbeClusterFailure, ProbeFailureReason};
+
+        let encoder = RtcEventLogEncoder::new();
+        let events = vec![
+            RtcEvent::ProbeClusterCreated(ProbeClusterCreated {
+                timestamp_ms: 3000,
+                id: 1,
+                bitrate_bps: 1_000_000,
+                min_packets: 5,
+            }),
+            RtcEvent::ProbeClusterSuccess(ProbeClusterSuccess {
+                timestamp_ms: 3100,
+                id: 1,
+                bitrate_bps: 950_000,
+            }),
+            RtcEvent::ProbeClusterFailure(ProbeClusterFailure {
+                timestamp_ms: 3200,
+                id: 2,
+                failure_reason: ProbeFailureReason::InvalidSendReceiveRatio,
+            }),
+        ];
+        let data = encoder.encode_batch(&events);
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+
+        assert_eq!(stream.probe_clusters.len(), 1);
+        let msg = &stream.probe_clusters[0];
+        assert_eq!(msg.id, Some(1));
+        assert_eq!(msg.bitrate_bps, Some(1_000_000));
+        assert_eq!(msg.min_packets, Some(5));
+        assert_eq!(msg.min_bytes, None);
+
+        assert_eq!(stream.probe_success.len(), 1);
+        let msg = &stream.probe_success[0];
+        assert_eq!(msg.id, Some(1));
+        assert_eq!(msg.bitrate_bps, Some(950_000));
+
+        assert_eq!(stream.probe_failure.len(), 1);
+        let msg = &stream.probe_failure[0];
+        assert_eq!(msg.id, Some(2));
+        assert_eq!(msg.failure, Some(2)); // INVALID_SEND_RECEIVE_RATIO
+    }
+
+    #[test]
+    fn encode_alr_state() {
+        use crate::events::AlrStateEvent;
+
+        let encoder = RtcEventLogEncoder::new();
+        let events = vec![
+            RtcEvent::AlrStateEvent(AlrStateEvent {
+                timestamp_ms: 4000,
+                in_alr: true,
+            }),
+            RtcEvent::AlrStateEvent(AlrStateEvent {
+                timestamp_ms: 5000,
+                in_alr: false,
+            }),
+        ];
+        let data = encoder.encode_batch(&events);
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+
+        assert_eq!(stream.alr_states.len(), 2);
+        assert_eq!(stream.alr_states[0].in_alr, Some(true));
+        assert_eq!(stream.alr_states[1].in_alr, Some(false));
+    }
+
+    #[test]
+    fn encode_probe_cluster_id_zero_in_rtp_batch() {
+        // Verify that probe_cluster_id=0 is correctly encoded in a batch
+        // where the base is None (first packet has no probe) and some
+        // subsequent packets have cluster_id=0 via delta encoding.
+        let encoder = RtcEventLogEncoder::new();
+
+        let ssrc = 0xAABBCCDD;
+        let mut events = Vec::new();
+
+        // 3 packets without probe_cluster_id, then 3 with cluster_id=0
+        for i in 0..6u32 {
+            let mut rtp = make_outgoing_rtp(1000 + i as i64, i + 1, ssrc);
+            if i >= 3 {
+                rtp.probe_cluster_id = Some(0);
+            }
+            events.push(RtcEvent::OutgoingRtp(rtp));
+        }
+
+        let data = encoder.encode_batch(&events);
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+
+        assert_eq!(stream.outgoing_rtp_packets.len(), 1);
+        let msg = &stream.outgoing_rtp_packets[0];
+
+        // Base probe_cluster_id should be None (first packet has no probe)
+        assert_eq!(msg.probe_cluster_id, None,
+            "base probe_cluster_id should be None for first non-probe packet");
+
+        // Deltas should exist because some packets have probe_cluster_id
+        assert!(msg.probe_cluster_id_deltas.is_some(),
+            "probe_cluster_id_deltas should be present when packets have mixed cluster ids");
+
+        // number_of_deltas should be 5 (6 packets total, 5 deltas)
+        assert_eq!(msg.number_of_deltas, Some(5));
+    }
+
+    #[test]
+    fn encode_probe_cluster_id_base_zero() {
+        // Verify that probe_cluster_id=0 as the BASE field is correctly
+        // round-tripped: it should be Some(0), not None.
+        let encoder = RtcEventLogEncoder::new();
+
+        let ssrc = 0x11223344;
+        let mut events = Vec::new();
+
+        // All packets have cluster_id=0
+        for i in 0..5u32 {
+            let mut rtp = make_outgoing_rtp(1000 + i as i64, i + 1, ssrc);
+            rtp.probe_cluster_id = Some(0);
+            events.push(RtcEvent::OutgoingRtp(rtp));
+        }
+
+        let data = encoder.encode_batch(&events);
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+
+        assert_eq!(stream.outgoing_rtp_packets.len(), 1);
+        let msg = &stream.outgoing_rtp_packets[0];
+
+        // Base probe_cluster_id should be Some(0), NOT None!
+        // This is critical: protobuf2 should distinguish "not set" from "set to 0"
+        assert_eq!(msg.probe_cluster_id, Some(0),
+            "probe_cluster_id=0 must be explicitly set, not confused with absence");
+
+        // All identical to base → no deltas needed
+        assert!(msg.probe_cluster_id_deltas.is_none(),
+            "all-same cluster_id should produce no deltas");
+    }
+
+    #[test]
+    fn encode_probe_cluster_id_mixed_clusters_in_batch() {
+        // Verify that a single SSRC batch containing packets from multiple
+        // probe clusters (e.g., 0 and 1) correctly delta-encodes both IDs.
+        let encoder = RtcEventLogEncoder::new();
+
+        let ssrc = 0xDEADBEEF;
+        let mut events = Vec::new();
+
+        // 2 non-probe packets, 3 from cluster 0, 3 from cluster 1
+        for i in 0..8u32 {
+            let mut rtp = make_outgoing_rtp(1000 + i as i64, i + 1, ssrc);
+            rtp.probe_cluster_id = match i {
+                0..=1 => None,
+                2..=4 => Some(0),
+                _ => Some(1),
+            };
+            events.push(RtcEvent::OutgoingRtp(rtp));
+        }
+
+        let data = encoder.encode_batch(&events);
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+
+        assert_eq!(stream.outgoing_rtp_packets.len(), 1);
+        let msg = &stream.outgoing_rtp_packets[0];
+
+        // Base is None (first packet has no cluster)
+        assert_eq!(msg.probe_cluster_id, None);
+        // Deltas must exist because subsequent packets have cluster IDs
+        assert!(msg.probe_cluster_id_deltas.is_some(),
+            "deltas must be present for mixed None/0/1 values");
+        assert_eq!(msg.number_of_deltas, Some(7));
+    }
+
+    #[test]
+    fn encode_probe_cluster_id_nonzero_base() {
+        // Verify that probe_cluster_id > 0 as base works correctly.
+        let encoder = RtcEventLogEncoder::new();
+
+        let ssrc = 0xCAFEBABE;
+        let mut events = Vec::new();
+
+        // All packets belong to cluster 5
+        for i in 0..4u32 {
+            let mut rtp = make_outgoing_rtp(1000 + i as i64, i + 1, ssrc);
+            rtp.probe_cluster_id = Some(5);
+            events.push(RtcEvent::OutgoingRtp(rtp));
+        }
+
+        let data = encoder.encode_batch(&events);
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+
+        assert_eq!(stream.outgoing_rtp_packets.len(), 1);
+        let msg = &stream.outgoing_rtp_packets[0];
+
+        assert_eq!(msg.probe_cluster_id, Some(5));
+        // All identical to base → no deltas
+        assert!(msg.probe_cluster_id_deltas.is_none());
+    }
+
+    #[test]
+    fn encode_probe_cluster_id_two_ssrcs_different_clusters() {
+        // Verify that two SSRCs with different probe cluster IDs produce
+        // separate RTP batch messages, each with the correct base.
+        let encoder = RtcEventLogEncoder::new();
+
+        let ssrc_main = 0x11111111;
+        let ssrc_rtx  = 0x22222222;
+        let mut events = Vec::new();
+
+        // Main SSRC: no probe
+        for i in 0..3u32 {
+            events.push(RtcEvent::OutgoingRtp(make_outgoing_rtp(1000 + i as i64, i + 1, ssrc_main)));
+        }
+        // RTX SSRC: all cluster 0 (probe padding)
+        for i in 0..3u32 {
+            let mut rtp = make_outgoing_rtp(1000 + i as i64, 100 + i + 1, ssrc_rtx);
+            rtp.probe_cluster_id = Some(0);
+            events.push(RtcEvent::OutgoingRtp(rtp));
+        }
+
+        let data = encoder.encode_batch(&events);
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+
+        // BTreeMap ordering: ssrc_main (0x11111111) before ssrc_rtx (0x22222222)
+        assert_eq!(stream.outgoing_rtp_packets.len(), 2);
+
+        let main_msg = &stream.outgoing_rtp_packets[0];
+        assert_eq!(main_msg.ssrc, Some(ssrc_main));
+        assert_eq!(main_msg.probe_cluster_id, None,
+            "main SSRC should have no probe_cluster_id");
+
+        let rtx_msg = &stream.outgoing_rtp_packets[1];
+        assert_eq!(rtx_msg.ssrc, Some(ssrc_rtx));
+        assert_eq!(rtx_msg.probe_cluster_id, Some(0),
+            "RTX SSRC probe padding should have cluster_id=0");
+    }
+
+    #[test]
+    fn encode_probe_events_with_id_zero() {
+        // Verify ProbeClusterCreated/Success/Failure events with id=0 encode correctly.
+        use crate::events::{ProbeClusterCreated, ProbeClusterSuccess, ProbeClusterFailure, ProbeFailureReason};
+
+        let encoder = RtcEventLogEncoder::new();
+        let events = vec![
+            RtcEvent::ProbeClusterCreated(ProbeClusterCreated {
+                timestamp_ms: 3000,
+                id: 0,
+                bitrate_bps: 1_500_000,
+                min_packets: 5,
+            }),
+            RtcEvent::ProbeClusterSuccess(ProbeClusterSuccess {
+                timestamp_ms: 3050,
+                id: 0,
+                bitrate_bps: 1_400_000,
+            }),
+            RtcEvent::ProbeClusterCreated(ProbeClusterCreated {
+                timestamp_ms: 3060,
+                id: 1,
+                bitrate_bps: 3_000_000,
+                min_packets: 5,
+            }),
+            RtcEvent::ProbeClusterFailure(ProbeClusterFailure {
+                timestamp_ms: 3200,
+                id: 1,
+                failure_reason: ProbeFailureReason::Timeout,
+            }),
+        ];
+        let data = encoder.encode_batch(&events);
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+
+        // Two created probes
+        assert_eq!(stream.probe_clusters.len(), 2);
+        assert_eq!(stream.probe_clusters[0].id, Some(0));
+        assert_eq!(stream.probe_clusters[0].bitrate_bps, Some(1_500_000));
+        assert_eq!(stream.probe_clusters[1].id, Some(1));
+
+        // One success for id=0
+        assert_eq!(stream.probe_success.len(), 1);
+        assert_eq!(stream.probe_success[0].id, Some(0));
+        assert_eq!(stream.probe_success[0].bitrate_bps, Some(1_400_000));
+
+        // One failure for id=1
+        assert_eq!(stream.probe_failure.len(), 1);
+        assert_eq!(stream.probe_failure[0].id, Some(1));
+        assert_eq!(stream.probe_failure[0].failure, Some(3)); // TIMEOUT
+    }
+
+    #[test]
+    fn encode_stream_config_events() {
+        use crate::events::{
+            AudioRecvStreamConfig, AudioSendStreamConfig, RtpHeaderExtensionConfig,
+            VideoRecvStreamConfig, VideoSendStreamConfig,
+        };
+
+        let encoder = RtcEventLogEncoder::new();
+
+        let ext_config = RtpHeaderExtensionConfig {
+            transmission_time_offset_id: Some(14),
+            absolute_send_time_id: Some(2),
+            transport_sequence_number_id: Some(3),
+            video_rotation_id: Some(13),
+            audio_level_id: Some(1),
+        };
+
+        let events = vec![
+            RtcEvent::VideoSendStreamConfig(VideoSendStreamConfig {
+                timestamp_ms: 1000,
+                ssrc: 1111,
+                rtx_ssrc: Some(2222),
+                header_extensions: RtpHeaderExtensionConfig {
+                    transmission_time_offset_id: Some(14),
+                    absolute_send_time_id: Some(2),
+                    transport_sequence_number_id: Some(3),
+                    video_rotation_id: Some(13),
+                    audio_level_id: None,
+                },
+            }),
+            RtcEvent::VideoRecvStreamConfig(VideoRecvStreamConfig {
+                timestamp_ms: 1000,
+                remote_ssrc: 3333,
+                local_ssrc: 4444,
+                rtx_ssrc: Some(5555),
+                header_extensions: RtpHeaderExtensionConfig {
+                    transmission_time_offset_id: Some(14),
+                    absolute_send_time_id: Some(2),
+                    transport_sequence_number_id: Some(3),
+                    video_rotation_id: Some(13),
+                    audio_level_id: None,
+                },
+            }),
+            RtcEvent::AudioSendStreamConfig(AudioSendStreamConfig {
+                timestamp_ms: 1000,
+                ssrc: 6666,
+                header_extensions: ext_config,
+            }),
+            RtcEvent::AudioRecvStreamConfig(AudioRecvStreamConfig {
+                timestamp_ms: 1000,
+                remote_ssrc: 7777,
+                local_ssrc: 8888,
+                header_extensions: RtpHeaderExtensionConfig {
+                    transmission_time_offset_id: None,
+                    absolute_send_time_id: Some(2),
+                    transport_sequence_number_id: Some(3),
+                    video_rotation_id: None,
+                    audio_level_id: Some(1),
+                },
+            }),
+        ];
+
+        let data = encoder.encode_batch(&events);
+        let stream = proto::EventStream::decode(data.as_slice()).unwrap();
+
+        // Video send config
+        assert_eq!(stream.video_send_stream_configs.len(), 1);
+        let vsc = &stream.video_send_stream_configs[0];
+        assert_eq!(vsc.timestamp_ms, Some(1000));
+        assert_eq!(vsc.ssrc, Some(1111));
+        assert_eq!(vsc.rtx_ssrc, Some(2222));
+        let ext = vsc.header_extensions.as_ref().unwrap();
+        assert_eq!(ext.transport_sequence_number_id, Some(3));
+        assert_eq!(ext.video_rotation_id, Some(13));
+        assert_eq!(ext.audio_level_id, None);
+
+        // Video recv config
+        assert_eq!(stream.video_recv_stream_configs.len(), 1);
+        let vrc = &stream.video_recv_stream_configs[0];
+        assert_eq!(vrc.remote_ssrc, Some(3333));
+        assert_eq!(vrc.local_ssrc, Some(4444));
+        assert_eq!(vrc.rtx_ssrc, Some(5555));
+
+        // Audio send config
+        assert_eq!(stream.audio_send_stream_configs.len(), 1);
+        let asc = &stream.audio_send_stream_configs[0];
+        assert_eq!(asc.ssrc, Some(6666));
+        let ext = asc.header_extensions.as_ref().unwrap();
+        assert_eq!(ext.audio_level_id, Some(1));
+        assert_eq!(ext.absolute_send_time_id, Some(2));
+
+        // Audio recv config
+        assert_eq!(stream.audio_recv_stream_configs.len(), 1);
+        let arc = &stream.audio_recv_stream_configs[0];
+        assert_eq!(arc.remote_ssrc, Some(7777));
+        assert_eq!(arc.local_ssrc, Some(8888));
+        let ext = arc.header_extensions.as_ref().unwrap();
+        assert_eq!(ext.audio_level_id, Some(1));
+        assert_eq!(ext.video_rotation_id, None);
+    }
+}

--- a/crates/rtc-event-log/src/events.rs
+++ b/crates/rtc-event-log/src/events.rs
@@ -1,0 +1,246 @@
+/// A single RTC event ready for encoding.
+///
+/// Each variant maps directly to a protobuf message in rtc_event_log2.proto.
+/// Events carry only metadata — never media payloads.
+pub enum RtcEvent {
+    /// Log session started. Must be the first event.
+    BeginLog(BeginLog),
+    /// Log session ended. Must be the last event.
+    EndLog(EndLog),
+    /// An RTP packet received from the network.
+    IncomingRtp(IncomingRtp),
+    /// An RTP packet sent to the network.
+    OutgoingRtp(OutgoingRtp),
+    /// An RTCP packet received from the network.
+    ///
+    /// SDES/APP filtering is applied at encode-time.
+    IncomingRtcp(IncomingRtcp),
+    /// An RTCP packet sent to the network.
+    ///
+    /// SDES/APP filtering is applied at encode-time.
+    OutgoingRtcp(OutgoingRtcp),
+    /// Loss-based BWE update.
+    LossBasedBweUpdate(LossBasedBweUpdate),
+    /// Delay-based BWE update.
+    DelayBasedBweUpdate(DelayBasedBweUpdate),
+    /// Probe cluster created (starting a bandwidth probe).
+    ProbeClusterCreated(ProbeClusterCreated),
+    /// Probe cluster completed successfully.
+    ProbeClusterSuccess(ProbeClusterSuccess),
+    /// Probe cluster failed.
+    ProbeClusterFailure(ProbeClusterFailure),
+    /// ALR (Application Limited Region) state change.
+    AlrStateEvent(AlrStateEvent),
+    /// Audio receive stream configuration.
+    AudioRecvStreamConfig(AudioRecvStreamConfig),
+    /// Audio send stream configuration.
+    AudioSendStreamConfig(AudioSendStreamConfig),
+    /// Video receive stream configuration.
+    VideoRecvStreamConfig(VideoRecvStreamConfig),
+    /// Video send stream configuration.
+    VideoSendStreamConfig(VideoSendStreamConfig),
+}
+
+pub struct BeginLog {
+    pub timestamp_ms: i64,
+    pub utc_time_ms: i64,
+}
+
+pub struct EndLog {
+    pub timestamp_ms: i64,
+}
+
+/// Logged outgoing RTP packet (no payload).
+pub struct OutgoingRtp {
+    pub timestamp_ms: i64,
+    pub ssrc: u32,
+    pub sequence_number: u32,
+    pub rtp_timestamp: u32,
+    pub payload_type: u32,
+    pub marker: bool,
+    pub payload_size: u32,
+    pub header_size: u32,
+    pub padding_size: u32,
+    pub transport_sequence_number: Option<u32>,
+    pub absolute_send_time: Option<u32>,
+    /// Signed 24-bit value, stored as u32 via reinterpret (i32 as u32).
+    pub transmission_time_offset: Option<u32>,
+    pub audio_level: Option<u32>,
+    pub voice_activity: Option<bool>,
+    pub video_rotation: Option<u32>,
+    pub rtx_original_sequence_number: Option<u32>,
+    /// Which probe cluster this packet belongs to, if any.
+    pub probe_cluster_id: Option<i32>,
+}
+
+/// Logged incoming RTP packet (no payload).
+pub struct IncomingRtp {
+    pub timestamp_ms: i64,
+    pub ssrc: u32,
+    pub sequence_number: u32,
+    pub rtp_timestamp: u32,
+    pub payload_type: u32,
+    pub marker: bool,
+    pub payload_size: u32,
+    pub header_size: u32,
+    pub padding_size: u32,
+    pub transport_sequence_number: Option<u32>,
+    pub absolute_send_time: Option<u32>,
+    /// Signed 24-bit value, stored as u32 via reinterpret (i32 as u32).
+    pub transmission_time_offset: Option<u32>,
+    pub audio_level: Option<u32>,
+    pub voice_activity: Option<bool>,
+    pub video_rotation: Option<u32>,
+    pub rtx_original_sequence_number: Option<u32>,
+}
+
+/// Logged RTCP packet (raw bytes as observed on the wire).
+///
+/// SDES/APP filtering is applied at encode-time.
+pub struct IncomingRtcp {
+    pub timestamp_ms: i64,
+    pub raw_packet: Vec<u8>,
+}
+
+/// Logged RTCP packet (raw bytes as observed on the wire).
+///
+/// SDES/APP filtering is applied at encode-time.
+pub struct OutgoingRtcp {
+    pub timestamp_ms: i64,
+    pub raw_packet: Vec<u8>,
+}
+
+/// Loss-based bandwidth estimate update.
+pub struct LossBasedBweUpdate {
+    pub timestamp_ms: i64,
+    /// Bandwidth estimate in bits per second after the update.
+    pub bitrate_bps: u32,
+    /// Fraction of lost packets (0-255 range, where 255 = 100% loss).
+    pub fraction_loss: u32,
+    /// Total number of packets that this BWE update is based on.
+    pub total_packets: u32,
+}
+
+/// Delay-based bandwidth estimate update.
+pub struct DelayBasedBweUpdate {
+    pub timestamp_ms: i64,
+    /// Bandwidth estimate in bits per second after the update.
+    pub bitrate_bps: u32,
+    /// Detector state at the time of the update.
+    pub detector_state: DetectorState,
+}
+
+/// Detector state for delay-based BWE, matching the proto enum values.
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetectorState {
+    Unknown = 0,
+    Normal = 1,
+    Underusing = 2,
+    Overusing = 3,
+}
+
+/// Probe cluster created — a bandwidth probe was initiated.
+pub struct ProbeClusterCreated {
+    pub timestamp_ms: i64,
+    /// Unique probe cluster ID.
+    pub id: u32,
+    /// Target bitrate in bits per second.
+    pub bitrate_bps: u32,
+    /// Minimum number of packets to send.
+    pub min_packets: u32,
+    // Note: the proto's min_bytes field (BweProbeCluster field 5) is left unset.
+    // str0m doesn't track min_bytes separately — it uses min_packet_count +
+    // min_probe_delta to determine probe completion.
+}
+
+/// Probe cluster completed successfully with a measured bitrate.
+pub struct ProbeClusterSuccess {
+    pub timestamp_ms: i64,
+    /// Probe cluster ID.
+    pub id: u32,
+    /// Measured bitrate in bits per second.
+    pub bitrate_bps: u32,
+}
+
+/// Probe cluster failed.
+pub struct ProbeClusterFailure {
+    pub timestamp_ms: i64,
+    /// Probe cluster ID.
+    pub id: u32,
+    /// Reason for failure.
+    pub failure_reason: ProbeFailureReason,
+}
+
+/// Probe failure reason, matching the proto enum values.
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeFailureReason {
+    Unknown = 0,
+    InvalidSendReceiveInterval = 1,
+    InvalidSendReceiveRatio = 2,
+    Timeout = 3,
+}
+
+/// ALR (Application Limited Region) state change.
+pub struct AlrStateEvent {
+    pub timestamp_ms: i64,
+    /// True if the application is now in ALR (sending less than capacity).
+    pub in_alr: bool,
+}
+
+/// RTP header extension IDs for stream config events.
+///
+/// Maps extension types to their negotiated 4-bit IDs.
+/// Only extensions relevant for BWE analysis are included.
+pub struct RtpHeaderExtensionConfig {
+    pub transmission_time_offset_id: Option<i32>,
+    pub absolute_send_time_id: Option<i32>,
+    pub transport_sequence_number_id: Option<i32>,
+    pub video_rotation_id: Option<i32>,
+    pub audio_level_id: Option<i32>,
+}
+
+/// Audio receive stream configuration.
+pub struct AudioRecvStreamConfig {
+    pub timestamp_ms: i64,
+    /// Remote SSRC being received.
+    pub remote_ssrc: u32,
+    /// Local SSRC used for sending RTCP (e.g. receiver reports).
+    pub local_ssrc: u32,
+    /// Header extension IDs negotiated for this stream.
+    pub header_extensions: RtpHeaderExtensionConfig,
+}
+
+/// Audio send stream configuration.
+pub struct AudioSendStreamConfig {
+    pub timestamp_ms: i64,
+    /// SSRC for the outgoing audio stream.
+    pub ssrc: u32,
+    /// Header extension IDs negotiated for this stream.
+    pub header_extensions: RtpHeaderExtensionConfig,
+}
+
+/// Video receive stream configuration.
+pub struct VideoRecvStreamConfig {
+    pub timestamp_ms: i64,
+    /// Remote SSRC being received.
+    pub remote_ssrc: u32,
+    /// Local SSRC used for sending RTCP (e.g. receiver reports).
+    pub local_ssrc: u32,
+    /// RTX SSRC for retransmissions, if configured.
+    pub rtx_ssrc: Option<u32>,
+    /// Header extension IDs negotiated for this stream.
+    pub header_extensions: RtpHeaderExtensionConfig,
+}
+
+/// Video send stream configuration.
+pub struct VideoSendStreamConfig {
+    pub timestamp_ms: i64,
+    /// SSRC for the outgoing video stream.
+    pub ssrc: u32,
+    /// RTX SSRC for retransmissions, if configured.
+    pub rtx_ssrc: Option<u32>,
+    /// Header extension IDs negotiated for this stream.
+    pub header_extensions: RtpHeaderExtensionConfig,
+}

--- a/crates/rtc-event-log/src/filter.rs
+++ b/crates/rtc-event-log/src/filter.rs
@@ -1,0 +1,117 @@
+/// Filter RTCP compound packet to only include allowed block types.
+///
+/// Walks the compound packet using 4-byte RTCP common headers, keeping
+/// only types relevant for BWE analysis and stripping PII-containing
+/// blocks (SDES) and application-specific blocks (APP).
+///
+/// This matches WebRTC's `RemoveNonAllowlistedRtcpBlocks()`.
+///
+/// **Allowed** (kept):
+/// - 200: Sender Report (SR)
+/// - 201: Receiver Report (RR)
+/// - 203: BYE
+/// - 205: RTPFB (Transport-layer Feedback — NACK, TWCC, etc.)
+/// - 206: PSFB (Payload-specific Feedback — PLI, FIR, etc.)
+/// - 207: XR (Extended Reports)
+///
+/// **Filtered out** (removed):
+/// - 202: SDES (contains CNAME, potentially PII)
+/// - 204: APP (application-specific, not useful for BWE analysis)
+/// - All other unknown types
+pub fn filter_rtcp(raw_rtcp: &[u8]) -> Vec<u8> {
+    let mut result = Vec::with_capacity(raw_rtcp.len());
+    let mut offset = 0;
+
+    while offset + 4 <= raw_rtcp.len() {
+        let pt = raw_rtcp[offset + 1];
+        let length_words = u16::from_be_bytes([raw_rtcp[offset + 2], raw_rtcp[offset + 3]]);
+        let block_len = (length_words as usize + 1) * 4;
+
+        if offset + block_len > raw_rtcp.len() {
+            break; // Truncated block — stop parsing
+        }
+
+        match pt {
+            // SR, RR, BYE, RTPFB, PSFB, XR — keep
+            200 | 201 | 203 | 205 | 206 | 207 => {
+                result.extend_from_slice(&raw_rtcp[offset..offset + block_len]);
+            }
+            // SDES (202), APP (204), unknown — strip
+            _ => {}
+        }
+
+        offset += block_len;
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_rtcp_block(pt: u8, payload_words: u16) -> Vec<u8> {
+        let mut block = vec![0x80, pt]; // V=2, P=0, RC=0
+        block.extend_from_slice(&payload_words.to_be_bytes());
+        // Fill payload (payload_words * 4 bytes, since length field is total words - 1)
+        block.resize((payload_words as usize + 1) * 4, 0);
+        block
+    }
+
+    #[test]
+    fn keeps_sr_rr_bye() {
+        let mut compound = Vec::new();
+        compound.extend(make_rtcp_block(200, 6)); // SR
+        compound.extend(make_rtcp_block(201, 1)); // RR
+        compound.extend(make_rtcp_block(203, 0)); // BYE
+
+        let filtered = filter_rtcp(&compound);
+        assert_eq!(filtered, compound);
+    }
+
+    #[test]
+    fn strips_sdes_and_app() {
+        let sr = make_rtcp_block(200, 6);
+        let sdes = make_rtcp_block(202, 2);
+        let app = make_rtcp_block(204, 3);
+        let rr = make_rtcp_block(201, 1);
+
+        let mut compound = Vec::new();
+        compound.extend(&sr);
+        compound.extend(&sdes);
+        compound.extend(&app);
+        compound.extend(&rr);
+
+        let filtered = filter_rtcp(&compound);
+
+        let mut expected = Vec::new();
+        expected.extend(&sr);
+        expected.extend(&rr);
+        assert_eq!(filtered, expected);
+    }
+
+    #[test]
+    fn keeps_feedback_and_xr() {
+        let mut compound = Vec::new();
+        compound.extend(make_rtcp_block(205, 2)); // RTPFB
+        compound.extend(make_rtcp_block(206, 1)); // PSFB
+        compound.extend(make_rtcp_block(207, 3)); // XR
+
+        let filtered = filter_rtcp(&compound);
+        assert_eq!(filtered, compound);
+    }
+
+    #[test]
+    fn empty_input() {
+        assert!(filter_rtcp(&[]).is_empty());
+    }
+
+    #[test]
+    fn truncated_block_stops_parsing() {
+        let mut compound = make_rtcp_block(200, 6); // 28 bytes
+        compound.truncate(20); // Truncate the block
+
+        let filtered = filter_rtcp(&compound);
+        assert!(filtered.is_empty()); // Block was too short, nothing kept
+    }
+}

--- a/crates/rtc-event-log/src/lib.rs
+++ b/crates/rtc-event-log/src/lib.rs
@@ -1,0 +1,29 @@
+//! WebRTC-compatible RTC event log encoder (version 2).
+//!
+//! This crate encodes RTC events into the binary format defined by
+//! Chrome/libWebRTC's `rtc_event_log2.proto`. The output is directly
+//! parseable by existing WebRTC analysis tools such as
+//! `event_log_analyzer`.
+//!
+//! # Overview
+//!
+//! Events are represented as lightweight Rust structs ([`events`] module),
+//! batched by type, delta-encoded, and serialized into protobuf
+//! `EventStream` messages by [`encoder::RtcEventLogEncoder`].
+//!
+//! RTCP packets are logged as raw bytes with SDES/APP blocks stripped
+//! for privacy ([`filter::filter_rtcp`]).
+//!
+//! This crate is used internally by str0m and is not intended for
+//! direct use by applications.
+
+mod delta;
+pub mod events;
+pub mod encoder;
+pub mod filter;
+
+/// Generated protobuf types from `rtc_event_log2.proto`.
+#[allow(clippy::all)]
+pub mod proto {
+    include!(concat!(env!("OUT_DIR"), "/webrtc.rtclog2.rs"));
+}

--- a/examples/rtc-event-log.rs
+++ b/examples/rtc-event-log.rs
@@ -1,0 +1,689 @@
+//! Example: RTC event log capture with BWE in a 2-client SFU.
+//!
+//! Two browser tabs connect and send camera/mic. Media is forwarded between
+//! them, which makes str0m's send-side BWE active on each outgoing path.
+//! Each client produces a separate event log file (`rtc_event_log_0.log`,
+//! `rtc_event_log_1.log`, etc.) containing RTP, RTCP, BWE estimates,
+//! probe clusters, and stream configs.
+//!
+//! # Usage
+//!
+//! ```text
+//! cargo run --example rtc-event-log
+//! ```
+//!
+//! 1. Open **two** browser tabs to the URL shown in the console
+//!    (e.g. `https://192.168.x.x:3000`).
+//! 2. Accept the self-signed certificate warning in each tab.
+//! 3. In **Tab 1**: click **Connect**, then click **Cam** and **Mic**.
+//! 4. In **Tab 2**: click **Connect**, then click **Cam** and **Mic**.
+//! 5. You should see the remote video/audio appear in each tab.
+//!    BWE probing starts automatically once media flows between clients.
+//! 6. Close one or both tabs to disconnect. The event log files are
+//!    written to the current directory on disconnect.
+//!
+//! # Output
+//!
+//! - `rtc_event_log_0.log` — event log for the first client
+//! - `rtc_event_log_1.log` — event log for the second client
+//!
+//! Analyze the event logs with libWebRTC's `event_log_visualizer`
+//!
+//! The generated HTML shows BWE estimates, probe results, RTP packet
+//! timelines, RTCP feedback, and stream configurations.
+
+#[macro_use]
+extern crate tracing;
+
+use std::collections::VecDeque;
+use std::fs::File;
+use std::io::{ErrorKind, Write};
+use std::net::{SocketAddr, UdpSocket};
+use std::ops::Deref;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError};
+use std::sync::{Arc, Weak};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use rouille::Server;
+use rouille::{Request, Response};
+use str0m::bwe::Bitrate;
+use str0m::change::{SdpAnswer, SdpOffer, SdpPendingOffer};
+use str0m::channel::{ChannelData, ChannelId};
+use str0m::crypto::from_feature_flags;
+use str0m::media::{Direction, KeyframeRequest, MediaData, Mid, Rid};
+use str0m::media::{KeyframeRequestKind, MediaKind};
+use str0m::net::Protocol;
+use str0m::{Candidate, Event, IceConnectionState, Input, Output, Rtc, RtcConfig, RtcError};
+use str0m::net::Receive;
+
+mod util;
+
+fn init_log() {
+    use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("rtc_event_log=info,str0m=info"));
+
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(env_filter)
+        .init();
+}
+
+pub fn main() {
+    init_log();
+
+    from_feature_flags().install_process_default();
+
+    let certificate = include_bytes!("cer.pem").to_vec();
+    let private_key = include_bytes!("key.pem").to_vec();
+
+    let (tx, rx) = mpsc::sync_channel(1);
+
+    // Single UDP socket for all clients (multiplexed).
+    let host_addr = util::select_host_address();
+    let socket = UdpSocket::bind(format!("{host_addr}:0")).expect("binding a random UDP port");
+    let addr = socket.local_addr().expect("a local socket address");
+    info!("Bound UDP port: {}", addr);
+
+    thread::spawn(move || {
+        if let Err(e) = run(socket, rx) {
+            eprintln!("Run loop exited: {e:?}");
+        }
+    });
+
+    let server = Server::new_ssl(
+        "0.0.0.0:3000",
+        move |request| web_request(request, addr, tx.clone()),
+        certificate,
+        private_key,
+    )
+    .expect("starting the web server");
+
+    let port = server.server_addr().port();
+    info!("Connect TWO browser tabs to https://{:?}:{:?}", addr.ip(), port);
+    info!("Steps: Tab1: Connect → Cam → Mic | Tab2: Connect → Cam → Mic");
+    info!("Close a tab to disconnect and write the event log file.");
+
+    server.run();
+}
+
+fn web_request(request: &Request, addr: SocketAddr, tx: SyncSender<Rtc>) -> Response {
+    if request.method() == "GET" {
+        return Response::html(include_str!("chat.html"));
+    }
+
+    let mut data = request.data().expect("body to be available");
+    let offer: SdpOffer = serde_json::from_reader(&mut data).expect("serialized offer");
+
+    // Build Rtc with event logging and BWE enabled.
+    let mut rtc = RtcConfig::new()
+        .enable_rtc_event_log(true)
+        .enable_bwe(Some(Bitrate::kbps(300)))
+        .build(Instant::now());
+
+    let candidate = Candidate::host(addr, "udp").expect("a host candidate");
+    rtc.add_local_candidate(candidate).unwrap();
+
+    let answer = rtc
+        .sdp_api()
+        .accept_offer(offer)
+        .expect("offer to be accepted");
+
+    tx.send(rtc).expect("to send Rtc instance");
+
+    let body = serde_json::to_vec(&answer).expect("answer to serialize");
+    Response::from_data("application/json", body)
+}
+
+/// Main run loop: polls all clients, forwards media, writes event logs.
+fn run(socket: UdpSocket, rx: Receiver<Rtc>) -> Result<(), RtcError> {
+    let mut clients: Vec<Client> = vec![];
+    let mut to_propagate: VecDeque<Propagated> = VecDeque::new();
+    let mut buf = vec![0; 2000];
+
+    loop {
+        // Clean out disconnected clients and flush their event logs.
+        clients.retain_mut(|c| {
+            if !c.rtc.is_alive() {
+                c.flush_event_log();
+                false
+            } else {
+                true
+            }
+        });
+
+        // Spawn new incoming clients.
+        if let Some(mut client) = spawn_new_client(&rx) {
+            for track in clients.iter().flat_map(|c| c.tracks_in.iter()) {
+                let weak = Arc::downgrade(&track.id);
+                client.handle_track_open(weak);
+            }
+            clients.push(client);
+        }
+
+        // Poll clients until they return timeout.
+        let mut timeout = Instant::now() + Duration::from_millis(100);
+        for client in clients.iter_mut() {
+            let t = poll_until_timeout(client, &mut to_propagate, &socket);
+            timeout = timeout.min(t);
+        }
+
+        // Propagate events between clients.
+        if let Some(p) = to_propagate.pop_front() {
+            propagate(&p, &mut clients);
+            continue;
+        }
+
+        let duration = (timeout - Instant::now()).max(Duration::from_millis(1));
+        socket
+            .set_read_timeout(Some(duration))
+            .expect("setting socket read timeout");
+
+        if let Some(input) = read_socket_input(&socket, &mut buf) {
+            if let Some(client) = clients.iter_mut().find(|c| c.rtc.accepts(&input)) {
+                client.handle_input(input);
+            }
+        }
+
+        let now = Instant::now();
+        for client in &mut clients {
+            client.handle_input(Input::Timeout(now));
+        }
+    }
+}
+
+fn spawn_new_client(rx: &Receiver<Rtc>) -> Option<Client> {
+    match rx.try_recv() {
+        Ok(rtc) => Some(Client::new(rtc)),
+        Err(TryRecvError::Empty) => None,
+        _ => panic!("Receiver<Rtc> disconnected"),
+    }
+}
+
+fn poll_until_timeout(
+    client: &mut Client,
+    queue: &mut VecDeque<Propagated>,
+    socket: &UdpSocket,
+) -> Instant {
+    loop {
+        if !client.rtc.is_alive() {
+            return Instant::now();
+        }
+
+        let propagated = client.poll_output(socket);
+
+        if let Propagated::Timeout(t) = propagated {
+            return t;
+        }
+
+        queue.push_back(propagated)
+    }
+}
+
+fn propagate(propagated: &Propagated, clients: &mut [Client]) {
+    let Some(client_id) = propagated.client_id() else {
+        return;
+    };
+
+    for client in &mut *clients {
+        if client.id == client_id {
+            continue;
+        }
+
+        match &propagated {
+            Propagated::TrackOpen(_, track_in) => client.handle_track_open(track_in.clone()),
+            Propagated::MediaData(_, data) => client.handle_media_data_out(client_id, data),
+            Propagated::KeyframeRequest(_, req, origin, mid_in) => {
+                if *origin == client.id {
+                    client.handle_keyframe_request(*req, *mid_in)
+                }
+            }
+            Propagated::Noop | Propagated::Timeout(_) => {}
+        }
+    }
+}
+
+fn read_socket_input<'a>(socket: &UdpSocket, buf: &'a mut Vec<u8>) -> Option<Input<'a>> {
+    buf.resize(2000, 0);
+
+    match socket.recv_from(buf) {
+        Ok((n, source)) => {
+            buf.truncate(n);
+            let Ok(contents) = buf.as_slice().try_into() else {
+                return None;
+            };
+            Some(Input::Receive(
+                Instant::now(),
+                Receive {
+                    proto: Protocol::Udp,
+                    source,
+                    destination: socket.local_addr().unwrap(),
+                    contents,
+                },
+            ))
+        }
+        Err(e) => match e.kind() {
+            ErrorKind::WouldBlock | ErrorKind::TimedOut => None,
+            _ => panic!("UdpSocket read failed: {e:?}"),
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+struct Client {
+    id: ClientId,
+    rtc: Rtc,
+    pending: Option<SdpPendingOffer>,
+    cid: Option<ChannelId>,
+    tracks_in: Vec<TrackInEntry>,
+    tracks_out: Vec<TrackOut>,
+    chosen_rid: Option<Rid>,
+    log_file: Option<File>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ClientId(u64);
+
+impl Deref for ClientId {
+    type Target = u64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug)]
+struct TrackIn {
+    origin: ClientId,
+    mid: Mid,
+    kind: MediaKind,
+}
+
+struct TrackInEntry {
+    id: Arc<TrackIn>,
+    last_keyframe_request: Option<Instant>,
+}
+
+struct TrackOut {
+    track_in: Weak<TrackIn>,
+    state: TrackOutState,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TrackOutState {
+    ToOpen,
+    Negotiating(Mid),
+    Open(Mid),
+}
+
+impl TrackOut {
+    fn mid(&self) -> Option<Mid> {
+        match self.state {
+            TrackOutState::ToOpen => None,
+            TrackOutState::Negotiating(m) | TrackOutState::Open(m) => Some(m),
+        }
+    }
+}
+
+impl Client {
+    fn new(rtc: Rtc) -> Client {
+        static ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+        let next_id = ID_COUNTER.fetch_add(1, Ordering::SeqCst);
+
+        let log_path = format!("rtc_event_log_{next_id}.log");
+        let log_file = File::create(&log_path).expect("creating event log file");
+        info!("Client {next_id}: event log → {log_path}");
+
+        Client {
+            id: ClientId(next_id),
+            rtc,
+            pending: None,
+            cid: None,
+            tracks_in: vec![],
+            tracks_out: vec![],
+            chosen_rid: None,
+            log_file: Some(log_file),
+        }
+    }
+
+    fn handle_input(&mut self, input: Input) {
+        if !self.rtc.is_alive() {
+            return;
+        }
+        if let Err(e) = self.rtc.handle_input(input) {
+            warn!("Client ({}) disconnected: {:?}", *self.id, e);
+            self.rtc.disconnect();
+        }
+    }
+
+    fn poll_output(&mut self, socket: &UdpSocket) -> Propagated {
+        if !self.rtc.is_alive() {
+            return Propagated::Noop;
+        }
+
+        if self.negotiate_if_needed() {
+            return Propagated::Noop;
+        }
+
+        match self.rtc.poll_output() {
+            Ok(output) => self.handle_output(output, socket),
+            Err(e) => {
+                warn!("Client ({}) poll_output failed: {:?}", *self.id, e);
+                self.rtc.disconnect();
+                Propagated::Noop
+            }
+        }
+    }
+
+    fn handle_output(&mut self, output: Output, socket: &UdpSocket) -> Propagated {
+        match output {
+            Output::Transmit(transmit) => {
+                socket
+                    .send_to(&transmit.contents, transmit.destination)
+                    .expect("sending UDP data");
+                Propagated::Noop
+            }
+            Output::Timeout(t) => Propagated::Timeout(t),
+            Output::Event(e) => match e {
+                Event::RtcEventLog(data) => {
+                    if let Some(f) = &mut self.log_file {
+                        f.write_all(&data).expect("writing event log");
+                    }
+                    Propagated::Noop
+                }
+                Event::IceConnectionStateChange(v) => {
+                    if v == IceConnectionState::Disconnected {
+                        self.rtc.disconnect();
+                    }
+                    Propagated::Noop
+                }
+                Event::MediaAdded(e) => {
+                    // First media track added — set desired bitrate to trigger probing.
+                    if self.tracks_in.is_empty() {
+                        self.rtc.bwe().set_desired_bitrate(Bitrate::mbps(3));
+                        info!("Client ({}): BWE desired bitrate set to 3 Mbps", *self.id);
+                    }
+                    self.handle_media_added(e.mid, e.kind)
+                }
+                Event::MediaData(data) => self.handle_media_data_in(data),
+                Event::KeyframeRequest(req) => self.handle_incoming_keyframe_req(req),
+                Event::ChannelOpen(cid, _) => {
+                    self.cid = Some(cid);
+                    Propagated::Noop
+                }
+                Event::ChannelData(data) => self.handle_channel_data(data),
+                Event::EgressBitrateEstimate(bwe) => {
+                    info!("Client ({}): BWE estimate: {:?}", *self.id, bwe);
+                    Propagated::Noop
+                }
+                _ => Propagated::Noop,
+            },
+        }
+    }
+
+    /// Stop event logging and write remaining data to the log file.
+    fn flush_event_log(&mut self) {
+        self.rtc.stop_rtc_event_log();
+
+        // Drain final event log chunks.
+        loop {
+            match self.rtc.poll_output() {
+                Ok(Output::Event(Event::RtcEventLog(data))) => {
+                    if let Some(f) = &mut self.log_file {
+                        f.write_all(&data).expect("writing event log");
+                    }
+                }
+                Ok(Output::Timeout(_)) | Err(_) => break,
+                _ => {}
+            }
+        }
+
+        if let Some(f) = self.log_file.take() {
+            drop(f);
+            info!("Client ({}): event log written", *self.id);
+        }
+    }
+
+    fn handle_media_added(&mut self, mid: Mid, kind: MediaKind) -> Propagated {
+        let track_in = TrackInEntry {
+            id: Arc::new(TrackIn {
+                origin: self.id,
+                mid,
+                kind,
+            }),
+            last_keyframe_request: None,
+        };
+
+        let weak = Arc::downgrade(&track_in.id);
+        self.tracks_in.push(track_in);
+
+        Propagated::TrackOpen(self.id, weak)
+    }
+
+    fn handle_media_data_in(&mut self, data: MediaData) -> Propagated {
+        if !data.contiguous {
+            self.request_keyframe_throttled(data.mid, data.rid, KeyframeRequestKind::Fir);
+        }
+        Propagated::MediaData(self.id, data)
+    }
+
+    fn request_keyframe_throttled(
+        &mut self,
+        mid: Mid,
+        rid: Option<Rid>,
+        kind: KeyframeRequestKind,
+    ) {
+        let Some(mut writer) = self.rtc.writer(mid) else {
+            return;
+        };
+
+        let Some(track_entry) = self.tracks_in.iter_mut().find(|t| t.id.mid == mid) else {
+            return;
+        };
+
+        if track_entry
+            .last_keyframe_request
+            .map(|t| t.elapsed() < Duration::from_secs(1))
+            .unwrap_or(false)
+        {
+            return;
+        }
+
+        _ = writer.request_keyframe(rid, kind);
+        track_entry.last_keyframe_request = Some(Instant::now());
+    }
+
+    fn handle_incoming_keyframe_req(&self, mut req: KeyframeRequest) -> Propagated {
+        let Some(track_out) = self.tracks_out.iter().find(|t| t.mid() == Some(req.mid)) else {
+            return Propagated::Noop;
+        };
+        let Some(track_in) = track_out.track_in.upgrade() else {
+            return Propagated::Noop;
+        };
+
+        req.rid = self.chosen_rid;
+
+        Propagated::KeyframeRequest(self.id, req, track_in.origin, track_in.mid)
+    }
+
+    fn negotiate_if_needed(&mut self) -> bool {
+        if self.cid.is_none() || self.pending.is_some() {
+            return false;
+        }
+
+        let mut change = self.rtc.sdp_api();
+
+        for track in &mut self.tracks_out {
+            if let TrackOutState::ToOpen = track.state {
+                if let Some(track_in) = track.track_in.upgrade() {
+                    let stream_id = track_in.origin.to_string();
+                    let mid = change.add_media(
+                        track_in.kind,
+                        Direction::SendOnly,
+                        Some(stream_id),
+                        None,
+                        None,
+                    );
+                    track.state = TrackOutState::Negotiating(mid);
+                }
+            }
+        }
+
+        if !change.has_changes() {
+            return false;
+        }
+
+        let Some((offer, pending)) = change.apply() else {
+            return false;
+        };
+
+        let Some(mut channel) = self.cid.and_then(|id| self.rtc.channel(id)) else {
+            return false;
+        };
+
+        let json = serde_json::to_string(&offer).unwrap();
+        channel
+            .write(false, json.as_bytes())
+            .expect("to write offer");
+
+        self.pending = Some(pending);
+
+        true
+    }
+
+    fn handle_channel_data(&mut self, d: ChannelData) -> Propagated {
+        if let Ok(offer) = serde_json::from_slice::<'_, SdpOffer>(&d.data) {
+            self.handle_offer(offer);
+        } else if let Ok(answer) = serde_json::from_slice::<'_, SdpAnswer>(&d.data) {
+            self.handle_answer(answer);
+        }
+        Propagated::Noop
+    }
+
+    fn handle_offer(&mut self, offer: SdpOffer) {
+        let answer = self
+            .rtc
+            .sdp_api()
+            .accept_offer(offer)
+            .expect("offer to be accepted");
+
+        for track in &mut self.tracks_out {
+            if let TrackOutState::Negotiating(_) = track.state {
+                track.state = TrackOutState::ToOpen;
+            }
+        }
+
+        let mut channel = self
+            .cid
+            .and_then(|id| self.rtc.channel(id))
+            .expect("channel to be open");
+
+        let json = serde_json::to_string(&answer).unwrap();
+        channel
+            .write(false, json.as_bytes())
+            .expect("to write answer");
+    }
+
+    fn handle_answer(&mut self, answer: SdpAnswer) {
+        if let Some(pending) = self.pending.take() {
+            self.rtc
+                .sdp_api()
+                .accept_answer(pending, answer)
+                .expect("answer to be accepted");
+
+            for track in &mut self.tracks_out {
+                if let TrackOutState::Negotiating(m) = track.state {
+                    track.state = TrackOutState::Open(m);
+                }
+            }
+        }
+    }
+
+    fn handle_track_open(&mut self, track_in: Weak<TrackIn>) {
+        self.tracks_out.push(TrackOut {
+            track_in,
+            state: TrackOutState::ToOpen,
+        });
+    }
+
+    fn handle_media_data_out(&mut self, origin: ClientId, data: &MediaData) {
+        let Some(mid) = self
+            .tracks_out
+            .iter()
+            .find(|o| {
+                o.track_in
+                    .upgrade()
+                    .filter(|i| i.origin == origin && i.mid == data.mid)
+                    .is_some()
+            })
+            .and_then(|o| o.mid())
+        else {
+            return;
+        };
+
+        if data.rid.is_some() && data.rid != Some("h".into()) {
+            return;
+        }
+
+        if self.chosen_rid != data.rid {
+            self.chosen_rid = data.rid;
+        }
+
+        let Some(writer) = self.rtc.writer(mid) else {
+            return;
+        };
+
+        let Some(pt) = writer.match_params(data.params) else {
+            return;
+        };
+
+        if let Err(e) = writer.write(pt, data.network_time, data.time, data.data.clone()) {
+            warn!("Client ({}) failed: {:?}", *self.id, e);
+            self.rtc.disconnect();
+        }
+    }
+
+    fn handle_keyframe_request(&mut self, req: KeyframeRequest, mid_in: Mid) {
+        if !self.tracks_in.iter().any(|i| i.id.mid == mid_in) {
+            return;
+        }
+
+        let Some(mut writer) = self.rtc.writer(mid_in) else {
+            return;
+        };
+
+        if let Err(e) = writer.request_keyframe(req.rid, req.kind) {
+            info!("request_keyframe failed: {:?}", e);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Propagated events between clients
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::large_enum_variant)]
+enum Propagated {
+    Noop,
+    Timeout(Instant),
+    TrackOpen(ClientId, Weak<TrackIn>),
+    MediaData(ClientId, MediaData),
+    KeyframeRequest(ClientId, KeyframeRequest, ClientId, Mid),
+}
+
+impl Propagated {
+    fn client_id(&self) -> Option<ClientId> {
+        match self {
+            Propagated::TrackOpen(id, _)
+            | Propagated::MediaData(id, _)
+            | Propagated::KeyframeRequest(id, _, _, _) => Some(*id),
+            _ => None,
+        }
+    }
+}

--- a/src/bwe/delay/control.rs
+++ b/src/bwe/delay/control.rs
@@ -147,6 +147,11 @@ impl DelayController {
         self.trendline_estimator.hypothesis() == BandwidthUsage::Overuse
     }
 
+    /// Current detector hypothesis (Normal/Overuse/Underuse).
+    pub fn hypothesis(&self) -> BandwidthUsage {
+        self.trendline_estimator.hypothesis()
+    }
+
     /// Update smoothed RTT using EWMA (RFC 6298, alpha = 1/8).
     fn update_rtt(&mut self, rtt: Duration) {
         // Keep history as fallback in case smoothed RTT is not yet available

--- a/src/bwe/mod.rs
+++ b/src/bwe/mod.rs
@@ -41,7 +41,7 @@ use macros::log_loss;
 use smoother::EstimateSmoother;
 
 pub(crate) use macros::{log_pacer_media_debt, log_pacer_padding_debt};
-pub(crate) use probe::{BandwidthLimitedCause, ProbeEstimator};
+pub(crate) use probe::{BandwidthLimitedCause, ProbeEstimator, ProbeFailureCategory};
 pub(crate) use probe::{ProbeClusterState, ProbeControl};
 
 #[cfg(feature = "_internal_test_exports")]
@@ -123,6 +123,16 @@ impl Bwe {
     pub fn set_desired_bitrate(&mut self, v: Bitrate) {
         self.desired_bitrate = v;
     }
+
+    /// Enable or disable event log buffering inside BWE.
+    pub fn set_event_log_active(&mut self, active: bool) {
+        self.bwe.event_log_active = active;
+    }
+
+    /// Drain buffered log events produced during the last update/timeout cycle.
+    pub fn drain_log_events(&mut self) -> std::vec::Drain<'_, BweLogEvent> {
+        self.bwe.bwe_log_events.drain(..)
+    }
 }
 
 struct SendSideBandwidthEstimator {
@@ -135,6 +145,20 @@ struct SendSideBandwidthEstimator {
     alr_detector: AlrDetector,
     link_capacity_estimator: LinkCapacityEstimator,
     last_updated_estimate: Option<Bitrate>,
+
+    // Event log fields — always compiled, cost ~50 bytes when inactive.
+    /// Whether event logging is active.
+    event_log_active: bool,
+    /// Buffered log events to be drained by Session.
+    bwe_log_events: Vec<BweLogEvent>,
+    /// Last logged delay-based estimate (for change detection).
+    last_logged_delay_bps: Option<u32>,
+    /// Last logged delay detector state (for change detection).
+    last_logged_detector_state: Option<BandwidthUsage>,
+    /// Last logged loss-based estimate (for change detection).
+    last_logged_loss_bps: Option<u32>,
+    /// Last known ALR state (for transition detection).
+    last_logged_alr_in: bool,
 }
 
 impl SendSideBandwidthEstimator {
@@ -158,6 +182,12 @@ impl SendSideBandwidthEstimator {
             alr_detector,
             link_capacity_estimator: LinkCapacityEstimator::new(),
             last_updated_estimate: None,
+            event_log_active: false,
+            bwe_log_events: Vec::new(),
+            last_logged_delay_bps: None,
+            last_logged_detector_state: None,
+            last_logged_loss_bps: None,
+            last_logged_alr_in: false,
         }
     }
 
@@ -188,6 +218,14 @@ impl SendSideBandwidthEstimator {
         for (config, bitrate) in self.probe_estimator.update(send_records.iter().copied()) {
             latest_probe_result = Some(bitrate);
 
+            // Log probe success for event log.
+            if self.event_log_active {
+                self.bwe_log_events.push(BweLogEvent::ProbeSuccess {
+                    id: *config.cluster() as u32,
+                    bitrate_bps: bitrate.as_u64() as u32,
+                });
+            }
+
             // Update link capacity estimator for every successful ALR probe, not just the latest.
             // The estimator internally takes the max of all probe results, building up knowledge
             // of proven link capacity. This differs from the delay controller, which only receives
@@ -200,8 +238,8 @@ impl SendSideBandwidthEstimator {
         let mut acked_packets = vec![];
 
         let mut max_rtt = None;
-        let mut count = 0;
-        let mut lost = 0;
+        let mut count: u32 = 0;
+        let mut lost: u32 = 0;
         for record in send_records.iter() {
             count += 1;
             let Ok(acked_packet) = (*record).try_into() else {
@@ -229,6 +267,24 @@ impl SendSideBandwidthEstimator {
         let maybe_estimate =
             self.delay_controller
                 .update(&acked_packets, acked_bitrate, probe_result, now);
+
+        // Log delay-based BWE update if estimate or detector state changed.
+        if self.event_log_active {
+            let detector_state = self.delay_controller.hypothesis();
+            if let Some(delay_estimate) = maybe_estimate {
+                let bps = delay_estimate.as_u64() as u32;
+                if self.last_logged_delay_bps != Some(bps)
+                    || self.last_logged_detector_state != Some(detector_state)
+                {
+                    self.last_logged_delay_bps = Some(bps);
+                    self.last_logged_detector_state = Some(detector_state);
+                    self.bwe_log_events.push(BweLogEvent::DelayBased {
+                        bitrate_bps: bps,
+                        detector_state,
+                    });
+                }
+            }
+        }
 
         let Some(delay_estimate) = maybe_estimate else {
             return;
@@ -259,6 +315,28 @@ impl SendSideBandwidthEstimator {
         // This corresponds to UpdateLossBasedEstimator + UpdateEstimate
         self.loss_controller
             .update_bandwidth_estimate(&send_records, delay_estimate);
+
+        // Log loss-based BWE update if estimate changed.
+        if self.event_log_active {
+            let loss_result = self.loss_controller.loss_based_result();
+            if let Some(loss_estimate) = loss_result.bandwidth_estimate {
+                let bps = loss_estimate.as_u64() as u32;
+                if self.last_logged_loss_bps != Some(bps) {
+                    self.last_logged_loss_bps = Some(bps);
+                    // Compute fraction_loss as 0-255 range (matching WebRTC's convention).
+                    let fraction_loss = if count == 0 {
+                        0u32
+                    } else {
+                        ((lost as u64 * 256) / count as u64).min(255) as u32
+                    };
+                    self.bwe_log_events.push(BweLogEvent::LossBased {
+                        bitrate_bps: bps,
+                        fraction_loss,
+                        total_packets: count,
+                    });
+                }
+            }
+        }
 
         // Loss-based result is capped by delay_based_limit
         let loss_result = self.loss_controller.loss_based_result();
@@ -304,6 +382,15 @@ impl SendSideBandwidthEstimator {
             self.probe_control.set_alr_stop_time(now);
         }
 
+        // Log ALR state transitions for event log.
+        if self.event_log_active {
+            let in_alr = alr_start_time.is_some();
+            if in_alr != self.last_logged_alr_in {
+                self.last_logged_alr_in = in_alr;
+                self.bwe_log_events.push(BweLogEvent::AlrState { in_alr });
+            }
+        }
+
         self.loss_controller.set_alr_start_time(alr_start_time);
 
         // Get link capacity estimate and forward to loss controller.
@@ -311,8 +398,25 @@ impl SendSideBandwidthEstimator {
         self.loss_controller
             .set_link_capacity_estimate(link_capacity);
 
-        // Clean up expired probe cluster state
-        self.probe_estimator.handle_timeout(now);
+        // Clean up expired probe cluster state and collect failures.
+        let probe_failures = self.probe_estimator.handle_timeout(now);
+        if self.event_log_active {
+            for (config, category) in probe_failures {
+                let reason = match category {
+                    ProbeFailureCategory::InvalidSendReceiveInterval => {
+                        ProbeFailureReason::InvalidSendReceiveInterval
+                    }
+                    ProbeFailureCategory::InvalidSendReceiveRatio => {
+                        ProbeFailureReason::InvalidSendReceiveRatio
+                    }
+                    ProbeFailureCategory::Timeout => ProbeFailureReason::Timeout,
+                };
+                self.bwe_log_events.push(BweLogEvent::ProbeFailure {
+                    id: *config.cluster() as u32,
+                    reason,
+                });
+            }
+        }
 
         // Feed the current estimate into subcontrollers, if it changed.
         self.propagate_estimate();
@@ -402,7 +506,9 @@ impl SendSideBandwidthEstimator {
     }
 
     pub fn reset(&mut self, init_bitrate: Bitrate) {
+        let was_active = self.event_log_active;
         *self = Self::new(init_bitrate);
+        self.event_log_active = was_active;
     }
 }
 
@@ -469,7 +575,7 @@ impl TryFrom<&TwccSendRecord> for AckedPacket {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum BandwidthUsage {
+pub(crate) enum BandwidthUsage {
     Overuse,
     Normal,
     Underuse,
@@ -483,4 +589,37 @@ impl fmt::Display for BandwidthUsage {
             BandwidthUsage::Underuse => write!(f, "underuse"),
         }
     }
+}
+
+/// Events produced by the BWE system for the RTC event log.
+///
+/// These are buffered inside `SendSideBandwidthEstimator` when event logging is active
+/// and drained by Session after each `bwe.update()` / `bwe.handle_timeout()` call.
+#[derive(Debug, Clone)]
+pub(crate) enum BweLogEvent {
+    /// Delay-based bandwidth estimate changed.
+    DelayBased {
+        bitrate_bps: u32,
+        detector_state: BandwidthUsage,
+    },
+    /// Loss-based bandwidth estimate changed.
+    LossBased {
+        bitrate_bps: u32,
+        fraction_loss: u32,
+        total_packets: u32,
+    },
+    /// Probe cluster completed successfully.
+    ProbeSuccess { id: u32, bitrate_bps: u32 },
+    /// Probe cluster failed.
+    ProbeFailure { id: u32, reason: ProbeFailureReason },
+    /// ALR state changed.
+    AlrState { in_alr: bool },
+}
+
+/// Probe failure reason for event logging.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProbeFailureReason {
+    InvalidSendReceiveInterval,
+    InvalidSendReceiveRatio,
+    Timeout,
 }

--- a/src/bwe/probe/estimator.rs
+++ b/src/bwe/probe/estimator.rs
@@ -204,7 +204,14 @@ impl ProbeEstimator {
     }
 
     /// Finalize probes that are ready.
-    pub fn handle_timeout(&mut self, now: Instant) {
+    ///
+    /// Returns expired probes that failed (cluster config + failure reason).
+    pub fn handle_timeout(
+        &mut self,
+        now: Instant,
+    ) -> Vec<(ProbeClusterConfig, ProbeFailureCategory)> {
+        let mut failures = Vec::new();
+
         self.states.retain(|s| {
             let do_keep = now < s.finalize_at;
             if do_keep {
@@ -212,15 +219,20 @@ impl ProbeEstimator {
             }
 
             let result = s.do_calculate_bitrate();
-            if let ProbeResult::Estimate(_) = result {
-                // Already logged in calculate_bitrate() during update().
-            } else {
-                // Log the final rejection reason for the probe.
-                trace!(%result, "Probe result");
+            match result {
+                ProbeResult::Estimate(_) => {
+                    // Already logged in calculate_bitrate() during update().
+                }
+                _ => {
+                    trace!(%result, "Probe result");
+                    failures.push((s.config, result.failure_category()));
+                }
             }
 
             false
         });
+
+        failures
     }
 
     /// Clear all active probes.
@@ -423,6 +435,38 @@ enum ProbeResult {
     InvalidDataSize,
     /// Missing timing information
     MissingTimingInfo,
+}
+
+impl ProbeResult {
+    /// Map to a high-level failure category matching the proto's FailureReason enum.
+    fn failure_category(&self) -> ProbeFailureCategory {
+        match self {
+            ProbeResult::Estimate(_) => unreachable!("success is not a failure"),
+            ProbeResult::SendIntervalTooLong { .. }
+            | ProbeResult::SendIntervalInvalid { .. }
+            | ProbeResult::RecvIntervalInvalid { .. } => {
+                ProbeFailureCategory::InvalidSendReceiveInterval
+            }
+            ProbeResult::InvalidSendReceiveRatio { .. } => {
+                ProbeFailureCategory::InvalidSendReceiveRatio
+            }
+            // Insufficient data, missing timing, etc. are all treated as timeout
+            // (probe expired before collecting enough data).
+            ProbeResult::ClusterTooSmall { .. }
+            | ProbeResult::InsufficientPackets { .. }
+            | ProbeResult::InsufficientBytes { .. }
+            | ProbeResult::InvalidDataSize
+            | ProbeResult::MissingTimingInfo => ProbeFailureCategory::Timeout,
+        }
+    }
+}
+
+/// High-level probe failure category matching the proto's FailureReason enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeFailureCategory {
+    InvalidSendReceiveInterval,
+    InvalidSendReceiveRatio,
+    Timeout,
 }
 
 impl fmt::Display for ProbeResult {

--- a/src/bwe/probe/mod.rs
+++ b/src/bwe/probe/mod.rs
@@ -4,4 +4,4 @@ mod estimator;
 
 pub use cluster::{ProbeClusterConfig, ProbeClusterState, ProbeKind};
 pub use control::{BandwidthLimitedCause, ProbeControl};
-pub use estimator::ProbeEstimator;
+pub use estimator::{ProbeEstimator, ProbeFailureCategory};

--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -235,14 +235,22 @@ impl<'a> DirectApi<'a> {
         mid: Mid,
         rid: Option<Rid>,
     ) -> &mut StreamRx {
-        let Some(_media) = self.rtc.session.media_by_mid(mid) else {
+        let Some(media) = self.rtc.session.media_by_mid(mid) else {
             panic!("No media declared for mid: {}", mid);
         };
+
+        let is_audio = media.kind().is_audio();
+        let exts = media.remote_extmap().clone();
 
         // By default we do not suppress nacks, this has to be called explicitly by the user of direct API.
         let suppress_nack = false;
 
         let midrid = MidRid(mid, rid);
+
+        // Record stream config for event log.
+        self.rtc
+            .session
+            .record_recv_stream_config(is_audio, *ssrc, rtx.map(|r| *r), &exts);
 
         self.rtc
             .session
@@ -291,6 +299,7 @@ impl<'a> DirectApi<'a> {
         };
 
         let is_audio = media.kind().is_audio();
+        let exts = media.remote_extmap().clone();
 
         let midrid = MidRid(mid, rid);
 
@@ -298,6 +307,11 @@ impl<'a> DirectApi<'a> {
         if let Some(rid) = rid {
             media.add_to_rid_tx(rid);
         }
+
+        // Record stream config for event log.
+        self.rtc
+            .session
+            .record_send_stream_config(is_audio, *ssrc, rtx.map(|r| *r), &exts);
 
         let stream = self
             .rtc

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -944,9 +944,17 @@ fn apply_offer(session: &mut Session, offer: SdpOffer) -> Result<(), RtcError> {
     let bundle_mids = offer.bundle_mids();
     let new_lines = sync_medias(session, &offer, true).map_err(RtcError::RemoteSdp)?;
 
+    // Collect mids of new m-lines before they are consumed.
+    let new_mids: Vec<Mid> = new_lines.iter().filter(|m| m.1.typ.is_media()).map(|m| m.1.mid()).collect();
+
     add_new_lines(session, &new_lines, true, bundle_mids).map_err(RtcError::RemoteSdp)?;
 
     ensure_stream_tx(session);
+
+    // Record stream configs for newly added media.
+    for mid in new_mids {
+        session.record_stream_configs_for_mid(mid);
+    }
 
     Ok(())
 }
@@ -968,12 +976,30 @@ fn apply_answer(
         return Err(RtcError::RemoteSdp(err));
     }
 
+    // Collect mids from both new m-lines and pending changes (offerer's pre-allocated streams).
+    // Use the pending mids as the source of truth — these are the mids for which the
+    // offerer created streams. New m-lines come from the same set, so pending_mids
+    // covers both paths without duplication.
+    let pending_mids: Vec<Mid> = pending
+        .0
+        .iter()
+        .filter_map(|c| match c {
+            Change::AddMedia(add) => Some(add.mid),
+            _ => None,
+        })
+        .collect();
+
     add_new_lines(session, &new_lines, false, bundle_mids).map_err(RtcError::RemoteSdp)?;
 
     // Add all pending changes (since we pre-allocated SSRC communicated in the Offer).
     add_pending_changes(session, pending);
 
     ensure_stream_tx(session);
+
+    // Record stream configs for newly added media.
+    for mid in &pending_mids {
+        session.record_stream_configs_for_mid(*mid);
+    }
 
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,8 @@ pub struct RtcConfig {
     pub(crate) send_buffer_video: usize,
     pub(crate) rtp_mode: bool,
     pub(crate) enable_raw_packets: bool,
+    pub(crate) enable_rtc_event_log: bool,
+    pub(crate) rtc_event_log_interval: Option<Duration>,
     pub(crate) dtls_version: DtlsVersion,
     pub(crate) vp9_packetizer_mode: Vp9PacketizerMode,
     pub(crate) snap_enabled: bool,
@@ -545,6 +547,27 @@ impl RtcConfig {
         self
     }
 
+    /// Enable RTC event logging.
+    ///
+    /// When enabled, str0m will emit [`Event::RtcEventLog(Vec<u8>)`][crate::Event::RtcEventLog]
+    /// events containing serialized protobuf data in WebRTC's rtc_event_log2 format.
+    ///
+    /// Write the bytes sequentially to a file to produce a log parseable by
+    /// Chrome's `webrtc_event_log_visualizer` or any rtc_event_log2 parser.
+    pub fn enable_rtc_event_log(mut self, enabled: bool) -> Self {
+        self.enable_rtc_event_log = enabled;
+        self
+    }
+
+    /// Set the flush interval for event log batches.
+    ///
+    /// Controls how often buffered events are serialized and emitted.
+    /// Default: 2 seconds.
+    pub fn set_rtc_event_log_interval(mut self, interval: Duration) -> Self {
+        self.rtc_event_log_interval = Some(interval);
+        self
+    }
+
     /// Enable SNAP (SCTP Negotiation Acceleration Protocol).
     ///
     /// When enabled, the `a=sctp-init` attribute is included in outgoing SDP
@@ -641,6 +664,8 @@ impl Default for RtcConfig {
             send_buffer_video: 1000,
             rtp_mode: false,
             enable_raw_packets: false,
+            enable_rtc_event_log: false,
+            rtc_event_log_interval: None,
             dtls_version: DtlsVersion::Dtls12,
             vp9_packetizer_mode: Vp9PacketizerMode::default(),
             snap_enabled: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -773,6 +773,8 @@ use util::{Soonest, not_happening};
 mod session;
 use session::Session;
 
+mod rtc_event_log;
+
 pub mod stats;
 
 use stats::{CandidatePairStats, CandidateStats, MediaEgressStats, MediaIngressStats};
@@ -950,6 +952,15 @@ pub enum Event {
     /// Should not be enabled outside of tests and troubleshooting.
     RawPacket(Box<RawPacket>),
 
+    /// Serialized RTC event log data (protobuf v2 format).
+    ///
+    /// Write these bytes sequentially to a file to produce a valid
+    /// WebRTC event log parseable by Chrome's tools.
+    ///
+    /// Only emitted when event logging has been enabled via
+    /// [`RtcConfig::enable_rtc_event_log()`].
+    RtcEventLog(Vec<u8>),
+
     /// For internal testing only.
     ///
     /// The probe cluster config when a probe fires.
@@ -1073,6 +1084,9 @@ pub enum Reason {
 
     /// The probe estimator of the BWE subsystem.
     BweProbeEstimator,
+
+    /// RTC event log flushing.
+    EventLog,
 }
 
 impl Rtc {
@@ -1116,7 +1130,7 @@ impl Rtc {
             // this expect message.
             .expect("a crash earlier if no crypto provider was set");
 
-        let session = Session::new(&config);
+        let session = Session::new(&config, start);
 
         let local_creds = config.local_ice_credentials.unwrap_or_else(IceCreds::new);
         let mut ice = IceAgent::with_hmac(local_creds, crypto_provider.sha1_hmac_provider);
@@ -1222,6 +1236,18 @@ impl Rtc {
             debug!("Set alive=false");
             self.alive = false;
         }
+    }
+
+    /// Stop RTC event logging and flush remaining events.
+    ///
+    /// After this call, one or more final `Event::RtcEventLog` events
+    /// will be emitted containing the remaining buffered events and
+    /// the EndLogEvent marker. Drain them via `poll_output()`.
+    ///
+    /// Must be called before dropping the `Rtc` instance to produce a
+    /// complete log file with the EndLogEvent marker.
+    pub fn stop_rtc_event_log(&mut self) {
+        self.session.stop_rtc_event_log(self.last_now);
     }
 
     /// Add a local ICE candidate. Local candidates are socket addresses the `Rtc` instance
@@ -1455,6 +1481,12 @@ impl Rtc {
 
     fn do_poll_output(&mut self) -> Result<Output, RtcError> {
         if !self.alive {
+            // Even when not alive, drain any pending event log data (e.g. EndLogEvent
+            // queued by stop_rtc_event_log()). This data is already serialized and
+            // must be delivered so the log file has a proper end marker.
+            if let Some(data) = self.session.poll_event_log() {
+                return Ok(Output::Event(Event::RtcEventLog(data)));
+            }
             self.last_timeout_reason = Reason::NotHappening;
             return Ok(Output::Timeout(not_happening()));
         }

--- a/src/rtc_event_log.rs
+++ b/src/rtc_event_log.rs
@@ -1,0 +1,471 @@
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+use str0m_rtc_event_log::encoder::RtcEventLogEncoder;
+use str0m_rtc_event_log::events::{
+    AlrStateEvent, AudioRecvStreamConfig, AudioSendStreamConfig, DelayBasedBweUpdate,
+    IncomingRtcp, IncomingRtp, LossBasedBweUpdate, OutgoingRtcp, OutgoingRtp,
+    ProbeClusterCreated, ProbeClusterFailure, ProbeClusterSuccess, RtcEvent,
+    RtpHeaderExtensionConfig, VideoRecvStreamConfig, VideoSendStreamConfig,
+};
+
+use crate::bwe_::{BandwidthUsage, ProbeFailureReason as BweProbeFailureReason};
+use crate::rtp_::{Extension, ExtensionMap, RtpHeader};
+use crate::util::InstantExt;
+
+/// Default flush interval for event log batches.
+const DEFAULT_FLUSH_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Maximum events before forcing a flush (safety measure against unbounded growth).
+const MAX_EVENTS: usize = 10_000;
+
+/// Collects RTC events and serializes them on a flush interval.
+///
+/// Events are recorded via cheap `Vec::push()` calls during packet processing.
+/// Serialization happens when `flush()` is called by the timeout system.
+///
+/// The `BeginLogEvent` is serialized eagerly at construction time and pushed
+/// to `pending_output` immediately, guaranteeing it is always the first bytes
+/// returned by `poll()`.
+pub(crate) struct RtcEventLogCollector {
+    /// Buffered events waiting to be encoded.
+    events: Vec<RtcEvent>,
+
+    /// Interval between flushes.
+    flush_interval: Duration,
+
+    /// Instant of next scheduled flush.
+    next_flush: Instant,
+
+    /// The encoder (stateless — delta chains reset per batch).
+    encoder: RtcEventLogEncoder,
+
+    /// Serialized bytes ready to be delivered via poll_output().
+    pending_output: VecDeque<Vec<u8>>,
+
+    /// Whether stop was requested and EndLogEvent has already been queued.
+    stopped: bool,
+}
+
+impl RtcEventLogCollector {
+    /// Create a new collector.
+    ///
+    /// The `BeginLogEvent` (with version=2 and UTC wall-clock time) is serialized
+    /// immediately and queued in `pending_output`. The first call to `poll()`
+    /// will return these bytes.
+    pub fn new(now: Instant, flush_interval: Duration) -> Self {
+        let encoder = RtcEventLogEncoder::new();
+        let timestamp_ms = to_timestamp_ms(now);
+        let utc_time_ms = timestamp_ms;
+
+        let begin_data = encoder.encode_log_start(timestamp_ms, utc_time_ms);
+
+        let mut pending_output = VecDeque::new();
+        pending_output.push_back(begin_data);
+
+        RtcEventLogCollector {
+            events: Vec::with_capacity(256),
+            flush_interval,
+            next_flush: now + flush_interval,
+            encoder,
+            pending_output,
+            stopped: false,
+        }
+    }
+
+    /// Create with default flush interval (2 seconds).
+    pub fn with_defaults(now: Instant) -> Self {
+        Self::new(now, DEFAULT_FLUSH_INTERVAL)
+    }
+
+    /// Record an outgoing RTP packet.
+    ///
+    /// Captures header fields and sizes. This is a cheap `Vec::push()`.
+    pub fn record_outgoing_rtp(
+        &mut self,
+        now: Instant,
+        header: &RtpHeader,
+        payload_size: usize,
+        cluster_id: Option<i32>,
+        rtx_osn: Option<u16>,
+    ) {
+        if self.stopped {
+            return;
+        }
+
+        let event = OutgoingRtp {
+            timestamp_ms: to_timestamp_ms(now),
+            ssrc: *header.ssrc,
+            sequence_number: header.sequence_number as u32,
+            rtp_timestamp: header.timestamp,
+            payload_type: *header.payload_type as u32,
+            marker: header.marker,
+            payload_size: payload_size as u32,
+            header_size: header.header_len as u32,
+            padding_size: 0,
+            transport_sequence_number: header.ext_vals.transport_cc.map(|v| v as u32),
+            // str0m decodes abs_send_time into an Instant, discarding the raw 24-bit
+            // fixed-point u32. Re-encoding would be a lossy round-trip, so we omit it.
+            absolute_send_time: None,
+            transmission_time_offset: header.ext_vals.tx_time_offs,
+            audio_level: header.ext_vals.audio_level.map(|v| (-v) as u8 as u32),
+            voice_activity: header.ext_vals.voice_activity,
+            video_rotation: header
+                .ext_vals
+                .video_orientation
+                .map(|v| v as u32),
+            rtx_original_sequence_number: rtx_osn.map(|v| v as u32),
+            probe_cluster_id: cluster_id,
+        };
+
+        self.events.push(RtcEvent::OutgoingRtp(event));
+    }
+
+    /// Record an incoming RTP packet.
+    ///
+    /// Called from `handle_rtp()` after SRTP decrypt, before un_rtx.
+    /// `padding_size` is read from the last byte of the decrypted payload
+    /// before unpadding. `rtx_osn` is the original sequence number extracted
+    /// from the first 2 bytes of RTX payloads.
+    pub fn record_incoming_rtp(
+        &mut self,
+        now: Instant,
+        header: &RtpHeader,
+        payload_size: usize,
+        padding_size: usize,
+        rtx_osn: Option<u16>,
+    ) {
+        if self.stopped {
+            return;
+        }
+
+        let event = IncomingRtp {
+            timestamp_ms: to_timestamp_ms(now),
+            ssrc: *header.ssrc,
+            sequence_number: header.sequence_number as u32,
+            rtp_timestamp: header.timestamp,
+            payload_type: *header.payload_type as u32,
+            marker: header.marker,
+            payload_size: payload_size as u32,
+            header_size: header.header_len as u32,
+            padding_size: padding_size as u32,
+            transport_sequence_number: header.ext_vals.transport_cc.map(|v| v as u32),
+            // str0m decodes abs_send_time into an Instant, discarding the raw 24-bit
+            // fixed-point u32. Re-encoding would be a lossy round-trip, so we omit it.
+            absolute_send_time: None,
+            transmission_time_offset: header.ext_vals.tx_time_offs,
+            audio_level: header.ext_vals.audio_level.map(|v| (-v) as u8 as u32),
+            voice_activity: header.ext_vals.voice_activity,
+            video_rotation: header.ext_vals.video_orientation.map(|v| v as u32),
+            rtx_original_sequence_number: rtx_osn.map(|v| v as u32),
+        };
+
+        self.events.push(RtcEvent::IncomingRtp(event));
+    }
+
+    /// Record an incoming RTCP packet (after SRTP decrypt).
+    ///
+    /// Raw bytes are stored as-is and filtered at encode-time (WebRTC parity).
+    pub fn record_incoming_rtcp(&mut self, now: Instant, raw: &[u8]) {
+        if self.stopped {
+            return;
+        }
+        let event = IncomingRtcp {
+            timestamp_ms: to_timestamp_ms(now),
+            raw_packet: raw.to_vec(),
+        };
+        self.events.push(RtcEvent::IncomingRtcp(event));
+    }
+
+    /// Record an outgoing RTCP packet (before SRTP protect).
+    ///
+    /// Raw bytes are stored as-is and filtered at encode-time (WebRTC parity).
+    pub fn record_outgoing_rtcp(&mut self, now: Instant, raw: &[u8]) {
+        if self.stopped {
+            return;
+        }
+        let event = OutgoingRtcp {
+            timestamp_ms: to_timestamp_ms(now),
+            raw_packet: raw.to_vec(),
+        };
+        self.events.push(RtcEvent::OutgoingRtcp(event));
+    }
+
+    /// Record a delay-based BWE update.
+    pub fn record_delay_based_bwe(
+        &mut self,
+        now: Instant,
+        bitrate_bps: u32,
+        detector_state: BandwidthUsage,
+    ) {
+        if self.stopped {
+            return;
+        }
+        let state = match detector_state {
+            BandwidthUsage::Normal => str0m_rtc_event_log::events::DetectorState::Normal,
+            BandwidthUsage::Underuse => str0m_rtc_event_log::events::DetectorState::Underusing,
+            BandwidthUsage::Overuse => str0m_rtc_event_log::events::DetectorState::Overusing,
+        };
+        self.events
+            .push(RtcEvent::DelayBasedBweUpdate(DelayBasedBweUpdate {
+                timestamp_ms: to_timestamp_ms(now),
+                bitrate_bps,
+                detector_state: state,
+            }));
+    }
+
+    /// Record a loss-based BWE update.
+    pub fn record_loss_based_bwe(
+        &mut self,
+        now: Instant,
+        bitrate_bps: u32,
+        fraction_loss: u32,
+        total_packets: u32,
+    ) {
+        if self.stopped {
+            return;
+        }
+        self.events
+            .push(RtcEvent::LossBasedBweUpdate(LossBasedBweUpdate {
+                timestamp_ms: to_timestamp_ms(now),
+                bitrate_bps,
+                fraction_loss,
+                total_packets,
+            }));
+    }
+
+    /// Record a probe cluster being created (bandwidth probe started).
+    pub fn record_probe_cluster_created(
+        &mut self,
+        now: Instant,
+        id: u32,
+        bitrate_bps: u32,
+        min_packets: u32,
+    ) {
+        if self.stopped {
+            return;
+        }
+        self.events
+            .push(RtcEvent::ProbeClusterCreated(ProbeClusterCreated {
+                timestamp_ms: to_timestamp_ms(now),
+                id,
+                bitrate_bps,
+                min_packets,
+            }));
+    }
+
+    /// Record a successful probe cluster result.
+    pub fn record_probe_cluster_success(
+        &mut self,
+        now: Instant,
+        id: u32,
+        bitrate_bps: u32,
+    ) {
+        if self.stopped {
+            return;
+        }
+        self.events
+            .push(RtcEvent::ProbeClusterSuccess(ProbeClusterSuccess {
+                timestamp_ms: to_timestamp_ms(now),
+                id,
+                bitrate_bps,
+            }));
+    }
+
+    /// Record a failed probe cluster result.
+    pub fn record_probe_cluster_failure(
+        &mut self,
+        now: Instant,
+        id: u32,
+        reason: BweProbeFailureReason,
+    ) {
+        if self.stopped {
+            return;
+        }
+        let failure_reason = match reason {
+            BweProbeFailureReason::InvalidSendReceiveInterval => {
+                str0m_rtc_event_log::events::ProbeFailureReason::InvalidSendReceiveInterval
+            }
+            BweProbeFailureReason::InvalidSendReceiveRatio => {
+                str0m_rtc_event_log::events::ProbeFailureReason::InvalidSendReceiveRatio
+            }
+            BweProbeFailureReason::Timeout => {
+                str0m_rtc_event_log::events::ProbeFailureReason::Timeout
+            }
+        };
+        self.events
+            .push(RtcEvent::ProbeClusterFailure(ProbeClusterFailure {
+                timestamp_ms: to_timestamp_ms(now),
+                id,
+                failure_reason,
+            }));
+    }
+
+    /// Record an ALR state change.
+    pub fn record_alr_state(&mut self, now: Instant, in_alr: bool) {
+        if self.stopped {
+            return;
+        }
+        self.events
+            .push(RtcEvent::AlrStateEvent(AlrStateEvent {
+                timestamp_ms: to_timestamp_ms(now),
+                in_alr,
+            }));
+    }
+
+    /// Record a video receive stream configuration.
+    pub fn record_video_recv_stream_config(
+        &mut self,
+        now: Instant,
+        remote_ssrc: u32,
+        local_ssrc: u32,
+        rtx_ssrc: Option<u32>,
+        exts: &ExtensionMap,
+    ) {
+        if self.stopped {
+            return;
+        }
+        self.events
+            .push(RtcEvent::VideoRecvStreamConfig(VideoRecvStreamConfig {
+                timestamp_ms: to_timestamp_ms(now),
+                remote_ssrc,
+                local_ssrc,
+                rtx_ssrc,
+                header_extensions: ext_config_from_map(exts),
+            }));
+    }
+
+    /// Record a video send stream configuration.
+    pub fn record_video_send_stream_config(
+        &mut self,
+        now: Instant,
+        ssrc: u32,
+        rtx_ssrc: Option<u32>,
+        exts: &ExtensionMap,
+    ) {
+        if self.stopped {
+            return;
+        }
+        self.events
+            .push(RtcEvent::VideoSendStreamConfig(VideoSendStreamConfig {
+                timestamp_ms: to_timestamp_ms(now),
+                ssrc,
+                rtx_ssrc,
+                header_extensions: ext_config_from_map(exts),
+            }));
+    }
+
+    /// Record an audio receive stream configuration.
+    pub fn record_audio_recv_stream_config(
+        &mut self,
+        now: Instant,
+        remote_ssrc: u32,
+        local_ssrc: u32,
+        exts: &ExtensionMap,
+    ) {
+        if self.stopped {
+            return;
+        }
+        self.events
+            .push(RtcEvent::AudioRecvStreamConfig(AudioRecvStreamConfig {
+                timestamp_ms: to_timestamp_ms(now),
+                remote_ssrc,
+                local_ssrc,
+                header_extensions: ext_config_from_map(exts),
+            }));
+    }
+
+    /// Record an audio send stream configuration.
+    pub fn record_audio_send_stream_config(
+        &mut self,
+        now: Instant,
+        ssrc: u32,
+        exts: &ExtensionMap,
+    ) {
+        if self.stopped {
+            return;
+        }
+        self.events
+            .push(RtcEvent::AudioSendStreamConfig(AudioSendStreamConfig {
+                timestamp_ms: to_timestamp_ms(now),
+                ssrc,
+                header_extensions: ext_config_from_map(exts),
+            }));
+    }
+
+    /// Returns the next time a flush should happen.
+    pub fn poll_timeout(&self) -> Option<Instant> {
+        if self.events.is_empty() && self.pending_output.is_empty() {
+            None
+        } else {
+            Some(self.next_flush)
+        }
+    }
+
+    /// Flush buffered events if the interval has elapsed or buffer is full.
+    pub fn flush(&mut self, now: Instant) {
+        if self.stopped {
+            return;
+        }
+
+        if now >= self.next_flush || self.events.len() >= MAX_EVENTS {
+            if !self.events.is_empty() {
+                let data = self.encoder.encode_batch(&self.events);
+                self.pending_output.push_back(data);
+                self.events.clear();
+            }
+            self.next_flush = now + self.flush_interval;
+        }
+    }
+
+    /// Drain the next chunk of serialized bytes for delivery.
+    pub fn poll(&mut self) -> Option<Vec<u8>> {
+        self.pending_output.pop_front()
+    }
+
+    /// Flush all remaining events and produce the EndLogEvent.
+    pub fn finish(&mut self, now: Instant) {
+        if self.stopped {
+            return;
+        }
+
+        // Flush remaining events
+        if !self.events.is_empty() {
+            let data = self.encoder.encode_batch(&self.events);
+            self.pending_output.push_back(data);
+            self.events.clear();
+        }
+
+        // Produce EndLogEvent
+        let end_data = self.encoder.encode_log_end(to_timestamp_ms(now));
+        self.pending_output.push_back(end_data);
+        self.stopped = true;
+    }
+}
+
+/// Convert an Instant to absolute wall-clock timestamp_ms.
+/// Uses str0m's `InstantExt::to_unix_duration()`.
+fn to_timestamp_ms(instant: Instant) -> i64 {
+    instant.to_unix_duration().as_millis() as i64
+}
+
+/// Build an `RtpHeaderExtensionConfig` from an `ExtensionMap`.
+///
+/// Looks up the IDs of the extensions relevant for BWE analysis.
+fn ext_config_from_map(exts: &ExtensionMap) -> RtpHeaderExtensionConfig {
+    RtpHeaderExtensionConfig {
+        transmission_time_offset_id: exts
+            .id_of(Extension::TransmissionTimeOffset)
+            .map(|id| id as i32),
+        absolute_send_time_id: exts
+            .id_of(Extension::AbsoluteSendTime)
+            .map(|id| id as i32),
+        transport_sequence_number_id: exts
+            .id_of(Extension::TransportSequenceNumber)
+            .map(|id| id as i32),
+        video_rotation_id: exts
+            .id_of(Extension::VideoOrientation)
+            .map(|id| id as i32),
+        audio_level_id: exts.id_of(Extension::AudioLevel).map(|id| id as i32),
+    }
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 
 use crate::Event;
 use crate::bwe::BweKind;
-use crate::bwe_::Bwe;
+use crate::bwe_::{Bwe, BweLogEvent};
 use crate::config::KeyingMaterial;
 use crate::crypto::CryptoProvider;
 use crate::crypto::dtls::SrtpProfile;
@@ -29,6 +29,7 @@ use crate::rtp_::{TwccRecvRegister, TwccSendRegister};
 use crate::stats::StatsSnapshot;
 use crate::streams::{RtpPacket, Streams};
 use crate::util::{Soonest, already_happened, not_happening};
+use crate::rtc_event_log::RtcEventLogCollector;
 use crate::{Reason, net};
 use crate::{RtcConfig, RtcError};
 
@@ -109,12 +110,19 @@ pub(crate) struct Session {
 
     raw_packets: Option<VecDeque<Box<RawPacket>>>,
 
+    /// RTC event log collector. None when event logging is not enabled.
+    event_log: Option<RtcEventLogCollector>,
+
+    /// Last known "now" for use in contexts where `now` is not passed as a parameter.
+    /// Updated by `handle_timeout()` and `new()`.
+    last_now: Instant,
+
     #[cfg(feature = "_internal_test_exports")]
     pending_probe: Option<crate::bwe_::ProbeClusterConfig>,
 }
 
 impl Session {
-    pub fn new(config: &RtcConfig) -> Self {
+    pub fn new(config: &RtcConfig, now: Instant) -> Self {
         let mut id = SessionId::new();
         // Max 2^62 - 1: https://bugzilla.mozilla.org/show_bug.cgi?id=861895
         const MAX_ID: u64 = 2_u64.pow(62) - 1;
@@ -132,7 +140,7 @@ impl Session {
 
         let enable_stats = config.stats_interval.is_some();
 
-        Session {
+        let mut session = Session {
             id,
             medias: vec![],
             streams: Streams::new(enable_stats),
@@ -173,13 +181,48 @@ impl Session {
             } else {
                 None
             },
+            event_log: if config.enable_rtc_event_log {
+                let interval = config.rtc_event_log_interval;
+                Some(if let Some(interval) = interval {
+                    RtcEventLogCollector::new(now, interval)
+                } else {
+                    RtcEventLogCollector::with_defaults(now)
+                })
+            } else {
+                None
+            },
+            last_now: now,
             #[cfg(feature = "_internal_test_exports")]
             pending_probe: None,
+        };
+
+        // Activate BWE event logging if both BWE and event log are enabled.
+        if session.event_log.is_some() {
+            if let Some(bwe) = &mut session.bwe {
+                bwe.set_event_log_active(true);
+            }
         }
+
+        session
     }
 
     pub fn id(&self) -> SessionId {
         self.id
+    }
+
+    pub fn stop_rtc_event_log(&mut self, now: Instant) {
+        if let Some(log) = &mut self.event_log {
+            log.finish(now);
+        }
+        // Keep event_log alive so pending_output can be drained via poll_event().
+        // It will be set to None after all data is drained, or the caller can
+        // simply let Rtc drop.
+    }
+
+    /// Drain pending event log data. Used by poll_output even when Rtc is not alive,
+    /// so EndLogEvent bytes queued by stop_rtc_event_log() can still be delivered.
+    pub fn poll_event_log(&mut self) -> Option<Vec<u8>> {
+        self.event_log.as_mut().and_then(|log| log.poll())
     }
 
     pub fn set_app(&mut self, mid: Mid, index: usize) -> Result<(), String> {
@@ -217,6 +260,8 @@ impl Session {
     }
 
     pub fn handle_timeout(&mut self, now: Instant) -> Result<(), RtcError> {
+        self.last_now = now;
+
         // Payload any waiting frames
         self.do_payload()?;
 
@@ -247,6 +292,11 @@ impl Session {
 
         self.handle_timeout_bwe(now);
 
+        // Flush event log if interval elapsed or buffer full
+        if let Some(log) = &mut self.event_log {
+            log.flush(now);
+        }
+
         Ok(())
     }
 
@@ -262,6 +312,16 @@ impl Session {
         if let Some(probe_config) = bwe.handle_timeout(now, do_probe) {
             // Only start the probe in the pacer if the estimator accepted it.
             if bwe.start_probe(probe_config, now) {
+                // Log probe cluster created for event log.
+                if let Some(log) = &mut self.event_log {
+                    log.record_probe_cluster_created(
+                        now,
+                        *probe_config.cluster() as u32,
+                        probe_config.target_bitrate().as_u64() as u32,
+                        probe_config.min_packet_count() as u32,
+                    );
+                }
+
                 #[cfg(feature = "_internal_test_exports")]
                 {
                     self.pending_probe = Some(probe_config);
@@ -270,9 +330,152 @@ impl Session {
             }
         }
 
+        // Drain BWE log events (ALR state changes, probe failures from expired probes).
+        self.drain_bwe_log_events(now);
+
         // Check if active probe just completed
         if let Some(cluster_id) = self.pacer.check_probe_complete(now) {
-            bwe.end_probe(now, cluster_id);
+            // bwe field is still available since we only borrow self.bwe
+            if let Some(bwe) = self.bwe.as_mut() {
+                bwe.end_probe(now, cluster_id);
+            }
+        }
+    }
+
+    /// Drain buffered BWE log events and forward them to the event log collector.
+    fn drain_bwe_log_events(&mut self, now: Instant) {
+        let (Some(bwe), Some(log)) = (self.bwe.as_mut(), self.event_log.as_mut()) else {
+            return;
+        };
+
+        for event in bwe.drain_log_events() {
+            match event {
+                BweLogEvent::DelayBased {
+                    bitrate_bps,
+                    detector_state,
+                } => {
+                    log.record_delay_based_bwe(now, bitrate_bps, detector_state);
+                }
+                BweLogEvent::LossBased {
+                    bitrate_bps,
+                    fraction_loss,
+                    total_packets,
+                } => {
+                    log.record_loss_based_bwe(now, bitrate_bps, fraction_loss, total_packets);
+                }
+                BweLogEvent::ProbeSuccess { id, bitrate_bps } => {
+                    log.record_probe_cluster_success(now, id, bitrate_bps);
+                }
+                BweLogEvent::ProbeFailure { id, reason } => {
+                    log.record_probe_cluster_failure(now, id, reason);
+                }
+                BweLogEvent::AlrState { in_alr } => {
+                    log.record_alr_state(now, in_alr);
+                }
+            }
+        }
+    }
+
+    /// Record stream configs for a media mid into the event log.
+    ///
+    /// Called when a `MediaAdded` event is about to be emitted, so the streams
+    /// for this mid are already set up.
+    pub(crate) fn record_stream_configs_for_mid(&mut self, mid: Mid) {
+        if self.event_log.is_none() {
+            return;
+        }
+
+        let Some(media) = self.medias.iter().find(|m| m.mid() == mid) else {
+            return;
+        };
+        let is_audio = media.kind().is_audio();
+        let exts = media.remote_extmap().clone();
+
+        // Collect TX stream SSRCs (uses &self on streams).
+        let tx_ssrcs = self.streams.ssrcs_tx(mid);
+
+        // Collect RX stream SSRCs. ssrcs_rx doesn't exist, so iterate manually.
+        let rx_ssrcs: Vec<(Ssrc, Option<Ssrc>)> = self
+            .streams
+            .streams_rx_by_mid(mid)
+            .map(|s| (s.ssrc(), s.rtx()))
+            .collect();
+
+        let local_ssrc = *self.streams.first_ssrc_local();
+
+        let log = self.event_log.as_mut().unwrap();
+        let now = self.last_now;
+
+        for (ssrc, rtx) in &tx_ssrcs {
+            if is_audio {
+                log.record_audio_send_stream_config(now, **ssrc, &exts);
+            } else {
+                log.record_video_send_stream_config(
+                    now,
+                    **ssrc,
+                    rtx.map(|r| *r),
+                    &exts,
+                );
+            }
+        }
+
+        for (remote_ssrc, rtx) in &rx_ssrcs {
+            if is_audio {
+                log.record_audio_recv_stream_config(
+                    now,
+                    **remote_ssrc,
+                    local_ssrc,
+                    &exts,
+                );
+            } else {
+                log.record_video_recv_stream_config(
+                    now,
+                    **remote_ssrc,
+                    local_ssrc,
+                    rtx.map(|r| *r),
+                    &exts,
+                );
+            }
+        }
+    }
+
+    /// Record a single receive stream config into the event log.
+    pub(crate) fn record_recv_stream_config(
+        &mut self,
+        is_audio: bool,
+        remote_ssrc: u32,
+        rtx_ssrc: Option<u32>,
+        exts: &ExtensionMap,
+    ) {
+        if self.event_log.is_none() {
+            return;
+        }
+        let local_ssrc = *self.streams.first_ssrc_local();
+        let now = self.last_now;
+        let log = self.event_log.as_mut().unwrap();
+        if is_audio {
+            log.record_audio_recv_stream_config(now, remote_ssrc, local_ssrc, exts);
+        } else {
+            log.record_video_recv_stream_config(now, remote_ssrc, local_ssrc, rtx_ssrc, exts);
+        }
+    }
+
+    /// Record a single send stream config into the event log.
+    pub(crate) fn record_send_stream_config(
+        &mut self,
+        is_audio: bool,
+        ssrc: u32,
+        rtx_ssrc: Option<u32>,
+        exts: &ExtensionMap,
+    ) {
+        let Some(log) = &mut self.event_log else {
+            return;
+        };
+        let now = self.last_now;
+        if is_audio {
+            log.record_audio_send_stream_config(now, ssrc, exts);
+        } else {
+            log.record_video_send_stream_config(now, ssrc, rtx_ssrc, exts);
         }
     }
 
@@ -490,6 +693,24 @@ impl Session {
             }
         };
 
+        // Record incoming RTP for event log (before unpad/un_rtx, header as on-the-wire)
+        if let Some(log) = &mut self.event_log {
+            let padding_size = if header.has_padding && !data.is_empty() {
+                data[data.len() - 1] as usize
+            } else {
+                0
+            };
+            let rtx_osn = if is_repair && data.len() >= padding_size + 2 {
+                Some(u16::from_be_bytes([data[0], data[1]]))
+            } else {
+                None
+            };
+            // payload_size = total decrypted data minus padding
+            // (includes RTX OSN prefix for RTX packets, matching Chrome behavior)
+            let payload_size = data.len().saturating_sub(padding_size);
+            log.record_incoming_rtp(now, &header, payload_size, padding_size, rtx_osn);
+        }
+
         if header.has_padding && !RtpHeader::unpad_payload(&mut data) {
             // Unpadding failed. Broken data?
             trace!("unpadding of unprotected payload failed");
@@ -578,6 +799,11 @@ impl Session {
         let srtp: &mut SrtpContext = self.srtp_rx.as_mut()?;
         let unprotected = srtp.unprotect_rtcp(buf)?;
 
+        // Record incoming RTCP for event log (raw bytes, before parsing)
+        if let Some(log) = &mut self.event_log {
+            log.record_incoming_rtcp(now, &unprotected);
+        }
+
         Rtcp::read_packet(&unprotected, &mut self.feedback_rx);
         let mut need_configure_pacer = false;
 
@@ -595,6 +821,7 @@ impl Session {
                 if let (Some(maybe_records), Some(bwe)) = (maybe_records, &mut self.bwe) {
                     bwe.update(maybe_records, now);
                 }
+
                 need_configure_pacer = true;
 
                 // The funky thing about TWCC reports is that they are never stapled
@@ -615,6 +842,10 @@ impl Session {
                 stream.handle_rtcp(now, fb);
             }
         }
+
+        // Drain BWE log events after the feedback loop completes.
+        // This is safe since TWCC reports are never stapled with other RTCP.
+        self.drain_bwe_log_events(now);
 
         // Not in the above if due to lifetime issues, still okay because the method
         // doesn't do anything when BWE isn't configured.
@@ -681,24 +912,48 @@ impl Session {
             return Some(Event::EgressBitrateEstimate(BweKind::Remb(mid, bitrate)));
         }
 
-        for media in &mut self.medias {
-            if media.need_open_event {
+        // Check for MediaAdded events first, then MediaChanged. This intentionally
+        // prioritizes open events over change events across all medias (the original
+        // single-loop checked per-media in iteration order; the split is needed to
+        // release the mutable borrow on self.medias before record_stream_configs).
+        let media_added = self
+            .medias
+            .iter_mut()
+            .find(|m| m.need_open_event)
+            .map(|media| {
                 media.need_open_event = false;
+                (
+                    media.mid(),
+                    media.kind(),
+                    media.direction(),
+                    media.simulcast().map(|s| s.clone().into()),
+                )
+            });
+        if let Some((mid, kind, direction, simulcast)) = media_added {
+            return Some(Event::MediaAdded(MediaAdded {
+                mid,
+                kind,
+                direction,
+                simulcast,
+            }));
+        }
 
-                return Some(Event::MediaAdded(MediaAdded {
-                    mid: media.mid(),
-                    kind: media.kind(),
-                    direction: media.direction(),
-                    simulcast: media.simulcast().map(|s| s.clone().into()),
-                }));
-            }
-
-            if media.need_changed_event {
+        let media_changed = self
+            .medias
+            .iter_mut()
+            .find(|m| m.need_changed_event)
+            .map(|media| {
                 media.need_changed_event = false;
-                return Some(Event::MediaChanged(MediaChanged {
-                    mid: media.mid(),
-                    direction: media.direction(),
-                }));
+                (media.mid(), media.direction())
+            });
+        if let Some((mid, direction)) = media_changed {
+            return Some(Event::MediaChanged(MediaChanged { mid, direction }));
+        }
+
+        // Event log data — polled LAST (bulk, non-urgent)
+        if let Some(log) = &mut self.event_log {
+            if let Some(data) = log.poll() {
+                return Some(Event::RtcEventLog(data));
             }
         }
 
@@ -731,7 +986,7 @@ impl Session {
         }
 
         let x = None
-            .or_else(|| self.poll_feedback())
+            .or_else(|| self.poll_feedback(now))
             .or_else(|| self.poll_packet(now));
 
         if let Some(x) = &x {
@@ -753,7 +1008,7 @@ impl Session {
         self.feedback_tx.clear();
     }
 
-    fn poll_feedback(&mut self) -> Option<net::DatagramSend> {
+    fn poll_feedback(&mut self, now: Instant) -> Option<net::DatagramSend> {
         if self.feedback_tx.is_empty() {
             return None;
         }
@@ -778,6 +1033,11 @@ impl Session {
         }
 
         data.truncate(len);
+
+        // Record outgoing RTCP for event log (raw bytes, before SRTP protect)
+        if let Some(log) = &mut self.event_log {
+            log.record_outgoing_rtcp(now, &data);
+        }
 
         let srtp = self.srtp_tx.as_mut()?;
         let protected = srtp.protect_rtcp(&data);
@@ -821,6 +1081,7 @@ impl Session {
             seq_no,
             is_padding,
             payload_size,
+            rtx_original_seq_no,
         } = receipt;
 
         trace!(payload_size, is_padding, "Poll RTP: {:?}", header);
@@ -833,6 +1094,13 @@ impl Session {
         }
 
         self.pacer.register_send(now, payload_size.into(), midrid);
+
+        // Record outgoing RTP for event log (before SRTP protect, cheap Vec::push)
+        if let Some(log) = &mut self.event_log {
+            let probe_id = cluster_id.map(|c| *c as i32);
+            let rtx_osn = rtx_original_seq_no.map(|s| *s as u16);
+            log.record_outgoing_rtp(now, &header, payload_size, probe_id, rtx_osn);
+        }
 
         if let Some(raw_packets) = &mut self.raw_packets {
             raw_packets.push_back(Box::new(RawPacket::RtpTx(header.clone(), buf.clone())));
@@ -879,6 +1147,8 @@ impl Session {
             // We should never see this reason.
             .unwrap_or((None, Reason::BweDelayControl));
 
+        let event_log_at = self.event_log.as_ref().and_then(|log| log.poll_timeout());
+
         (feedback_at, Reason::Feedback)
             .soonest((nack_at, Reason::Nack))
             .soonest((twcc_at, Reason::Twcc))
@@ -887,6 +1157,7 @@ impl Session {
             .soonest((paused_at, Reason::PauseCheck))
             .soonest((send_stream_at, Reason::SendStream))
             .soonest(bwe_at)
+            .soonest((event_log_at, Reason::EventLog))
     }
 
     pub fn has_mid(&self, mid: Mid) -> bool {
@@ -1081,6 +1352,8 @@ pub struct PacketReceipt {
     pub seq_no: SeqNo,
     pub is_padding: bool,
     pub payload_size: usize,
+    /// For RTX resends, the original sequence number being retransmitted.
+    pub rtx_original_seq_no: Option<SeqNo>,
 }
 
 /// Find the PayloadParams for the given Pt, either when the Pt is the main Pt for the Codec or

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -550,7 +550,8 @@ impl StreamTx {
         }
 
         let seq_no = next.seq_no;
-        if next.kind == NextPacketKind::Regular {
+        let next_kind = next.kind;
+        if next_kind == NextPacketKind::Regular {
             self.last_sent_seq_no = seq_no;
         }
 
@@ -582,11 +583,18 @@ impl StreamTx {
             }
         }
 
+        let rtx_original_seq_no = if let NextPacketKind::Resend(orig) = next_kind {
+            Some(orig)
+        } else {
+            None
+        };
+
         Some(PacketReceipt {
             header,
             seq_no,
             is_padding,
             payload_size: body_len,
+            rtx_original_seq_no,
         })
     }
 

--- a/tests/rtc-event-log.rs
+++ b/tests/rtc-event-log.rs
@@ -1,0 +1,830 @@
+use std::net::Ipv4Addr;
+use std::time::{Duration, Instant};
+
+use prost::Message;
+use str0m::bwe::Bitrate;
+use str0m::media::{Direction, MediaKind};
+use str0m::{Event, RtcConfig, RtcError};
+
+mod common;
+use common::{Peer, TestRtc, init_crypto_default, init_log, progress};
+
+#[test]
+fn rtc_event_log_outgoing_rtp() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let now = Instant::now();
+
+    // Left peer has event logging enabled
+    let rtc1 = RtcConfig::new()
+        .enable_rtc_event_log(true)
+        .set_rtc_event_log_interval(Duration::from_millis(500))
+        .build(now);
+    let mut l = TestRtc::new_with_rtc(Peer::Left.span(), rtc1);
+    let mut r = TestRtc::new(Peer::Right);
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    let mut change = l.sdp_api();
+    let mid = change.add_media(MediaKind::Audio, Direction::SendOnly, None, None, None);
+    let (offer, pending) = change.apply().unwrap();
+
+    let answer = r.rtc.sdp_api().accept_offer(offer)?;
+    l.rtc.sdp_api().accept_answer(pending, answer)?;
+
+    // Connect the peers
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r)?;
+    }
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    let params = l.params_opus();
+    let pt = params.pt();
+
+    // Send some audio packets
+    for i in 0..20 {
+        let wallclock = l.start + l.duration();
+        let time = l.duration().into();
+
+        let data = vec![i as u8; 80];
+        l.writer(mid)
+            .unwrap()
+            .write(pt, wallclock, time, data)
+            .unwrap();
+
+        progress(&mut l, &mut r)?;
+    }
+
+    // Now stop event logging to flush
+    l.rtc.stop_rtc_event_log();
+
+    // Drain remaining events
+    loop {
+        match l.rtc.poll_output()? {
+            str0m::Output::Event(ev) => {
+                l.events.push((l.last, ev));
+            }
+            str0m::Output::Timeout(_) => break,
+            _ => {}
+        }
+    }
+
+    // Collect all RtcEventLog events
+    let event_log_data: Vec<Vec<u8>> = l
+        .events
+        .iter()
+        .filter_map(|(_, ev)| {
+            if let Event::RtcEventLog(data) = ev {
+                Some(data.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Should have at least: BeginLog + maybe a batch + EndLog flush
+    assert!(
+        !event_log_data.is_empty(),
+        "Expected at least one RtcEventLog event"
+    );
+
+    // Concatenate all chunks — this is the full event log file content
+    let full_log: Vec<u8> = event_log_data.into_iter().flatten().collect();
+    assert!(
+        full_log.len() > 10,
+        "Event log should contain meaningful data, got {} bytes",
+        full_log.len()
+    );
+
+    // Verify the log is valid protobuf by parsing the first EventStream
+    // (BeginLog should be present)
+    // Parse just the first EventStream from concatenated data.
+    // prost will consume as many bytes as it can for a single message.
+    let stream = str0m_rtc_event_log::proto::EventStream::decode(full_log.as_slice())
+        .expect("first concatenated chunk should decode as EventStream");
+    assert!(!stream.begin_log_events.is_empty(), "BeginLogEvent should be present");
+
+    // The concatenated format may not parse as a single EventStream,
+    // but the first bytes (BeginLog) should parse fine. Let's at least
+    // verify the data is non-empty and starts with valid protobuf.
+    assert!(full_log[0] != 0 || full_log.len() > 1, "Data should be non-trivial");
+
+    // Verify EndLog is present exactly once across emitted chunks.
+    let mut end_log_count = 0usize;
+    for (_, ev) in &l.events {
+        if let Event::RtcEventLog(data) = ev {
+            if let Ok(stream) = str0m_rtc_event_log::proto::EventStream::decode(data.as_slice()) {
+                end_log_count += stream.end_log_events.len();
+            }
+        }
+    }
+    assert_eq!(end_log_count, 1, "Expected exactly one EndLogEvent");
+
+    Ok(())
+}
+
+#[test]
+fn rtc_event_log_disabled_produces_no_events() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let now = Instant::now();
+
+    // Event logging NOT enabled
+    let rtc1 = RtcConfig::new().build(now);
+    let mut l = TestRtc::new_with_rtc(Peer::Left.span(), rtc1);
+    let mut r = TestRtc::new(Peer::Right);
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    let mut change = l.sdp_api();
+    let _mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+    let (offer, pending) = change.apply().unwrap();
+
+    let answer = r.rtc.sdp_api().accept_offer(offer)?;
+    l.rtc.sdp_api().accept_answer(pending, answer)?;
+
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r)?;
+    }
+
+    for _ in 0..10 {
+        progress(&mut l, &mut r)?;
+    }
+
+    let event_log_count = l
+        .events
+        .iter()
+        .filter(|(_, ev)| matches!(ev, Event::RtcEventLog(_)))
+        .count();
+
+    assert_eq!(
+        event_log_count, 0,
+        "No RtcEventLog events should be produced when disabled"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn rtc_event_log_incoming_rtp_and_rtcp() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let now = Instant::now();
+
+    // Right peer (receiver) has event logging enabled
+    let mut l = TestRtc::new(Peer::Left);
+    let rtc2 = RtcConfig::new()
+        .enable_rtc_event_log(true)
+        .set_rtc_event_log_interval(Duration::from_millis(500))
+        .build(now);
+    let mut r = TestRtc::new_with_rtc(Peer::Right.span(), rtc2);
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    // Left sends audio to Right
+    let mut change = l.sdp_api();
+    let mid = change.add_media(MediaKind::Audio, Direction::SendOnly, None, None, None);
+    let (offer, pending) = change.apply().unwrap();
+
+    let answer = r.rtc.sdp_api().accept_offer(offer)?;
+    l.rtc.sdp_api().accept_answer(pending, answer)?;
+
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r)?;
+    }
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    let params = l.params_opus();
+    let pt = params.pt();
+
+    // Send audio packets from Left → Right
+    for i in 0..20 {
+        let wallclock = l.start + l.duration();
+        let time = l.duration().into();
+
+        let data = vec![i as u8; 80];
+        l.writer(mid)
+            .unwrap()
+            .write(pt, wallclock, time, data)
+            .unwrap();
+
+        progress(&mut l, &mut r)?;
+    }
+
+    // Stop event logging on receiver to flush
+    r.rtc.stop_rtc_event_log();
+
+    // Drain remaining events from receiver
+    loop {
+        match r.rtc.poll_output()? {
+            str0m::Output::Event(ev) => {
+                r.events.push((r.last, ev));
+            }
+            str0m::Output::Timeout(_) => break,
+            _ => {}
+        }
+    }
+
+    // Collect all RtcEventLog events from receiver
+    let event_log_data: Vec<Vec<u8>> = r
+        .events
+        .iter()
+        .filter_map(|(_, ev)| {
+            if let Event::RtcEventLog(data) = ev {
+                Some(data.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert!(
+        !event_log_data.is_empty(),
+        "Receiver should have RtcEventLog events"
+    );
+
+    // Parse all EventStream messages from the concatenated log
+    let mut total_incoming_rtp = 0usize;
+    let mut total_incoming_rtcp = 0usize;
+    let mut total_outgoing_rtcp = 0usize;
+
+    for chunk in &event_log_data {
+        if let Ok(stream) = str0m_rtc_event_log::proto::EventStream::decode(chunk.as_slice()) {
+            for msg in &stream.incoming_rtp_packets {
+                // Count base event + deltas
+                total_incoming_rtp += 1 + msg.number_of_deltas.unwrap_or(0) as usize;
+
+                // Verify SSRC is set
+                assert!(msg.ssrc.is_some(), "incoming RTP should have SSRC");
+                assert!(msg.payload_type.is_some(), "incoming RTP should have PT");
+            }
+            for msg in &stream.incoming_rtcp_packets {
+                total_incoming_rtcp += 1 + msg.number_of_deltas.unwrap_or(0) as usize;
+                assert!(msg.raw_packet.is_some(), "incoming RTCP should have raw_packet");
+            }
+            for msg in &stream.outgoing_rtcp_packets {
+                total_outgoing_rtcp += 1 + msg.number_of_deltas.unwrap_or(0) as usize;
+                assert!(msg.raw_packet.is_some(), "outgoing RTCP should have raw_packet");
+            }
+        }
+    }
+
+    let mut end_log_count = 0usize;
+    for chunk in &event_log_data {
+        if let Ok(stream) = str0m_rtc_event_log::proto::EventStream::decode(chunk.as_slice()) {
+            end_log_count += stream.end_log_events.len();
+        }
+    }
+    assert_eq!(end_log_count, 1, "Expected exactly one EndLogEvent");
+
+    // The receiver should have logged incoming RTP packets
+    assert!(
+        total_incoming_rtp > 0,
+        "Expected incoming RTP packets in event log, got {total_incoming_rtp}"
+    );
+
+    // RTCP should be present (receiver sends RR, sender sends SR)
+    // Due to timing, we may or may not have RTCP logged but at minimum
+    // the outgoing RTCP (receiver reports) should be there.
+
+    Ok(())
+}
+
+#[test]
+fn rtc_event_log_stop_is_idempotent() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let now = Instant::now();
+
+    let rtc1 = RtcConfig::new()
+        .enable_rtc_event_log(true)
+        .set_rtc_event_log_interval(Duration::from_millis(500))
+        .build(now);
+    let mut l = TestRtc::new_with_rtc(Peer::Left.span(), rtc1);
+    let mut r = TestRtc::new(Peer::Right);
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    let mut change = l.sdp_api();
+    let _mid = change.add_media(MediaKind::Audio, Direction::SendOnly, None, None, None);
+    let (offer, pending) = change.apply().unwrap();
+
+    let answer = r.rtc.sdp_api().accept_offer(offer)?;
+    l.rtc.sdp_api().accept_answer(pending, answer)?;
+
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r)?;
+    }
+
+    // Repeated stops must not append multiple EndLogEvents.
+    l.rtc.stop_rtc_event_log();
+    l.rtc.stop_rtc_event_log();
+
+    let mut event_log_chunks = Vec::new();
+    loop {
+        match l.rtc.poll_output()? {
+            str0m::Output::Event(Event::RtcEventLog(data)) => event_log_chunks.push(data),
+            str0m::Output::Event(_) => {}
+            str0m::Output::Timeout(_) => break,
+            _ => {}
+        }
+    }
+
+    let mut end_log_count = 0usize;
+    for chunk in &event_log_chunks {
+        if let Ok(stream) = str0m_rtc_event_log::proto::EventStream::decode(chunk.as_slice()) {
+            end_log_count += stream.end_log_events.len();
+        }
+    }
+
+    assert_eq!(end_log_count, 1, "Expected exactly one EndLogEvent");
+    Ok(())
+}
+
+#[test]
+fn rtc_event_log_filters_sdes_from_live_outgoing_rtcp() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let now = Instant::now();
+
+    // Left peer has event logging enabled.
+    let rtc1 = RtcConfig::new()
+        .enable_rtc_event_log(true)
+        .set_rtc_event_log_interval(Duration::from_millis(500))
+        .build(now);
+    let mut l = TestRtc::new_with_rtc(Peer::Left.span(), rtc1);
+    let mut r = TestRtc::new(Peer::Right);
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    // Left sends audio to ensure sender reports are produced.
+    let mut change = l.sdp_api();
+    let mid = change.add_media(MediaKind::Audio, Direction::SendOnly, None, None, None);
+    let (offer, pending) = change.apply().unwrap();
+
+    let answer = r.rtc.sdp_api().accept_offer(offer)?;
+    l.rtc.sdp_api().accept_answer(pending, answer)?;
+
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r)?;
+    }
+
+    let params = l.params_opus();
+    let pt = params.pt();
+
+    // Send media and progress enough to trigger RTCP generation.
+    for i in 0..40 {
+        let wallclock = l.start + l.duration();
+        let time = l.duration().into();
+        let data = vec![i as u8; 120];
+        l.writer(mid)
+            .unwrap()
+            .write(pt, wallclock, time, data)
+            .unwrap();
+        progress(&mut l, &mut r)?;
+    }
+
+    let wait_until = l.last + Duration::from_secs(3);
+    while l.last < wait_until || r.last < wait_until {
+        progress(&mut l, &mut r)?;
+    }
+
+    l.rtc.stop_rtc_event_log();
+
+    loop {
+        match l.rtc.poll_output()? {
+            str0m::Output::Event(ev) => l.events.push((l.last, ev)),
+            str0m::Output::Timeout(_) => break,
+            _ => {}
+        }
+    }
+
+    let event_log_data: Vec<Vec<u8>> = l
+        .events
+        .iter()
+        .filter_map(|(_, ev)| match ev {
+            Event::RtcEventLog(data) => Some(data.clone()),
+            _ => None,
+        })
+        .collect();
+
+    let mut seen_outgoing_rtcp = 0usize;
+
+    for chunk in &event_log_data {
+        if let Ok(stream) = str0m_rtc_event_log::proto::EventStream::decode(chunk.as_slice()) {
+            for msg in &stream.outgoing_rtcp_packets {
+                seen_outgoing_rtcp += 1;
+
+                if let Some(raw) = &msg.raw_packet {
+                    for pt in rtcp_packet_types(raw) {
+                        assert_ne!(pt, 202, "SDES block leaked into logged RTCP");
+                        assert_ne!(pt, 204, "APP block leaked into logged RTCP");
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        seen_outgoing_rtcp > 0,
+        "Expected outgoing RTCP packets in event log"
+    );
+
+    Ok(())
+}
+
+fn rtcp_packet_types(raw_rtcp: &[u8]) -> Vec<u8> {
+    let mut pts = Vec::new();
+    let mut offset = 0usize;
+
+    while offset + 4 <= raw_rtcp.len() {
+        let pt = raw_rtcp[offset + 1];
+        let length_words = u16::from_be_bytes([raw_rtcp[offset + 2], raw_rtcp[offset + 3]]);
+        let block_len = (length_words as usize + 1) * 4;
+        if offset + block_len > raw_rtcp.len() {
+            break;
+        }
+        pts.push(pt);
+        offset += block_len;
+    }
+
+    pts
+}
+
+#[test]
+fn rtc_event_log_bwe_events() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let now = Instant::now();
+
+    // Left peer: BWE + event logging enabled. Sends video to Right.
+    let rtc1 = RtcConfig::new()
+        .enable_bwe(Some(Bitrate::kbps(500)))
+        .enable_rtc_event_log(true)
+        .set_rtc_event_log_interval(Duration::from_millis(500))
+        .build(now);
+    let mut l = TestRtc::new_with_rtc(Peer::Left.span(), rtc1);
+    let mut r = TestRtc::new(Peer::Right);
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    let mut change = l.sdp_api();
+    let mid = change.add_media(MediaKind::Video, Direction::SendOnly, None, None, None);
+    let (offer, pending) = change.apply().unwrap();
+
+    let answer = r.rtc.sdp_api().accept_offer(offer)?;
+    l.rtc.sdp_api().accept_answer(pending, answer)?;
+
+    // Connect the peers
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r)?;
+    }
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    let params = l.params_vp8();
+    let pt = params.pt();
+
+    // Send some initial packets to establish the padding queue (needs RTX + first packet sent).
+    for i in 0..20 {
+        let wallclock = l.start + l.duration();
+        let time = l.duration().into();
+        let data = vec![i as u8; 800];
+        l.writer(mid)
+            .unwrap()
+            .write(pt, wallclock, time, data)
+            .unwrap();
+        progress(&mut l, &mut r)?;
+    }
+
+    // Set desired bitrate much higher than the initial 500kbps estimate.
+    // This triggers the probe controller to create probe clusters.
+    l.rtc.bwe().set_desired_bitrate(Bitrate::mbps(5));
+
+    // Send more traffic so TWCC feedback arrives and probes can complete.
+    for i in 20..200 {
+        let wallclock = l.start + l.duration();
+        let time = l.duration().into();
+        let data = vec![i as u8; 800];
+        l.writer(mid)
+            .unwrap()
+            .write(pt, wallclock, time, data)
+            .unwrap();
+        progress(&mut l, &mut r)?;
+    }
+
+    // Allow extra time for probe completion and BWE convergence.
+    let wait_until = l.last + Duration::from_secs(2);
+    while l.last < wait_until || r.last < wait_until {
+        progress(&mut l, &mut r)?;
+    }
+
+    // Stop event logging to flush everything
+    l.rtc.stop_rtc_event_log();
+
+    // Drain remaining events
+    loop {
+        match l.rtc.poll_output()? {
+            str0m::Output::Event(ev) => {
+                l.events.push((l.last, ev));
+            }
+            str0m::Output::Timeout(_) => break,
+            _ => {}
+        }
+    }
+
+    // Collect all RtcEventLog chunks
+    let event_log_data: Vec<Vec<u8>> = l
+        .events
+        .iter()
+        .filter_map(|(_, ev)| {
+            if let Event::RtcEventLog(data) = ev {
+                Some(data.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert!(
+        !event_log_data.is_empty(),
+        "Expected at least one RtcEventLog event"
+    );
+
+    // Parse all EventStream messages and collect BWE-related events.
+    let mut total_delay_bwe = 0usize;
+    let mut total_loss_bwe = 0usize;
+    let mut total_alr_states = 0usize;
+
+    // Collect probe events with their field values for cross-referencing.
+    let mut created_probes: Vec<(u32, u32, u32)> = Vec::new(); // (id, bitrate, min_packets)
+    let mut success_probes: Vec<(u32, u32)> = Vec::new(); // (id, bitrate)
+    let mut failure_probes: Vec<(u32, i32)> = Vec::new(); // (id, reason)
+
+    for chunk in &event_log_data {
+        let stream = str0m_rtc_event_log::proto::EventStream::decode(chunk.as_slice())
+            .expect("chunk should decode as EventStream");
+
+        total_delay_bwe += stream.delay_based_bwe_updates.len();
+        total_loss_bwe += stream.loss_based_bwe_updates.len();
+        total_alr_states += stream.alr_states.len();
+
+        // Validate delay BWE events have valid data
+        for msg in &stream.delay_based_bwe_updates {
+            assert!(msg.timestamp_ms.is_some(), "delay BWE missing timestamp");
+            assert!(msg.bitrate_bps.is_some(), "delay BWE missing bitrate");
+            assert!(msg.detector_state.is_some(), "delay BWE missing detector state");
+            let state = msg.detector_state.unwrap();
+            // DetectorState enum: 0=UNKNOWN, 1=NORMAL, 2=UNDERUSING, 3=OVERUSING
+            assert!(
+                (0..=3).contains(&state),
+                "Invalid detector state: {state}"
+            );
+        }
+
+        // Validate loss BWE events
+        for msg in &stream.loss_based_bwe_updates {
+            assert!(msg.timestamp_ms.is_some(), "loss BWE missing timestamp");
+            assert!(msg.bitrate_bps.is_some(), "loss BWE missing bitrate");
+            if let Some(fraction) = msg.fraction_loss {
+                assert!(
+                    fraction <= 255,
+                    "fraction_loss must be 0-255, got {fraction}"
+                );
+            }
+        }
+
+        // Validate and collect probe cluster created events
+        for msg in &stream.probe_clusters {
+            assert!(msg.timestamp_ms.is_some(), "probe cluster missing timestamp");
+            let id = msg.id.expect("probe cluster missing id");
+            let bitrate = msg.bitrate_bps.expect("probe cluster missing bitrate");
+            let min_packets = msg.min_packets.expect("probe cluster missing min_packets");
+
+            assert!(bitrate > 0, "probe cluster bitrate must be positive, got {bitrate}");
+            assert!(min_packets > 0, "probe cluster min_packets must be positive, got {min_packets}");
+            // min_bytes is intentionally unset (str0m doesn't track it)
+            assert!(msg.min_bytes.is_none(), "min_bytes should be unset");
+
+            created_probes.push((id, bitrate, min_packets));
+        }
+
+        // Validate and collect probe success events
+        for msg in &stream.probe_success {
+            assert!(msg.timestamp_ms.is_some(), "probe success missing timestamp");
+            let id = msg.id.expect("probe success missing id");
+            let bitrate = msg.bitrate_bps.expect("probe success missing bitrate");
+
+            assert!(bitrate > 0, "probe success bitrate must be positive, got {bitrate}");
+
+            success_probes.push((id, bitrate));
+        }
+
+        // Validate and collect probe failure events
+        for msg in &stream.probe_failure {
+            assert!(msg.timestamp_ms.is_some(), "probe failure missing timestamp");
+            let id = msg.id.expect("probe failure missing id");
+            let reason = msg.failure.expect("probe failure missing reason");
+
+            // ProbeFailureReason: 0=UNKNOWN, 1=INVALID_SEND_RECEIVE_INTERVAL,
+            // 2=INVALID_SEND_RECEIVE_RATIO, 3=TIMEOUT
+            assert!(
+                (0..=3).contains(&reason),
+                "Invalid probe failure reason: {reason}"
+            );
+
+            failure_probes.push((id, reason));
+        }
+    }
+
+    let total_probe_clusters = created_probes.len();
+    let total_probe_success = success_probes.len();
+    let total_probe_failure = failure_probes.len();
+
+    // With BWE enabled and video traffic, we expect delay-based BWE updates.
+    assert!(
+        total_delay_bwe > 0,
+        "Expected at least one delay-based BWE update in the event log"
+    );
+
+    // With set_desired_bitrate(5 Mbps) >> initial estimate (500 kbps), probe clusters
+    // must be created to explore the available bandwidth.
+    assert!(
+        total_probe_clusters > 0,
+        "Expected probe clusters to be created after set_desired_bitrate"
+    );
+
+    // Every probe should eventually complete as success or failure.
+    let created_ids: std::collections::HashSet<u32> =
+        created_probes.iter().map(|(id, ..)| *id).collect();
+    let completed_ids: std::collections::HashSet<u32> = success_probes
+        .iter()
+        .map(|(id, _)| *id)
+        .chain(failure_probes.iter().map(|(id, _)| *id))
+        .collect();
+
+    // Every success/failure ID must reference a created probe.
+    for id in &completed_ids {
+        assert!(
+            created_ids.contains(id),
+            "Probe result id={id} has no matching ProbeClusterCreated event"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn rtc_event_log_stream_configs() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let now = Instant::now();
+
+    let rtc1 = RtcConfig::new()
+        .enable_rtc_event_log(true)
+        .set_rtc_event_log_interval(Duration::from_millis(500))
+        .build(now);
+    let mut l = TestRtc::new_with_rtc(Peer::Left.span(), rtc1);
+    let mut r = TestRtc::new(Peer::Right);
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    // Add audio and video in SendRecv so we get both send and recv configs
+    let mut change = l.sdp_api();
+    let _audio_mid =
+        change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+    let _video_mid =
+        change.add_media(MediaKind::Video, Direction::SendRecv, None, None, None);
+    let (offer, pending) = change.apply().unwrap();
+
+    let answer = r.rtc.sdp_api().accept_offer(offer)?;
+    l.rtc.sdp_api().accept_answer(pending, answer)?;
+
+    // Connect peers
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r)?;
+    }
+
+    // Progress a bit to emit MediaAdded events (which trigger stream config logging)
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    for _ in 0..20 {
+        progress(&mut l, &mut r)?;
+    }
+
+    // Stop event logging
+    l.rtc.stop_rtc_event_log();
+
+    // Drain remaining events
+    loop {
+        match l.rtc.poll_output()? {
+            str0m::Output::Event(ev) => {
+                l.events.push((l.last, ev));
+            }
+            str0m::Output::Timeout(_) => break,
+            _ => {}
+        }
+    }
+
+    // Parse all event log chunks
+    let mut audio_send_configs = 0usize;
+    let mut audio_recv_configs = 0usize;
+    let mut video_send_configs = 0usize;
+    let mut video_recv_configs = 0usize;
+
+    for (_, ev) in &l.events {
+        if let Event::RtcEventLog(data) = ev {
+            if let Ok(stream) =
+                str0m_rtc_event_log::proto::EventStream::decode(data.as_slice())
+            {
+                audio_send_configs += stream.audio_send_stream_configs.len();
+                audio_recv_configs += stream.audio_recv_stream_configs.len();
+                video_send_configs += stream.video_send_stream_configs.len();
+                video_recv_configs += stream.video_recv_stream_configs.len();
+
+                // Verify each config has required fields
+                for cfg in &stream.audio_send_stream_configs {
+                    assert!(cfg.timestamp_ms.is_some(), "audio send config missing timestamp");
+                    assert!(cfg.ssrc.is_some(), "audio send config missing ssrc");
+                    assert!(
+                        cfg.header_extensions.is_some(),
+                        "audio send config missing extensions"
+                    );
+                }
+                for cfg in &stream.video_send_stream_configs {
+                    assert!(cfg.timestamp_ms.is_some(), "video send config missing timestamp");
+                    assert!(cfg.ssrc.is_some(), "video send config missing ssrc");
+                    assert!(
+                        cfg.header_extensions.is_some(),
+                        "video send config missing extensions"
+                    );
+                }
+                for cfg in &stream.video_recv_stream_configs {
+                    assert!(cfg.remote_ssrc.is_some(), "video recv config missing remote_ssrc");
+                    assert!(cfg.local_ssrc.is_some(), "video recv config missing local_ssrc");
+                }
+                for cfg in &stream.audio_recv_stream_configs {
+                    assert!(cfg.remote_ssrc.is_some(), "audio recv config missing remote_ssrc");
+                    assert!(cfg.local_ssrc.is_some(), "audio recv config missing local_ssrc");
+                }
+            }
+        }
+    }
+
+    // We added audio and video in SendRecv direction, so we should have send configs
+    assert!(
+        audio_send_configs > 0,
+        "Expected at least one audio send stream config"
+    );
+    assert!(
+        video_send_configs > 0,
+        "Expected at least one video send stream config"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Add WebRTC-compatible event logging that records RTP, RTCP, and BWE events, serialized into Chromium's rtc_event_log2 protobuf format. Output is delivered via Event::RtcEventLog(Vec<u8>) through poll_output(), keeping the sans-IO contract.

New crate: crates/rtc-event-log/
- Delta encoding matching WebRTC's delta_encoding.cc exactly
- Batching by event type, RTP sub-grouped by SSRC
- RTCP filtering (strips SDES/APP blocks for privacy)
- Proto copied from WebRTC source (BSD licensed)

Integration with str0m:
- RtcEventLogCollector in src/rtc_event_log.rs buffers events and flushes on a configurable interval (default 2s)
- Runtime-gated via Option<T>, matching bwe/stats/raw_packets pattern
- Hook points: handle_rtp, poll_packet, handle_rtcp, poll_feedback, handle_timeout_bwe, and stream config on media add
- BWE internals buffer log events (delay/loss estimates, probe results, ALR state) and drain via Session

User API:
- RtcConfig::enable_rtc_event_log(bool)
- RtcConfig::set_rtc_event_log_interval(Duration)
- Rtc::stop_rtc_event_log() flushes remaining events + EndLogEvent