### PR TITLE
drv: use identity ToStatic impls for the Copy identity types

### DIFF
--- a/src/format/codec.rs
+++ b/src/format/codec.rs
@@ -8,7 +8,6 @@ use super::format_params::FormatParams;
 
 /// Codec specification
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct CodecSpec {
     /// The codec identifier.
     pub codec: Codec,
@@ -26,7 +25,6 @@ pub struct CodecSpec {
 
 /// Known codecs.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "drv", derive(drv::Input))]
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum Codec {
@@ -52,6 +50,9 @@ pub enum Codec {
     #[doc(hidden)]
     Unknown,
 }
+
+#[cfg(feature = "drv")]
+crate::drv_identity_copy!(Codec, CodecSpec);
 
 impl Codec {
     /// Tells if codec is audio.

--- a/src/format/format_params.rs
+++ b/src/format/format_params.rs
@@ -5,7 +5,6 @@ use crate::sdp::FormatParam;
 
 /// Codec specific format parameters.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct FormatParams {
     /// Opus specific parameter.
     ///
@@ -100,6 +99,9 @@ pub struct FormatParams {
     /// out-of-order NAL unit decoding.
     pub sprop_max_don_diff: Option<u16>,
 }
+
+#[cfg(feature = "drv")]
+crate::drv_identity_copy!(FormatParams);
 
 impl FormatParams {
     /// Parse an fmtp line to create a FormatParams.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -687,6 +687,27 @@ use streams::RtpPacket;
 use streams::StreamPaused;
 use util::InstantExt;
 
+// Identity `drv::ToStatic` (`Static = Self`) for the `Copy` identity types.
+// Used instead of `#[derive(drv::Input)]` because the derive's generated
+// shadow type isn't `Eq`/`Hash`/`Borrow<Self>`, so it can't be a `HashMap`
+// key inside a `#[drv::memo]` projection; `Static = Self` can. `eq_static`
+// defers to each type's own `PartialEq`. Each module invokes this for its
+// own types.
+#[cfg(feature = "drv")]
+macro_rules! drv_identity_copy {
+    ($($t:ty),* $(,)?) => {
+        $(
+            impl drv::ToStatic for $t {
+                type Static = $t;
+                fn to_static(&self) -> $t { *self }
+                fn eq_static(&self, other: &$t) -> bool { self == other }
+            }
+        )*
+    };
+}
+#[cfg(feature = "drv")]
+pub(crate) use drv_identity_copy;
+
 /// Cryptographic provider traits and implementations.
 ///
 /// This module provides the traits for pluggable cryptographic operations

--- a/src/packet/h265_profile.rs
+++ b/src/packet/h265_profile.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 /// Represents the three SDP fmtp parameters `profile-id`, `tier-flag`, and `level-id`
 /// as defined in RFC 7798 §7.1 and ITU-T H.265 Annex A.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct H265ProfileTierLevel {
     profile: H265Profile,
     tier: H265Tier,
@@ -95,7 +94,6 @@ impl From<(u8, u8, u8)> for H265ProfileTierLevel {
 
 /// H.265 profile as defined in ITU-T H.265 Annex A.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub enum H265Profile {
     /// Main profile (profile_id=1).
     Main,
@@ -162,7 +160,6 @@ impl H265Profile {
 
 /// H.265 tier (Main or High).
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub enum H265Tier {
     /// Main tier (tier_flag=0).
     Main,
@@ -195,7 +192,6 @@ impl H265Tier {
 ///
 /// Level IDs are 30× the level number (e.g., Level 3.1 = 93).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "drv", derive(drv::Input))]
 #[repr(u8)]
 #[rustfmt::skip]
 pub enum H265Level {
@@ -226,6 +222,9 @@ pub enum H265Level {
     /// Level 6.2 (level_id=186).
     Level6_2 = 186_u8,
 }
+
+#[cfg(feature = "drv")]
+crate::drv_identity_copy!(H265ProfileTierLevel, H265Profile, H265Tier, H265Level);
 
 impl H265Level {
     /// Returns the ordinal position (0-12) representing capability order.

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -67,7 +67,6 @@ mod payload;
 pub(crate) use payload::Payloader;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "drv", derive(drv::Input))]
 /// Types of media.
 pub enum MediaKind {
     /// Audio media.
@@ -75,6 +74,9 @@ pub enum MediaKind {
     /// Video media.
     Video,
 }
+
+#[cfg(feature = "drv")]
+crate::drv_identity_copy!(MediaKind);
 
 impl MediaKind {
     /// Tests if this is `MediaKind::Audio`

--- a/src/rtp/dir.rs
+++ b/src/rtp/dir.rs
@@ -4,7 +4,6 @@ use std::fmt;
 ///
 /// And also extmap direction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub enum Direction {
     /// Send only direction.
     SendOnly,
@@ -15,6 +14,9 @@ pub enum Direction {
     /// Disabled direction.
     Inactive,
 }
+
+#[cfg(feature = "drv")]
+crate::drv_identity_copy!(Direction);
 
 impl Direction {
     /// Change the direction to the opposite.

--- a/src/rtp/ext.rs
+++ b/src/rtp/ext.rs
@@ -1222,7 +1222,6 @@ impl fmt::Debug for ExtensionMap {
 
 /// How the video is rotated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub enum VideoOrientation {
     /// Not rotated.
     Deg0 = 0,
@@ -1233,6 +1232,9 @@ pub enum VideoOrientation {
     /// 90 degrees counter clockwise.
     Deg270 = 1,
 }
+
+#[cfg(feature = "drv")]
+crate::drv_identity_copy!(VideoOrientation);
 
 impl From<u8> for VideoOrientation {
     fn from(value: u8) -> Self {

--- a/src/rtp/id.rs
+++ b/src/rtp/id.rs
@@ -123,7 +123,6 @@ macro_rules! num_id {
 /// 3 incoming StreamRx, but since they belong to the same media,
 /// the have the same `Mid`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct Mid([u8; 16]);
 str_id!(Mid, "Mid", 16, 3);
 
@@ -135,7 +134,6 @@ str_id!(Mid, "Mid", 16, 3);
 /// In SDP this is an optional value that will be seen in [`MediaData`][crate::media::MediaData]
 /// if the remote peer is configured for simulcast.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct Rid([u8; 8]);
 str_id!(Rid, "Rid", 8, 3);
 
@@ -145,7 +143,6 @@ str_id!(Rid, "Rid", 8, 3);
 /// with at least one synchronization source. Multiple sources for the same stream happens
 /// for RTX (resend) and simulcast.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct Ssrc(u32);
 num_id!(Ssrc, u32);
 
@@ -166,7 +163,6 @@ impl Ssrc {
 ///
 /// PTs in RTP headers are 7 bits. Values >=128 are not valid.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct Pt(u8);
 num_id!(Pt, u8);
 
@@ -174,7 +170,6 @@ num_id!(Pt, u8);
 ///
 /// This value is rarely interesting, but is part of the SDP OFFER and ANSWER.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct SessionId(u64);
 num_id!(SessionId, u64);
 
@@ -199,9 +194,11 @@ num_id!(SessionId, u64);
 /// assert_eq!(b, 1);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct SeqNo(u64);
 num_id!(SeqNo, u64);
+
+#[cfg(feature = "drv")]
+crate::drv_identity_copy!(Mid, Rid, Ssrc, Pt, SessionId, SeqNo);
 
 /// TWCC-specific sequence number.
 ///

--- a/src/rtp/mtime.rs
+++ b/src/rtp/mtime.rs
@@ -33,7 +33,6 @@ use serde::{Deserialize, Serialize};
 /// let mtime = MediaTime::new(2000, freq);
 /// ```
 #[derive(Debug, Clone, Copy, Serialize)]
-#[cfg_attr(feature = "drv", derive(drv::Input))]
 pub struct Frequency(NonZeroU32);
 
 impl Frequency {
@@ -333,21 +332,8 @@ impl PartialEq for MediaTime {
 }
 impl Eq for MediaTime {}
 
-// `MediaTime`'s `PartialEq` rebases to a common timebase before comparing,
-// so the structural `drv::Input` derive (raw numerator + frequency) would
-// diverge from its real equality. It's `Copy + 'static`, so give it an
-// identity `ToStatic` that defers to that `PartialEq` — mirroring how drv
-// treats primitives.
 #[cfg(feature = "drv")]
-impl drv::ToStatic for MediaTime {
-    type Static = MediaTime;
-    fn to_static(&self) -> MediaTime {
-        *self
-    }
-    fn eq_static(&self, other: &MediaTime) -> bool {
-        self == other
-    }
-}
+crate::drv_identity_copy!(Frequency, MediaTime);
 
 impl PartialOrd for MediaTime {
     #[inline(always)]

--- a/tests/drv_input.rs
+++ b/tests/drv_input.rs
@@ -3,6 +3,8 @@
 //! identity types so downstream `#[drv::memo]` queries can take them by
 //! value. `Frequency` exercises the `NonZeroU32` path specifically.
 
+use std::collections::HashMap;
+
 use str0m::format::Codec;
 use str0m::media::{Frequency, MediaKind, MediaTime, Mid};
 
@@ -59,4 +61,22 @@ fn media_time_is_a_valid_memo_input() {
     assert_eq!(a, b);
     assert_eq!(micros(TimeFacts { at: a }), 2_000_000);
     assert_eq!(micros(TimeFacts { at: b }), 2_000_000);
+}
+
+#[derive(drv::Input)]
+struct MidMapInput<'a> {
+    pub by_mid: &'a HashMap<Mid, u32>,
+}
+
+#[drv::memo(single)]
+fn mid_count(input: MidMapInput<'_>) -> usize {
+    input.by_mid.len()
+}
+
+#[test]
+fn mid_works_as_a_projected_hashmap_key() {
+    let mut by_mid = HashMap::new();
+    by_mid.insert(Mid::from("0"), 1u32);
+    by_mid.insert(Mid::from("1"), 2u32);
+    assert_eq!(mid_count(MidMapInput { by_mid: &by_mid }), 2);
 }


### PR DESCRIPTION
## Summary

Follow-up to #974. That PR added the `drv` feature via `#[derive(drv::Input)]` on the `Copy` identity types — but the derive generates a separate shadow `Static` type that isn't `Eq`/`Hash`/`Borrow<Self>`, so a derived type **can't be a `HashMap`/`HashSet` key** inside a `#[drv::memo]` projection (drv requires those bounds on `K::Static`). That blocks the common case of projecting a `HashMap<Mid, _>` into a memo.

These types are all `Copy` with a structural `PartialEq`, so the correct shape is an identity `ToStatic` impl (`Static = Self`) — it works as both a value and a map key, mirroring how drv handles primitives. `eq_static` defers to each type's own `PartialEq`.

Replaces the per-type derive with a small gated `drv_identity_copy!` macro across: `Mid`, `Rid`, `Ssrc`, `Pt`, `SessionId`, `SeqNo`, `Direction`, `MediaKind`, `VideoOrientation`, `Codec`, `Frequency`, `CodecSpec`, `FormatParams`, `H265ProfileTierLevel`, `H265Profile`, `H265Tier`, `H265Level`, and `MediaTime` (folding in its former hand-written impl).

The feature stays off by default. `tests/drv_input.rs` gains `mid_works_as_a_projected_hashmap_key`, the case the derive couldn't satisfy.