### PR TITLE
Allow sctp outgoing buffer limit to be configured

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,10 +2,9 @@ use std::ops::RangeInclusive;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use crate::Rtc;
 use crate::config::DtlsCert;
-use crate::crypto::CryptoProvider;
 use crate::crypto::dtls::DtlsVersion;
+use crate::crypto::CryptoProvider;
 use crate::format::CodecConfig;
 use crate::format::Vp9PacketizerMode;
 use crate::ice::IceCreds;
@@ -14,6 +13,7 @@ use crate::io::DATAGRAM_MTU_TARGET_MAX;
 use crate::io::DATAGRAM_MTU_TARGET_MIN;
 use crate::io::DATAGRAM_MTU_WARN;
 use crate::rtp_::{Bitrate, Extension, ExtensionMap};
+use crate::Rtc;
 
 /// Customized config for creating an [`Rtc`] instance.
 ///
@@ -53,6 +53,7 @@ pub struct RtcConfig {
     pub(crate) vp9_packetizer_mode: Vp9PacketizerMode,
     pub(crate) snap_enabled: bool,
     pub(crate) mtu: RangeInclusive<usize>,
+    pub(crate) sctp_max_buffered: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -574,6 +575,12 @@ impl RtcConfig {
         self
     }
 
+    /// set the maximum amount of outgoing data buffered for the sctp associations
+    pub fn set_sctp_max_buffered(mut self, bufsize: usize) -> Self {
+        self.sctp_max_buffered = Some(bufsize);
+        self
+    }
+
     /// Set which DTLS version to use.
     ///
     /// Defaults to [`DtlsVersion::Dtls12`].
@@ -693,6 +700,7 @@ impl Default for RtcConfig {
             vp9_packetizer_mode: Vp9PacketizerMode::default(),
             snap_enabled: false,
             mtu: DATAGRAM_MTU_TARGET..=DATAGRAM_MTU_WARN,
+            sctp_max_buffered: None,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,9 +2,10 @@ use std::ops::RangeInclusive;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use crate::Rtc;
 use crate::config::DtlsCert;
-use crate::crypto::dtls::DtlsVersion;
 use crate::crypto::CryptoProvider;
+use crate::crypto::dtls::DtlsVersion;
 use crate::format::CodecConfig;
 use crate::format::Vp9PacketizerMode;
 use crate::ice::IceCreds;
@@ -13,7 +14,6 @@ use crate::io::DATAGRAM_MTU_TARGET_MAX;
 use crate::io::DATAGRAM_MTU_TARGET_MIN;
 use crate::io::DATAGRAM_MTU_WARN;
 use crate::rtp_::{Bitrate, Extension, ExtensionMap};
-use crate::Rtc;
 
 /// Customized config for creating an [`Rtc`] instance.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1232,6 +1232,10 @@ impl Rtc {
             sctp.enable_snap();
         }
 
+        if let Some(bufsize) = config.sctp_max_buffered {
+            sctp.max_buffered_across_streams(bufsize);
+        }
+
         Ok(Rtc {
             alive: true,
             ice,

--- a/src/sctp/mod.rs
+++ b/src/sctp/mod.rs
@@ -1134,9 +1134,10 @@ mod tests {
         init_data.local_init_chunk().unwrap();
 
         let err = sctp.init(true, now, Some(init_data)).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("SNAP requires both local and remote SCTP INIT chunks"));
+        assert!(
+            err.to_string()
+                .contains("SNAP requires both local and remote SCTP INIT chunks")
+        );
     }
 
     #[test]

--- a/src/sctp/mod.rs
+++ b/src/sctp/mod.rs
@@ -27,7 +27,7 @@ mod error;
 pub use error::SctpError;
 
 /// Bytes that can be buffered inside str0m across all streams.
-const MAX_BUFFERED_ACROSS_STREAMS: usize = 128 * 1024;
+const DEFAULT_MAX_BUFFERED_ACROSS_STREAMS: usize = 128 * 1024;
 
 pub(crate) struct RtcSctp {
     state: RtcSctpState,
@@ -41,6 +41,7 @@ pub(crate) struct RtcSctp {
     client: bool,
     snap_enabled: bool,
     snap_init: Option<SctpInitData>,
+    max_buffered: usize,
     #[cfg(test)]
     max_payload_size: usize,
 }
@@ -272,6 +273,7 @@ impl RtcSctp {
             client: false,
             snap_enabled: false,
             snap_init: None,
+            max_buffered: DEFAULT_MAX_BUFFERED_ACROSS_STREAMS,
             #[cfg(test)]
             max_payload_size,
         }
@@ -346,6 +348,10 @@ impl RtcSctp {
         }
 
         Ok(())
+    }
+
+    pub fn max_buffered_across_streams(&mut self, bufsize: usize) {
+        self.max_buffered = bufsize;
     }
 
     pub fn is_client(&self) -> bool {
@@ -525,7 +531,7 @@ impl RtcSctp {
             })
             .sum();
 
-        MAX_BUFFERED_ACROSS_STREAMS - total
+        self.max_buffered - total
     }
 
     pub fn write(&mut self, id: u16, binary: bool, buf: &[u8]) -> Result<usize, SctpError> {
@@ -1128,10 +1134,9 @@ mod tests {
         init_data.local_init_chunk().unwrap();
 
         let err = sctp.init(true, now, Some(init_data)).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("SNAP requires both local and remote SCTP INIT chunks")
-        );
+        assert!(err
+            .to_string()
+            .contains("SNAP requires both local and remote SCTP INIT chunks"));
     }
 
     #[test]


### PR DESCRIPTION
I'm continuing to search for ways to increase datachannel throughput for my application, which pairs a 1080p h264 stream with an extra ~256k of data for each frame on a datachannel. Increasing this outgoing buffer size to 512k achieved some extra throughput. Let me know what you think.