### PR TITLE
fix: add_recv_layer should push to recv, not send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Fix `Simulcast::add_recv_layer` to push to recv instead of send #968
   * Accept any non-empty SDP session name (`s=`), not just `s=-` (RFC 8866 section 5.3)
 
 # 0.20.0

--- a/src/media/event.rs
+++ b/src/media/event.rs
@@ -105,7 +105,7 @@ impl Simulcast {
 
     /// Add a receive layer
     pub fn add_recv_layer(&mut self, layer: SimulcastLayer) {
-        self.send.push(layer);
+        self.recv.push(layer);
     }
 }
 


### PR DESCRIPTION
Fixes #968

`Simulcast::add_recv_layer` was pushing the layer onto `self.send` instead of `self.recv`, making it a duplicate of `add_send_layer`.