### PR TITLE
Make MTU size configurable

### DIFF
--- a/crates/is/src/agent.rs
+++ b/crates/is/src/agent.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashSet, VecDeque};
 use std::fmt;
 use std::net::SocketAddr;
+use std::ops::RangeInclusive;
 use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -11,7 +12,7 @@ use crate::Sha1HmacProvider;
 use crate::preference::default_local_preference;
 use crate::stun::{Class as StunClass, Method as StunMethod, StunTiming};
 use crate::stun::{StunMessage, StunPacket, TransId};
-use str0m_proto::{DATAGRAM_MTU, DATAGRAM_MTU_WARN, Id, Transmit};
+use str0m_proto::{DATAGRAM_MTU_TARGET, DATAGRAM_MTU_WARN, Id, Transmit};
 use str0m_proto::{NonCryptographicRng, Pii, Protocol};
 
 use crate::candidate::{Candidate, CandidateKind};
@@ -106,6 +107,10 @@ pub struct IceAgent {
 
     /// Pluggable calculation of local preference.
     local_preference: LocalPreferenceHolder,
+
+    /// Target MTU (start) and warn threshold (end). Buffer sizing uses the
+    /// target; oversized outgoing datagrams above the warn threshold log a warning.
+    mtu: RangeInclusive<usize>,
 }
 
 /// IceAgent contains only static references to thread-safe traits,
@@ -341,7 +346,23 @@ impl IceAgent {
             timing_config: StunTiming::default(),
             local_preference: LocalPreferenceHolder(Arc::new(default_local_preference)),
             sha1_hmac_provider,
+            mtu: DATAGRAM_MTU_TARGET..=DATAGRAM_MTU_WARN,
         }
+    }
+
+    /// Set the UDP datagram MTU range used for sizing internal buffers (target..=warn).
+    pub fn set_mtu(&mut self, mtu: RangeInclusive<usize>) {
+        self.mtu = mtu;
+    }
+
+    /// Target MTU used for sizing outgoing STUN buffers.
+    pub fn mtu(&self) -> usize {
+        *self.mtu.start()
+    }
+
+    /// Threshold above which an outgoing datagram triggers an MTU warning.
+    pub fn mtu_warn(&self) -> usize {
+        *self.mtu.end()
     }
 
     /// Sets the control tie breaker of this agent.
@@ -1265,8 +1286,8 @@ impl IceAgent {
     pub fn poll_transmit(&mut self) -> Option<Transmit> {
         let x = self.transmit.pop_front();
         if let Some(x) = &x {
-            if x.contents.len() > DATAGRAM_MTU_WARN {
-                warn!("ICE above MTU {}: {}", DATAGRAM_MTU_WARN, x.contents.len());
+            if x.contents.len() > self.mtu_warn() {
+                warn!("ICE above MTU {}: {}", self.mtu_warn(), x.contents.len());
             }
             trace!("Poll transmit: {:?}", x);
         }
@@ -1601,7 +1622,7 @@ impl IceAgent {
             local_addr, remote_addr, reply
         );
 
-        let mut buf = vec![0_u8; DATAGRAM_MTU];
+        let mut buf = vec![0_u8; self.mtu()];
 
         let sha1_hmac =
             |key: &[u8], payloads: &[&[u8]]| self.sha1_hmac_provider.sha1_hmac(key, payloads);
@@ -1632,7 +1653,7 @@ impl IceAgent {
             req.source,
         );
 
-        let mut buf = vec![0_u8; DATAGRAM_MTU];
+        let mut buf = vec![0_u8; self.mtu()];
 
         let sha1_hmac =
             |key: &[u8], payloads: &[&[u8]]| self.sha1_hmac_provider.sha1_hmac(key, payloads);
@@ -1707,7 +1728,7 @@ impl IceAgent {
             binding
         );
 
-        let mut buf = vec![0_u8; DATAGRAM_MTU];
+        let mut buf = vec![0_u8; self.mtu()];
 
         let sha1_hmac =
             |key: &[u8], payloads: &[&[u8]]| self.sha1_hmac_provider.sha1_hmac(key, payloads);
@@ -2672,7 +2693,7 @@ mod test {
     /// Serializing will calculate a message integrity for it. You can then re-parse to get a message
     /// that contains that correct integrity value.
     fn serialize_stun_msg(msg: StunMessage<'_>, password: &str) -> Vec<u8> {
-        let mut buf = vec![0_u8; DATAGRAM_MTU];
+        let mut buf = vec![0_u8; DATAGRAM_MTU_TARGET];
 
         let sha1_hmac =
             |key: &[u8], payloads: &[&[u8]]| DefaultSha1HmacProvider.sha1_hmac(key, payloads);
@@ -2682,5 +2703,16 @@ mod test {
         buf.truncate(n);
 
         buf
+    }
+
+    #[test]
+    fn set_mtu_updates_mtu() {
+        let mut agent = IceAgent::new(IceCreds::new());
+        assert_eq!(agent.mtu(), DATAGRAM_MTU_TARGET);
+        assert_eq!(agent.mtu_warn(), DATAGRAM_MTU_WARN);
+
+        agent.set_mtu(900..=1280);
+        assert_eq!(agent.mtu(), 900);
+        assert_eq!(agent.mtu_warn(), 1280);
     }
 }

--- a/crates/proto/src/crypto/provider.rs
+++ b/crates/proto/src/crypto/provider.rs
@@ -147,11 +147,15 @@ pub trait DtlsProvider: CryptoSafe {
     fn generate_certificate(&self) -> Option<DtlsCert>;
 
     /// Create a new DTLS instance with the given certificate.
+    ///
+    /// mtu: Backends that can size their record layer according to the provided MTU should do so;
+    /// backends that cannot ignore it. `None` means use the backend's default.
     fn new_dtls(
         &self,
         cert: &DtlsCert,
         now: Instant,
         dtls_version: DtlsVersion,
+        mtu: Option<usize>,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError>;
 
     /// Whether the provider is used in a test context.

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -1,9 +1,15 @@
 //! Shared protocol types and traits for str0m.
 
-/// Targeted MTU
-pub const DATAGRAM_MTU: usize = 1150;
+/// Default target MTU when no MTU is explicitly configured via [`RtcConfig::set_mtu`].
+pub const DATAGRAM_MTU_TARGET: usize = 1150;
 
-/// Warn if any packet we are about to send is above this size.
+/// Lower bound for the target MTU.
+pub const DATAGRAM_MTU_TARGET_MIN: usize = 576;
+
+/// Upper bound for the target MTU.
+pub const DATAGRAM_MTU_TARGET_MAX: usize = 1500;
+
+/// Default warning threshold for MTU when no warning threshold is configured via [`RtcConfig::set_mtu`].
 pub const DATAGRAM_MTU_WARN: usize = 1280;
 
 mod bandwidth;

--- a/crypto/apple-crypto/src/dtls.rs
+++ b/crypto/apple-crypto/src/dtls.rs
@@ -89,6 +89,7 @@ impl DtlsProvider for AppleCryptoDtlsProvider {
         cert: &DtlsCert,
         now: Instant,
         dtls_version: DtlsVersion,
+        mtu: Option<usize>,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         let dimpl_cert = DtlsCertificate {
             certificate: cert.certificate.clone(),
@@ -98,6 +99,9 @@ impl DtlsProvider for AppleCryptoDtlsProvider {
         // Create a dimpl Config with Apple CommonCrypto crypto provider
         // ICE verifies return routability before DTLS, making server cookies redundant.
         let mut builder = Config::builder().use_server_cookie(false);
+        if let Some(mtu) = mtu {
+            builder = builder.mtu(mtu);
+        }
         if self.is_test() {
             // We need the DTLS impl to be deterministic for the BWE tests.
             builder = builder.dangerously_set_rng_seed(42);

--- a/crypto/aws-lc-rs/src/dtls.rs
+++ b/crypto/aws-lc-rs/src/dtls.rs
@@ -30,6 +30,7 @@ impl DtlsProvider for AwsLcRsDtlsProvider {
         cert: &DtlsCert,
         now: Instant,
         dtls_version: DtlsVersion,
+        mtu: Option<usize>,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         let dimpl_cert = dimpl::DtlsCertificate {
             certificate: cert.certificate.clone(),
@@ -39,6 +40,9 @@ impl DtlsProvider for AwsLcRsDtlsProvider {
         // Create a default dimpl Config with AWS-LC-RS crypto provider
         // ICE verifies return routability before DTLS, making server cookies redundant.
         let mut builder = dimpl::Config::builder().use_server_cookie(false);
+        if let Some(mtu) = mtu {
+            builder = builder.mtu(mtu);
+        }
         if self.is_test() {
             // We need the DTLS impl to be deterministic for the BWE tests.
             builder = builder.dangerously_set_rng_seed(42);

--- a/crypto/openssl/src/dtls_dimpl.rs
+++ b/crypto/openssl/src/dtls_dimpl.rs
@@ -29,6 +29,7 @@ impl DtlsProvider for OsslDtlsProvider {
         cert: &DtlsCert,
         now: Instant,
         dtls_version: DtlsVersion,
+        mtu: Option<usize>,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         let dimpl_cert = dimpl::DtlsCertificate {
             certificate: cert.certificate.clone(),
@@ -37,6 +38,9 @@ impl DtlsProvider for OsslDtlsProvider {
 
         // ICE verifies return routability before DTLS, making server cookies redundant.
         let mut builder = dimpl::Config::builder().use_server_cookie(false);
+        if let Some(mtu) = mtu {
+            builder = builder.mtu(mtu);
+        }
         if self.is_test() {
             // We need the DTLS impl to be deterministic for the BWE tests.
             builder = builder.dangerously_set_rng_seed(42);

--- a/crypto/openssl/src/dtls_ossl.rs
+++ b/crypto/openssl/src/dtls_ossl.rs
@@ -12,10 +12,10 @@ use openssl::ssl::{SslContext, SslContextBuilder, SslMethod};
 use openssl::ssl::{SslOptions, SslStream, SslVerifyMode};
 use openssl::x509::X509;
 
+use str0m_proto::DATAGRAM_MTU_TARGET;
 use str0m_proto::crypto::dtls::{DtlsCert, KeyingMaterial, SrtpProfile};
 use str0m_proto::crypto::dtls::{DtlsImplError, DtlsInstance, DtlsOutput, DtlsProvider};
 use str0m_proto::crypto::{CryptoError, DtlsVersion};
-use str0m_proto::{DATAGRAM_MTU, DATAGRAM_MTU_WARN};
 
 // ============================================================================
 // IO Buffer
@@ -290,9 +290,9 @@ struct OsslDtlsImpl {
 }
 
 impl OsslDtlsImpl {
-    fn new(cert: &DtlsCert) -> Result<Self, CryptoError> {
+    fn new(cert: &DtlsCert, mtu: usize) -> Result<Self, CryptoError> {
         let context = dtls_create_ctx(cert)?;
-        let ssl = dtls_ssl_create(&context)?;
+        let ssl = dtls_ssl_create(&context, mtu)?;
         Ok(OsslDtlsImpl {
             tls: TlsStream::new(ssl, IoBuffer::default()),
         })
@@ -347,9 +347,6 @@ impl OsslDtlsImpl {
     fn poll_datagram(&mut self) -> Option<Vec<u8>> {
         let x = self.tls.inner_mut().pop_outgoing();
         if let Some(x) = &x {
-            if x.len() > DATAGRAM_MTU_WARN {
-                warn!("DTLS above MTU {}: {}", DATAGRAM_MTU_WARN, x.len());
-            }
             trace!("Poll datagram: {}", x.len());
         }
         x
@@ -407,9 +404,9 @@ fn dtls_create_ctx(cert: &DtlsCert) -> Result<SslContext, CryptoError> {
     Ok(ctx.build())
 }
 
-fn dtls_ssl_create(ctx: &SslContext) -> Result<Ssl, CryptoError> {
+fn dtls_ssl_create(ctx: &SslContext, mtu: usize) -> Result<Ssl, CryptoError> {
     let mut ssl = Ssl::new(ctx)?;
-    ssl.set_mtu(DATAGRAM_MTU as u32)?;
+    ssl.set_mtu(mtu as u32)?;
     Ok(ssl)
 }
 
@@ -446,8 +443,8 @@ impl std::fmt::Debug for OsslDtlsInstance {
 }
 
 impl OsslDtlsInstance {
-    pub(super) fn new(cert: &DtlsCert) -> Result<Self, CryptoError> {
-        let inner = OsslDtlsImpl::new(cert)?;
+    pub(super) fn new(cert: &DtlsCert, mtu: usize) -> Result<Self, CryptoError> {
+        let inner = OsslDtlsImpl::new(cert, mtu)?;
         Ok(Self {
             inner,
             pending_packets: VecDeque::new(),
@@ -638,9 +635,11 @@ impl DtlsProvider for OsslDtlsProvider {
         cert: &DtlsCert,
         _now: Instant,
         dtls_version: DtlsVersion,
+        mtu: Option<usize>,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
+        let mtu = mtu.unwrap_or(DATAGRAM_MTU_TARGET);
         match dtls_version {
-            DtlsVersion::Dtls12 => Ok(Box::new(OsslDtlsInstance::new(cert)?)),
+            DtlsVersion::Dtls12 => Ok(Box::new(OsslDtlsInstance::new(cert, mtu)?)),
             _ => Err(CryptoError::Other(
                 "OpenSSL DTLS provider only supports DTLS 1.2 without dimpl. \
                  Enable the openssl-dimpl feature for DTLS 1.3/Auto."

--- a/crypto/rust-crypto/src/dtls.rs
+++ b/crypto/rust-crypto/src/dtls.rs
@@ -30,6 +30,7 @@ impl DtlsProvider for RustCryptoDtlsProvider {
         cert: &DtlsCert,
         now: Instant,
         dtls_version: DtlsVersion,
+        mtu: Option<usize>,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         let dimpl_cert = dimpl::DtlsCertificate {
             certificate: cert.certificate.clone(),
@@ -39,6 +40,9 @@ impl DtlsProvider for RustCryptoDtlsProvider {
         // Create a default dimpl Config with RustCrypto crypto provider
         // ICE verifies return routability before DTLS, making server cookies redundant.
         let mut builder = dimpl::Config::builder().use_server_cookie(false);
+        if let Some(mtu) = mtu {
+            builder = builder.mtu(mtu);
+        }
         if self.is_test() {
             // We need the DTLS impl to be deterministic for the BWE tests.
             builder = builder.dangerously_set_rng_seed(42);

--- a/crypto/wincrypto/src/dtls_dimpl.rs
+++ b/crypto/wincrypto/src/dtls_dimpl.rs
@@ -26,6 +26,7 @@ impl DtlsProvider for WinCryptoDtlsProvider {
         cert: &DtlsCert,
         now: Instant,
         dtls_version: DtlsVersion,
+        mtu: Option<usize>,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         let dimpl_cert = DtlsCertificate {
             certificate: cert.certificate.clone(),
@@ -34,6 +35,9 @@ impl DtlsProvider for WinCryptoDtlsProvider {
 
         // ICE verifies return routability before DTLS, making server cookies redundant.
         let mut builder = Config::builder().use_server_cookie(false);
+        if let Some(mtu) = mtu {
+            builder = builder.mtu(mtu);
+        }
         if self.is_test() {
             builder = builder.dangerously_set_rng_seed(42);
         }

--- a/crypto/wincrypto/src/dtls_schannel.rs
+++ b/crypto/wincrypto/src/dtls_schannel.rs
@@ -3,6 +3,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, Instant};
+use str0m_proto::DATAGRAM_MTU_TARGET;
 use str0m_proto::crypto::dtls::{DtlsCert, DtlsImplError, DtlsInstance, DtlsOutput, DtlsProvider};
 use str0m_proto::crypto::dtls::{KeyingMaterial, SrtpProfile};
 use str0m_proto::crypto::{CryptoError, DtlsVersion};
@@ -43,6 +44,7 @@ impl DtlsProvider for WinCryptoDtlsProvider {
         cert: &DtlsCert,
         _now: Instant,
         dtls_version: DtlsVersion,
+        mtu: Option<usize>,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         if !matches!(dtls_version, DtlsVersion::Dtls12 | DtlsVersion::Auto) {
             return Err(CryptoError::Other(
@@ -64,8 +66,12 @@ impl DtlsProvider for WinCryptoDtlsProvider {
                 )
             })?;
 
-        let dtls =
-            Dtls::new(win_cert).map_err(|e| CryptoError::Other(format!("DTLS creation: {}", e)))?;
+        let mtu = mtu.unwrap_or(DATAGRAM_MTU_TARGET);
+        let mtu_u16 = u16::try_from(mtu).map_err(|_| {
+            CryptoError::Other(format!("MTU {} does not fit in u16 for SChannel", mtu))
+        })?;
+        let dtls = Dtls::new(win_cert, mtu_u16)
+            .map_err(|e| CryptoError::Other(format!("DTLS creation: {}", e)))?;
 
         Ok(Box::new(WinCryptoDtlsInstance {
             dtls,

--- a/crypto/wincrypto/src/sys/dtls.rs
+++ b/crypto/wincrypto/src/sys/dtls.rs
@@ -89,21 +89,15 @@ const SRTP_PROTECTION_PROFILES_SECBUFFER: SecBuffer = SecBuffer {
     pvBuffer: &SRTP_PROTECTION_PROFILES_BUFFER_INSTANCE as *const _ as *mut _,
 };
 
-const DTLS_MTU_BUFFER_INSTANCE: SEC_DTLS_MTU = SEC_DTLS_MTU {
-    PathMTU: DATAGRAM_MTU as u16,
-};
-const DTLS_MTU_SECBUFFER: SecBuffer = SecBuffer {
-    cbBuffer: std::mem::size_of::<SEC_DTLS_MTU>() as u32,
-    BufferType: SECBUFFER_DTLS_MTU,
-    pvBuffer: &DTLS_MTU_BUFFER_INSTANCE as *const _ as *mut _,
-};
+const DTLS_MTU_BUFFER_SIZE: u32 = std::mem::size_of::<SEC_DTLS_MTU>() as u32;
 
 // The label used for SRTP key derivation from: https://datatracker.ietf.org/doc/html/rfc5764#section-4.2
 const DTLS_KEY_LABEL: &[u8] = b"EXTRACTOR-dtls_srtp\0";
 
-// This size includes the encaptulation overhead of DTLS. So it must be larger than the MTU Str0m
-// uses for SCTP.
-const DATAGRAM_MTU: usize = 1200;
+// Scratch buffer size for SChannel token/alert output. Large enough to hold
+// a worst-case DTLS record on common networks; the actual on-wire MTU is
+// communicated to SChannel via SEC_DTLS_MTU::PathMTU per instance.
+const MAX_DTLS_BUFFER: usize = 1500;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 enum EstablishmentState {
@@ -131,12 +125,13 @@ pub struct Dtls {
     cred_handle: Option<SecHandle>,
     security_ctx: Option<SecHandle>,
     encrypt_message_input_sizes: SecPkgContext_StreamSizes,
+    mtu: u16,
 
     output_datagrams: VecDeque<Vec<u8>>,
 }
 
 impl Dtls {
-    pub fn new(cert: Arc<Certificate>) -> Result<Self, WinCryptoError> {
+    pub fn new(cert: Arc<Certificate>, mtu: u16) -> Result<Self, WinCryptoError> {
         Ok(Dtls {
             cert,
             is_client: None,
@@ -144,6 +139,7 @@ impl Dtls {
             cred_handle: None,
             security_ctx: None,
             encrypt_message_input_sizes: SecPkgContext_StreamSizes::default(),
+            mtu,
             output_datagrams: VecDeque::default(),
         })
     }
@@ -301,8 +297,16 @@ impl Dtls {
         };
         let mut new_ctx_handle = SecHandle::default();
 
+        // Per-instance MTU buffer (read synchronously by SChannel during this call).
+        let dtls_mtu_buffer = SEC_DTLS_MTU { PathMTU: self.mtu };
+        let dtls_mtu_secbuffer = SecBuffer {
+            cbBuffer: DTLS_MTU_BUFFER_SIZE,
+            BufferType: SECBUFFER_DTLS_MTU,
+            pvBuffer: &dtls_mtu_buffer as *const _ as *mut _,
+        };
+
         let mut buffers = [
-            DTLS_MTU_SECBUFFER,
+            dtls_mtu_secbuffer,
             SRTP_PROTECTION_PROFILES_SECBUFFER,
             SecBuffer {
                 cbBuffer: 0,
@@ -339,8 +343,8 @@ impl Dtls {
             },
         };
 
-        let mut token_buffer = [0u8; DATAGRAM_MTU];
-        let mut alert_buffer = [0u8; DATAGRAM_MTU];
+        let mut token_buffer = [0u8; MAX_DTLS_BUFFER];
+        let mut alert_buffer = [0u8; MAX_DTLS_BUFFER];
         let mut out_buffers = [
             SecBuffer {
                 cbBuffer: token_buffer.len() as u32,

--- a/crypto/wincrypto/src/sys/provider.rs
+++ b/crypto/wincrypto/src/sys/provider.rs
@@ -303,6 +303,7 @@ impl DtlsProvider for WinCryptoDtlsProvider {
         cert: &DtlsCert,
         _now: Instant,
         dtls_version: DtlsVersion,
+        mtu: Option<usize>,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         if dtls_version != DtlsVersion::Dtls12 {
             return Err(CryptoError::Other(
@@ -316,7 +317,11 @@ impl DtlsProvider for WinCryptoDtlsProvider {
         let win_cert = crate::Certificate::new_self_signed(true, "CN=WebRTC")
             .map_err(|e| CryptoError::Other(format!("Certificate creation: {}", e)))?;
 
-        let dtls = crate::Dtls::new(Arc::new(win_cert))
+        let mtu = mtu.unwrap_or(str0m_proto::DATAGRAM_MTU_TARGET);
+        let mtu_u16 = u16::try_from(mtu).map_err(|_| {
+            CryptoError::Other(format!("MTU {} does not fit in u16 for SChannel", mtu))
+        })?;
+        let dtls = crate::Dtls::new(Arc::new(win_cert), mtu_u16)
             .map_err(|e| CryptoError::Other(format!("DTLS creation: {}", e)))?;
 
         Ok(Box::new(WinCryptoDtlsInstance { dtls }))

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use std::ops::RangeInclusive;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -8,6 +9,10 @@ use crate::crypto::dtls::DtlsVersion;
 use crate::format::CodecConfig;
 use crate::format::Vp9PacketizerMode;
 use crate::ice::IceCreds;
+use crate::io::DATAGRAM_MTU_TARGET;
+use crate::io::DATAGRAM_MTU_TARGET_MAX;
+use crate::io::DATAGRAM_MTU_TARGET_MIN;
+use crate::io::DATAGRAM_MTU_WARN;
 use crate::rtp_::{Bitrate, Extension, ExtensionMap};
 
 /// Customized config for creating an [`Rtc`] instance.
@@ -47,6 +52,7 @@ pub struct RtcConfig {
     pub(crate) dtls_version: DtlsVersion,
     pub(crate) vp9_packetizer_mode: Vp9PacketizerMode,
     pub(crate) snap_enabled: bool,
+    pub(crate) mtu: RangeInclusive<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -581,6 +587,48 @@ impl RtcConfig {
         self.dtls_version
     }
 
+    /// Set the MTU as a `target..=warn` inclusive range.
+    ///
+    /// * `*range.start()` is the **target** MTU: the size str0m aims for when
+    ///   fragmenting outgoing packets. Must be within
+    ///   `[DATAGRAM_MTU_TARGET_MIN, DATAGRAM_MTU_TARGET_MAX]`.
+    /// * `*range.end()` is the **warn** threshold: packets whose length
+    ///   exceeds the target trigger a warning.
+    ///
+    ///  Set as `target..=target` to warn packets bigger than target.
+    ///  Set as `target..=usize::MAX` to disable warning.
+    ///
+    /// Defaults to `DATAGRAM_MTU_TARGET..=DATAGRAM_MTU_WARN`.
+    pub fn set_mtu(mut self, range: RangeInclusive<usize>) -> Self {
+        let (start, end) = (*range.start(), *range.end());
+        assert!(
+            DATAGRAM_MTU_TARGET_MIN <= start && start <= DATAGRAM_MTU_TARGET_MAX,
+            "mtu target {} out of bounds [{}, {}]",
+            start,
+            DATAGRAM_MTU_TARGET_MIN,
+            DATAGRAM_MTU_TARGET_MAX,
+        );
+        assert!(
+            start <= end,
+            "mtu range start must be <= end, got {}..={}",
+            start,
+            end,
+        );
+        self.mtu = range;
+        self
+    }
+
+    /// Get the configured target MTU (the value str0m aims for).
+    pub fn mtu(&self) -> usize {
+        *self.mtu.start()
+    }
+
+    /// Get the configured warn threshold above which outgoing packets
+    /// trigger a warning trace.
+    pub fn mtu_warn(&self) -> usize {
+        *self.mtu.end()
+    }
+
     /// Set the VP9 packetizer mode.
     ///
     /// VP9 supports two RTP payload descriptor formats:
@@ -644,6 +692,61 @@ impl Default for RtcConfig {
             dtls_version: DtlsVersion::Dtls12,
             vp9_packetizer_mode: Vp9PacketizerMode::default(),
             snap_enabled: false,
+            mtu: DATAGRAM_MTU_TARGET..=DATAGRAM_MTU_WARN,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_mtu_is_datagram_mtu_target() {
+        let cfg = RtcConfig::default();
+        assert_eq!(cfg.mtu(), DATAGRAM_MTU_TARGET);
+        assert_eq!(cfg.mtu_warn(), DATAGRAM_MTU_WARN);
+    }
+
+    #[test]
+    fn set_mtu_round_trips() {
+        let cfg = RtcConfig::default().set_mtu(900..=1400);
+        assert_eq!(cfg.mtu(), 900);
+        assert_eq!(cfg.mtu_warn(), 1400);
+
+        let cfg = RtcConfig::default().set_mtu(900..=usize::MAX);
+        assert_eq!(cfg.mtu(), 900);
+        assert_eq!(cfg.mtu_warn(), usize::MAX);
+    }
+
+    #[test]
+    fn set_mtu_accepts_equal_bounds() {
+        let cfg = RtcConfig::default().set_mtu(1200..=1200);
+        assert_eq!(cfg.mtu(), 1200);
+        assert_eq!(cfg.mtu_warn(), 1200);
+
+        let cfg = RtcConfig::default().set_mtu(DATAGRAM_MTU_TARGET_MIN..=DATAGRAM_MTU_TARGET_MIN);
+        assert_eq!(cfg.mtu(), DATAGRAM_MTU_TARGET_MIN);
+
+        let cfg = RtcConfig::default().set_mtu(DATAGRAM_MTU_TARGET_MAX..=DATAGRAM_MTU_TARGET_MAX);
+        assert_eq!(cfg.mtu(), DATAGRAM_MTU_TARGET_MAX);
+    }
+
+    #[test]
+    #[should_panic(expected = "mtu target")]
+    fn set_mtu_panics_on_target_below_min() {
+        let _ = RtcConfig::default().set_mtu((DATAGRAM_MTU_TARGET_MIN - 1)..=usize::MAX);
+    }
+
+    #[test]
+    #[should_panic(expected = "mtu target")]
+    fn set_mtu_panics_on_target_above_max() {
+        let _ = RtcConfig::default().set_mtu((DATAGRAM_MTU_TARGET_MAX + 1)..=usize::MAX);
+    }
+
+    #[test]
+    #[should_panic(expected = "mtu range start must be <= end")]
+    fn set_mtu_panics_on_inverted_range() {
+        let _ = RtcConfig::default().set_mtu(1300..=1299);
     }
 }

--- a/src/dtls.rs
+++ b/src/dtls.rs
@@ -1,5 +1,6 @@
 use std::collections::VecDeque;
 use std::io;
+use std::ops::RangeInclusive;
 use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::time::Instant;
 
@@ -30,6 +31,11 @@ pub struct Dtls {
 
     /// Packets to be sent.
     pending_packets: VecDeque<DatagramSend>,
+
+    /// Target MTU (start) and warn threshold (end). The target is forwarded to
+    /// the backend's fragmenter; outgoing records larger than the warn
+    /// threshold log a warning.
+    mtu: RangeInclusive<usize>,
 }
 
 pub(crate) fn is_would_block(error: &DtlsError) -> bool {
@@ -54,9 +60,10 @@ impl Dtls {
         sha256_provider: &dyn Sha256Provider,
         now: Instant,
         dtls_version: DtlsVersion,
+        mtu: RangeInclusive<usize>,
     ) -> Result<Self, DtlsError> {
         let instance = dtls_provider
-            .new_dtls(cert, now, dtls_version)
+            .new_dtls(cert, now, dtls_version, Some(*mtu.start()))
             .map_err(DtlsError::CryptoError)?;
 
         // Compute fingerprint from the certificate DER bytes
@@ -71,7 +78,13 @@ impl Dtls {
             remote_fingerprint: None,
             active_state: None,
             pending_packets: VecDeque::new(),
+            mtu,
         })
+    }
+
+    /// Threshold above which an outgoing DTLS record triggers an MTU warning.
+    pub fn mtu_warn(&self) -> usize {
+        *self.mtu.end()
     }
 
     /// Tells if this instance has been inited (set_active called).
@@ -110,6 +123,9 @@ impl Dtls {
         let next = self.instance.poll_output(buf);
 
         if let DtlsOutput::Packet(packet) = next {
+            if packet.len() > self.mtu_warn() {
+                warn!("DTLS above MTU {}: {}", self.mtu_warn(), packet.len());
+            }
             self.pending_packets.push_back(packet.to_vec().into());
 
             // Return timeout indicating we want another poll straight away

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -10,7 +10,9 @@ use serde::{Deserialize, Serialize};
 
 pub use is::stun::StunMessage;
 
-pub use str0m_proto::DATAGRAM_MTU;
+pub use str0m_proto::DATAGRAM_MTU_TARGET;
+pub use str0m_proto::DATAGRAM_MTU_TARGET_MAX;
+pub use str0m_proto::DATAGRAM_MTU_TARGET_MIN;
 pub use str0m_proto::DATAGRAM_MTU_WARN;
 
 /// Max UDP packet size
@@ -18,6 +20,11 @@ pub(crate) const DATAGRAM_MAX_PACKET_SIZE: usize = 2000;
 
 /// Max expected RTP header over, with full extensions etc.
 pub const MAX_RTP_OVERHEAD: usize = 80;
+
+/// Max expected DTLS record overhead (record header + explicit nonce + AEAD
+/// auth tag), worst case across DTLS 1.2/1.3 and common AEAD ciphers
+/// (AES-GCM, AES-CCM, CHACHA20-POLY1305).
+pub const MAX_DTLS_OVERHEAD: usize = 48;
 
 mod error;
 pub use self::error::NetError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -708,6 +708,15 @@ pub use is::{Candidate, CandidateBuilder, CandidateKind, IceConnectionState, Ice
 mod config_mod;
 pub use config_mod::RtcConfig;
 
+/// Default target MTU used when none is configured.
+pub use io::DATAGRAM_MTU_TARGET;
+/// Upper bound that the target endpoint of [`RtcConfig::set_mtu`] must satisfy.
+pub use io::DATAGRAM_MTU_TARGET_MAX;
+/// Lower bound that the target endpoint of [`RtcConfig::set_mtu`] must satisfy.
+pub use io::DATAGRAM_MTU_TARGET_MIN;
+/// Default warning threshold for over-sized packets.
+pub use io::DATAGRAM_MTU_WARN;
+
 /// Additional configuration.
 pub mod config {
     pub use super::crypto::dtls::{DtlsCert, DtlsVersion, KeyingMaterial};
@@ -1165,6 +1174,9 @@ impl Rtc {
 
         let session = Session::new(&config);
 
+        // Capture before any partial moves of `config` below.
+        let mtu = config.mtu.clone();
+
         let local_creds = config.local_ice_credentials.unwrap_or_else(IceCreds::new);
         let mut ice = IceAgent::with_hmac(local_creds, crypto_provider.sha1_hmac_provider);
         if config.ice_lite {
@@ -1183,6 +1195,8 @@ impl Rtc {
             ice.set_max_stun_retransmits(max_stun_retransmits);
         }
 
+        ice.set_mtu(mtu.clone());
+
         let dtls_cert = config
             .dtls_cert
             .or_else(|| crypto_provider.dtls_provider.generate_certificate())
@@ -1192,7 +1206,7 @@ impl Rtc {
              crypto provider that supports certificate generation.",
             );
 
-        let mut sctp = RtcSctp::new();
+        let mut sctp = RtcSctp::new(*mtu.start());
         if config.snap_enabled {
             sctp.enable_snap();
         }
@@ -1206,6 +1220,7 @@ impl Rtc {
                 crypto_provider.sha256_provider,
                 start,
                 config.dtls_version,
+                mtu,
             )
             .expect("DTLS to init without problem"),
             dtls_connected: false,

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 use crate::RtcError;
 use crate::change::AddMedia;
 use crate::format::CodecConfig;
-use crate::io::DATAGRAM_MTU;
+
 use crate::packet::{CodecDepacketizer, DepacketizingBuffer, Payloader, RtpMeta};
 use crate::rtp_::ExtensionMap;
 use crate::rtp_::MidRid;
@@ -465,6 +465,7 @@ impl Media {
         streams: &mut Streams,
         params: &[PayloadParams],
         vp9_mode: Vp9PacketizerMode,
+        mtu: usize,
     ) -> Result<(), RtcError> {
         let Some(to_payload) = self.to_payload.pop_front() else {
             return Ok(());
@@ -486,12 +487,12 @@ impl Media {
 
         let payloader = self.payloader_for(pt, *rid, params, vp9_mode);
 
-        const RTP_SIZE: usize = DATAGRAM_MTU - SRTP_OVERHEAD;
+        let rtp_size: usize = mtu - SRTP_OVERHEAD;
         // align to SRTP block size to minimize padding needs
-        const MTU: usize = RTP_SIZE - RTP_SIZE % SRTP_BLOCK_SIZE;
+        let aligned_mtu: usize = rtp_size - rtp_size % SRTP_BLOCK_SIZE;
 
         payloader
-            .push_sample(to_payload, MTU, is_audio, stream)
+            .push_sample(to_payload, aligned_mtu, is_audio, stream)
             .map_err(|e| RtcError::Packet(self.mid, pt, e))?;
 
         Ok(())

--- a/src/packet/av1.rs
+++ b/src/packet/av1.rs
@@ -1254,4 +1254,25 @@ mod test {
         assert!(!detect_av1_keyframe(&[0x70])); // Y=1, W=11, N=0
         assert!(!detect_av1_keyframe(&[0xF0])); // Z=1, Y=1, W=11, N=0
     }
+
+    #[test]
+    fn packetize_respects_mtu() {
+        // OBU header (frame-type, no size field) + payload bytes.
+        let mut payload = vec![0x30u8];
+        payload.extend(std::iter::repeat(0xABu8).take(2000));
+        for &mtu in &[100usize, 300, 600, 1200] {
+            let mut packetizer = Av1Packetizer::default();
+            let pkts = packetizer
+                .packetize(mtu, &payload)
+                .expect("AV1 packetize ok");
+            assert!(!pkts.is_empty(), "AV1 produced no packets at mtu {mtu}");
+            for (i, pkt) in pkts.iter().enumerate() {
+                assert!(
+                    pkt.len() <= mtu,
+                    "AV1 packet {i} size {} > mtu {mtu}",
+                    pkt.len()
+                );
+            }
+        }
+    }
 }

--- a/src/packet/g7xx.rs
+++ b/src/packet/g7xx.rs
@@ -143,4 +143,22 @@ mod test {
 
         Ok(())
     }
+
+    #[test]
+    fn packetize_respects_mtu() -> Result<(), PacketError> {
+        let payload = vec![0xABu8; 2000];
+        for &mtu in &[100usize, 300, 600, 1200] {
+            let mut pck = G711Packetizer::default();
+            let pkts = pck.packetize(mtu, &payload)?;
+            assert!(!pkts.is_empty(), "G7xx produced no packets at mtu {mtu}");
+            for (i, pkt) in pkts.iter().enumerate() {
+                assert!(
+                    pkt.len() <= mtu,
+                    "G7xx packet {i} size {} > mtu {mtu}",
+                    pkt.len()
+                );
+            }
+        }
+        Ok(())
+    }
 }

--- a/src/packet/h264.rs
+++ b/src/packet/h264.rs
@@ -904,4 +904,24 @@ mod test {
         // FU-A too short
         assert!(!detect_h264_keyframe(&[0x7C]));
     }
+
+    #[test]
+    fn packetize_respects_mtu() -> Result<(), PacketError> {
+        // NAL header byte (type=5, IDR slice) + payload.
+        let mut payload = vec![0x05u8];
+        payload.extend(std::iter::repeat(0xABu8).take(2000));
+        for &mtu in &[100usize, 300, 600, 1200] {
+            let mut pck = H264Packetizer::default();
+            let pkts = pck.packetize(mtu, &payload)?;
+            assert!(!pkts.is_empty(), "H264 produced no packets at mtu {mtu}");
+            for (i, pkt) in pkts.iter().enumerate() {
+                assert!(
+                    pkt.len() <= mtu,
+                    "H264 packet {i} size {} > mtu {mtu}",
+                    pkt.len()
+                );
+            }
+        }
+        Ok(())
+    }
 }

--- a/src/packet/h265.rs
+++ b/src/packet/h265.rs
@@ -5180,4 +5180,24 @@ mod test {
         // FU too short (no FU header byte)
         assert!(!detect_h265_keyframe(&fu_header_bytes.0.to_be_bytes()));
     }
+
+    #[test]
+    fn packetize_respects_mtu() -> Result<()> {
+        // 2-byte NAL header (non-parameter-set type) + payload.
+        let mut nalu = vec![0x02u8, 0x01];
+        nalu.extend(std::iter::repeat(0xABu8).take(2000));
+        for &mtu in &[100usize, 300, 600, 1200] {
+            let mut p = H265Packetizer::default();
+            let pkts = p.packetize(mtu, &nalu)?;
+            assert!(!pkts.is_empty(), "H265 produced no packets at mtu {mtu}");
+            for (i, pkt) in pkts.iter().enumerate() {
+                assert!(
+                    pkt.len() <= mtu,
+                    "H265 packet {i} size {} > mtu {mtu}",
+                    pkt.len()
+                );
+            }
+        }
+        Ok(())
+    }
 } // end test module

--- a/src/packet/opus.rs
+++ b/src/packet/opus.rs
@@ -128,4 +128,22 @@ mod test {
 
         Ok(())
     }
+
+    #[test]
+    fn packetize_respects_mtu() -> Result<(), PacketError> {
+        let payload = vec![0xABu8; 2000];
+        for &mtu in &[100usize, 300, 600, 1200] {
+            let mut pck = OpusPacketizer;
+            let pkts = pck.packetize(mtu, &payload)?;
+            assert!(!pkts.is_empty(), "Opus produced no packets at mtu {mtu}");
+            for (i, pkt) in pkts.iter().enumerate() {
+                assert!(
+                    pkt.len() <= mtu,
+                    "Opus packet {i} size {} > mtu {mtu}",
+                    pkt.len()
+                );
+            }
+        }
+        Ok(())
+    }
 }

--- a/src/packet/vp8.rs
+++ b/src/packet/vp8.rs
@@ -1243,4 +1243,22 @@ mod test {
             assert_eq!(descriptor_starts_keyframe, detect_vp8_keyframe(payload));
         }
     }
+
+    #[test]
+    fn packetize_respects_mtu() -> Result<(), PacketError> {
+        let payload = vec![0xABu8; 2000];
+        for &mtu in &[100usize, 300, 600, 1200] {
+            let mut pck = Vp8Packetizer::default();
+            let pkts = pck.packetize(mtu, &payload)?;
+            assert!(!pkts.is_empty(), "VP8 produced no packets at mtu {mtu}");
+            for (i, pkt) in pkts.iter().enumerate() {
+                assert!(
+                    pkt.len() <= mtu,
+                    "VP8 packet {i} size {} > mtu {mtu}",
+                    pkt.len()
+                );
+            }
+        }
+        Ok(())
+    }
 }

--- a/src/packet/vp9.rs
+++ b/src/packet/vp9.rs
@@ -1542,4 +1542,27 @@ mod test {
         assert!(!detect_vp9_keyframe(&[0x40])); // P=1 only
         assert!(!detect_vp9_keyframe(&[0xD5])); // I=1, P=1, F=1, E=1, Z=1
     }
+
+    #[test]
+    fn packetize_respects_mtu() -> Result<(), PacketError> {
+        // VP9 profile 0 keyframe header followed by payload bytes.
+        let mut payload = vec![0x82u8];
+        payload.extend(std::iter::repeat(0xABu8).take(2000));
+        for &mtu in &[100usize, 300, 600, 1200] {
+            let mut pck = Vp9Packetizer {
+                initial_picture_id: 100,
+                ..Default::default()
+            };
+            let pkts = pck.packetize(mtu, &payload)?;
+            assert!(!pkts.is_empty(), "VP9 produced no packets at mtu {mtu}");
+            for (i, pkt) in pkts.iter().enumerate() {
+                assert!(
+                    pkt.len() <= mtu,
+                    "VP9 packet {i} size {} > mtu {mtu}",
+                    pkt.len()
+                );
+            }
+        }
+        Ok(())
+    }
 }

--- a/src/sctp/mod.rs
+++ b/src/sctp/mod.rs
@@ -41,6 +41,8 @@ pub(crate) struct RtcSctp {
     client: bool,
     snap_enabled: bool,
     snap_init: Option<SctpInitData>,
+    #[cfg(test)]
+    max_payload_size: usize,
 }
 
 /// This is okay because there is no way for a user of Rtc to interact with the Sctp subsystem
@@ -233,13 +235,26 @@ impl StreamEntry {
     }
 }
 
+/// SCTP framing per outgoing datagram: 12-byte common header + ~16-byte DATA
+/// chunk header + some extra.
+const SCTP_OVERHEAD: usize = 40;
+
+/// Empirical: SCTP `max_payload_size` of 1200 has produced 1277-byte DTLS-wrapped
+/// datagrams (77 bytes combined SCTP + DTLS overhead).
+const _: () = assert!(
+    crate::io::MAX_DTLS_OVERHEAD + SCTP_OVERHEAD >= 80,
+    "MAX_DTLS_OVERHEAD + SCTP_OVERHEAD must cover observed 77-byte SCTP-over-DTLS overhead"
+);
+
 impl RtcSctp {
-    pub fn new() -> Self {
+    pub fn new(mtu: usize) -> Self {
         let mut config = EndpointConfig::default();
-        // Default here is 1200, I've seen warnings that are 77 over.
-        // DTLS above MTU 1200: 1277
-        // Let's try 1120, see if we can avoid warnings.
-        config.max_payload_size(1120);
+        let max_payload = mtu
+            .saturating_sub(crate::io::MAX_DTLS_OVERHEAD)
+            .saturating_sub(SCTP_OVERHEAD);
+        config.max_payload_size(max_payload as u32);
+        #[cfg(test)]
+        let max_payload_size = max_payload;
         let mut server_config = ServerConfig::default();
         server_config.transport = webrtc_transport_config();
         let endpoint = Endpoint::new(Arc::new(config), Some(Arc::new(server_config)));
@@ -257,7 +272,14 @@ impl RtcSctp {
             client: false,
             snap_enabled: false,
             snap_init: None,
+            #[cfg(test)]
+            max_payload_size,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn max_payload_size(&self) -> usize {
+        self.max_payload_size
     }
 
     pub fn is_inited(&self) -> bool {
@@ -370,7 +392,7 @@ impl RtcSctp {
     pub fn local_sctp_init_for_sdp(&self) -> Option<String> {
         let d = self.snap_init.as_ref()?;
         if self.is_inited() && d.remote_init.is_none() {
-            // Established non-SNAP association — MUST NOT inject sctp-init.
+            // Established non-SNAP association - MUST NOT inject sctp-init.
             return None;
         }
         d.local_init.as_ref().map(|b| b64_encode(b))
@@ -1095,11 +1117,12 @@ impl From<(ReliabilityType, u32)> for Reliability {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use str0m_proto::DATAGRAM_MTU_TARGET;
 
     #[test]
     fn partial_snap_init_requires_both_chunks() {
         let now = Instant::now();
-        let mut sctp = RtcSctp::new();
+        let mut sctp = RtcSctp::new(DATAGRAM_MTU_TARGET);
         let mut init_data = SctpInitData::new();
 
         init_data.local_init_chunk().unwrap();
@@ -1113,7 +1136,7 @@ mod tests {
 
     #[test]
     fn malformed_remote_snap_does_not_disable_local_opt_in() {
-        let mut sctp = RtcSctp::new();
+        let mut sctp = RtcSctp::new(DATAGRAM_MTU_TARGET);
         sctp.enable_snap();
 
         assert!(!sctp.set_remote_snap_init_string("!!!not-valid-base64!!!"));
@@ -1125,8 +1148,8 @@ mod tests {
     /// Helper to connect a client and server RtcSctp pair to Established state.
     fn connect_client_server() -> (RtcSctp, RtcSctp) {
         let now = Instant::now();
-        let mut client = RtcSctp::new();
-        let mut server = RtcSctp::new();
+        let mut client = RtcSctp::new(DATAGRAM_MTU_TARGET);
+        let mut server = RtcSctp::new(DATAGRAM_MTU_TARGET);
 
         client.init(true, now, None).unwrap();
         server.init(false, now, None).unwrap();
@@ -1228,5 +1251,19 @@ mod tests {
         // Verify entry transitioned to Closed.
         let entry = client.entries.iter().find(|e| e.id == stream_id).unwrap();
         assert_eq!(entry.state, StreamEntryState::Closed);
+    }
+
+    #[test]
+    fn max_payload_size_matches_mtu_minus_overhead() {
+        let overhead = crate::io::MAX_DTLS_OVERHEAD + SCTP_OVERHEAD;
+
+        let default_sctp = RtcSctp::new(DATAGRAM_MTU_TARGET);
+        assert_eq!(
+            default_sctp.max_payload_size(),
+            DATAGRAM_MTU_TARGET - overhead
+        );
+
+        let small_sctp = RtcSctp::new(900);
+        assert_eq!(small_sctp.max_payload_size(), 900 - overhead);
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, VecDeque};
+use std::ops::RangeInclusive;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -11,7 +12,7 @@ use crate::crypto::dtls::SrtpProfile;
 use crate::format::CodecConfig;
 use crate::format::PayloadParams;
 use crate::format::Vp9PacketizerMode;
-use crate::io::{DATAGRAM_MTU, DATAGRAM_MTU_WARN, DatagramSend};
+use crate::io::DatagramSend;
 use crate::media::Media;
 use crate::media::{KeyframeRequestKind, MID_PROBE};
 use crate::media::{MediaAdded, MediaChanged};
@@ -114,6 +115,10 @@ pub(crate) struct Session {
 
     raw_packets: Option<VecDeque<Box<RawPacket>>>,
 
+    /// Target MTU (start) and warn threshold (end). Buffer sizing uses the
+    /// target; oversized outgoing datagrams above the warn threshold log a warning.
+    mtu: RangeInclusive<usize>,
+
     #[cfg(feature = "_internal_test_exports")]
     pending_probe: Option<crate::bwe_::ProbeClusterConfig>,
 }
@@ -140,7 +145,7 @@ impl Session {
         Session {
             id,
             medias: vec![],
-            streams: Streams::new(enable_stats),
+            streams: Streams::new(enable_stats, *config.mtu.end()),
             app: None,
             reordering_size_audio: config.reordering_size_audio,
             reordering_size_video: config.reordering_size_video,
@@ -180,9 +185,18 @@ impl Session {
             } else {
                 None
             },
+            mtu: config.mtu.clone(),
             #[cfg(feature = "_internal_test_exports")]
             pending_probe: None,
         }
+    }
+
+    fn mtu(&self) -> usize {
+        *self.mtu.start()
+    }
+
+    fn mtu_warn(&self) -> usize {
+        *self.mtu.end()
     }
 
     pub fn id(&self) -> SessionId {
@@ -300,7 +314,7 @@ impl Session {
 
     fn create_twcc_feedback(&mut self, sender_ssrc: Ssrc, now: Instant) -> Option<()> {
         self.last_twcc = now;
-        let mut twcc = self.twcc_rx_register.build_report(DATAGRAM_MTU - 100)?;
+        let mut twcc = self.twcc_rx_register.build_report(self.mtu() - 100)?;
 
         // These SSRC are on media level, but twcc is on session level,
         // we fill in the first discovered media SSRC in each direction.
@@ -761,8 +775,8 @@ impl Session {
             // In RTP mode we trust the API user feeds the RTP packet sizes they
             // need for the MTU they are targeting. This warning is only for when
             // str0m does the RTP packetization.
-            if !self.rtp_mode && x.len() > DATAGRAM_MTU_WARN {
-                warn!("RTP above MTU {}: {}", DATAGRAM_MTU_WARN, x.len());
+            if !self.rtp_mode && x.len() > self.mtu_warn() {
+                warn!("RTP above MTU {}: {}", self.mtu_warn(), x.len());
             }
         }
 
@@ -782,10 +796,10 @@ impl Session {
         }
 
         // Round to nearest multiple of 4 bytes.
-        const ENCRYPTABLE_MTU: usize = (DATAGRAM_MTU - SRTCP_OVERHEAD) & !3;
-        assert!(ENCRYPTABLE_MTU % 4 == 0);
+        let encryptable_mtu: usize = (self.mtu() - SRTCP_OVERHEAD) & !3;
+        assert!(encryptable_mtu % 4 == 0);
 
-        let mut data = vec![0_u8; ENCRYPTABLE_MTU];
+        let mut data = vec![0_u8; encryptable_mtu];
 
         let mut raw_packets = self.raw_packets.as_mut();
         let output = move |fb| {
@@ -806,7 +820,7 @@ impl Session {
         let protected = srtp.protect_rtcp(&data);
 
         assert!(
-            protected.len() < DATAGRAM_MTU,
+            protected.len() < self.mtu(),
             "Encrypted SRTCP should be less than MTU"
         );
 
@@ -1038,11 +1052,13 @@ impl Session {
     }
 
     fn do_payload(&mut self) -> Result<(), RtcError> {
+        let mtu = self.mtu();
         for m in &mut self.medias {
             m.do_payload(
                 &mut self.streams,
                 &self.codec_config,
                 self.vp9_packetizer_mode,
+                mtu,
             )?;
         }
 
@@ -1124,5 +1140,23 @@ fn update_max_seq(map: &mut HashMap<Ssrc, SeqNo>, ssrc: Ssrc, seq_no: SeqNo) {
     let current = map.entry(ssrc).or_insert(seq_no);
     if seq_no > *current {
         *current = seq_no;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RtcConfig;
+    use crate::io::DATAGRAM_MTU_TARGET;
+
+    #[test]
+    fn session_mtu_matches_config() {
+        let cfg = RtcConfig::default();
+        let s = Session::new(&cfg);
+        assert_eq!(s.mtu(), DATAGRAM_MTU_TARGET);
+
+        let cfg = RtcConfig::default().set_mtu(900..=1280);
+        let s = Session::new(&cfg);
+        assert_eq!(s.mtu(), 900);
     }
 }

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -159,6 +159,10 @@ pub(crate) struct Streams {
     /// Whether periodic statistics reports are expected to be generated. This informs us on
     /// whether we should be holding onto data needed for those reports or not.
     enable_stats: bool,
+
+    /// Threshold above which an outgoing RTP packet triggers an MTU warning. Used as a
+    /// hard cap when selecting RTX cache entries for spurious padding.
+    mtu_warn: usize,
 }
 
 /// Delay between cleaning up the RxLookup.
@@ -175,7 +179,7 @@ struct RxLookup {
 }
 
 impl Streams {
-    pub(crate) fn new(enable_stats: bool) -> Self {
+    pub(crate) fn new(enable_stats: bool, mtu_warn: usize) -> Self {
         Self {
             streams_rx: Default::default(),
             rx_lookup: Default::default(),
@@ -185,6 +189,7 @@ impl Streams {
             mids_to_report: Vec::with_capacity(10),
             any_nack_active: None,
             enable_stats,
+            mtu_warn,
         }
     }
 
@@ -339,7 +344,7 @@ impl Streams {
     ) -> &mut StreamTx {
         self.streams_tx
             .entry(ssrc)
-            .or_insert_with(|| StreamTx::new(ssrc, rtx, midrid, self.enable_stats))
+            .or_insert_with(|| StreamTx::new(ssrc, rtx, midrid, self.enable_stats, self.mtu_warn))
     }
 
     pub fn remove_stream_tx(&mut self, ssrc: Ssrc) -> bool {

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -6,7 +6,6 @@ use std::time::Instant;
 use crate::format::CodecConfig;
 use crate::format::PayloadParams;
 use crate::io::DATAGRAM_MAX_PACKET_SIZE;
-use crate::io::DATAGRAM_MTU_WARN;
 use crate::io::MAX_RTP_OVERHEAD;
 use crate::media::KeyframeRequestKind;
 use crate::media::Media;
@@ -135,6 +134,9 @@ pub struct StreamTx {
 
     // Same as `remote_acked_ssrc`, but for the RTX SSRC
     remote_acked_rtx_ssrc: bool,
+
+    /// MTU warn threshold; used to cap spurious-padding RTX cache lookups.
+    mtu_warn: usize,
 }
 
 /// RTP packet data to enqueue on a direct RTP send stream.
@@ -252,7 +254,13 @@ impl RtpWrite {
 }
 
 impl StreamTx {
-    pub(crate) fn new(ssrc: Ssrc, rtx: Option<Ssrc>, midrid: MidRid, enable_stats: bool) -> Self {
+    pub(crate) fn new(
+        ssrc: Ssrc,
+        rtx: Option<Ssrc>,
+        midrid: MidRid,
+        enable_stats: bool,
+        mtu_warn: usize,
+    ) -> Self {
         debug!("Create StreamTx for SSRC: {}", ssrc);
 
         StreamTx {
@@ -282,6 +290,7 @@ impl StreamTx {
             pt_for_padding: None,
             remote_acked_ssrc: false,
             remote_acked_rtx_ssrc: false,
+            mtu_warn,
         }
     }
 
@@ -793,7 +802,7 @@ impl StreamTx {
             if self.padding > MIN_SPURIOUS_PADDING_SIZE {
                 // Find a historic packet that is smaller than this max size. The max size
                 // is a headroom since we can accept slightly larger padding than asked for.
-                let max_size = (self.padding * 2).min(DATAGRAM_MTU_WARN - MAX_RTP_OVERHEAD);
+                let max_size = (self.padding * 2).min(self.mtu_warn - MAX_RTP_OVERHEAD);
 
                 let Some(pkt) = self.rtx_cache.get_cached_packet_smaller_than(max_size) else {
                     // Couldn't find spurious packet, try a blank packet instead.

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,4 +1,5 @@
 #![allow(unused)]
+use std::cell::Cell;
 use std::io::Cursor;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::ops::{Deref, DerefMut};
@@ -228,6 +229,26 @@ pub fn progress(l: &mut TestRtc, r: &mut TestRtc) -> Result<(), RtcError> {
     Ok(())
 }
 
+thread_local! {
+    /// When set, [`rtc_poll_to_timeout`] asserts every [`Output::Transmit`]
+    /// for which `contents.len() <= mtu`.
+    static STRICT_MTU: Cell<Option<usize>> = const { Cell::new(None) };
+}
+
+struct StrictMtuGuard(Option<usize>);
+impl Drop for StrictMtuGuard {
+    fn drop(&mut self) {
+        STRICT_MTU.with(|c| c.set(self.0));
+    }
+}
+
+/// Like [`progress`] but asserts every outgoing datagram is `<= mtu` bytes.
+pub fn progress_strict_mtu(l: &mut TestRtc, r: &mut TestRtc, mtu: usize) -> Result<(), RtcError> {
+    let prev = STRICT_MTU.with(|c| c.replace(Some(mtu)));
+    let _guard = StrictMtuGuard(prev);
+    progress(l, r)
+}
+
 fn progress_one(
     l: &mut TestRtc,
     r: &mut TestRtc,
@@ -310,6 +331,17 @@ fn rtc_poll_to_timeout(
                 break;
             }
             Output::Transmit(v) => {
+                if let Some(mtu) = STRICT_MTU.with(|c| c.get()) {
+                    assert!(
+                        v.contents.len() <= mtu,
+                        "outgoing datagram {} bytes exceeds strict mtu {} (proto={:?}, {}->{})",
+                        v.contents.len(),
+                        mtu,
+                        v.proto,
+                        v.source,
+                        v.destination,
+                    );
+                }
                 let packet = PendingPacket {
                     proto: v.proto,
                     source: v.source,

--- a/tests/mtu-compliance.rs
+++ b/tests/mtu-compliance.rs
@@ -1,0 +1,110 @@
+use std::net::Ipv4Addr;
+use std::time::{Duration, Instant};
+
+use str0m::format::Codec;
+use str0m::media::{Direction, MediaKind};
+use str0m::{DATAGRAM_MTU_TARGET_MAX, DATAGRAM_MTU_TARGET_MIN, Event, Rtc, RtcError};
+
+mod common;
+use common::{Peer, TestRtc, init_crypto_default, init_log, progress_strict_mtu};
+
+/// End-to-end MTU compliance: walk a full ICE/DTLS/SCTP/SRTP session and
+/// assert every outgoing datagram on either side has `len() <= mtu`. The
+/// check fires inside the test pump via [`progress_strict_mtu`], so any
+/// oversized datagram fails the test at the source.
+fn run_mtu_compliance(mtu: usize) -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let now = Instant::now();
+    let l_rtc = Rtc::builder().set_mtu(mtu..=mtu).build(now);
+    let r_rtc = Rtc::builder().set_mtu(mtu..=mtu).build(now);
+
+    let mut l = TestRtc::new_with_rtc(Peer::Left.span(), l_rtc);
+    let mut r = TestRtc::new_with_rtc(Peer::Right.span(), r_rtc);
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    // Add an audio m-line and a data channel in the same offer.
+    let mut change = l.sdp_api();
+    let audio_mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+    let cid = change.add_channel("mtu-test".into());
+    let (offer, pending) = change.apply().unwrap();
+    let answer = r.rtc.sdp_api().accept_offer(offer)?;
+    l.rtc.sdp_api().accept_answer(pending, answer)?;
+
+    // ICE + DTLS handshake under strict MTU.
+    loop {
+        if l.is_connected() && r.is_connected() {
+            break;
+        }
+        progress_strict_mtu(&mut l, &mut r, mtu)?;
+    }
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    // Wait for the data channel to open on L.
+    while l.channel(cid).is_none() {
+        progress_strict_mtu(&mut l, &mut r, mtu)?;
+    }
+
+    // Small data-channel send.
+    l.channel(cid)
+        .unwrap()
+        .write(false, b"hello mtu world")
+        .expect("small write");
+
+    // Large data-channel send to exercise SCTP fragmentation.
+    let big = vec![0xCDu8; 32 * 1024];
+    l.channel(cid)
+        .unwrap()
+        .write(true, &big)
+        .expect("large write");
+
+    // Audio writes (Opus) at typical 20 ms cadence.
+    let params = l.params_opus();
+    assert_eq!(params.spec().codec, Codec::Opus);
+    let pt = params.pt();
+    let audio_payload = vec![0xAAu8; 160];
+
+    let deadline = Duration::from_secs(2);
+    while l.duration() < deadline {
+        let wallclock = l.start + l.duration();
+        let time = l.duration().into();
+        if let Some(w) = l.writer(audio_mid) {
+            w.write(pt, wallclock, time, audio_payload.clone())?;
+        }
+        progress_strict_mtu(&mut l, &mut r, mtu)?;
+    }
+
+    // Sanity: r received the small + part of the large data-channel send.
+    let chan_events = r
+        .events
+        .iter()
+        .filter(|(_, e)| matches!(e, Event::ChannelData(_)))
+        .count();
+    assert!(
+        chan_events >= 1,
+        "expected at least one ChannelData event at r, got {chan_events}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn mtu_compliance_min() -> Result<(), RtcError> {
+    run_mtu_compliance(DATAGRAM_MTU_TARGET_MIN)
+}
+
+#[test]
+fn mtu_compliance_mid() -> Result<(), RtcError> {
+    run_mtu_compliance((DATAGRAM_MTU_TARGET_MIN + DATAGRAM_MTU_TARGET_MAX) / 2)
+}
+
+#[test]
+fn mtu_compliance_max() -> Result<(), RtcError> {
+    run_mtu_compliance(DATAGRAM_MTU_TARGET_MAX)
+}


### PR DESCRIPTION
Make MTU configurable via RtcConfig .  Tested with Dimpl+aws-lc-rs, Dimpl+CNG, and Schannel DTLS backends so far. 

As of now, not deliverable; depends on sctp-proto > 0.9.0 .