### PR TITLE
Add optional drv feature deriving drv::Input on identity types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "drv"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb67531e2bd07035971a7b45c7ca013024e6691a348736801675914847f03b21"
+dependencies = [
+ "drv-macros",
+]
+
+[[package]]
+name = "drv-macros"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d1fa8647349fd4f292c87823cc96987a404b38181da2736ce7773d9d5601298"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,6 +1910,7 @@ dependencies = [
  "base64ct",
  "combine",
  "dimpl",
+ "drv",
  "fastrand",
  "is",
  "pcap-file",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ subtle = "2.0.0"
 arrayvec = "0.7.6"
 serde = { version = "1.0.152", features = ["derive"] }
 dimpl = { version = "0.6.2", default-features = false }
+drv = { version = "0.4.3" }
 time = "0.3"
 base64ct = "1"
 
@@ -118,6 +119,13 @@ examples = ["rouille/rustls"]
 _internal_dont_use_log_stats = []
 _internal_test_exports = ["str0m-proto/_internal_test_exports", "is/_internal_test_exports"]
 
+# Derives `drv::Input` (drv's memoization cache-key plumbing) on the public
+# identity types — Mid, Rid, Ssrc, Pt, SessionId, SeqNo, Direction, MediaKind,
+# Frequency, Codec, CodecSpec, FormatParams, VideoOrientation, and the H265
+# profile types — so downstream `#[drv::memo]` queries can take them by value.
+# Off by default.
+drv = ["dep:drv"]
+
 [dependencies]
 tracing.workspace = true
 fastrand.workspace = true
@@ -134,6 +142,8 @@ dimpl.workspace = true
 
 str0m-proto = { workspace = true, features = ["dtls"] }
 is.workspace = true
+
+drv = { workspace = true, optional = true }
 
 # Crypto providers
 str0m-aws-lc-rs = { workspace = true, optional = true }

--- a/src/format/codec.rs
+++ b/src/format/codec.rs
@@ -8,6 +8,7 @@ use super::format_params::FormatParams;
 
 /// Codec specification
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct CodecSpec {
     /// The codec identifier.
     pub codec: Codec,
@@ -25,6 +26,7 @@ pub struct CodecSpec {
 
 /// Known codecs.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum Codec {

--- a/src/format/format_params.rs
+++ b/src/format/format_params.rs
@@ -5,6 +5,7 @@ use crate::sdp::FormatParam;
 
 /// Codec specific format parameters.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct FormatParams {
     /// Opus specific parameter.
     ///

--- a/src/packet/h265_profile.rs
+++ b/src/packet/h265_profile.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 /// Represents the three SDP fmtp parameters `profile-id`, `tier-flag`, and `level-id`
 /// as defined in RFC 7798 §7.1 and ITU-T H.265 Annex A.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct H265ProfileTierLevel {
     profile: H265Profile,
     tier: H265Tier,
@@ -94,6 +95,7 @@ impl From<(u8, u8, u8)> for H265ProfileTierLevel {
 
 /// H.265 profile as defined in ITU-T H.265 Annex A.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub enum H265Profile {
     /// Main profile (profile_id=1).
     Main,
@@ -160,6 +162,7 @@ impl H265Profile {
 
 /// H.265 tier (Main or High).
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub enum H265Tier {
     /// Main tier (tier_flag=0).
     Main,
@@ -192,6 +195,7 @@ impl H265Tier {
 ///
 /// Level IDs are 30× the level number (e.g., Level 3.1 = 93).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 #[repr(u8)]
 #[rustfmt::skip]
 pub enum H265Level {

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -67,6 +67,7 @@ mod payload;
 pub(crate) use payload::Payloader;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 /// Types of media.
 pub enum MediaKind {
     /// Audio media.

--- a/src/rtp/dir.rs
+++ b/src/rtp/dir.rs
@@ -4,6 +4,7 @@ use std::fmt;
 ///
 /// And also extmap direction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub enum Direction {
     /// Send only direction.
     SendOnly,

--- a/src/rtp/ext.rs
+++ b/src/rtp/ext.rs
@@ -1222,6 +1222,7 @@ impl fmt::Debug for ExtensionMap {
 
 /// How the video is rotated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub enum VideoOrientation {
     /// Not rotated.
     Deg0 = 0,

--- a/src/rtp/id.rs
+++ b/src/rtp/id.rs
@@ -123,6 +123,7 @@ macro_rules! num_id {
 /// 3 incoming StreamRx, but since they belong to the same media,
 /// the have the same `Mid`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct Mid([u8; 16]);
 str_id!(Mid, "Mid", 16, 3);
 
@@ -134,6 +135,7 @@ str_id!(Mid, "Mid", 16, 3);
 /// In SDP this is an optional value that will be seen in [`MediaData`][crate::media::MediaData]
 /// if the remote peer is configured for simulcast.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct Rid([u8; 8]);
 str_id!(Rid, "Rid", 8, 3);
 
@@ -143,6 +145,7 @@ str_id!(Rid, "Rid", 8, 3);
 /// with at least one synchronization source. Multiple sources for the same stream happens
 /// for RTX (resend) and simulcast.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct Ssrc(u32);
 num_id!(Ssrc, u32);
 
@@ -163,6 +166,7 @@ impl Ssrc {
 ///
 /// PTs in RTP headers are 7 bits. Values >=128 are not valid.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct Pt(u8);
 num_id!(Pt, u8);
 
@@ -170,6 +174,7 @@ num_id!(Pt, u8);
 ///
 /// This value is rarely interesting, but is part of the SDP OFFER and ANSWER.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct SessionId(u64);
 num_id!(SessionId, u64);
 
@@ -194,6 +199,7 @@ num_id!(SessionId, u64);
 /// assert_eq!(b, 1);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct SeqNo(u64);
 num_id!(SeqNo, u64);
 

--- a/src/rtp/mtime.rs
+++ b/src/rtp/mtime.rs
@@ -33,6 +33,7 @@ use serde::{Deserialize, Serialize};
 /// let mtime = MediaTime::new(2000, freq);
 /// ```
 #[derive(Debug, Clone, Copy, Serialize)]
+#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct Frequency(NonZeroU32);
 
 impl Frequency {

--- a/src/rtp/mtime.rs
+++ b/src/rtp/mtime.rs
@@ -333,6 +333,22 @@ impl PartialEq for MediaTime {
 }
 impl Eq for MediaTime {}
 
+// `MediaTime`'s `PartialEq` rebases to a common timebase before comparing,
+// so the structural `drv::Input` derive (raw numerator + frequency) would
+// diverge from its real equality. It's `Copy + 'static`, so give it an
+// identity `ToStatic` that defers to that `PartialEq` — mirroring how drv
+// treats primitives.
+#[cfg(feature = "drv")]
+impl drv::ToStatic for MediaTime {
+    type Static = MediaTime;
+    fn to_static(&self) -> MediaTime {
+        *self
+    }
+    fn eq_static(&self, other: &MediaTime) -> bool {
+        self == other
+    }
+}
+
 impl PartialOrd for MediaTime {
     #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {

--- a/tests/drv_input.rs
+++ b/tests/drv_input.rs
@@ -4,7 +4,7 @@
 //! value. `Frequency` exercises the `NonZeroU32` path specifically.
 
 use str0m::format::Codec;
-use str0m::media::{Frequency, MediaKind, Mid};
+use str0m::media::{Frequency, MediaKind, MediaTime, Mid};
 
 #[derive(drv::Input)]
 struct TrackFacts {
@@ -37,4 +37,26 @@ fn identity_types_are_valid_memo_inputs() {
         clock_rate: Frequency::NINETY_KHZ,
     };
     assert!(!is_opus_audio(video));
+}
+
+#[derive(drv::Input)]
+struct TimeFacts {
+    pub at: MediaTime,
+}
+
+#[drv::memo(single)]
+fn micros(input: TimeFacts) -> i64 {
+    // identity work; the point is that MediaTime is a valid memo input
+    input.at.rebase(Frequency::MICROS).numer() as i64
+}
+
+#[test]
+fn media_time_is_a_valid_memo_input() {
+    // Same instant expressed in two timebases — MediaTime's PartialEq
+    // (which the ToStatic impl defers to) treats them equal.
+    let a = MediaTime::new(2_000, Frequency::MILLIS);
+    let b = MediaTime::new(2_000_000, Frequency::MICROS);
+    assert_eq!(a, b);
+    assert_eq!(micros(TimeFacts { at: a }), 2_000_000);
+    assert_eq!(micros(TimeFacts { at: b }), 2_000_000);
 }

--- a/tests/drv_input.rs
+++ b/tests/drv_input.rs
@@ -1,0 +1,40 @@
+#![cfg(feature = "drv")]
+//! Verifies the `drv` feature derives `drv::Input` on str0m's public
+//! identity types so downstream `#[drv::memo]` queries can take them by
+//! value. `Frequency` exercises the `NonZeroU32` path specifically.
+
+use str0m::format::Codec;
+use str0m::media::{Frequency, MediaKind, Mid};
+
+#[derive(drv::Input)]
+struct TrackFacts {
+    pub mid: Mid,
+    pub kind: MediaKind,
+    pub codec: Codec,
+    pub clock_rate: Frequency,
+}
+
+#[drv::memo(single)]
+fn is_opus_audio(input: TrackFacts) -> bool {
+    matches!(input.kind, MediaKind::Audio) && matches!(input.codec, Codec::Opus)
+}
+
+#[test]
+fn identity_types_are_valid_memo_inputs() {
+    let mid = Mid::from("0");
+    let audio = TrackFacts {
+        mid,
+        kind: MediaKind::Audio,
+        codec: Codec::Opus,
+        clock_rate: Frequency::FORTY_EIGHT_KHZ,
+    };
+    assert!(is_opus_audio(audio));
+
+    let video = TrackFacts {
+        mid,
+        kind: MediaKind::Video,
+        codec: Codec::Vp8,
+        clock_rate: Frequency::NINETY_KHZ,
+    };
+    assert!(!is_opus_audio(video));
+}


### PR DESCRIPTION
## Summary

Adds a default-off `drv` feature that makes str0m's public identity types usable as [`drv::Input`](https://docs.rs/drv) cache keys, so downstream `#[drv::memo]` query functions can take them by value or project them — including as `HashMap` keys.

The `Copy` identity types get a hand-written **identity `ToStatic` impl** (`Static = Self`) via a small gated `drv_identity_copy!` macro, rather than `#[derive(drv::Input)]`. The derive generates a separate shadow `Static` type that is *not* `Eq`/`Hash`/`Borrow<Self>`, so a derived type can't be a `HashMap`/`HashSet` key inside a projection (drv requires those bounds on `K::Static`). `Static = Self` satisfies them and is also simpler — the same shape drv ships for primitives. `eq_static` defers to each type's own `PartialEq`.

Covered (all `Copy`): `Mid`, `Rid`, `Ssrc`, `Pt`, `SessionId`, `SeqNo`, `Direction`, `MediaKind`, `VideoOrientation`, `Codec`, `Frequency`, `CodecSpec`, `FormatParams`, `H265ProfileTierLevel`, `H265Profile`, `H265Tier`, `H265Level`, and `MediaTime`.

`Frequency(NonZeroU32)` relies on drv 0.4.3's `NonZero*` impls, hence `drv = { version = "0.4.3", optional = true }`. The feature is off by default, so non-drv consumers compile exactly as before. `tests/drv_input.rs` covers value use, the `MediaTime` timebase-equality semantics, and (new) `Mid` as a projected `HashMap` key.

### Out of scope

- `PayloadParams` — its hand-written `PartialEq` ignores `locked`/`fb_remb`; an identity impl would defer to that (fine), but it's left out until a use appears.
- `Extension` — its `UnknownUri(String, Arc<dyn ExtensionSerializer>)` variant holds a trait object, not `ToStatic`.
- `CodecExtra` and the H.265 NALU/payload types — payload-carrying, not identity.