### PR TITLE
fix: abs-capture-time dropped on receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-  * Add `abs-capture-time` writer support and fixed receiver-side extension propagation (breaking)
+  * Add `abs-capture-time` writer support and fixed receiver-side extension propagation (breaking) #964
   * Expose ICE candidate pair RTT in CandidatePairStats #962
   * Add stereo to opus format params #955
   * Use `Arc<[u8]>` as input/output of media data (breaking) #959

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Add `abs-capture-time` writer support and fixed receiver-side extension propagation (breaking)
   * Expose ICE candidate pair RTT in CandidatePairStats #962
   * Add stereo to opus format params #955
   * Use `Arc<[u8]>` as input/output of media data (breaking) #959

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -338,7 +338,7 @@ impl Media {
                     network_time: dep.first_network_time(),
                     seq_range: dep.seq_range(),
                     contiguous: dep.contiguous,
-                    ext_vals: dep.ext_vals().clone(),
+                    ext_vals: dep.ext_vals(),
                     codec_extra: dep.codec_extra,
                     last_sender_info: dep.first_sender_info(),
                     audio_start_of_talk_spurt: codec.spec().codec.is_audio()

--- a/src/media/writer.rs
+++ b/src/media/writer.rs
@@ -5,6 +5,7 @@ use crate::RtcError;
 use crate::format::PayloadParams;
 use crate::rtp_::MidRid;
 use crate::rtp_::VideoOrientation;
+use crate::rtp_::AbsCaptureTime;
 use crate::session::Session;
 
 use super::{ExtensionValues, KeyframeRequestKind, Media, MediaTime, Mid, Pt, Rid, ToPayload};
@@ -95,6 +96,12 @@ impl<'a> Writer<'a> {
     /// whether the video requires to be rotated to show correctly.
     pub fn video_orientation(mut self, o: VideoOrientation) -> Self {
         self.ext_vals.video_orientation = Some(o);
+        self
+    }
+
+    /// Set absolute capture time for this packet.
+    pub fn abs_capture_time(mut self, capture_time: AbsCaptureTime) -> Self {
+        self.ext_vals.abs_capture_time = Some(capture_time);
         self
     }
 

--- a/src/media/writer.rs
+++ b/src/media/writer.rs
@@ -99,7 +99,7 @@ impl<'a> Writer<'a> {
         self
     }
 
-    /// Set absolute capture time for this packet.
+    /// Set absolute capture time for this frame.
     pub fn abs_capture_time(mut self, capture_time: AbsCaptureTime) -> Self {
         self.ext_vals.abs_capture_time = Some(capture_time);
         self

--- a/src/media/writer.rs
+++ b/src/media/writer.rs
@@ -3,9 +3,9 @@ use std::time::Instant;
 
 use crate::RtcError;
 use crate::format::PayloadParams;
+use crate::rtp_::AbsCaptureTime;
 use crate::rtp_::MidRid;
 use crate::rtp_::VideoOrientation;
-use crate::rtp_::AbsCaptureTime;
 use crate::session::Session;
 
 use super::{ExtensionValues, KeyframeRequestKind, Media, MediaTime, Mid, Pt, Rid, ToPayload};

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -76,15 +76,31 @@ impl Depacketized {
             .marker
     }
 
-    pub fn ext_vals(&self) -> &ExtensionValues {
-        // We use the extensions from the last packet because certain extensions, such as video
-        // orientation, are only added on the last packet to save bytes.
-        &self
+    pub fn ext_vals(&self) -> ExtensionValues {
+        let last = &self
             .meta
             .last()
-            .expect("a depacketized to consist of at least one packet")
+            .expect("depacketized video frame must contain a trailing packet")
             .header
-            .ext_vals
+            .ext_vals;
+
+        let first = &self
+            .meta
+            .first()
+            .expect("depacketized video frame must contain a leading packet")
+            .header
+            .ext_vals;
+
+        // We use the extensions from the last packet because certain extensions, such as video
+        // orientation, are only added on the last packet to save bytes.
+        let mut merged = last.clone();
+
+        // str0m strictly attaches abs_capture_time to the first packet of a frame.
+        // Ensure we don't accidentally lose it by cloning from the last packet.
+        if let Some(first_val) = &first.abs_capture_time {
+            merged.abs_capture_time = Some(*first_val);
+        }
+        merged
     }
 }
 
@@ -394,9 +410,11 @@ impl fmt::Debug for Depacketized {
 
 #[cfg(test)]
 mod test {
+    use std::time::{Duration, Instant, SystemTime};
+
     use super::*;
     use crate::packet::vp9::Vp9Depacketizer;
-    use crate::rtp_::{Frequency, MediaTime, Pt, Ssrc};
+    use crate::rtp_::{AbsCaptureTime, Frequency, MediaTime, Pt, Ssrc, VideoOrientation};
 
     #[test]
     fn end_on_marker() {
@@ -405,6 +423,72 @@ mod test {
             (1, 1, &[1], &[]),
             (2, 1, &[9], &[(1, &[1, 9])]),
         ])
+    }
+
+    #[test]
+    fn ext_vals_extracts_abs_capture_time_from_first_packet() {
+        let first_time = Instant::now();
+        let abs_capture_time = AbsCaptureTime {
+            capture_time: SystemTime::UNIX_EPOCH + Duration::from_secs(1),
+            clock_offset: None,
+        };
+
+        let first_header = RtpHeader {
+            version: 2,
+            has_padding: false,
+            has_extension: true,
+            csrc_count: 0,
+            marker: false,
+            payload_type: Pt::new_with_value(98),
+            sequence_number: 1,
+            timestamp: 100,
+            ssrc: Ssrc::from(42),
+            csrc: [0; 15],
+            ext_vals: ExtensionValues {
+                abs_capture_time: Some(abs_capture_time),
+                ..Default::default()
+            },
+            header_len: 0,
+        };
+
+        let last_header = RtpHeader {
+            ext_vals: ExtensionValues {
+                video_orientation: Some(VideoOrientation::Deg90),
+                ..Default::default()
+            },
+            ..first_header.clone()
+        };
+
+        let time_value = 100_u64;
+        let dep = Depacketized {
+            time: MediaTime::new(time_value, Frequency::new(90000).unwrap()),
+            contiguous: true,
+            meta: vec![
+                RtpMeta {
+                    received: first_time,
+                    time: MediaTime::new(time_value, Frequency::new(90000).unwrap()),
+                    seq_no: SeqNo::from(1u64),
+                    header: first_header,
+                    last_sender_info: None,
+                },
+                RtpMeta {
+                    received: first_time + Duration::from_millis(1),
+                    time: MediaTime::new(time_value, Frequency::new(90000).unwrap()),
+                    seq_no: SeqNo::from(2u64),
+                    header: last_header,
+                    last_sender_info: None,
+                },
+            ],
+            data: Vec::new(),
+            codec_extra: CodecExtra::None,
+        };
+
+        let merged = dep.ext_vals();
+        assert_eq!(
+            merged.abs_capture_time.unwrap().capture_time,
+            abs_capture_time.capture_time
+        );
+        assert_eq!(merged.video_orientation, Some(VideoOrientation::Deg90));
     }
 
     #[test]

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -4,6 +4,7 @@ use std::ops::{Range, RangeInclusive};
 use std::sync::Arc;
 use std::time::Instant;
 
+use crate::rtp::vla::VideoLayersAllocation;
 use crate::rtp_::{ExtensionValues, MediaTime, RtpHeader, SenderInfo, SeqNo};
 
 use super::contiguity::Contiguity;
@@ -95,11 +96,15 @@ impl Depacketized {
         // orientation, are only added on the last packet to save bytes.
         let mut merged = last.clone();
 
-        // str0m strictly attaches abs_capture_time to the first packet of a frame.
-        // Ensure we don't accidentally lose it by cloning from the last packet.
+        // str0m strictly attaches some fields to the first packet of a frame.
         if let Some(first_val) = &first.abs_capture_time {
             merged.abs_capture_time = Some(*first_val);
         }
+
+        if let Some(first_val) = first.user_values.get_arc::<VideoLayersAllocation>() {
+            merged.user_values.set_arc(first_val);
+        }
+
         merged
     }
 }
@@ -414,6 +419,7 @@ mod test {
 
     use super::*;
     use crate::packet::vp9::Vp9Depacketizer;
+    use crate::rtp::UserExtensionValues;
     use crate::rtp_::{AbsCaptureTime, Frequency, MediaTime, Pt, Ssrc, VideoOrientation};
 
     #[test]
@@ -426,12 +432,17 @@ mod test {
     }
 
     #[test]
-    fn ext_vals_extracts_abs_capture_time_from_first_packet() {
+    fn ext_vals_extracts_from_first_and_last_packet() {
         let first_time = Instant::now();
         let abs_capture_time = AbsCaptureTime {
             capture_time: SystemTime::UNIX_EPOCH + Duration::from_secs(1),
             clock_offset: None,
         };
+        let mut vla = UserExtensionValues::default();
+        vla.set(VideoLayersAllocation {
+            current_simulcast_stream_index: 1,
+            simulcast_streams: vec![],
+        });
 
         let first_header = RtpHeader {
             version: 2,
@@ -446,6 +457,7 @@ mod test {
             csrc: [0; 15],
             ext_vals: ExtensionValues {
                 abs_capture_time: Some(abs_capture_time),
+                user_values: vla.clone(),
                 ..Default::default()
             },
             header_len: 0,
@@ -487,6 +499,16 @@ mod test {
         assert_eq!(
             merged.abs_capture_time.unwrap().capture_time,
             abs_capture_time.capture_time
+        );
+        assert_eq!(
+            merged
+                .user_values
+                .get::<VideoLayersAllocation>()
+                .unwrap()
+                .current_simulcast_stream_index,
+            vla.get::<VideoLayersAllocation>()
+                .unwrap()
+                .current_simulcast_stream_index,
         );
         assert_eq!(merged.video_orientation, Some(VideoOrientation::Deg90));
     }

--- a/tests/vla.rs
+++ b/tests/vla.rs
@@ -172,7 +172,8 @@ pub fn vla_frame_mode() -> Result<(), RtcError> {
 
     writer
         .user_extension_value(vla.clone())
-        .write(pt, last, MediaTime::ZERO, vec![0xAA; 10])?;
+        // Create ~3-4 packets to make sure vla is propagated properly to the receiver
+        .write(pt, last, MediaTime::ZERO, vec![0xAA; 5000])?;
 
     let mut vla_received = false;
     for _ in 0..100 {


### PR DESCRIPTION
The motivation is to use this abs-capture-time to measure the end-to-end latency from the publisher -> sfu -> subscriber. In my case, all of these use str0m. But the publisher and subscriber run on the default mode (frame mode). 

Changes:

1. Add a public API for setting the frame's absolute capture time
2. Fix the missing abs-capture-time on the receiver
    * This is a breaking change because we need to merge the first packet's value. On the sender side, we only include abs-capture-time in the first packet.