### PR TITLE
feat(is): handle role conflicts as per RFC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
   * Expose H265 some already referenced profile structs #948
+  * Implement ICE role conflict resolution #950
 
 # 0.18.1
 

--- a/crates/is/src/agent.rs
+++ b/crates/is/src/agent.rs
@@ -2481,6 +2481,53 @@ mod test {
         assert!(stun_message.is_successful_binding_response());
     }
 
+    /// On simultaneous controlling/controlling startup, the lower-tiebreaker
+    /// agent typically receives the peer's request first (server-side swap)
+    /// while its own in-flight requests — sent under the old role — are
+    /// still being 487'd by the peer. Each of those stale 487s must be
+    /// ignored, otherwise the role flaps with every retransmit until the
+    /// in-flight drain finishes.
+    #[test]
+    pub fn ignores_stale_487_after_role_swap() {
+        let mut agent = new_test_agent();
+        agent.set_controlling(true);
+        let remote_creds = IceCreds::new();
+        agent.set_remote_credentials(remote_creds.clone());
+        agent
+            .add_local_candidate(Candidate::host(ipv4_1(), "udp").unwrap())
+            .unwrap();
+        let mut remote_candidate = Candidate::host(ipv4_3(), "udp").unwrap();
+        remote_candidate.set_ufrag(&remote_creds.ufrag);
+        agent.add_remote_candidate(remote_candidate);
+
+        // Drive one binding request out — recorded as `controlling=true`.
+        agent.handle_timeout(Instant::now());
+        let req_payload = Vec::from(agent.poll_transmit().unwrap().contents);
+        let trans_id = StunMessage::parse(&req_payload).unwrap().trans_id();
+
+        // Simulate that an earlier 487 (or a server-side conflict from an
+        // incoming peer request) already moved us to controlled.
+        agent.set_controlling(false);
+
+        // Now the original request's 487 lands. It is stale: the attempt was
+        // sent as controlling, but we are no longer controlling.
+        let reply = make_role_conflict_reply(trans_id, &remote_creds.pass);
+        agent.handle_packet(
+            Instant::now(),
+            StunPacket {
+                proto: Protocol::Udp,
+                source: ipv4_3(),
+                destination: ipv4_1(),
+                message: StunMessage::parse(&reply).unwrap(),
+            },
+        );
+
+        assert!(
+            !agent.controlling(),
+            "stale 487 must not flip role back to controlling"
+        );
+    }
+
     #[test]
     pub fn discards_packet_from_unknown_candidate() {
         let mut agent = new_test_agent();
@@ -2558,6 +2605,11 @@ mod test {
 
     fn make_authenticated_stun_reply(tx_id: TransId, addr: SocketAddr, password: &str) -> Vec<u8> {
         let reply = StunMessage::binding_reply(tx_id, addr);
+        serialize_stun_msg(reply, password)
+    }
+
+    fn make_role_conflict_reply(tx_id: TransId, password: &str) -> Vec<u8> {
+        let reply = StunMessage::binding_role_conflict_reply(tx_id);
         serialize_stun_msg(reply, password)
     }
 

--- a/crates/is/src/agent.rs
+++ b/crates/is/src/agent.rs
@@ -1386,6 +1386,29 @@ impl IceAgent {
             return;
         }
 
+        // Drop requests that did not arrive on one of our local candidates
+        // before doing anything else. We must not mutate state, send replies
+        // (including 487 Role Conflict) or create peer-reflexive candidates
+        // for traffic that isn't actually directed at one of our interfaces.
+        let local_idx = match self.local_candidates.iter().position(|v| {
+            matches!(v.kind(), CandidateKind::Host | CandidateKind::Relayed)
+                && v.addr() == req.destination
+                && v.proto() == req.proto
+        }) {
+            Some(i) => i,
+            None => {
+                // Receiving traffic for an IP address that neither is a HOST nor RELAY
+                // is most likely a configuration fault where the user forgot to add a
+                // candidate for the local interface. We are network-connected application
+                // so we need to handle this gracefully: Log a message and discard the packet.
+                debug!(
+                    "Discarding STUN request on unknown interface: {}",
+                    Pii(req.destination)
+                );
+                return;
+            }
+        };
+
         if req.use_candidate && self.controlling {
             // the other side is not controlling, and it sent USE-CANDIDATE. that's wrong.
             debug!("STUN request rejected, USE-CANDIDATE when local is controlling");
@@ -1453,31 +1476,6 @@ impl IceAgent {
             self.remote_candidates.push(c);
 
             self.remote_candidates.len() - 1
-        };
-
-        let local_idx = match self.local_candidates.iter().enumerate().find(|(_, v)| {
-            // The local candidate will be
-            // either a host candidate (for cases where the request was not received
-            // through a relay) or a relayed candidate (for cases where it is
-            // received through a relay).  The local candidate can never be a
-            // server-reflexive candidate.
-            matches!(v.kind(), CandidateKind::Host | CandidateKind::Relayed)
-                && v.addr() == req.destination
-                && v.proto() == req.proto
-        }) {
-            Some((i, _)) => i,
-            None => {
-                // Receiving traffic for an IP address that neither is a HOST nor RELAY
-                // is most likely a configuration fault where the user forgot to add a
-                // candidate for the local interface. We are network-connected application
-                // so we need to handle this gracefully: Log a message and discard the packet.
-
-                debug!(
-                    "Discarding STUN request on unknown interface: {}",
-                    Pii(req.destination)
-                );
-                return;
-            }
         };
 
         let maybe_pair = self

--- a/crates/is/src/agent.rs
+++ b/crates/is/src/agent.rs
@@ -151,6 +151,24 @@ struct StunRequest {
     ice_controlled: Option<u64>,
 }
 
+impl StunRequest {
+    fn role_conflict_tiebreaker(&self, controlling: bool) -> Option<u64> {
+        if controlling {
+            self.ice_controlling
+        } else {
+            self.ice_controlled
+        }
+    }
+}
+
+fn role_name(controlling: bool) -> &'static str {
+    if controlling {
+        "controlling"
+    } else {
+        "controlled"
+    }
+}
+
 const REMOTE_PEER_REFLEXIVE_TEMP_FOUNDATION: &str = "tmp_prflx";
 
 /// States the ICE connection can be in.
@@ -1125,6 +1143,8 @@ impl IceAgent {
             self.stun_server_handle_message(now, &packet);
         } else if packet.message.is_successful_binding_response() {
             self.stun_client_handle_response(now, packet.message);
+        } else if packet.message.is_failed_binding_response() {
+            self.stun_client_handle_error(packet.message);
         }
 
         self.emit_event(IceAgentEvent::DiscoveredRecv {
@@ -1413,6 +1433,24 @@ impl IceAgent {
             }
         };
 
+        // Role conflict detection: if the peer claims the same role as us,
+        // the agent with the higher tiebreaker keeps its role and the loser yields.
+        if let Some(peer_tb) = req.role_conflict_tiebreaker(self.controlling) {
+            debug!(
+                "Role conflict on {} role: ours={}, peer={}",
+                role_name(self.controlling),
+                self.control_tie_breaker,
+                peer_tb,
+            );
+
+            if self.control_tie_breaker >= peer_tb {
+                self.send_role_conflict_reply(&req);
+                return;
+            }
+
+            self.switch_role(!self.controlling);
+        }
+
         if req.use_candidate && self.controlling {
             // the other side is not controlling, and it sent USE-CANDIDATE. that's wrong.
             debug!("STUN request rejected, USE-CANDIDATE when local is controlling");
@@ -1574,6 +1612,63 @@ impl IceAgent {
         self.transmit.push_back(trans);
     }
 
+    fn send_role_conflict_reply(&mut self, req: &StunRequest) {
+        let (_, password) = self.stun_credentials(true);
+
+        let reply = StunMessage::binding_role_conflict_reply(req.trans_id);
+
+        debug!(
+            "Reply 487 Role Conflict (keep {} role): {} -> {}",
+            role_name(self.controlling),
+            req.destination,
+            req.source,
+        );
+
+        let mut buf = vec![0_u8; DATAGRAM_MTU];
+
+        let sha1_hmac =
+            |key: &[u8], payloads: &[&[u8]]| self.sha1_hmac_provider.sha1_hmac(key, payloads);
+        let n = reply
+            .to_bytes(Some(password.as_bytes()), &mut buf, sha1_hmac)
+            .expect("IO error writing STUN error reply");
+        buf.truncate(n);
+
+        let trans = Transmit {
+            proto: req.proto,
+            source: req.destination,
+            destination: req.source,
+            contents: buf.into(),
+        };
+
+        self.transmit.push_back(trans);
+    }
+
+    /// Switches the controlling/controlled role and recomputes pair priorities
+    /// per RFC 8445 §7.3.1.1.
+    fn switch_role(&mut self, controlling: bool) {
+        if self.controlling == controlling {
+            return;
+        }
+
+        debug!(
+            "Switch role: {} -> {}",
+            role_name(self.controlling),
+            role_name(controlling),
+        );
+
+        self.controlling = controlling;
+
+        for i in 0..self.candidate_pairs.len() {
+            let local_idx = self.candidate_pairs[i].local_idx();
+            let remote_idx = self.candidate_pairs[i].remote_idx();
+            let local_prio = self.local_candidates[local_idx].prio();
+            let remote_prio = self.remote_candidates[remote_idx].prio();
+            let new_prio = CandidatePair::calculate_prio(controlling, remote_prio, local_prio);
+            self.candidate_pairs[i].set_prio(new_prio);
+        }
+        self.candidate_pairs.sort();
+    }
+
     fn stun_client_binding_request(&mut self, now: Instant, pair_idx: usize) {
         let (username, password) = self.stun_credentials(false);
 
@@ -1621,6 +1716,48 @@ impl IceAgent {
         };
 
         self.transmit.push_back(trans);
+    }
+
+    /// Handle a STUN binding error response.
+    ///
+    /// We only act on 487 (Role Conflict) per RFC 8445 §7.3.1.1: switch to
+    /// the opposite role, but only if the request that triggered the 487 was
+    /// sent under our current role. Otherwise the response is stale —
+    /// in-flight from before an earlier swap — and acting on it would flap.
+    fn stun_client_handle_error(&mut self, message: StunMessage<'_>) {
+        let Some((code, _)) = message.error_code() else {
+            return;
+        };
+        if code != 487 {
+            debug!("Ignoring binding error response with code {code}");
+            return;
+        }
+
+        let trans_id = message.trans_id();
+        let attempt = self
+            .candidate_pairs
+            .iter()
+            .find_map(|p| p.binding_attempt(trans_id));
+
+        let Some(attempt) = attempt else {
+            debug!("Ignore 487 for unknown transaction id");
+            return;
+        };
+
+        if attempt.controlling() != self.controlling {
+            debug!(
+                "Ignore stale 487 (request was sent as {}, we are now {})",
+                role_name(attempt.controlling()),
+                role_name(self.controlling),
+            );
+            return;
+        }
+
+        debug!(
+            "Got 487 Role Conflict, switching from {}",
+            role_name(self.controlling),
+        );
+        self.switch_role(!self.controlling);
     }
 
     fn stun_client_handle_response(&mut self, now: Instant, message: StunMessage<'_>) {

--- a/crates/is/src/agent.rs
+++ b/crates/is/src/agent.rs
@@ -147,6 +147,8 @@ struct StunRequest {
     prio: u32,
     use_candidate: bool,
     remote_ufrag: String,
+    ice_controlling: Option<u64>,
+    ice_controlled: Option<u64>,
 }
 
 const REMOTE_PEER_REFLEXIVE_TEMP_FOUNDATION: &str = "tmp_prflx";
@@ -1339,6 +1341,8 @@ impl IceAgent {
             prio,
             use_candidate,
             remote_ufrag: remote_ufrag.into(),
+            ice_controlling: message.ice_controlling(),
+            ice_controlled: message.ice_controlled(),
         };
 
         if self.remote_credentials.is_some() {

--- a/crates/is/src/agent.rs
+++ b/crates/is/src/agent.rs
@@ -344,6 +344,14 @@ impl IceAgent {
         }
     }
 
+    /// Sets the control tie breaker of this agent.
+    ///
+    /// By default, this is randomly generated and per the ICE spec,
+    /// this MUST be the same for the duration of an ICE session.
+    pub fn set_control_tie_breaker(&mut self, tie_breaker: u64) {
+        self.control_tie_breaker = tie_breaker;
+    }
+
     /// The maximum number of candidate pairs to test.
     ///
     /// Any pairs above this limit will be dropped (worst priority first).

--- a/crates/is/src/agent.rs
+++ b/crates/is/src/agent.rs
@@ -1069,7 +1069,7 @@ impl IceAgent {
                 let belongs_to_a_candidate_pair = self
                     .candidate_pairs
                     .iter()
-                    .any(|pair| pair.has_binding_attempt(message.trans_id()));
+                    .any(|pair| pair.binding_attempt(message.trans_id()).is_some());
 
                 if !belongs_to_a_candidate_pair {
                     trace!(
@@ -1627,7 +1627,7 @@ impl IceAgent {
         let maybe_pair = self
             .candidate_pairs
             .iter_mut()
-            .find(|p| p.has_binding_attempt(trans_id));
+            .find(|p| p.binding_attempt(trans_id).is_some());
 
         self.stats.bind_success_recv += 1;
 

--- a/crates/is/src/agent.rs
+++ b/crates/is/src/agent.rs
@@ -1584,7 +1584,7 @@ impl IceAgent {
         // Only the controlling side sends USE-CANDIDATE.
         let use_candidate = self.controlling && pair.is_nominated();
 
-        let trans_id = pair.new_attempt(now, &self.timing_config);
+        let trans_id = pair.new_attempt(now, &self.timing_config, self.controlling);
 
         self.stats.bind_request_sent += 1;
 

--- a/crates/is/src/lib.rs
+++ b/crates/is/src/lib.rs
@@ -297,6 +297,46 @@ pub(crate) mod test {
         );
     }
 
+    // RFC 8445 §7.3.1.1: when both agents claim the controlling role, the
+    // role conflict is resolved deterministically by the tiebreaker — the
+    // higher-tiebreaker agent keeps the role, the other yields. Tiebreakers
+    // here are the random ones picked by the constructor, so we cannot
+    // predict which side wins; we only assert that the conflict resolves:
+    // the connection still establishes and exactly one side ends up
+    // controlled.
+    #[test]
+    pub fn role_conflict_resolves_to_one_controlled_side() {
+        let mut a1 = TestAgent::new(info_span!("L"));
+        let mut a2 = TestAgent::new(info_span!("R"));
+
+        let c1 = a1.add_host_candidate("1.1.1.1:1000");
+        a2.add_remote_candidate(c1);
+
+        let c2 = a2.add_host_candidate("2.2.2.2:1000");
+        a1.add_remote_candidate(c2);
+
+        a1.set_controlling(true);
+        a2.set_controlling(true);
+
+        loop {
+            if a1.state().is_connected() && a2.state().is_connected() {
+                break;
+            }
+            progress(&mut a1, &mut a2);
+        }
+
+        assert!(
+            a1.controlling() ^ a2.controlling(),
+            "role conflict must leave exactly one side controlling, got a1={} a2={}",
+            a1.controlling(),
+            a2.controlling(),
+        );
+        assert!(
+            a1.stats().nomination_send_count > 0 || a2.stats().nomination_send_count > 0,
+            "role conflict must not block nomination",
+        );
+    }
+
     // str0m performs calculations on `now` internally
     // To ensure that these never panic, we run a happy-path of `host-host` that uses a very early `Instant`.
     #[test]

--- a/crates/is/src/pair.rs
+++ b/crates/is/src/pair.rs
@@ -197,6 +197,10 @@ impl CandidatePair {
         self.prio
     }
 
+    pub fn set_prio(&mut self, prio: u64) {
+        self.prio = prio;
+    }
+
     pub fn state(&self) -> CheckState {
         self.state
     }

--- a/crates/is/src/pair.rs
+++ b/crates/is/src/pair.rs
@@ -106,6 +106,20 @@ pub struct BindingAttempt {
 
     /// Whether the binding attempt is nominated.
     nominated: bool,
+
+    /// The agent's `controlling` value at request time.
+    ///
+    /// Used to decide whether a 487 (Role Conflict) response is
+    /// stale: if the agent has already swapped role since the
+    /// request was sent, the 487 must be ignored to avoid flapping
+    /// when in-flight requests with the old role get rejected.
+    controlling: bool,
+}
+
+impl BindingAttempt {
+    pub fn controlling(&self) -> bool {
+        self.controlling
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -239,7 +253,12 @@ impl CandidatePair {
     /// Records a new binding request attempt.
     ///
     /// Returns the transaction id to use in the STUN message.
-    pub fn new_attempt(&mut self, now: Instant, timing_config: &StunTiming) -> TransId {
+    pub fn new_attempt(
+        &mut self,
+        now: Instant,
+        timing_config: &StunTiming,
+        controlling: bool,
+    ) -> TransId {
         // calculate a new time
         self.cached_next_attempt_time = None;
 
@@ -253,6 +272,7 @@ impl CandidatePair {
             request_sent: now,
             respone_recv: None,
             nominated: self.is_nominated(),
+            controlling,
         };
 
         self.binding_attempts.push_back(attempt);
@@ -503,7 +523,7 @@ mod tests {
         let mut now = Instant::now();
 
         for _ in 0..20 {
-            let id = pair.new_attempt(now, &stun_timing);
+            let id = pair.new_attempt(now, &stun_timing, false);
 
             now += Duration::from_millis(500);
 
@@ -513,7 +533,7 @@ mod tests {
         let offline_at = now;
 
         while pair.is_still_possible(now, &stun_timing) {
-            pair.new_attempt(now, &stun_timing);
+            pair.new_attempt(now, &stun_timing, false);
             now = pair.next_binding_attempt(now, &stun_timing);
         }
 

--- a/crates/is/src/pair.rs
+++ b/crates/is/src/pair.rs
@@ -278,9 +278,12 @@ impl CandidatePair {
         last.trans_id
     }
 
-    /// Tells if this pair caused the binding request for a STUN transaction id.
-    pub fn has_binding_attempt(&self, trans_id: TransId) -> bool {
-        self.binding_attempts.iter().any(|b| b.trans_id == trans_id)
+    /// Returns the binding attempt for the given STUN transaction id, if
+    /// this pair sent it.
+    pub fn binding_attempt(&self, trans_id: TransId) -> Option<&BindingAttempt> {
+        self.binding_attempts
+            .iter()
+            .find(|b| b.trans_id == trans_id)
     }
 
     /// Marks a binding request attempt as having a successful response.

--- a/crates/is/src/stun.rs
+++ b/crates/is/src/stun.rs
@@ -214,11 +214,15 @@ impl<'a> StunMessage<'a> {
     }
 
     /// Whether this STUN message is a _successful_ BINDING response.
-    ///
-    /// STUN binding requests are very simple, they just return the observed address.
-    /// As such, they cannot actually fail which is why we don't have `is_failed_binding_response`.
     pub fn is_successful_binding_response(&self) -> bool {
         self.method == Method::Binding && self.class == Class::Success
+    }
+
+    /// Whether this STUN message is a _failed_ BINDING response.
+    ///
+    /// In ICE, this is used for 487 Role Conflict (RFC 8445 §7.3.1.1).
+    pub fn is_failed_binding_response(&self) -> bool {
+        self.method == Method::Binding && self.class == Class::Failure
     }
 
     /// Whether this STUN message is an ALLOCATE request (TURN).

--- a/crates/is/src/stun.rs
+++ b/crates/is/src/stun.rs
@@ -377,6 +377,16 @@ impl<'a> StunMessage<'a> {
             .build(trans_id)
     }
 
+    /// Constructs a STUN BINDING error reply with a 487 Role Conflict
+    /// error code (RFC 8445 §7.3.1.1).
+    pub fn binding_role_conflict_reply(trans_id: TransId) -> StunMessage<'a> {
+        StunMessageBuilder::new()
+            .binding()
+            .failure()
+            .error_code(487, "Role Conflict")
+            .build(trans_id)
+    }
+
     /// Verify the integrity of this message against the provided password.
     #[must_use]
     pub fn verify(&self, password: &[u8], sha1_hmac: impl Fn(&[u8], &[&[u8]]) -> [u8; 20]) -> bool {


### PR DESCRIPTION
This implements role conflict resolution as per the ICE RFC. The idea is simple: If both agents want to be the controlling side, the u64 tie breaker value decides which one gets to actually be the controlling side. By default, this tie breaker value is randomly generated but we allow users to change it via the `set_control_tie_breaker` method for advanced use cases.