### PR TITLE
Add optional drv feature deriving drv::Input on identity types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "drv"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb67531e2bd07035971a7b45c7ca013024e6691a348736801675914847f03b21"
+dependencies = [
+ "drv-macros",
+]
+
+[[package]]
+name = "drv-macros"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d1fa8647349fd4f292c87823cc96987a404b38181da2736ce7773d9d5601298"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1138,7 @@ dependencies = [
  "_str0m_test",
  "combine",
  "crc",
+ "drv",
  "fastrand",
  "hmac",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,12 @@ sha1 = ["dep:sha1"]
 # Uses native Windows API to implement cryptographic features, use instead on openssl and sha1.
 wincrypto = ["dep:str0m-wincrypto"]
 
+# Derives `drv::Input` (drv's memoization cache-key plumbing) on the public
+# identity types — Mid, Rid, Ssrc, Pt, SessionId, SeqNo, Direction, MediaKind,
+# Frequency, Codec, CodecSpec, FormatParams, VideoOrientation — so downstream
+# `#[drv::memo]` queries can take them by value. Off by default.
+drv = ["dep:drv"]
+
 _internal_dont_use_log_stats = []
 _internal_test_exports = []
 
@@ -54,6 +60,7 @@ libc = { version = "0.2", optional = true }
 hmac = "0.12.1"
 crc = "3.0.0"
 serde = { version = "1.0.152", features = ["derive"] }
+drv = { version = "0.4.3", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 sha1 = { version = "0.10.6", features = ["asm"], optional = true }

--- a/src/format.rs
+++ b/src/format.rs
@@ -84,6 +84,7 @@ impl Eq for PayloadParams {}
 
 /// Codec specification
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct CodecSpec {
     /// The codec identifier.
     pub codec: Codec,
@@ -101,6 +102,7 @@ pub struct CodecSpec {
 
 /// Known codecs.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum Codec {
@@ -127,6 +129,7 @@ pub enum Codec {
 
 /// Codec specific format parameters.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct FormatParams {
     /// Opus specific parameter.
     ///

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -51,6 +51,7 @@ pub(crate) use pacer::{LeakyBucketPacer, NullPacer, Pacer, PacerImpl};
 pub(crate) use pacer::{QueuePriority, QueueSnapshot, QueueState};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 /// Types of media.
 pub enum MediaKind {
     /// Audio media.

--- a/src/rtp/dir.rs
+++ b/src/rtp/dir.rs
@@ -4,6 +4,7 @@ use std::fmt;
 ///
 /// And also extmap direction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub enum Direction {
     /// Send only direction.
     SendOnly,

--- a/src/rtp/ext.rs
+++ b/src/rtp/ext.rs
@@ -1140,6 +1140,7 @@ impl fmt::Debug for ExtensionMap {
 
 /// How the video is rotated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub enum VideoOrientation {
     /// Not rotated.
     Deg0 = 0,

--- a/src/rtp/id.rs
+++ b/src/rtp/id.rs
@@ -115,6 +115,7 @@ macro_rules! num_id {
 /// 3 incoming StreamRx, but since they belong to the same media,
 /// the have the same `Mid`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct Mid([u8; 16]);
 str_id!(Mid, "Mid", 16, 3);
 
@@ -126,6 +127,7 @@ str_id!(Mid, "Mid", 16, 3);
 /// In SDP this is an optional value that will be seen in [`MediaData`][crate::media::MediaData]
 /// if the remote peer is configured for simulcast.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct Rid([u8; 8]);
 str_id!(Rid, "Rid", 8, 3);
 
@@ -135,6 +137,7 @@ str_id!(Rid, "Rid", 8, 3);
 /// with at least one synchronization source. Multiple sources for the same stream happens
 /// for RTX (resend) and simulcast.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct Ssrc(u32);
 num_id!(Ssrc, u32);
 
@@ -145,6 +148,7 @@ num_id!(Ssrc, u32);
 ///
 /// PTs in RTP headers are 7 bits. Values >=128 are not valid.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct Pt(u8);
 num_id!(Pt, u8);
 
@@ -152,6 +156,7 @@ num_id!(Pt, u8);
 ///
 /// This value is rarely interesting, but is part of the SDP OFFER and ANSWER.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct SessionId(u64);
 num_id!(SessionId, u64);
 
@@ -176,6 +181,7 @@ num_id!(SessionId, u64);
 /// assert_eq!(b, 1);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct SeqNo(u64);
 num_id!(SeqNo, u64);
 

--- a/src/rtp/mtime.rs
+++ b/src/rtp/mtime.rs
@@ -33,6 +33,7 @@ use serde::{Deserialize, Serialize};
 /// let mtime = MediaTime::new(2000, freq);
 /// ```
 #[derive(Debug, Clone, Copy, Serialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct Frequency(NonZeroU32);
 
 impl Frequency {

--- a/tests/drv_input.rs
+++ b/tests/drv_input.rs
@@ -1,0 +1,40 @@
+#![cfg(feature = "drv")]
+//! Verifies the `drv` feature derives `drv::Input` on str0m's public
+//! identity types so downstream `#[drv::memo]` queries can take them by
+//! value. `Frequency` exercises the `NonZeroU32` path specifically.
+
+use str0m::format::Codec;
+use str0m::media::{Frequency, MediaKind, Mid};
+
+#[derive(drv::Input)]
+struct TrackFacts {
+    pub mid: Mid,
+    pub kind: MediaKind,
+    pub codec: Codec,
+    pub clock_rate: Frequency,
+}
+
+#[drv::memo(single)]
+fn is_opus_audio(input: TrackFacts) -> bool {
+    matches!(input.kind, MediaKind::Audio) && matches!(input.codec, Codec::Opus)
+}
+
+#[test]
+fn identity_types_are_valid_memo_inputs() {
+    let mid = Mid::from("0");
+    let audio = TrackFacts {
+        mid,
+        kind: MediaKind::Audio,
+        codec: Codec::Opus,
+        clock_rate: Frequency::FORTY_EIGHT_KHZ,
+    };
+    assert!(is_opus_audio(audio));
+
+    let video = TrackFacts {
+        mid,
+        kind: MediaKind::Video,
+        codec: Codec::Vp8,
+        clock_rate: Frequency::NINETY_KHZ,
+    };
+    assert!(!is_opus_audio(video));
+}


### PR DESCRIPTION
## Summary

Adds a default-off `drv` feature that derives [`drv::Input`](https://docs.rs/drv) — drv's memoization cache-key plumbing — on str0m's public identity types, so downstream `#[drv::memo]` query functions can take them by value (or project them in a `drv::Input` struct) as cache keys.

Without it, a drv-based consumer can't satisfy drv's `ToStatic` bound on these types: the orphan rule blocks a consumer-side `impl drv::ToStatic for str0m::media::Mid`, forcing local newtypes (with conversions at every boundary) or pre-collapsing values into primitives.

Types covered:

- **rtp ids:** `Mid`, `Rid`, `Ssrc`, `Pt`, `SessionId`, `SeqNo`
- **enums:** `Direction`, `MediaKind`, `Codec`, `VideoOrientation`
- **format:** `Frequency`, `CodecSpec`, `FormatParams`

`Frequency(NonZeroU32)` relies on drv 0.4.3's new `NonZero*` `ToStatic` impls, hence `drv = { version = "0.4.3", optional = true }`.

The feature is **off by default**, gated with `#[cfg_attr(feature = "drv", derive(drv::Input))]`, so non-drv consumers compile exactly as before and pay no extra dependency. A feature-gated test (`tests/drv_input.rs`) confirms the types work as `#[drv::memo]` inputs.

### Out of scope

- `PayloadParams` — its hand-written `PartialEq` deliberately ignores `locked`/`fb_remb`; drv's field-by-field `eq_static` would diverge from that equality, so it's left out.
- `Extension` — its `UnknownUri(String, Arc<dyn ExtensionSerializer>)` variant holds a trait object, which isn't `ToStatic`.
- `MediaTime`, `CodecExtra`, and the H.265 payload/NALU types — value-/payload-carrying, not identity.