### PR TITLE
Expose negotiated DTLS version via an event

### DIFF
--- a/crates/proto/src/crypto/mod.rs
+++ b/crates/proto/src/crypto/mod.rs
@@ -14,6 +14,7 @@ pub mod dtls {
 
     pub use dimpl::DtlsCertificate as DtlsCert;
     pub use dimpl::KeyingMaterial;
+    pub use dimpl::ProtocolVersion;
     pub use dimpl::SrtpProfile;
     // Note: dimpl::Error is renamed to DtlsImplError to avoid conflict with str0m's DtlsError
     pub use dimpl::{Error as DtlsImplError, Output as DtlsOutput};

--- a/crypto/openssl/src/dtls_ossl.rs
+++ b/crypto/openssl/src/dtls_ossl.rs
@@ -14,7 +14,9 @@ use openssl::x509::X509;
 
 use str0m_proto::DATAGRAM_MTU_TARGET;
 use str0m_proto::crypto::dtls::{DtlsCert, KeyingMaterial, SrtpProfile};
-use str0m_proto::crypto::dtls::{DtlsImplError, DtlsInstance, DtlsOutput, DtlsProvider};
+use str0m_proto::crypto::dtls::{
+    DtlsImplError, DtlsInstance, DtlsOutput, DtlsProvider, ProtocolVersion,
+};
 use str0m_proto::crypto::{CryptoError, DtlsVersion};
 
 // ============================================================================
@@ -434,6 +436,7 @@ pub(super) struct OsslDtlsInstance {
     queued_app_data: VecDeque<Vec<u8>>,
     next_timeout: Option<Instant>,
     connected_emitted: bool,
+    negotiated_version_emitted: bool,
 }
 
 impl std::fmt::Debug for OsslDtlsInstance {
@@ -454,6 +457,7 @@ impl OsslDtlsInstance {
             queued_app_data: VecDeque::new(),
             next_timeout: None,
             connected_emitted: false,
+            negotiated_version_emitted: false,
         })
     }
 
@@ -545,6 +549,13 @@ impl DtlsInstance for OsslDtlsInstance {
         if self.inner.is_connected() && !self.connected_emitted {
             self.connected_emitted = true;
             return DtlsOutput::Connected;
+        }
+
+        // Return negotiated version event (immediately after Connected per dimpl contract).
+        // OpenSSL backend only supports DTLS 1.2.
+        if self.inner.is_connected() && !self.negotiated_version_emitted {
+            self.negotiated_version_emitted = true;
+            return DtlsOutput::NegotiatedVersion(ProtocolVersion::DTLS1_2);
         }
 
         // Return peer certificate DER

--- a/crypto/wincrypto/src/dtls_schannel.rs
+++ b/crypto/wincrypto/src/dtls_schannel.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, Instant};
 use str0m_proto::DATAGRAM_MTU_TARGET;
 use str0m_proto::crypto::dtls::{DtlsCert, DtlsImplError, DtlsInstance, DtlsOutput, DtlsProvider};
-use str0m_proto::crypto::dtls::{KeyingMaterial, SrtpProfile};
+use str0m_proto::crypto::dtls::{KeyingMaterial, ProtocolVersion, SrtpProfile};
 use str0m_proto::crypto::{CryptoError, DtlsVersion};
 
 use crate::sys::{Certificate, Dtls, DtlsEvent};
@@ -98,6 +98,7 @@ struct WinCryptoDtlsInstance {
 #[derive(Debug)]
 enum PendingOutput {
     Connected,
+    NegotiatedVersion(ProtocolVersion),
     PeerCert(Vec<u8>),
     KeyingMaterial(KeyingMaterial, SrtpProfile),
     ApplicationData(Vec<u8>),
@@ -124,8 +125,11 @@ impl WinCryptoDtlsInstance {
                     _ => return, // Unknown profile, ignore
                 };
 
-                // Queue up the sequence: Connected -> PeerCert -> KeyingMaterial
+                // Queue up the sequence: Connected -> NegotiatedVersion -> PeerCert -> KeyingMaterial.
                 self.pending_outputs.push_back(PendingOutput::Connected);
+                // SChannel backend only supports DTLS 1.2.
+                self.pending_outputs
+                    .push_back(PendingOutput::NegotiatedVersion(ProtocolVersion::DTLS1_2));
                 self.pending_outputs
                     .push_back(PendingOutput::PeerCert(peer_cert_der));
                 self.pending_outputs
@@ -188,6 +192,7 @@ impl DtlsInstance for WinCryptoDtlsInstance {
         if let Some(pending) = self.pending_outputs.pop_front() {
             return match pending {
                 PendingOutput::Connected => DtlsOutput::Connected,
+                PendingOutput::NegotiatedVersion(v) => DtlsOutput::NegotiatedVersion(v),
                 PendingOutput::PeerCert(cert) => {
                     let len = cert.len().min(buf.len());
                     buf[..len].copy_from_slice(&cert[..len]);

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -12,6 +12,7 @@ pub mod dtls {
 
     pub use dimpl::DtlsCertificate as DtlsCert;
     pub use dimpl::KeyingMaterial;
+    pub use dimpl::ProtocolVersion;
     pub use dimpl::SrtpProfile;
     // Note: dimpl::Error is renamed to DtlsImplError to avoid conflict with str0m's DtlsError
     pub use super::provider::DtlsVersion;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -716,7 +716,7 @@ pub mod crypto;
 use crypto::Fingerprint;
 
 mod dtls;
-use crate::crypto::dtls::DtlsOutput;
+use crate::crypto::dtls::{DtlsOutput, DtlsVersion, ProtocolVersion};
 use crate::crypto::{CryptoProvider, DtlsError, from_feature_flags};
 use crate::dtls::is_would_block;
 use dtls::Dtls;
@@ -1639,6 +1639,16 @@ impl Rtc {
                 DtlsOutput::Timeout(t) => {
                     self.next_dtls_timeout = Some(t);
                     break;
+                }
+                DtlsOutput::NegotiatedVersion(v) => {
+                    let mapped = match v {
+                        ProtocolVersion::DTLS1_2 => Some(DtlsVersion::Dtls12),
+                        ProtocolVersion::DTLS1_3 => Some(DtlsVersion::Dtls13),
+                        _ => None,
+                    };
+                    if let Some(dv) = mapped {
+                        debug!("DTLS negotiated version: {}", dv);
+                    }
                 }
                 other => {
                     return Err(RtcError::Dtls(DtlsError::Io(std::io::Error::other(


### PR DESCRIPTION
This PR is the str0m part of exposing the negotiated DTLS version via an event. 

It can be merged only after https://github.com/algesten/dimpl/pull/145 is merged to Dimpl. Thus a draft PR for now.