### PR TITLE
feat(is): expose `Candidate::local` publicly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 
-  * Expose H265 some already referenced profile structs #948
+  * IceCandidate expose str0m/is-unique local property #951
   * Implement ICE role conflict resolution #950
+  * Expose H265 some already referenced profile structs #948
 
 # 0.18.1
 

--- a/crates/is/src/candidate.rs
+++ b/crates/is/src/candidate.rs
@@ -499,6 +499,20 @@ impl Candidate {
         self.addr
     }
 
+    /// Returns the _local_ address of this ICE candidate.
+    ///
+    /// This is an extension to the ICE spec that we use to track
+    /// local interfaces also for relayed candidates.
+    /// Specifically, for relayed candidates, the local interface
+    /// is the address the agent uses to communicate with the TURN
+    /// server using the TURN protocol.
+    ///
+    /// For all other candidates, this refers to either the
+    /// candidate itself (host) or the base (srflx/prflx).
+    pub fn local(&self) -> SocketAddr {
+        self.local
+    }
+
     /// Returns a reference to the String containing the transport protocol of
     /// the ICE candidate. For example tcp/udp/..
     pub fn proto(&self) -> Protocol {
@@ -545,11 +559,6 @@ impl Candidate {
 
     pub(crate) fn clear_ufrag(&mut self) {
         self.ufrag = None;
-    }
-
-    #[doc(hidden)]
-    pub fn local(&self) -> SocketAddr {
-        self.local
     }
 
     /// Generates a candidate attribute string.

--- a/crates/is/src/candidate.rs
+++ b/crates/is/src/candidate.rs
@@ -547,7 +547,8 @@ impl Candidate {
         self.ufrag = None;
     }
 
-    pub(crate) fn local(&self) -> SocketAddr {
+    #[doc(hidden)]
+    pub fn local(&self) -> SocketAddr {
         self.local
     }
 


### PR DESCRIPTION
Right now, it is not possible to replace `default_local_preference` from outside the crate because `Candidate::local` is `pub(crate)`.