### PR TITLE
Fix peer media stats counters

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -97,6 +97,10 @@ pub(crate) struct Session {
     // Whether we sent a single outgoing RTP packet.
     packet_first_sent: bool,
 
+    // Total RTP payload bytes for media, including retransmissions.
+    media_bytes_rx: u64,
+    media_bytes_tx: u64,
+
     pub ice_lite: bool,
 
     /// Whether we are running in RTP-mode.
@@ -164,6 +168,8 @@ impl Session {
             poll_packet_buf: vec![0; 2000],
             pending_packet: None,
             packet_first_sent: false,
+            media_bytes_rx: 0,
+            media_bytes_tx: 0,
             ice_lite: config.ice_lite,
             rtp_mode: config.rtp_mode,
             vp9_packetizer_mode: config.vp9_packetizer_mode,
@@ -562,6 +568,8 @@ impl Session {
             return;
         }
 
+        self.media_bytes_rx += data.len() as u64;
+
         // One-shot conversion to Arc<[u8]>: a single allocation that copies
         // only the trimmed payload bytes out of the SRTP scratch buffer.
         let payload: Arc<[u8]> = Arc::from(data);
@@ -870,6 +878,10 @@ impl Session {
             bwe.on_media_sent(payload_size.into(), is_padding, now);
         }
 
+        if !is_padding && !header.ssrc.is_probe() {
+            self.media_bytes_tx += payload_size as u64;
+        }
+
         if !self.packet_first_sent {
             self.packet_first_sent = true;
         }
@@ -949,8 +961,8 @@ impl Session {
             stream.visit_stats(snapshot, now);
         }
 
-        snapshot.tx = snapshot.egress.values().map(|s| s.bytes).sum();
-        snapshot.rx = snapshot.ingress.values().map(|s| s.bytes).sum();
+        snapshot.tx = self.media_bytes_tx;
+        snapshot.rx = self.media_bytes_rx;
         snapshot.bwe_tx = self.bwe.as_ref().and_then(|bwe| bwe.last_estimate());
 
         snapshot.egress_loss_fraction = self.twcc_tx_register.loss(Duration::from_secs(1), now);

--- a/tests/stats.rs
+++ b/tests/stats.rs
@@ -3,12 +3,13 @@ use std::time::{Duration, Instant};
 
 use str0m::format::Codec;
 use str0m::media::{Direction, MediaKind};
-use str0m::stats::MediaEgressStats;
+use str0m::rtp::{RtpWrite, Ssrc};
+use str0m::stats::{MediaEgressStats, PeerStats};
 use str0m::{Event, RtcConfig, RtcError};
 use tracing::info_span;
 
 mod common;
-use common::{TestRtc, init_crypto_default, init_log, progress};
+use common::{TestRtc, connect_l_r_with_rtc, init_crypto_default, init_log, progress};
 
 #[test]
 pub fn stats() -> Result<(), RtcError> {
@@ -139,4 +140,87 @@ pub fn stats() -> Result<(), RtcError> {
     );
 
     Ok(())
+}
+
+#[test]
+pub fn peer_media_stats_do_not_drop_when_streams_are_removed() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let now = Instant::now();
+    let config_l = RtcConfig::new()
+        .set_rtp_mode(true)
+        .set_stats_interval(Some(Duration::from_secs(1)));
+    let config_r = RtcConfig::new()
+        .set_rtp_mode(true)
+        .set_stats_interval(Some(Duration::from_secs(1)));
+    let (mut l, mut r) = connect_l_r_with_rtc(config_l.build(now), config_r.build(now));
+
+    let mid = "aud".into();
+    let ssrc: Ssrc = 1.into();
+
+    l.direct_api().declare_media(mid, MediaKind::Audio);
+    l.direct_api().declare_stream_tx(ssrc, None, mid, None);
+    r.direct_api().declare_media(mid, MediaKind::Audio);
+    r.direct_api().expect_stream_rx(ssrc, None, mid, None);
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    let params = l.params_opus();
+    assert_eq!(params.spec().codec, Codec::Opus);
+    let pt = params.pt();
+
+    for i in 0..3 {
+        let wallclock = l.start + l.duration();
+        let time = (48_000 * i) as u32;
+        let seq_no = (1000 + i).into();
+        let payload = vec![i as u8; 80];
+
+        l.direct_api()
+            .stream_tx(&ssrc)
+            .unwrap()
+            .write_rtp(RtpWrite::new(pt, seq_no, time, wallclock, payload));
+
+        progress(&mut l, &mut r)?;
+    }
+
+    let before_l = wait_for_peer_stats(&mut l, &mut r, true, |s| s.bytes_tx > 0)?;
+    let before_r = wait_for_peer_stats(&mut l, &mut r, false, |s| s.bytes_rx > 0)?;
+
+    l.direct_api().remove_media(mid);
+    r.direct_api().remove_media(mid);
+
+    let after_l = wait_for_peer_stats(&mut l, &mut r, true, |s| s.timestamp > before_l.timestamp)?;
+    let after_r = wait_for_peer_stats(&mut l, &mut r, false, |s| s.timestamp > before_r.timestamp)?;
+
+    assert_eq!(after_l.bytes_tx, before_l.bytes_tx);
+    assert_eq!(after_r.bytes_rx, before_r.bytes_rx);
+
+    Ok(())
+}
+
+fn wait_for_peer_stats(
+    l: &mut TestRtc,
+    r: &mut TestRtc,
+    left: bool,
+    predicate: impl Fn(&PeerStats) -> bool,
+) -> Result<PeerStats, RtcError> {
+    for _ in 0..1000 {
+        progress(l, r)?;
+
+        let events = if left { &l.events } else { &r.events };
+        if let Some(stats) = events.iter().rev().find_map(|(_, e)| {
+            if let Event::PeerStats(stats) = e {
+                predicate(stats).then(|| stats.clone())
+            } else {
+                None
+            }
+        }) {
+            return Ok(stats);
+        }
+    }
+
+    panic!("timed out waiting for PeerStats");
 }


### PR DESCRIPTION
## Summary
- track peer media byte totals as session-level cumulative counters
- keep PeerStats bytes_rx/bytes_tx from dropping when RTP streams are removed
- add a regression test covering stream removal after media stats are emitted

## Semantics
MediaIngressStats and MediaEgressStats remain tied to live stream stats objects. PeerStats.bytes_rx and PeerStats.bytes_tx are peer-level media payload byte totals and remain cumulative across stream removal.

## Tests
- cargo test --test stats