### PR TITLE
feat: add ICE candidate pair RTT stats to CandidatePairStats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Expose ICE candidate pair RTT in CandidatePairStats #962
   * Add stereo to opus format params #955
   * Use `Arc<[u8]>` as input/output of media data (breaking) #959
 

--- a/crates/is/src/agent.rs
+++ b/crates/is/src/agent.rs
@@ -1930,6 +1930,28 @@ impl IceAgent {
             .find_map(|p| (p.id() == id).then_some(p.prio()))
     }
 
+    /// The round-trip time of the most recent successful STUN binding
+    /// transaction on the nominated candidate pair.
+    ///
+    /// Returns `None` if there is no nominated pair, or no successful
+    /// binding response has been recorded on it.
+    ///
+    /// This is the ICE-level equivalent of
+    /// [`RTCIceCandidatePairStats.currentRoundTripTime`][1] and is updated
+    /// on every STUN keepalive/consent exchange — useful for measuring RTT
+    /// on receive-only endpoints where RTP-based RTT estimates aren't
+    /// available.
+    ///
+    /// [1]: https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatepairstats-currentroundtriptime
+    pub fn nominated_pair_rtt(&self) -> Option<Duration> {
+        let id = self.nominated_send?;
+
+        self.candidate_pairs
+            .iter()
+            .find(|p| p.id() == id)
+            .and_then(|p| p.last_successful_rtt())
+    }
+
     fn set_connection_state(&mut self, state: IceConnectionState, reason: &'static str) {
         if self.state != state {
             debug!("State change ({}): {:?} -> {:?}", reason, self.state, state);

--- a/crates/is/src/agent.rs
+++ b/crates/is/src/agent.rs
@@ -1930,6 +1930,11 @@ impl IceAgent {
             .find_map(|p| (p.id() == id).then_some(p.prio()))
     }
 
+    fn nominated_pair(&self) -> Option<&CandidatePair> {
+        let id = self.nominated_send?;
+        self.candidate_pairs.iter().find(|p| p.id() == id)
+    }
+
     /// The round-trip time of the most recent successful STUN binding
     /// transaction on the nominated candidate pair.
     ///
@@ -1944,12 +1949,33 @@ impl IceAgent {
     ///
     /// [1]: https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatepairstats-currentroundtriptime
     pub fn nominated_pair_rtt(&self) -> Option<Duration> {
-        let id = self.nominated_send?;
+        self.nominated_pair().and_then(|p| p.last_successful_rtt())
+    }
 
-        self.candidate_pairs
-            .iter()
-            .find(|p| p.id() == id)
-            .and_then(|p| p.last_successful_rtt())
+    /// Sum of all RTTs measured from successful STUN binding transactions
+    /// on the nominated candidate pair over its lifetime.
+    ///
+    /// Spec equivalent of [`RTCIceCandidatePairStats.totalRoundTripTime`][1].
+    /// Divide by [`nominated_pair_responses_received`] to get the average.
+    ///
+    /// Returns `None` if there is no nominated pair.
+    ///
+    /// [`nominated_pair_responses_received`]: Self::nominated_pair_responses_received
+    /// [1]: https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatepairstats-totalroundtriptime
+    pub fn nominated_pair_total_rtt(&self) -> Option<Duration> {
+        self.nominated_pair().map(|p| p.total_round_trip_time())
+    }
+
+    /// Total number of STUN binding responses received on the nominated
+    /// candidate pair over its lifetime.
+    ///
+    /// Spec equivalent of [`RTCIceCandidatePairStats.responsesReceived`][1].
+    ///
+    /// Returns `None` if there is no nominated pair.
+    ///
+    /// [1]: https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatepairstats-responsesreceived
+    pub fn nominated_pair_responses_received(&self) -> Option<u64> {
+        self.nominated_pair().map(|p| p.responses_received())
     }
 
     fn set_connection_state(&mut self, state: IceConnectionState, reason: &'static str) {

--- a/crates/is/src/pair.rs
+++ b/crates/is/src/pair.rs
@@ -352,6 +352,17 @@ impl CandidatePair {
         self.binding_attempts.back().map(|b| b.request_sent)
     }
 
+    /// The round-trip time of the most recent successful STUN binding
+    /// transaction recorded for this pair.
+    ///
+    /// `None` if no binding response has been received yet.
+    pub fn last_successful_rtt(&self) -> Option<Duration> {
+        self.binding_attempts
+            .iter()
+            .rev()
+            .find_map(|b| b.respone_recv.map(|r| r - b.request_sent))
+    }
+
     /// From the back of binding_attempts, go through all unanswered and find
     /// the time when we started having an outage.
     ///
@@ -544,5 +555,37 @@ mod tests {
         let duration = now.duration_since(offline_at);
 
         assert_eq!(duration, stun_timing.timeout())
+    }
+
+    #[test]
+    fn last_successful_rtt_returns_most_recent() {
+        let stun_timing = StunTiming::default();
+        let mut pair = CandidatePair::new(0, CandidateKind::Host, 0, CandidateKind::Host, 0);
+        let now = Instant::now();
+
+        assert_eq!(pair.last_successful_rtt(), None);
+
+        let id1 = pair.new_attempt(now, &stun_timing, false);
+        pair.record_binding_response(now + Duration::from_millis(50), id1, 0);
+        assert_eq!(
+            pair.last_successful_rtt(),
+            Some(Duration::from_millis(50))
+        );
+
+        // Newer in-flight attempt without response shouldn't shadow the
+        // older successful one.
+        let _id2 = pair.new_attempt(now + Duration::from_millis(100), &stun_timing, false);
+        assert_eq!(
+            pair.last_successful_rtt(),
+            Some(Duration::from_millis(50))
+        );
+
+        // A newer successful attempt replaces the value.
+        let id3 = pair.new_attempt(now + Duration::from_millis(200), &stun_timing, false);
+        pair.record_binding_response(now + Duration::from_millis(220), id3, 0);
+        assert_eq!(
+            pair.last_successful_rtt(),
+            Some(Duration::from_millis(20))
+        );
     }
 }

--- a/crates/is/src/pair.rs
+++ b/crates/is/src/pair.rs
@@ -52,6 +52,14 @@ pub struct CandidatePair {
 
     /// State of nomination for this candidate pair.
     nomination_state: NominationState,
+
+    /// Total number of STUN binding responses received on this pair,
+    /// across the whole pair lifetime (not bounded by `binding_attempts`).
+    responses_received: u64,
+
+    /// Sum of all RTTs measured from successful STUN binding transactions
+    /// on this pair, across the whole pair lifetime.
+    total_round_trip_time: Duration,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -153,6 +161,8 @@ impl CandidatePair {
             remote_binding_requests: Default::default(),
             remote_binding_request_time: Default::default(),
             nomination_state: Default::default(),
+            responses_received: 0,
+            total_round_trip_time: Duration::ZERO,
         }
     }
 
@@ -328,6 +338,9 @@ impl CandidatePair {
 
         attempt.respone_recv = Some(now);
 
+        self.responses_received += 1;
+        self.total_round_trip_time += now - attempt.request_sent;
+
         if attempt.nominated && self.nomination_state == NominationState::Attempt {
             self.nomination_state = NominationState::Success;
             debug!("Nomination success: {:?}", Pii(&self));
@@ -361,6 +374,18 @@ impl CandidatePair {
             .iter()
             .rev()
             .find_map(|b| b.respone_recv.map(|r| r - b.request_sent))
+    }
+
+    /// Total number of STUN binding responses received on this pair over
+    /// the pair's lifetime.
+    pub fn responses_received(&self) -> u64 {
+        self.responses_received
+    }
+
+    /// Sum of all RTTs measured from successful STUN binding transactions
+    /// on this pair over the pair's lifetime.
+    pub fn total_round_trip_time(&self) -> Duration {
+        self.total_round_trip_time
     }
 
     /// From the back of binding_attempts, go through all unanswered and find
@@ -564,6 +589,8 @@ mod tests {
         let now = Instant::now();
 
         assert_eq!(pair.last_successful_rtt(), None);
+        assert_eq!(pair.responses_received(), 0);
+        assert_eq!(pair.total_round_trip_time(), Duration::ZERO);
 
         let id1 = pair.new_attempt(now, &stun_timing, false);
         pair.record_binding_response(now + Duration::from_millis(50), id1, 0);
@@ -571,21 +598,26 @@ mod tests {
             pair.last_successful_rtt(),
             Some(Duration::from_millis(50))
         );
+        assert_eq!(pair.responses_received(), 1);
+        assert_eq!(pair.total_round_trip_time(), Duration::from_millis(50));
 
         // Newer in-flight attempt without response shouldn't shadow the
-        // older successful one.
+        // older successful one or change cumulative counters.
         let _id2 = pair.new_attempt(now + Duration::from_millis(100), &stun_timing, false);
         assert_eq!(
             pair.last_successful_rtt(),
             Some(Duration::from_millis(50))
         );
+        assert_eq!(pair.responses_received(), 1);
 
-        // A newer successful attempt replaces the value.
+        // A newer successful attempt replaces current rtt and accumulates totals.
         let id3 = pair.new_attempt(now + Duration::from_millis(200), &stun_timing, false);
         pair.record_binding_response(now + Duration::from_millis(220), id3, 0);
         assert_eq!(
             pair.last_successful_rtt(),
             Some(Duration::from_millis(20))
         );
+        assert_eq!(pair.responses_received(), 2);
+        assert_eq!(pair.total_round_trip_time(), Duration::from_millis(70));
     }
 }

--- a/crates/is/src/pair.rs
+++ b/crates/is/src/pair.rs
@@ -594,29 +594,20 @@ mod tests {
 
         let id1 = pair.new_attempt(now, &stun_timing, false);
         pair.record_binding_response(now + Duration::from_millis(50), id1, 0);
-        assert_eq!(
-            pair.last_successful_rtt(),
-            Some(Duration::from_millis(50))
-        );
+        assert_eq!(pair.last_successful_rtt(), Some(Duration::from_millis(50)));
         assert_eq!(pair.responses_received(), 1);
         assert_eq!(pair.total_round_trip_time(), Duration::from_millis(50));
 
         // Newer in-flight attempt without response shouldn't shadow the
         // older successful one or change cumulative counters.
         let _id2 = pair.new_attempt(now + Duration::from_millis(100), &stun_timing, false);
-        assert_eq!(
-            pair.last_successful_rtt(),
-            Some(Duration::from_millis(50))
-        );
+        assert_eq!(pair.last_successful_rtt(), Some(Duration::from_millis(50)));
         assert_eq!(pair.responses_received(), 1);
 
         // A newer successful attempt replaces current rtt and accumulates totals.
         let id3 = pair.new_attempt(now + Duration::from_millis(200), &stun_timing, false);
         pair.record_binding_response(now + Duration::from_millis(220), id3, 0);
-        assert_eq!(
-            pair.last_successful_rtt(),
-            Some(Duration::from_millis(20))
-        );
+        assert_eq!(pair.last_successful_rtt(), Some(Duration::from_millis(20)));
         assert_eq!(pair.responses_received(), 2);
         assert_eq!(pair.total_round_trip_time(), Duration::from_millis(70));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1889,10 +1889,8 @@ impl Rtc {
                 snapshot.peer_rx = self.peer_bytes_rx;
                 snapshot.peer_tx = self.peer_bytes_tx;
                 let current_round_trip_time = self.ice.nominated_pair_rtt();
-                let total_round_trip_time =
-                    self.ice.nominated_pair_total_rtt().unwrap_or_default();
-                let responses_received =
-                    self.ice.nominated_pair_responses_received().unwrap_or(0);
+                let total_round_trip_time = self.ice.nominated_pair_total_rtt().unwrap_or_default();
+                let responses_received = self.ice.nominated_pair_responses_received().unwrap_or(0);
                 snapshot.selected_candidate_pair =
                     self.send_addr.as_ref().map(|s| CandidatePairStats {
                         protocol: s.proto,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1889,6 +1889,10 @@ impl Rtc {
                 snapshot.peer_rx = self.peer_bytes_rx;
                 snapshot.peer_tx = self.peer_bytes_tx;
                 let current_round_trip_time = self.ice.nominated_pair_rtt();
+                let total_round_trip_time =
+                    self.ice.nominated_pair_total_rtt().unwrap_or_default();
+                let responses_received =
+                    self.ice.nominated_pair_responses_received().unwrap_or(0);
                 snapshot.selected_candidate_pair =
                     self.send_addr.as_ref().map(|s| CandidatePairStats {
                         protocol: s.proto,
@@ -1897,6 +1901,8 @@ impl Rtc {
                             addr: s.destination,
                         },
                         current_round_trip_time,
+                        total_round_trip_time,
+                        responses_received,
                     });
                 self.session.visit_stats(now, &mut snapshot);
                 stats.do_handle_timeout(&mut snapshot);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1888,6 +1888,7 @@ impl Rtc {
                 let mut snapshot = StatsSnapshot::new(now);
                 snapshot.peer_rx = self.peer_bytes_rx;
                 snapshot.peer_tx = self.peer_bytes_tx;
+                let current_round_trip_time = self.ice.nominated_pair_rtt();
                 snapshot.selected_candidate_pair =
                     self.send_addr.as_ref().map(|s| CandidatePairStats {
                         protocol: s.proto,
@@ -1895,6 +1896,7 @@ impl Rtc {
                         remote: CandidateStats {
                             addr: s.destination,
                         },
+                        current_round_trip_time,
                     });
                 self.session.visit_stats(now, &mut snapshot);
                 stats.do_handle_timeout(&mut snapshot);

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -105,6 +105,21 @@ pub struct CandidatePairStats {
     ///
     /// [1]: https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatepairstats-currentroundtriptime
     pub current_round_trip_time: Option<Duration>,
+    /// Sum of all RTTs measured from successful STUN binding transactions
+    /// on the nominated pair over its lifetime. Divide by
+    /// [`responses_received`][Self::responses_received] for the average.
+    ///
+    /// Spec equivalent of [`RTCIceCandidatePairStats.totalRoundTripTime`][1].
+    ///
+    /// [1]: https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatepairstats-totalroundtriptime
+    pub total_round_trip_time: Duration,
+    /// Total number of STUN binding responses received on the nominated
+    /// pair over its lifetime.
+    ///
+    /// Spec equivalent of [`RTCIceCandidatePairStats.responsesReceived`][1].
+    ///
+    /// [1]: https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatepairstats-responsesreceived
+    pub responses_received: u64,
 }
 
 #[derive(Debug, Clone)]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -94,6 +94,17 @@ pub struct CandidatePairStats {
     pub local: CandidateStats,
     /// The remote candidate.
     pub remote: CandidateStats,
+    /// Round-trip time of the most recent STUN binding transaction on the
+    /// nominated pair.
+    ///
+    /// Spec equivalent of [`RTCIceCandidatePairStats.currentRoundTripTime`][1].
+    ///
+    /// This is sourced from the ICE keepalive/consent traffic and is
+    /// available even on receive-only endpoints where RTP-based RTT
+    /// estimates aren't.
+    ///
+    /// [1]: https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatepairstats-currentroundtriptime
+    pub current_round_trip_time: Option<Duration>,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
Extends `CandidatePairStats` with the three RTT-related fields from the WebRTC stats spec for [`RTCIceCandidatePairStats`](https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatepairstats), sourced from the STUN keepalive/consent exchanges on the nominated pair:

- `current_round_trip_time: Option<Duration>` — RTT of the most recent successful STUN binding transaction. Updates every keepalive, so receive-only endpoints get a continuously-fresh RTT without needing TWCC or waiting on the 5–15s RTCP DLRR interval.
- `total_round_trip_time: Duration` — cumulative RTT sum over the pair's lifetime. Divide by `responses_received` for the average.
- `responses_received: u64` — total successful binding responses on the pair.

Internally adds `IceAgent::nominated_pair_rtt()` / `nominated_pair_total_rtt()` / `nominated_pair_responses_received()` and the corresponding accessors on `CandidatePair`. The cumulative counters live on `CandidatePair` directly so they aren't bounded by the binding-attempt ring buffer.

`PeerStats.rtt` is intentionally left alone — it keeps its TWCC/RR/DLRR-sourced connection-level meaning. Consumers wanting the ICE-level value read it off `selected_candidate_pair`. This matches the spec layering, where `RTCPeerConnectionStats` and `RTCIceCandidatePairStats` are separate dictionaries.

Closes #961

## Test plan
- [x] `cargo test` (workspace) — all passing
- [x] New unit test `pair::tests::last_successful_rtt_returns_most_recent` covers: no attempts, one success, in-flight after success (no shadowing of current rtt or counters), accumulation of total/responses across multiple successes
- [x] `cargo build` clean, no new clippy warnings in changed files