### PR TITLE
Handle DTLS close_notify shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Send DTLS `close_notify` on `Rtc::close()` #956
   * Fix `Simulcast::add_recv_layer` to push to recv instead of send #968
   * Accept any non-empty SDP session name (`s=`), not just `s=-` (RFC 8866 section 5.3)
 

--- a/crates/proto/src/crypto/provider.rs
+++ b/crates/proto/src/crypto/provider.rs
@@ -192,6 +192,9 @@ pub trait DtlsInstance: CryptoSafe {
 
     /// Return the negotiated DTLS protocol version. May return `None` before handshake completion.
     fn protocol_version(&self) -> Option<ProtocolVersion>;
+
+    /// Initiate graceful shutdown by sending a DTLS `close_notify` alert.
+    fn close(&mut self) -> Result<(), DtlsImplError>;
 }
 
 // ============================================================================

--- a/crypto/apple-crypto/src/dtls.rs
+++ b/crypto/apple-crypto/src/dtls.rs
@@ -169,6 +169,10 @@ impl DtlsInstance for AppleCryptoDtlsInstance {
     fn protocol_version(&self) -> Option<ProtocolVersion> {
         self.dtls.protocol_version()
     }
+
+    fn close(&mut self) -> Result<(), DtlsImplError> {
+        self.dtls.close()
+    }
 }
 
 #[cfg(test)]

--- a/crypto/aws-lc-rs/src/dtls.rs
+++ b/crypto/aws-lc-rs/src/dtls.rs
@@ -111,4 +111,8 @@ impl DtlsInstance for AwsLcRsDtlsInstance {
     fn protocol_version(&self) -> Option<ProtocolVersion> {
         self.dtls.protocol_version()
     }
+
+    fn close(&mut self) -> Result<(), DtlsImplError> {
+        self.dtls.close()
+    }
 }

--- a/crypto/openssl/src/dtls_dimpl.rs
+++ b/crypto/openssl/src/dtls_dimpl.rs
@@ -112,4 +112,8 @@ impl DtlsInstance for DimplDtlsInstance {
     fn protocol_version(&self) -> Option<ProtocolVersion> {
         self.dtls.protocol_version()
     }
+
+    fn close(&mut self) -> Result<(), DtlsImplError> {
+        self.dtls.close()
+    }
 }

--- a/crypto/openssl/src/dtls_ossl.rs
+++ b/crypto/openssl/src/dtls_ossl.rs
@@ -434,6 +434,10 @@ pub(super) struct OsslDtlsInstance {
     queued_app_data: VecDeque<Vec<u8>>,
     next_timeout: Option<Instant>,
     connected_emitted: bool,
+    /// Close handling
+    close_notify_received: bool,
+    close_notify_emitted: bool,
+    close_notify_sent: bool,
 }
 
 impl std::fmt::Debug for OsslDtlsInstance {
@@ -454,6 +458,9 @@ impl OsslDtlsInstance {
             queued_app_data: VecDeque::new(),
             next_timeout: None,
             connected_emitted: false,
+            close_notify_received: false,
+            close_notify_emitted: false,
+            close_notify_sent: false,
         })
     }
 
@@ -498,7 +505,30 @@ impl DtlsInstance for OsslDtlsInstance {
     fn handle_packet(&mut self, packet: &[u8]) -> Result<(), DtlsImplError> {
         match self.inner.handle_receive(packet) {
             Ok(Some(data)) => {
-                self.pending_application_data.push_back(data);
+                if data.is_empty() {
+                    // Zero-length read — confirm it's a close_notify via SSL_get_shutdown
+                    let is_shutdown =
+                        if let State::Established(ref mut stream) = self.inner.tls.state {
+                            stream
+                                .get_shutdown()
+                                .contains(openssl::ssl::ShutdownState::RECEIVED)
+                        } else {
+                            false
+                        };
+                    if is_shutdown {
+                        self.close_notify_received = true;
+                        // Send reciprocal close_notify per RFC 5246 §7.2.1,
+                        // but only if we haven't already sent one ourselves.
+                        if !self.close_notify_sent {
+                            if let State::Established(ref mut stream) = self.inner.tls.state {
+                                let _ = stream.shutdown();
+                            }
+                            self.close_notify_sent = true;
+                        }
+                    }
+                } else {
+                    self.pending_application_data.push_back(data);
+                }
             }
             Ok(None) => {}
             Err(e) => {
@@ -568,6 +598,12 @@ impl DtlsInstance for OsslDtlsInstance {
             }
         }
 
+        // Return close_notify event (after packets so reciprocal alert goes out first)
+        if self.close_notify_received && !self.close_notify_emitted {
+            self.close_notify_emitted = true;
+            return DtlsOutput::CloseNotify;
+        }
+
         // Return application data
         if let Some(data) = self.pending_application_data.pop_front() {
             if data.len() <= buf.len() {
@@ -614,6 +650,15 @@ impl DtlsInstance for OsslDtlsInstance {
 
     fn protocol_version(&self) -> Option<ProtocolVersion> {
         Some(ProtocolVersion::DTLS1_2)
+    }
+
+    fn close(&mut self) -> Result<(), DtlsImplError> {
+        if let State::Established(ref mut stream) = self.inner.tls.state {
+            let _ = stream.shutdown();
+            self.close_notify_sent = true;
+            self.collect_output();
+        }
+        Ok(())
     }
 }
 

--- a/crypto/rust-crypto/src/dtls.rs
+++ b/crypto/rust-crypto/src/dtls.rs
@@ -111,4 +111,8 @@ impl DtlsInstance for RustCryptoDtlsInstance {
     fn protocol_version(&self) -> Option<ProtocolVersion> {
         self.dtls.protocol_version()
     }
+
+    fn close(&mut self) -> Result<(), DtlsImplError> {
+        self.dtls.close()
+    }
 }

--- a/crypto/wincrypto/src/dtls_dimpl.rs
+++ b/crypto/wincrypto/src/dtls_dimpl.rs
@@ -102,6 +102,10 @@ impl DtlsInstance for WinCryptoDtlsInstance {
     fn protocol_version(&self) -> Option<ProtocolVersion> {
         self.dtls.protocol_version()
     }
+
+    fn close(&mut self) -> Result<(), DtlsImplError> {
+        self.dtls.close()
+    }
 }
 
 // ============================================================================

--- a/crypto/wincrypto/src/dtls_schannel.rs
+++ b/crypto/wincrypto/src/dtls_schannel.rs
@@ -252,4 +252,10 @@ impl DtlsInstance for WinCryptoDtlsInstance {
     fn protocol_version(&self) -> Option<ProtocolVersion> {
         Some(ProtocolVersion::DTLS1_2)
     }
+
+    fn close(&mut self) -> Result<(), DtlsImplError> {
+        Err(DtlsImplError::CryptoError(
+            "SChannel native DTLS does not support close_notify".into(),
+        ))
+    }
 }

--- a/crypto/wincrypto/src/sys/provider.rs
+++ b/crypto/wincrypto/src/sys/provider.rs
@@ -409,4 +409,10 @@ impl DtlsInstance for WinCryptoDtlsInstance {
     fn is_active(&self) -> bool {
         self.dtls.is_client().unwrap_or(false)
     }
+
+    fn close(&mut self) -> Result<(), DtlsImplError> {
+        Err(DtlsImplError::CryptoError(
+            "SChannel native DTLS does not support close_notify".into(),
+        ))
+    }
 }

--- a/src/dtls.rs
+++ b/src/dtls.rs
@@ -173,4 +173,11 @@ impl Dtls {
             .handle_timeout(now)
             .map_err(|e| DtlsError::CryptoError(CryptoError::Other(format!("DTLS error: {}", e))))
     }
+
+    /// Initiate graceful shutdown by sending a close_notify alert.
+    pub fn close(&mut self) -> Result<(), DtlsError> {
+        self.instance
+            .close()
+            .map_err(|e| DtlsError::CryptoError(CryptoError::Other(format!("DTLS error: {}", e))))
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -898,6 +898,7 @@ pub use error::RtcError;
 /// ```
 pub struct Rtc {
     alive: bool,
+    closing: bool,
     ice: IceAgent,
     dtls: Dtls,
     dtls_connected: bool,
@@ -1237,6 +1238,7 @@ impl Rtc {
 
         Ok(Rtc {
             alive: true,
+            closing: false,
             ice,
             dtls: Dtls::new(
                 &dtls_cert,
@@ -1545,6 +1547,34 @@ impl Rtc {
 
     fn do_poll_output(&mut self) -> Result<Output, RtcError> {
         if !self.alive {
+            self.last_timeout_reason = Reason::NotHappening;
+            return Ok(Output::Timeout(not_happening()));
+        }
+
+        if self.closing {
+            // Drain DTLS output to move packets into the poll_packet queue
+            loop {
+                match self.dtls.poll_output(&mut self.dtls_buf) {
+                    DtlsOutput::Timeout(_) => break,
+                    _ => {}
+                }
+            }
+
+            // Transmit any pending DTLS packets (the close_notify record)
+            if let Some(send) = &self.send_addr {
+                if let Some(contents) = self.dtls.poll_packet() {
+                    let t = net::Transmit {
+                        proto: send.proto,
+                        source: send.source,
+                        destination: send.destination,
+                        contents,
+                    };
+                    return Ok(Output::Transmit(t));
+                }
+            }
+
+            // All packets drained — mark as not alive
+            self.alive = false;
             self.last_timeout_reason = Reason::NotHappening;
             return Ok(Output::Timeout(not_happening()));
         }
@@ -1905,7 +1935,13 @@ impl Rtc {
     }
 
     /// Sends the DTLS close_notify to the remote.
+    /// Sends the DTLS close_notify to the remote.
+    ///
+    /// The close_notify packet will be emitted via the next `poll_output()` call
+    /// as a `Transmit`. Once the packet is drained, the `Rtc` instance becomes
+    /// not alive.
     pub fn close(&mut self) -> Result<(), RtcError> {
+        self.closing = true;
         Ok(self.dtls.close()?)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -898,6 +898,7 @@ pub use error::RtcError;
 /// ```
 pub struct Rtc {
     alive: bool,
+    closing: bool,
     ice: IceAgent,
     dtls: Dtls,
     dtls_connected: bool,
@@ -1237,6 +1238,7 @@ impl Rtc {
 
         Ok(Rtc {
             alive: true,
+            closing: false,
             ice,
             dtls: Dtls::new(
                 &dtls_cert,
@@ -1436,6 +1438,10 @@ impl Rtc {
             panic!("In rtp_mode use direct_api().stream_tx().write_rtp()");
         }
 
+        if !self.alive  || self.closing {
+            return None;
+        }
+
         // This does not catch potential RIDs required to send simulcast, but
         // it's a good start. An error might arise later on RID mismatch.
         self.session.media_by_mid_mut(mid)?;
@@ -1545,6 +1551,46 @@ impl Rtc {
             return Ok(Output::Timeout(not_happening()));
         }
 
+        if self.closing {
+            // Drain DTLS output to collect packets and detect incoming CloseNotify
+            match self.dtls.poll_output(&mut self.dtls_buf) {
+                DtlsOutput::CloseNotify => {
+                    return Ok(Output::Event(Event::Closed));
+                }
+                _ => {}
+            }
+
+            // Transmit any pending DTLS packets (e.g. the close_notify record)
+            if let Some(send) = &self.send_addr {
+                if let Some(contents) = self.dtls.poll_packet() {
+                    let t = net::Transmit {
+                        proto: send.proto,
+                        source: send.source,
+                        destination: send.destination,
+                        contents,
+                    };
+                    return Ok(Output::Transmit(t));
+                }
+            }
+
+            let time_and_reason =
+                (None, Reason::NotHappening).soonest((self.next_dtls_timeout, Reason::DTLS));
+
+            let time = time_and_reason.0.unwrap_or_else(not_happening);
+            let reason = time_and_reason.1;
+
+            // We want to guarantee time doesn't go backwards.
+            let next = if time < self.last_now {
+                self.last_now
+            } else {
+                time
+            };
+
+            self.last_timeout_reason = reason;
+
+            return Ok(Output::Timeout(next));
+        }
+
         while let Some(e) = self.ice.poll_event() {
             match e {
                 IceAgentEvent::IceRestart(_) => {
@@ -1644,6 +1690,7 @@ impl Rtc {
                     break;
                 }
                 DtlsOutput::CloseNotify => {
+                    self.closing = true;
                     return Ok(Output::Event(Event::Closed));
                 }
                 other => {
@@ -1902,6 +1949,7 @@ impl Rtc {
 
     /// Sends the DTLS close_notify to the remote.
     pub fn close(&mut self) -> Result<(), RtcError> {
+        self.closing = true;
         Ok(self.dtls.close()?)
     }
 
@@ -1972,6 +2020,17 @@ impl Rtc {
 
         self.peer_bytes_rx += bytes_rx as u64;
 
+        if self.closing {
+            // We are closing, process only DTLS close_notify
+            match r.contents.inner {
+                Dtls(dtls) => self.dtls.handle_receive(dtls)?,
+                _ => {
+                    // Ignore everything else
+                }
+            }
+            return Ok(());
+        }
+
         match r.contents.inner {
             Stun(stun) => {
                 let packet = is::stun::StunPacket {
@@ -2007,7 +2066,7 @@ impl Rtc {
     /// // TODO write data channel data.
     /// ```
     pub fn channel(&mut self, id: ChannelId) -> Option<Channel<'_>> {
-        if !self.alive {
+        if !self.alive || self.closing {
             return None;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1559,7 +1559,8 @@ impl Rtc {
                 }
             }
 
-            // Transmit any pending DTLS packets (the close_notify record)
+            // Transmit pending DTLS packets one at a time (the close_notify record).
+            // The caller must keep calling poll_output() until we return Timeout.
             if let Some(send) = &self.send_addr {
                 if let Some(contents) = self.dtls.poll_packet() {
                     let t = net::Transmit {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1438,7 +1438,7 @@ impl Rtc {
             panic!("In rtp_mode use direct_api().stream_tx().write_rtp()");
         }
 
-        if !self.alive  || self.closing {
+        if !self.alive || self.closing {
             return None;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -898,7 +898,6 @@ pub use error::RtcError;
 /// ```
 pub struct Rtc {
     alive: bool,
-    closing: bool,
     ice: IceAgent,
     dtls: Dtls,
     dtls_connected: bool,
@@ -1238,7 +1237,6 @@ impl Rtc {
 
         Ok(Rtc {
             alive: true,
-            closing: false,
             ice,
             dtls: Dtls::new(
                 &dtls_cert,
@@ -1438,7 +1436,7 @@ impl Rtc {
             panic!("In rtp_mode use direct_api().stream_tx().write_rtp()");
         }
 
-        if !self.alive || self.closing {
+        if !self.alive {
             return None;
         }
 
@@ -1551,43 +1549,6 @@ impl Rtc {
             return Ok(Output::Timeout(not_happening()));
         }
 
-        if self.closing {
-            // Drain DTLS output to collect packets and detect incoming CloseNotify
-            if let DtlsOutput::CloseNotify = self.dtls.poll_output(&mut self.dtls_buf) {
-                return Ok(Output::Event(Event::Closed));
-            }
-
-            // Transmit any pending DTLS packets (e.g. the close_notify record)
-            if let Some(send) = &self.send_addr {
-                if let Some(contents) = self.dtls.poll_packet() {
-                    let t = net::Transmit {
-                        proto: send.proto,
-                        source: send.source,
-                        destination: send.destination,
-                        contents,
-                    };
-                    return Ok(Output::Transmit(t));
-                }
-            }
-
-            let time_and_reason =
-                (None, Reason::NotHappening).soonest((self.next_dtls_timeout, Reason::DTLS));
-
-            let time = time_and_reason.0.unwrap_or_else(not_happening);
-            let reason = time_and_reason.1;
-
-            // We want to guarantee time doesn't go backwards.
-            let next = if time < self.last_now {
-                self.last_now
-            } else {
-                time
-            };
-
-            self.last_timeout_reason = reason;
-
-            return Ok(Output::Timeout(next));
-        }
-
         while let Some(e) = self.ice.poll_event() {
             match e {
                 IceAgentEvent::IceRestart(_) => {
@@ -1687,7 +1648,6 @@ impl Rtc {
                     break;
                 }
                 DtlsOutput::CloseNotify => {
-                    self.closing = true;
                     return Ok(Output::Event(Event::Closed));
                 }
                 other => {
@@ -1946,7 +1906,6 @@ impl Rtc {
 
     /// Sends the DTLS close_notify to the remote.
     pub fn close(&mut self) -> Result<(), RtcError> {
-        self.closing = true;
         Ok(self.dtls.close()?)
     }
 
@@ -2017,17 +1976,6 @@ impl Rtc {
 
         self.peer_bytes_rx += bytes_rx as u64;
 
-        if self.closing {
-            // We are closing, process only DTLS close_notify
-            match r.contents.inner {
-                Dtls(dtls) => self.dtls.handle_receive(dtls)?,
-                _ => {
-                    // Ignore everything else
-                }
-            }
-            return Ok(());
-        }
-
         match r.contents.inner {
             Stun(stun) => {
                 let packet = is::stun::StunPacket {
@@ -2063,7 +2011,7 @@ impl Rtc {
     /// // TODO write data channel data.
     /// ```
     pub fn channel(&mut self, id: ChannelId) -> Option<Channel<'_>> {
-        if !self.alive || self.closing {
+        if !self.alive {
             return None;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1935,7 +1935,6 @@ impl Rtc {
     }
 
     /// Sends the DTLS close_notify to the remote.
-    /// Sends the DTLS close_notify to the remote.
     ///
     /// The close_notify packet will be emitted via the next `poll_output()` call
     /// as a `Transmit`. Once the packet is drained, the `Rtc` instance becomes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1553,11 +1553,8 @@ impl Rtc {
 
         if self.closing {
             // Drain DTLS output to collect packets and detect incoming CloseNotify
-            match self.dtls.poll_output(&mut self.dtls_buf) {
-                DtlsOutput::CloseNotify => {
-                    return Ok(Output::Event(Event::Closed));
-                }
-                _ => {}
+            if let DtlsOutput::CloseNotify = self.dtls.poll_output(&mut self.dtls_buf) {
+                return Ok(Output::Event(Event::Closed));
             }
 
             // Transmit any pending DTLS packets (e.g. the close_notify record)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1018,6 +1018,9 @@ pub enum Event {
     /// Incoming RTP data.
     RtpPacket(RtpPacket),
 
+    /// We have received the DTLS close packet
+    Closed,
+
     /// Debug output of incoming and outgoing RTCP/RTP packets.
     ///
     /// Enable using [`RtcConfig::enable_raw_packets()`].
@@ -1640,6 +1643,9 @@ impl Rtc {
                     self.next_dtls_timeout = Some(t);
                     break;
                 }
+                DtlsOutput::CloseNotify => {
+                    return Ok(Output::Event(Event::Closed));
+                }
                 other => {
                     return Err(RtcError::Dtls(DtlsError::Io(std::io::Error::other(
                         format!("Unexpected DTLS output: {other:?}"),
@@ -1892,6 +1898,11 @@ impl Rtc {
             }
         }
         Ok(())
+    }
+
+    /// Sends the DTLS close_notify to the remote.
+    pub fn close(&mut self) -> Result<(), RtcError> {
+        Ok(self.dtls.close()?)
     }
 
     fn init_time(&mut self, now: Instant) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1554,9 +1554,8 @@ impl Rtc {
         if self.closing {
             // Drain DTLS output to move packets into the poll_packet queue
             loop {
-                match self.dtls.poll_output(&mut self.dtls_buf) {
-                    DtlsOutput::Timeout(_) => break,
-                    _ => {}
+                if let DtlsOutput::Timeout(_) = self.dtls.poll_output(&mut self.dtls_buf) {
+                    break;
                 }
             }
 

--- a/tests/dtls-close.rs
+++ b/tests/dtls-close.rs
@@ -87,8 +87,5 @@ fn close_notify_received_by_remote() {
         r_got_closed,
         "R should receive Event::Closed after L sends close_notify"
     );
-    assert!(
-        l_got_closed,
-        "L should receive reciprocal Event::Closed"
-    );
+    assert!(l_got_closed, "L should receive reciprocal Event::Closed");
 }

--- a/tests/dtls-close.rs
+++ b/tests/dtls-close.rs
@@ -1,0 +1,88 @@
+//! Test that calling `Rtc::close()` sends a DTLS close_notify alert
+//! and the remote peer receives `Event::Closed`.
+#![cfg(any(
+    feature = "aws-lc-rs",
+    feature = "rust-crypto",
+    feature = "openssl",
+    feature = "openssl-dimpl",
+    feature = "wincrypto-dimpl",
+    feature = "apple-crypto",
+))]
+
+use std::net::Ipv4Addr;
+use std::time::Instant;
+
+use str0m::{Candidate, Event, Rtc};
+use tracing::info_span;
+
+mod common;
+use common::{TestRtc, init_crypto_default, init_log, progress};
+
+#[test]
+fn close_notify_received_by_remote() {
+    init_log();
+    init_crypto_default();
+
+    let now = Instant::now();
+    let mut l = TestRtc::new_with_rtc(info_span!("L"), Rtc::new(now));
+    let mut r = TestRtc::new_with_rtc(info_span!("R"), Rtc::new(now));
+
+    let host_l = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp").unwrap();
+    let host_r = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp").unwrap();
+    l.add_local_candidate(host_l.clone());
+    l.add_remote_candidate(host_r.clone());
+    r.add_local_candidate(host_r);
+    r.add_remote_candidate(host_l);
+
+    let finger_l = l.direct_api().local_dtls_fingerprint().clone();
+    let finger_r = r.direct_api().local_dtls_fingerprint().clone();
+    l.direct_api().set_remote_fingerprint(finger_r);
+    r.direct_api().set_remote_fingerprint(finger_l);
+
+    let creds_l = l.direct_api().local_ice_credentials();
+    let creds_r = r.direct_api().local_ice_credentials();
+    l.direct_api().set_remote_ice_credentials(creds_r);
+    r.direct_api().set_remote_ice_credentials(creds_l);
+
+    l.direct_api().set_ice_controlling(true);
+    r.direct_api().set_ice_controlling(false);
+
+    l.direct_api().start_dtls(true).unwrap();
+    r.direct_api().start_dtls(false).unwrap();
+    l.direct_api().start_sctp(true);
+    r.direct_api().start_sctp(false);
+
+    // Drive both sides until connected.
+    let mut iterations = 0;
+    while !(l.is_connected() && r.is_connected()) {
+        progress(&mut l, &mut r).unwrap();
+        iterations += 1;
+        assert!(iterations < 500, "DTLS handshake did not complete");
+    }
+    println!("Both peers connected after {iterations} iterations");
+
+    // L initiates close.
+    println!("L calling close()");
+    l.rtc.close().unwrap();
+
+    // Drive the close_notify packet from L to R.
+    let mut r_got_closed = false;
+    let mut l_got_closed = false;
+    for i in 0..100 {
+        progress(&mut l, &mut r).unwrap();
+        if !r_got_closed && r.events.iter().any(|(_, e)| matches!(e, Event::Closed)) {
+            println!("R received Event::Closed after {i} progress iterations");
+            r_got_closed = true;
+        }
+        if !l_got_closed && l.events.iter().any(|(_, e)| matches!(e, Event::Closed)) {
+            println!("L received Event::Closed after {i} progress iterations");
+            l_got_closed = true;
+        }
+        if r_got_closed && l_got_closed {
+            break;
+        }
+    }
+
+    assert!(r_got_closed, "R should receive Event::Closed after L sends close_notify");
+    println!("L received reciprocal close_notify: {l_got_closed}");
+}

--- a/tests/dtls-close.rs
+++ b/tests/dtls-close.rs
@@ -1,5 +1,5 @@
 //! Test that calling `Rtc::close()` sends a DTLS close_notify alert
-//! and the remote peer receives `Event::Closed`.
+//! and marks the Rtc instance as not alive.
 #![cfg(any(
     feature = "aws-lc-rs",
     feature = "rust-crypto",
@@ -63,22 +63,15 @@ fn close_notify_received_by_remote() {
 
     // L initiates close.
     println!("L calling close()");
-    l.rtc.close().unwrap();
+    l.rtc.close().expect("L close");
 
     // Drive the close_notify packet from L to R.
     let mut r_got_closed = false;
-    let mut l_got_closed = false;
     for i in 0..100 {
         progress(&mut l, &mut r).unwrap();
-        if !r_got_closed && r.events.iter().any(|(_, e)| matches!(e, Event::Closed)) {
+        if r.events.iter().any(|(_, e)| matches!(e, Event::Closed)) {
             println!("R received Event::Closed after {i} progress iterations");
             r_got_closed = true;
-        }
-        if !l_got_closed && l.events.iter().any(|(_, e)| matches!(e, Event::Closed)) {
-            println!("L received Event::Closed after {i} progress iterations");
-            l_got_closed = true;
-        }
-        if r_got_closed && l_got_closed {
             break;
         }
     }
@@ -87,5 +80,16 @@ fn close_notify_received_by_remote() {
         r_got_closed,
         "R should receive Event::Closed after L sends close_notify"
     );
-    assert!(l_got_closed, "L should receive reciprocal Event::Closed");
+
+    // After close, L should no longer be alive
+    assert!(!l.rtc.is_alive(), "L should not be alive after close");
+
+    // R also initiates close and drains.
+    println!("R calling close()");
+    r.rtc.close().expect("R close");
+    for _ in 0..10 {
+        progress(&mut l, &mut r).unwrap();
+    }
+
+    assert!(!r.rtc.is_alive(), "R should not be alive after close");
 }

--- a/tests/dtls-close.rs
+++ b/tests/dtls-close.rs
@@ -83,6 +83,9 @@ fn close_notify_received_by_remote() {
         }
     }
 
-    assert!(r_got_closed, "R should receive Event::Closed after L sends close_notify");
+    assert!(
+        r_got_closed,
+        "R should receive Event::Closed after L sends close_notify"
+    );
     println!("L received reciprocal close_notify: {l_got_closed}");
 }

--- a/tests/dtls-close.rs
+++ b/tests/dtls-close.rs
@@ -87,5 +87,8 @@ fn close_notify_received_by_remote() {
         r_got_closed,
         "R should receive Event::Closed after L sends close_notify"
     );
-    println!("L received reciprocal close_notify: {l_got_closed}");
+    assert!(
+        l_got_closed,
+        "L should receive reciprocal Event::Closed"
+    );
 }

--- a/tests/dtls-close.rs
+++ b/tests/dtls-close.rs
@@ -87,8 +87,15 @@ fn close_notify_received_by_remote() {
     // R also initiates close and drains.
     println!("R calling close()");
     r.rtc.close().expect("R close");
-    for _ in 0..10 {
+
+    // poll_output needs to be called on R to drain the close and set alive=false.
+    // We need enough progress() calls to let R catch up timewise with L
+    // since progress() uses a 5ms window per call.
+    for _ in 0..100 {
         progress(&mut l, &mut r).unwrap();
+        if !r.rtc.is_alive() {
+            break;
+        }
     }
 
     assert!(!r.rtc.is_alive(), "R should not be alive after close");


### PR DESCRIPTION
Summary

  * Send DTLS close_notify alerts from Rtc::close().
  * Emit Event::Closed when a DTLS close_notify is received and respond with a reciprocal alert.
  * Wire close handling through the DTLS provider implementations and document the change in the changelog.