### PR TITLE
Add RFC 2198 RED (redundant audio) support for all audio codecs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+  * Add RFC 2198 RED (redundant audio) for Opus via `RtcConfig::enable_red`: transparent send/recv
+    with single-loss recovery in frame mode, pass-through in rtp mode, and public `RedEncoder`/`RedDecoder` #982
+
 # 0.21.0
 
   * Upgrade to  dimpl 0.7.0 (breaking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 # 0.23.1
 
   * Guard SRTP/SRTCP and RTCP parsing against malformed input #1029
+  * Add RFC 2198 RED (redundant audio) via `RtcConfig::enable_red` for all audio codecs (Opus, PCMU,
+    PCMA, G722): transparent send/recv with best-effort loss recovery in frame mode, a configurable
+    redundancy pattern via `RtcConfig::set_red_distances`, a runtime send-side on/off toggle via
+    `SdpApi`/`DirectApi::set_red_send`, pass-through in rtp mode, and public `RedEncoder`/`RedDecoder` #982
 
 # 0.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,7 @@
 # 0.23.1
 
   * Guard SRTP/SRTCP and RTCP parsing against malformed input #1029
-  * Add RFC 2198 RED (redundant audio) via `RtcConfig::enable_red` for all audio codecs (Opus, PCMU,
-    PCMA, G722): transparent send/recv with best-effort loss recovery in frame mode, a configurable
-    redundancy pattern via `RtcConfig::set_red_distances`, a runtime send-side on/off toggle via
-    `SdpApi`/`DirectApi::set_red_send`, pass-through in rtp mode, and public `RedEncoder`/`RedDecoder` #982
+  * Add RFC 2198 RED (redundant audio) support for all audio codecs #982
 
 # 0.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Unreleased
 
+  * Add RFC 2198 RED (redundant audio) support for all audio codecs #982
+
 # 0.23.1
 
   * Guard SRTP/SRTCP and RTCP parsing against malformed input #1029
-  * Add RFC 2198 RED (redundant audio) support for all audio codecs #982
 
 # 0.23.0
 

--- a/crates/fuzz/Cargo.toml
+++ b/crates/fuzz/Cargo.toml
@@ -86,3 +86,9 @@ name = "depack_direct"
 path = "fuzz_targets/depack_direct.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "red_decode"
+path = "fuzz_targets/red_decode.rs"
+test = false
+doc = false

--- a/crates/fuzz/fuzz_targets/red_decode.rs
+++ b/crates/fuzz/fuzz_targets/red_decode.rs
@@ -1,0 +1,9 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use str0m::rtp::RedDecoder;
+
+fuzz_target!(|data: &[u8]| {
+    // RFC 2198 RED payloads come from untrusted peers; decoding must never panic.
+    let _ = RedDecoder::decode(data);
+});

--- a/src/_internal_test_exports/setup.rs
+++ b/src/_internal_test_exports/setup.rs
@@ -39,7 +39,7 @@ pub fn random_config(rng: &mut Rng) -> Option<RtcConfig> {
     c = c.set_ice_lite(rng.bool()?);
     c = c.set_fingerprint_verification(rng.bool()?);
     c = c.clear_codecs();
-    c = c.enable_opus(rng.bool()?);
+    c = c.enable_opus(rng.bool()?, false);
     c = c.enable_h264(rng.bool()?);
     c = c.enable_vp8(rng.bool()?);
     c = c.enable_vp9(rng.bool()?);

--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -237,6 +237,15 @@ impl<'a> DirectApi<'a> {
         self.rtc.session.remove_media(mid);
     }
 
+    /// Turn RFC 2198 RED wrapping on or off on the send side at runtime.
+    ///
+    /// This only decides whether outgoing packets are wrapped in RED right now; it needs no
+    /// renegotiation. Enabling has no effect on media where RED is not available. Returns whether
+    /// the setting changed (`false` if the media does not exist or the value was already set).
+    pub fn set_red_send(&mut self, mid: Mid, enabled: bool) -> bool {
+        self.rtc.session.set_red_send(mid, enabled)
+    }
+
     /// Allow incoming traffic from remote peer for the given SSRC.
     ///
     /// Can be called multiple times if the `rtx` is discovered later via RTP header extensions.

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -1521,6 +1521,9 @@ impl AsSdpMediaLine for Media {
             if let Some(rtx) = p.resend() {
                 pts.push(rtx);
             }
+            if let Some(red) = p.red() {
+                pts.push(red);
+            }
         }
 
         if let Some(s) = self.simulcast() {

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -362,17 +362,6 @@ impl<'a> SdpApi<'a> {
         }
     }
 
-    /// Turn RFC 2198 RED wrapping on or off on the send side at runtime.
-    ///
-    /// RED availability is fixed when the m-line is negotiated; this only decides whether outgoing
-    /// packets are wrapped in RED right now, and needs no renegotiation (so it applies immediately,
-    /// with or without a following [`SdpApi::apply()`]). Enabling has no effect on media where RED
-    /// was not negotiated. This is the send-side lever an SFU uses to turn redundancy on for a leg
-    /// that is losing packets and off again when it recovers.
-    pub fn set_red_send(&mut self, mid: Mid, enabled: bool) {
-        self.rtc.session.set_red_send(mid, enabled);
-    }
-
     /// Stop an already existing media.
     ///
     /// The next generated offer emits the m-line with port 0 and excludes

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -362,6 +362,17 @@ impl<'a> SdpApi<'a> {
         }
     }
 
+    /// Turn RFC 2198 RED wrapping on or off on the send side at runtime.
+    ///
+    /// RED availability is fixed when the m-line is negotiated; this only decides whether outgoing
+    /// packets are wrapped in RED right now, and needs no renegotiation (so it applies immediately,
+    /// with or without a following [`SdpApi::apply()`]). Enabling has no effect on media where RED
+    /// was not negotiated. This is the send-side lever an SFU uses to turn redundancy on for a leg
+    /// that is losing packets and off again when it recovers.
+    pub fn set_red_send(&mut self, mid: Mid, enabled: bool) {
+        self.rtc.session.set_red_send(mid, enabled);
+    }
+
     /// Stop an already existing media.
     ///
     /// The next generated offer emits the m-line with port 0 and excludes
@@ -1520,6 +1531,9 @@ impl AsSdpMediaLine for Media {
             pts.push(p.pt());
             if let Some(rtx) = p.resend() {
                 pts.push(rtx);
+            }
+            if let Some(red) = p.red() {
+                pts.push(red);
             }
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -229,6 +229,19 @@ impl RtcConfig {
         self
     }
 
+    /// Enable RFC 2198 RED (redundant Opus audio). Off by default. Requires Opus.
+    ///
+    /// RED carries a redundant copy of the previous Opus frame in each packet so the
+    /// receiver can recover single packet losses without retransmission, at the cost of
+    /// roughly doubling audio payload size.
+    ///
+    /// Call this after [`Self::enable_opus`]: RED folds onto the enabled Opus payload, so
+    /// enabling it while no Opus codec is configured is a no-op (and is logged).
+    pub fn enable_red(mut self, enabled: bool) -> Self {
+        self.codec_config.enable_red(enabled);
+        self
+    }
+
     /// Enable PCM μ-law audio codec.
     ///
     /// This is 14-bit audio compressed to 8-bit as specified by G.711

--- a/src/config.rs
+++ b/src/config.rs
@@ -224,7 +224,7 @@ impl RtcConfig {
     /// // For the session to use only OPUS and VP8.
     /// let mut rtc = RtcConfig::default()
     ///     .clear_codecs()
-    ///     .enable_opus(true)
+    ///     .enable_opus(true, false)
     ///     .enable_vp8(true)
     ///     .build(Instant::now());
     /// # }
@@ -234,28 +234,16 @@ impl RtcConfig {
         self
     }
 
-    /// Enable opus audio codec.
+    /// Enable opus audio codec, optionally with RFC 2198 RED (redundant audio).
     ///
-    /// Enabled by default.
-    pub fn enable_opus(mut self, enabled: bool) -> Self {
-        self.codec_config.enable_opus(enabled);
-        self
-    }
-
-    /// Enable RFC 2198 RED (redundant audio). Off by default. Requires an audio codec.
-    ///
-    /// RED carries redundant copies of earlier frames in each packet so the receiver can recover
-    /// packet losses without retransmission, at the cost of extra audio payload size. It applies to
-    /// every enabled audio codec (Opus, PCMU, PCMA, G722), each getting its own RED payload type.
-    ///
-    /// Call this after enabling audio codecs: RED folds onto the enabled audio payloads, so
-    /// enabling it while no audio codec is configured is a no-op (and is logged). The redundancy
-    /// depth is set with [`Self::set_red_distances`] (default one level, the previous frame), and
-    /// wrapping can be toggled at runtime on the send side without renegotiation via
-    /// [`SdpApi::set_red_send`][crate::change::SdpApi::set_red_send] /
+    /// Enabled by default (without RED). `use_red` folds a RED payload type onto Opus so the
+    /// receiver can recover packet loss without retransmission, at the cost of extra audio payload
+    /// size. Each audio codec carries its own RED payload type. The redundancy depth is set with
+    /// [`Self::set_red_distances`] (default one level, the previous frame), and wrapping can be
+    /// toggled at runtime on the send side without renegotiation via
     /// [`DirectApi::set_red_send`][crate::change::DirectApi::set_red_send].
-    pub fn enable_red(mut self, enabled: bool) -> Self {
-        self.codec_config.enable_red(enabled);
+    pub fn enable_opus(mut self, enabled: bool, use_red: bool) -> Self {
+        self.codec_config.enable_opus(enabled, use_red);
         self
     }
 
@@ -265,25 +253,27 @@ impl RtcConfig {
     ///
     /// The pattern is sanitised (zeros and values deeper than the recovery depth are dropped, then
     /// sorted and de-duped), falling back to `[1]` if empty. This only sets the pattern; enable RED
-    /// with [`Self::enable_red`] for it to take effect.
+    /// via the `use_red` argument of an audio codec (e.g. [`Self::enable_opus`]) for it to take effect.
     pub fn set_red_distances(mut self, distances: &[u32]) -> Self {
         self.codec_config.set_red_distances(distances);
         self
     }
 
-    /// Enable PCM μ-law audio codec.
+    /// Enable PCM μ-law audio codec, optionally with RFC 2198 RED (see [`Self::enable_opus`] for
+    /// `use_red`).
     ///
     /// This is 14-bit audio compressed to 8-bit as specified by G.711
-    pub fn enable_pcmu(mut self, enabled: bool) -> Self {
-        self.codec_config.enable_pcmu(enabled);
+    pub fn enable_pcmu(mut self, enabled: bool, use_red: bool) -> Self {
+        self.codec_config.enable_pcmu(enabled, use_red);
         self
     }
 
-    /// Enable PCM a-law audio codec.
+    /// Enable PCM a-law audio codec, optionally with RFC 2198 RED (see [`Self::enable_opus`] for
+    /// `use_red`).
     ///
     /// This is 13-bit audio compressed to 8-bit as specified by G.711
-    pub fn enable_pcma(mut self, enabled: bool) -> Self {
-        self.codec_config.enable_pcma(enabled);
+    pub fn enable_pcma(mut self, enabled: bool, use_red: bool) -> Self {
+        self.codec_config.enable_pcma(enabled, use_red);
         self
     }
 
@@ -294,8 +284,10 @@ impl RtcConfig {
     /// codec samples at 16 kHz. str0m treats G722 as a 16 kHz codec in the API and
     /// handles the 8 kHz RTP timestamp mapping internally. See
     /// <https://en.wikipedia.org/wiki/RTP_payload_formats#cite_note-55>
-    pub fn enable_g722(mut self, enabled: bool) -> Self {
-        self.codec_config.enable_g722(enabled);
+    ///
+    /// See [`Self::enable_opus`] for `use_red`.
+    pub fn enable_g722(mut self, enabled: bool, use_red: bool) -> Self {
+        self.codec_config.enable_g722(enabled, use_red);
         self
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -242,6 +242,35 @@ impl RtcConfig {
         self
     }
 
+    /// Enable RFC 2198 RED (redundant audio). Off by default. Requires an audio codec.
+    ///
+    /// RED carries redundant copies of earlier frames in each packet so the receiver can recover
+    /// packet losses without retransmission, at the cost of extra audio payload size. It applies to
+    /// every enabled audio codec (Opus, PCMU, PCMA, G722), each getting its own RED payload type.
+    ///
+    /// Call this after enabling audio codecs: RED folds onto the enabled audio payloads, so
+    /// enabling it while no audio codec is configured is a no-op (and is logged). The redundancy
+    /// depth is set with [`Self::set_red_distances`] (default one level, the previous frame), and
+    /// wrapping can be toggled at runtime on the send side without renegotiation via
+    /// [`SdpApi::set_red_send`][crate::change::SdpApi::set_red_send] /
+    /// [`DirectApi::set_red_send`][crate::change::DirectApi::set_red_send].
+    pub fn enable_red(mut self, enabled: bool) -> Self {
+        self.codec_config.enable_red(enabled);
+        self
+    }
+
+    /// Set the RFC 2198 RED send-side redundancy pattern: how many packets back each redundant
+    /// level carries. `[1]` (the default) sends one level, the previous frame, as browsers do;
+    /// `[1, 3, 5]` sends three levels for higher loss at the cost of more bandwidth.
+    ///
+    /// The pattern is sanitised (zeros and values deeper than the recovery depth are dropped, then
+    /// sorted and de-duped), falling back to `[1]` if empty. This only sets the pattern; enable RED
+    /// with [`Self::enable_red`] for it to take effect.
+    pub fn set_red_distances(mut self, distances: &[u32]) -> Self {
+        self.codec_config.set_red_distances(distances);
+        self
+    }
+
     /// Enable PCM μ-law audio codec.
     ///
     /// This is 14-bit audio compressed to 8-bit as specified by G.711

--- a/src/config.rs
+++ b/src/config.rs
@@ -252,7 +252,8 @@ impl RtcConfig {
     /// `[1, 3, 5]` sends three levels for higher loss at the cost of more bandwidth.
     ///
     /// The pattern is sanitised (zeros and values deeper than the recovery depth are dropped, then
-    /// sorted and de-duped), falling back to `[1]` if empty. This only sets the pattern; enable RED
+    /// sorted and de-duped) and always includes distance 1 as the recovery anchor (so `[2, 4]`
+    /// becomes `[1, 2, 4]`), falling back to `[1]` if empty. This only sets the pattern; enable RED
     /// via the `use_red` argument of an audio codec (e.g. [`Self::enable_opus`]) for it to take effect.
     pub fn set_red_distances(mut self, distances: &[u32]) -> Self {
         self.codec_config.set_red_distances(distances);

--- a/src/format/codec.rs
+++ b/src/format/codec.rs
@@ -46,6 +46,10 @@ pub enum Codec {
     /// in `a=rtpmap` lines.
     #[doc(hidden)]
     Rtx,
+    /// RFC 2198 redundant encoding (RED). Like `Rtx`, technically not a codec;
+    /// it appears in `a=rtpmap` lines and wraps a primary audio codec.
+    #[doc(hidden)]
+    Red,
     /// For RTP mode. No codec.
     #[doc(hidden)]
     Null,
@@ -93,6 +97,7 @@ impl<'a> From<&'a str> for Codec {
             "vp9" => Codec::Vp9,
             "av1" => Codec::Av1,
             "rtx" => Codec::Rtx, // resends
+            "red" => Codec::Red, // RFC 2198 redundancy
             _ => Codec::Unknown,
         }
     }
@@ -111,8 +116,22 @@ impl fmt::Display for Codec {
             Codec::Vp9 => write!(f, "VP9"),
             Codec::Av1 => write!(f, "AV1"),
             Codec::Rtx => write!(f, "rtx"),
+            Codec::Red => write!(f, "red"),
             Codec::Null => write!(f, "null"),
             Codec::Unknown => write!(f, "unknown"),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn red_codec_string_roundtrip() {
+        assert_eq!(Codec::from("red"), Codec::Red);
+        assert_eq!(Codec::Red.to_string(), "red");
+        assert!(!Codec::Red.is_audio());
+        assert!(!Codec::Red.is_video());
     }
 }

--- a/src/format/codec.rs
+++ b/src/format/codec.rs
@@ -70,6 +70,10 @@ pub enum Codec {
     /// in `a=rtpmap` lines.
     #[doc(hidden)]
     Rtx,
+    /// RFC 2198 redundant encoding (RED). Like `Rtx`, technically not a codec;
+    /// it appears in `a=rtpmap` lines and wraps a primary audio codec.
+    #[doc(hidden)]
+    Red,
     /// For RTP mode. No codec.
     #[doc(hidden)]
     Null,
@@ -119,6 +123,7 @@ impl<'a> From<&'a str> for Codec {
             "vp9" => Codec::Vp9,
             "av1" => Codec::Av1,
             "rtx" => Codec::Rtx, // resends
+            "red" => Codec::Red, // RFC 2198 redundancy
             _ => Codec::Unknown,
         }
     }
@@ -139,6 +144,7 @@ impl fmt::Display for Codec {
             Codec::Vp9 => write!(f, "VP9"),
             Codec::Av1 => write!(f, "AV1"),
             Codec::Rtx => write!(f, "rtx"),
+            Codec::Red => write!(f, "red"),
             Codec::Null => write!(f, "null"),
             Codec::Unknown => write!(f, "unknown"),
         }
@@ -207,5 +213,13 @@ mod test {
             format: FormatParams::default(),
         };
         assert_eq!(spec.rtp_clock_rate(), Frequency::FORTY_EIGHT_KHZ);
+    }
+
+    #[test]
+    fn red_codec_string_roundtrip() {
+        assert_eq!(Codec::from("red"), Codec::Red);
+        assert_eq!(Codec::Red.to_string(), "red");
+        assert!(!Codec::Red.is_audio());
+        assert!(!Codec::Red.is_video());
     }
 }

--- a/src/format/codec_config.rs
+++ b/src/format/codec_config.rs
@@ -49,6 +49,9 @@ pub(crate) const PT_H266_RTX: Pt = Pt::new_with_value(105);
 /// Default payload type for Opus.
 pub(crate) const PT_OPUS: Pt = Pt::new_with_value(111);
 
+/// Default payload type for RFC 2198 RED (redundant Opus).
+pub(crate) const PT_RED: Pt = Pt::new_with_value(63);
+
 /// Session config for all codecs.
 #[derive(Debug, Clone, Default)]
 pub struct CodecConfig {
@@ -119,6 +122,7 @@ impl CodecConfig {
                 format,
             },
             resend,
+            red: None,
             fb_transport_cc,
             fb_fir,
             fb_nack,
@@ -230,6 +234,21 @@ impl CodecConfig {
                 ..Default::default()
             },
         )
+    }
+
+    /// Enable RFC 2198 RED (redundant Opus) for the audio m-line. Off by default.
+    ///
+    /// RED roughly doubles audio payload size, so it is opt-in. This is a no-op when
+    /// Opus is not enabled.
+    pub fn enable_red(&mut self, enabled: bool) {
+        if enabled && !self.params.iter().any(|p| p.spec.codec == Codec::Opus) {
+            warn!("enable_red(true) ignored: Opus is not enabled");
+        }
+        for p in &mut self.params {
+            if p.spec.codec == Codec::Opus {
+                p.red = if enabled { Some(PT_RED) } else { None };
+            }
+        }
     }
 
     /// Add a default VP8 payload type.
@@ -444,6 +463,10 @@ impl CodecConfig {
             if let Some(rtx) = p.resend {
                 claimed.assert_claim_once(rtx);
             }
+
+            if let Some(red) = p.red {
+                claimed.assert_claim_once(red);
+            }
         }
 
         // Collect all currently unlocked PTs since we will need to avoid them when reassigning.
@@ -451,7 +474,7 @@ impl CodecConfig {
             .params
             .iter()
             .filter(|p| !p.locked)
-            .flat_map(|p| [Some(p.pt()), p.resend()])
+            .flat_map(|p| [Some(p.pt()), p.resend(), p.red()])
             .flatten()
             .collect::<HashSet<_>>();
 
@@ -489,6 +512,25 @@ impl CodecConfig {
 
                 claimed.assert_claim_once(pt);
                 unlocked.remove(&pt);
+            }
+
+            // RED rides its own PT (like RTX); reassign it if it now collides.
+            if let Some(red) = p.red {
+                if claimed.is_claimed(red) {
+                    match claimed.find_unclaimed(PREFERED_RANGES, &unlocked) {
+                        Some(new_red) => {
+                            debug!("Reassigned RED PT {:?} => {:?}", p.red, new_red);
+                            p.red = Some(new_red);
+                            claimed.assert_claim_once(new_red);
+                            unlocked.remove(&new_red);
+                        }
+                        // RED is opt-in; drop it rather than panic if no PT is free.
+                        None => {
+                            debug!("No free PT for RED; dropping it");
+                            p.red = None;
+                        }
+                    }
+                }
             }
 
             let Some(rtx) = p.resend else {
@@ -553,6 +595,62 @@ mod test {
 
     use super::*;
     use crate::format::{CodecSpec, FormatParams};
+
+    #[test]
+    fn enable_red_links_opus() {
+        let mut c = CodecConfig::empty();
+        c.enable_opus(true);
+        c.enable_red(true);
+        let opus = c
+            .params()
+            .iter()
+            .find(|p| p.spec().codec == Codec::Opus)
+            .unwrap();
+        assert_eq!(opus.red(), Some(PT_RED));
+    }
+
+    #[test]
+    fn red_kept_when_both_sides_enable() {
+        let mut local = CodecConfig::empty();
+        local.enable_opus(true);
+        local.enable_red(true);
+
+        let mut remote = CodecConfig::empty();
+        remote.enable_opus(true);
+        remote.enable_red(true);
+
+        local.update_params(remote.params(), Direction::SendRecv);
+
+        let opus = local
+            .params()
+            .iter()
+            .find(|p| p.spec().codec == Codec::Opus)
+            .unwrap();
+        assert_eq!(opus.red(), Some(PT_RED));
+    }
+
+    #[test]
+    fn red_dropped_when_remote_lacks_red() {
+        let mut local = CodecConfig::empty();
+        local.enable_opus(true);
+        local.enable_red(true);
+
+        let mut remote = CodecConfig::empty();
+        remote.enable_opus(true); // remote does not offer RED
+
+        local.update_params(remote.params(), Direction::SendRecv);
+
+        let opus = local
+            .params()
+            .iter()
+            .find(|p| p.spec().codec == Codec::Opus)
+            .unwrap();
+        assert_eq!(
+            opus.red(),
+            None,
+            "RED must be dropped when remote doesn't offer it"
+        );
+    }
 
     #[test]
     fn test_pt_conflict_different_directions() {

--- a/src/format/codec_config.rs
+++ b/src/format/codec_config.rs
@@ -684,6 +684,7 @@ impl CodecSpec {
 
 #[cfg(test)]
 mod test {
+    use crate::io::MultiplexKind;
     use crate::packet::MediaKind;
     use crate::rtp_::Direction;
     use crate::rtp_::Frequency;
@@ -709,6 +710,18 @@ mod test {
         }
 
         assert!(CodecSpec::from_static_pt(PT_OPUS).is_none());
+    }
+
+    #[test]
+    fn default_red_payload_types_are_demultiplexed_as_rtp() {
+        for pt in [PT_G722_RED, PT_PCMU_RED, PT_PCMA_RED] {
+            let packet = [0x80, *pt, 0];
+            assert_eq!(
+                MultiplexKind::try_from(packet.as_slice()).unwrap(),
+                MultiplexKind::Rtp,
+                "RED payload type {pt} must not be demultiplexed as RTCP"
+            );
+        }
     }
 
     #[test]
@@ -934,6 +947,31 @@ mod test {
             opus.red(),
             None,
             "RED must be dropped when remote doesn't offer it"
+        );
+    }
+
+    #[test]
+    fn conflicting_remote_red_mappings_do_not_panic() {
+        let shared_red_pt = Pt::new_with_value(63);
+
+        let mut local = CodecConfig::empty();
+        local.enable_g722(true, true);
+        local.enable_pcmu(true, true);
+
+        let mut remote = CodecConfig::empty();
+        remote.enable_g722(true, true);
+        remote.enable_pcmu(true, true);
+        for p in remote.params.iter_mut() {
+            p.red = Some(shared_red_pt);
+        }
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            local.update_params(remote.params(), Direction::SendRecv);
+        }));
+
+        assert!(
+            result.is_ok(),
+            "a conflicting remote RED mapping must be rejected or negotiated without panicking"
         );
     }
 

--- a/src/format/codec_config.rs
+++ b/src/format/codec_config.rs
@@ -59,11 +59,12 @@ pub(crate) const PT_OPUS: Pt = Pt::new_with_value(111);
 /// Default RFC 2198 RED payload types, one per audio codec. RED links a single primary codec
 /// via `a=fmtp` and carries that codec's clock rate in `a=rtpmap`, so each audio codec that has
 /// RED needs its own RED payload type. These are the defaults; they are reassigned on conflict
-/// during negotiation, mirroring RTX.
+/// during negotiation, mirroring RTX. They stay below 64 so they are never mistaken for RTCP by
+/// the RTP/RTCP demultiplexer (which reserves payload types 64..=95, see `MultiplexKind`).
 pub(crate) const PT_RED: Pt = Pt::new_with_value(63);
-pub(crate) const PT_G722_RED: Pt = Pt::new_with_value(64);
-pub(crate) const PT_PCMU_RED: Pt = Pt::new_with_value(65);
-pub(crate) const PT_PCMA_RED: Pt = Pt::new_with_value(66);
+pub(crate) const PT_G722_RED: Pt = Pt::new_with_value(62);
+pub(crate) const PT_PCMU_RED: Pt = Pt::new_with_value(61);
+pub(crate) const PT_PCMA_RED: Pt = Pt::new_with_value(60);
 
 /// Session config for all codecs.
 #[derive(Debug, Clone, Default)]
@@ -322,8 +323,11 @@ impl CodecConfig {
     /// levels for higher loss. Deeper redundancy trades bandwidth for resilience.
     ///
     /// The input is sanitised: zeros and values deeper than the receiver recovery depth are
-    /// dropped, then the rest is sorted and de-duplicated. An empty or fully invalid input falls
-    /// back to the default `[1]`. This only sets the pattern; RED still has to be enabled via the
+    /// dropped, then the rest is sorted and de-duplicated. Distance 1 is always included: recovery
+    /// derives each block's sequence distance from the closest redundant block, treating it as one
+    /// packet back, so a pattern must anchor on distance 1 or the receiver maps the blocks to the
+    /// wrong sequence numbers (a `[2, 4]` pattern becomes `[1, 2, 4]`). An empty or fully invalid
+    /// input falls back to `[1]`. This only sets the pattern; RED still has to be enabled via the
     /// `use_red` argument of an audio enable fn (e.g. [`Self::enable_opus`]) or negotiated.
     pub fn set_red_distances(&mut self, distances: &[u32]) {
         let mut sane: Vec<u32> = distances
@@ -333,6 +337,11 @@ impl CodecConfig {
             .collect();
         sane.sort_unstable();
         sane.dedup();
+        // Always anchor on distance 1 so the receiver can establish the packet duration from the
+        // closest block; without it a pattern like `[2, 4]` is silently mis-recovered.
+        if sane.first() != Some(&1) {
+            sane.insert(0, 1);
+        }
         self.red_distances = sane.into_boxed_slice();
     }
 
@@ -908,6 +917,13 @@ mod test {
         // Empty or fully invalid input falls back to the default single level.
         c.set_red_distances(&[0, 999]);
         assert_eq!(c.red_distances(), &[1]);
+
+        // Distance 1 is always included as the recovery anchor: a pattern without it (which the
+        // receiver would mis-map) gets 1 prepended rather than mis-recovered.
+        c.set_red_distances(&[2, 4]);
+        assert_eq!(c.red_distances(), &[1, 2, 4]);
+        c.set_red_distances(&[3, 5]);
+        assert_eq!(c.red_distances(), &[1, 3, 5]);
     }
 
     #[test]

--- a/src/format/codec_config.rs
+++ b/src/format/codec_config.rs
@@ -91,7 +91,7 @@ impl CodecConfig {
     /// Creates a new config with all default configurations enabled.
     pub fn new_with_defaults() -> Self {
         let mut c = Self::empty();
-        c.enable_opus(true);
+        c.enable_opus(true, false);
 
         c.enable_vp8(true);
         c.enable_h264(true);
@@ -139,12 +139,12 @@ impl CodecConfig {
                 format,
             },
             resend,
-            red: None,
             fb_transport_cc,
             fb_fir,
             fb_nack,
             fb_pli,
             fb_remb,
+            red: None,
             locked: false,
         };
 
@@ -213,22 +213,33 @@ impl CodecConfig {
         )
     }
 
-    /// Convenience for adding a PCM u-law payload type.
-    pub fn enable_pcmu(&mut self, enabled: bool) {
+    /// Convenience for adding a PCM u-law payload type, optionally with RFC 2198 RED.
+    ///
+    /// `use_red` folds a RED payload type onto this codec so the receiver can recover packet loss
+    /// without retransmission, at the cost of extra audio payload size.
+    pub fn enable_pcmu(&mut self, enabled: bool, use_red: bool) {
         self.params.retain(|c| c.spec.codec != Codec::PCMU);
         if !enabled {
             return;
         }
         self.add_static_config(PT_PCMU);
+        if use_red {
+            self.set_red_pt(Codec::PCMU, PT_PCMU_RED);
+        }
     }
 
-    /// Convenience for adding a PCM a-law payload type.
-    pub fn enable_pcma(&mut self, enabled: bool) {
+    /// Convenience for adding a PCM a-law payload type, optionally with RFC 2198 RED.
+    ///
+    /// See [`Self::enable_pcmu`] for `use_red`.
+    pub fn enable_pcma(&mut self, enabled: bool, use_red: bool) {
         self.params.retain(|c| c.spec.codec != Codec::PCMA);
         if !enabled {
             return;
         }
         self.add_static_config(PT_PCMA);
+        if use_red {
+            self.set_red_pt(Codec::PCMA, PT_PCMA_RED);
+        }
     }
 
     /// Convenience for adding a G722 payload type.
@@ -237,12 +248,17 @@ impl CodecConfig {
     /// 8000 Hz. The codec is configured at 16 kHz here; str0m maps to 8 kHz for the
     /// SDP `a=rtpmap` line and when converting to/from RTP timestamps. See
     /// <https://en.wikipedia.org/wiki/RTP_payload_formats#cite_note-55>
-    pub fn enable_g722(&mut self, enabled: bool) {
+    ///
+    /// See [`Self::enable_pcmu`] for `use_red`.
+    pub fn enable_g722(&mut self, enabled: bool, use_red: bool) {
         self.params.retain(|c| c.spec.codec != Codec::G722);
         if !enabled {
             return;
         }
         self.add_static_config(PT_G722);
+        if use_red {
+            self.set_red_pt(Codec::G722, PT_G722_RED);
+        }
     }
 
     /// Add the static Comfort Noise payload type at 8000 Hz.
@@ -257,8 +273,10 @@ impl CodecConfig {
         self.add_static_config(PT_COMFORT_NOISE);
     }
 
-    /// Add a default OPUS payload type.
-    pub fn enable_opus(&mut self, enabled: bool) {
+    /// Add a default OPUS payload type, optionally with RFC 2198 RED.
+    ///
+    /// See [`Self::enable_pcmu`] for `use_red`.
+    pub fn enable_opus(&mut self, enabled: bool, use_red: bool) {
         self.params.retain(|c| c.spec.codec != Codec::Opus);
         if !enabled {
             return;
@@ -274,27 +292,18 @@ impl CodecConfig {
                 use_inband_fec: Some(true),
                 ..Default::default()
             },
-        )
+        );
+        if use_red {
+            self.set_red_pt(Codec::Opus, PT_RED);
+        }
     }
 
-    /// Enable RFC 2198 RED (redundant audio) for the enabled audio codecs. Off by default.
-    ///
-    /// RED roughly doubles audio payload size, so it is opt-in. Applies to every enabled audio
-    /// codec (Opus, PCMU, PCMA, G722), each getting its own RED payload type. This is a no-op
-    /// when no audio codec is enabled.
-    pub fn enable_red(&mut self, enabled: bool) {
-        if enabled && !self.params.iter().any(|p| p.spec.codec.is_audio()) {
-            warn!("enable_red(true) ignored: no audio codec is enabled");
-        }
-        for p in &mut self.params {
-            let default_red_pt = match p.spec.codec {
-                Codec::Opus => Some(PT_RED),
-                Codec::G722 => Some(PT_G722_RED),
-                Codec::PCMU => Some(PT_PCMU_RED),
-                Codec::PCMA => Some(PT_PCMA_RED),
-                _ => None,
-            };
-            p.red = if enabled { default_red_pt } else { None };
+    /// Fold the given RFC 2198 RED payload type onto the enabled param for `codec`. Used by the
+    /// audio enable fns when `use_red` is set; each audio codec has its own RED payload type so the
+    /// `a=rtpmap` entries (which carry each codec's clock rate) don't collide in SDP.
+    fn set_red_pt(&mut self, codec: Codec, red_pt: Pt) {
+        if let Some(p) = self.params.iter_mut().find(|p| p.spec.codec == codec) {
+            p.red = Some(red_pt);
         }
     }
 
@@ -314,8 +323,8 @@ impl CodecConfig {
     ///
     /// The input is sanitised: zeros and values deeper than the receiver recovery depth are
     /// dropped, then the rest is sorted and de-duplicated. An empty or fully invalid input falls
-    /// back to the default `[1]`. This only sets the pattern; RED still has to be enabled with
-    /// [`Self::enable_red`] (or negotiated) for any redundancy to be sent.
+    /// back to the default `[1]`. This only sets the pattern; RED still has to be enabled via the
+    /// `use_red` argument of an audio enable fn (e.g. [`Self::enable_opus`]) or negotiated.
     pub fn set_red_distances(&mut self, distances: &[u32]) {
         let mut sane: Vec<u32> = distances
             .iter()
@@ -832,8 +841,7 @@ mod test {
     #[test]
     fn enable_red_links_opus() {
         let mut c = CodecConfig::empty();
-        c.enable_opus(true);
-        c.enable_red(true);
+        c.enable_opus(true, true);
         let opus = c
             .params()
             .iter()
@@ -845,11 +853,10 @@ mod test {
     #[test]
     fn enable_red_links_all_audio_codecs_with_distinct_pts() {
         let mut c = CodecConfig::empty();
-        c.enable_opus(true);
-        c.enable_g722(true);
-        c.enable_pcmu(true);
-        c.enable_pcma(true);
-        c.enable_red(true);
+        c.enable_opus(true, true);
+        c.enable_g722(true, true);
+        c.enable_pcmu(true, true);
+        c.enable_pcma(true, true);
 
         let params = c.params();
         let red_of = |codec| {
@@ -893,12 +900,10 @@ mod test {
     #[test]
     fn red_kept_when_both_sides_enable() {
         let mut local = CodecConfig::empty();
-        local.enable_opus(true);
-        local.enable_red(true);
+        local.enable_opus(true, true);
 
         let mut remote = CodecConfig::empty();
-        remote.enable_opus(true);
-        remote.enable_red(true);
+        remote.enable_opus(true, true);
 
         local.update_params(remote.params(), Direction::SendRecv);
 
@@ -913,11 +918,10 @@ mod test {
     #[test]
     fn red_dropped_when_remote_lacks_red() {
         let mut local = CodecConfig::empty();
-        local.enable_opus(true);
-        local.enable_red(true);
+        local.enable_opus(true, true);
 
         let mut remote = CodecConfig::empty();
-        remote.enable_opus(true); // remote does not offer RED
+        remote.enable_opus(true, false); // remote does not offer RED
 
         local.update_params(remote.params(), Direction::SendRecv);
 

--- a/src/format/codec_config.rs
+++ b/src/format/codec_config.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::ops::{Deref, DerefMut};
 
 use crate::packet::H266ProfileTierLevel;
+use crate::packet::MAX_RED_RECOVERY_DEPTH;
 use crate::packet::MediaKind;
 use crate::rtp_::Pt;
 use crate::rtp_::{Direction, Frequency};
@@ -55,10 +56,22 @@ pub(crate) const PT_H266_RTX: Pt = Pt::new_with_value(105);
 /// Default payload type for Opus.
 pub(crate) const PT_OPUS: Pt = Pt::new_with_value(111);
 
+/// Default RFC 2198 RED payload types, one per audio codec. RED links a single primary codec
+/// via `a=fmtp` and carries that codec's clock rate in `a=rtpmap`, so each audio codec that has
+/// RED needs its own RED payload type. These are the defaults; they are reassigned on conflict
+/// during negotiation, mirroring RTX.
+pub(crate) const PT_RED: Pt = Pt::new_with_value(63);
+pub(crate) const PT_G722_RED: Pt = Pt::new_with_value(64);
+pub(crate) const PT_PCMU_RED: Pt = Pt::new_with_value(65);
+pub(crate) const PT_PCMA_RED: Pt = Pt::new_with_value(66);
+
 /// Session config for all codecs.
 #[derive(Debug, Clone, Default)]
 pub struct CodecConfig {
     params: Vec<PayloadParams>,
+    /// RFC 2198 RED send-side redundancy pattern: how many packets back each redundant level
+    /// carries. Empty means the default single level `[1]` (see [`Self::red_distances`]).
+    red_distances: Box<[u32]>,
 }
 
 impl CodecConfig {
@@ -71,6 +84,7 @@ impl CodecConfig {
     pub fn new_from_payload_params(payload_params: Vec<PayloadParams>) -> Self {
         CodecConfig {
             params: payload_params,
+            ..Default::default()
         }
     }
 
@@ -125,6 +139,7 @@ impl CodecConfig {
                 format,
             },
             resend,
+            red: None,
             fb_transport_cc,
             fb_fir,
             fb_nack,
@@ -260,6 +275,56 @@ impl CodecConfig {
                 ..Default::default()
             },
         )
+    }
+
+    /// Enable RFC 2198 RED (redundant audio) for the enabled audio codecs. Off by default.
+    ///
+    /// RED roughly doubles audio payload size, so it is opt-in. Applies to every enabled audio
+    /// codec (Opus, PCMU, PCMA, G722), each getting its own RED payload type. This is a no-op
+    /// when no audio codec is enabled.
+    pub fn enable_red(&mut self, enabled: bool) {
+        if enabled && !self.params.iter().any(|p| p.spec.codec.is_audio()) {
+            warn!("enable_red(true) ignored: no audio codec is enabled");
+        }
+        for p in &mut self.params {
+            let default_red_pt = match p.spec.codec {
+                Codec::Opus => Some(PT_RED),
+                Codec::G722 => Some(PT_G722_RED),
+                Codec::PCMU => Some(PT_PCMU_RED),
+                Codec::PCMA => Some(PT_PCMA_RED),
+                _ => None,
+            };
+            p.red = if enabled { default_red_pt } else { None };
+        }
+    }
+
+    /// The RFC 2198 RED send-side redundancy pattern: how many packets back each redundant level
+    /// carries. Defaults to `[1]` (one level, the previous packet, as browsers send).
+    pub fn red_distances(&self) -> &[u32] {
+        if self.red_distances.is_empty() {
+            &[1]
+        } else {
+            &self.red_distances
+        }
+    }
+
+    /// Set the RFC 2198 RED send-side redundancy pattern. Each entry is how many packets back a
+    /// redundant level carries: `[1]` is one level (the previous packet), `[1, 3, 5]` sends three
+    /// levels for higher loss. Deeper redundancy trades bandwidth for resilience.
+    ///
+    /// The input is sanitised: zeros and values deeper than the receiver recovery depth are
+    /// dropped, then the rest is sorted and de-duplicated. An empty or fully invalid input falls
+    /// back to the default `[1]`. This only sets the pattern; RED still has to be enabled with
+    /// [`Self::enable_red`] (or negotiated) for any redundancy to be sent.
+    pub fn set_red_distances(&mut self, distances: &[u32]) {
+        let mut sane: Vec<u32> = distances
+            .iter()
+            .copied()
+            .filter(|&d| (1..=MAX_RED_RECOVERY_DEPTH as u32).contains(&d))
+            .collect();
+        sane.sort_unstable();
+        sane.dedup();
+        self.red_distances = sane.into_boxed_slice();
     }
 
     /// Add a default VP8 payload type.
@@ -474,6 +539,10 @@ impl CodecConfig {
             if let Some(rtx) = p.resend {
                 claimed.assert_claim_once(rtx);
             }
+
+            if let Some(red) = p.red {
+                claimed.assert_claim_once(red);
+            }
         }
 
         // Collect all currently unlocked PTs since we will need to avoid them when reassigning.
@@ -481,7 +550,7 @@ impl CodecConfig {
             .params
             .iter()
             .filter(|p| !p.locked)
-            .flat_map(|p| [Some(p.pt()), p.resend()])
+            .flat_map(|p| [Some(p.pt()), p.resend(), p.red()])
             .flatten()
             .collect::<HashSet<_>>();
 
@@ -519,6 +588,25 @@ impl CodecConfig {
 
                 claimed.assert_claim_once(pt);
                 unlocked.remove(&pt);
+            }
+
+            // RED rides its own PT (like RTX); reassign it if it now collides.
+            if let Some(red) = p.red {
+                if claimed.is_claimed(red) {
+                    match claimed.find_unclaimed(PREFERED_RANGES, &unlocked) {
+                        Some(new_red) => {
+                            debug!("Reassigned RED PT {:?} => {:?}", p.red, new_red);
+                            p.red = Some(new_red);
+                            claimed.assert_claim_once(new_red);
+                            unlocked.remove(&new_red);
+                        }
+                        // RED is opt-in; drop it rather than panic if no PT is free.
+                        None => {
+                            debug!("No free PT for RED; dropping it");
+                            p.red = None;
+                        }
+                    }
+                }
             }
 
             let Some(rtx) = p.resend else {
@@ -738,6 +826,110 @@ mod test {
         assert_eq!(
             configured,
             vec![(96, 16_000), (97, 24_000), (98, 32_000), (99, 48_000)]
+        );
+    }
+
+    #[test]
+    fn enable_red_links_opus() {
+        let mut c = CodecConfig::empty();
+        c.enable_opus(true);
+        c.enable_red(true);
+        let opus = c
+            .params()
+            .iter()
+            .find(|p| p.spec().codec == Codec::Opus)
+            .unwrap();
+        assert_eq!(opus.red(), Some(PT_RED));
+    }
+
+    #[test]
+    fn enable_red_links_all_audio_codecs_with_distinct_pts() {
+        let mut c = CodecConfig::empty();
+        c.enable_opus(true);
+        c.enable_g722(true);
+        c.enable_pcmu(true);
+        c.enable_pcma(true);
+        c.enable_red(true);
+
+        let params = c.params();
+        let red_of = |codec| {
+            params
+                .iter()
+                .find(|p| p.spec().codec == codec)
+                .unwrap()
+                .red()
+        };
+
+        // Every enabled audio codec gets RED, each with its own distinct payload type so the
+        // `a=rtpmap` entries (which each carry that codec's clock rate) don't collide in SDP.
+        assert_eq!(red_of(Codec::Opus), Some(PT_RED));
+        assert_eq!(red_of(Codec::G722), Some(PT_G722_RED));
+        assert_eq!(red_of(Codec::PCMU), Some(PT_PCMU_RED));
+        assert_eq!(red_of(Codec::PCMA), Some(PT_PCMA_RED));
+        // All four RED payload types are distinct.
+        let pts = [PT_RED, PT_G722_RED, PT_PCMU_RED, PT_PCMA_RED];
+        for (i, a) in pts.iter().enumerate() {
+            for b in &pts[i + 1..] {
+                assert_ne!(a, b, "RED payload types must be distinct");
+            }
+        }
+    }
+
+    #[test]
+    fn set_red_distances_sanitises_input() {
+        let mut c = CodecConfig::empty();
+        // Default is a single level, the previous packet.
+        assert_eq!(c.red_distances(), &[1]);
+
+        // Unsorted, duplicated, zero, and over-cap values are cleaned to a sorted distinct set.
+        c.set_red_distances(&[5, 1, 0, 3, 3, 1, 999]);
+        assert_eq!(c.red_distances(), &[1, 3, 5]);
+
+        // Empty or fully invalid input falls back to the default single level.
+        c.set_red_distances(&[0, 999]);
+        assert_eq!(c.red_distances(), &[1]);
+    }
+
+    #[test]
+    fn red_kept_when_both_sides_enable() {
+        let mut local = CodecConfig::empty();
+        local.enable_opus(true);
+        local.enable_red(true);
+
+        let mut remote = CodecConfig::empty();
+        remote.enable_opus(true);
+        remote.enable_red(true);
+
+        local.update_params(remote.params(), Direction::SendRecv);
+
+        let opus = local
+            .params()
+            .iter()
+            .find(|p| p.spec().codec == Codec::Opus)
+            .unwrap();
+        assert_eq!(opus.red(), Some(PT_RED));
+    }
+
+    #[test]
+    fn red_dropped_when_remote_lacks_red() {
+        let mut local = CodecConfig::empty();
+        local.enable_opus(true);
+        local.enable_red(true);
+
+        let mut remote = CodecConfig::empty();
+        remote.enable_opus(true); // remote does not offer RED
+
+        local.update_params(remote.params(), Direction::SendRecv);
+
+        let opus = local
+            .params()
+            .iter()
+            .find(|p| p.spec().codec == Codec::Opus)
+            .unwrap();
+        assert_eq!(
+            opus.red(),
+            None,
+            "RED must be dropped when remote doesn't offer it"
         );
     }
 

--- a/src/format/format_params.rs
+++ b/src/format/format_params.rs
@@ -157,6 +157,7 @@ impl FormatParams {
             H266ProfileTierLevel(v) => self.h266_profile_tier_level = Some(*v),
             SpropMaxDonDiff(v) => self.sprop_max_don_diff = Some(*v),
             Apt(_) => {}
+            Red(_) => {}
             Unknown => {}
         }
     }

--- a/src/format/payload_params.rs
+++ b/src/format/payload_params.rs
@@ -85,6 +85,10 @@ pub struct PayloadParams {
     /// This is used to, via PT, separate RTX resend streams from the main stream.
     pub(crate) resend: Option<Pt>,
 
+    /// The RFC 2198 RED payload type that wraps this primary codec, if negotiated.
+    /// Like `resend`, this links a secondary PT to this primary via SDP.
+    pub(crate) red: Option<Pt>,
+
     /// The codec with settings for this group of parameters.
     pub(crate) spec: CodecSpec,
 
@@ -116,6 +120,7 @@ impl PartialEq for PayloadParams {
     fn eq(&self, other: &Self) -> bool {
         self.pt == other.pt
             && self.resend == other.resend
+            && self.red == other.red
             && self.spec == other.spec
             && self.fb_transport_cc == other.fb_transport_cc
             && self.fb_nack == other.fb_nack
@@ -155,6 +160,7 @@ impl PayloadParams {
         PayloadParams {
             pt,
             resend,
+            red: None,
 
             spec,
 
@@ -183,6 +189,7 @@ impl PayloadParams {
         PayloadParams {
             pt,
             resend: None,
+            red: None,
             spec: CodecSpec {
                 codec: Codec::Null,
                 clock_rate: Frequency::NINETY_KHZ,
@@ -207,6 +214,11 @@ impl PayloadParams {
     /// This is used to, via PT, separate RTX resend streams from the main stream.
     pub fn resend(&self) -> Option<Pt> {
         self.resend
+    }
+
+    /// The RFC 2198 RED payload type wrapping this primary codec, if negotiated.
+    pub fn red(&self) -> Option<Pt> {
+        self.red
     }
 
     /// The codec with settings for this group of parameters.
@@ -688,6 +700,13 @@ impl PayloadParams {
                     self.resend, remote_rtx
                 );
             }
+
+            if self.red != first.red {
+                warn!(
+                    "Ignore remote PT RED change {:?} => {:?}",
+                    self.red, first.red
+                );
+            }
         } else {
             // Before locking, check if the remote PT conflicts with an already locked PT.
             // If we're receiving, we control what PTs to use,
@@ -738,6 +757,33 @@ impl PayloadParams {
                 claimed.assert_claim_once(rtx);
             }
 
+            // RED is opt-in on our side and Opus-only: keep it only if the matched remote also
+            // offers RED (`and`) and our codec is Opus (str0m supports RED only for Opus, like
+            // `enable_red`). Adopt the remote's RED PT, remapping on conflict when we control it.
+            let mut remote_red = self
+                .red
+                .and(first.red)
+                .filter(|_| self.spec.codec == Codec::Opus);
+            if local_is_controlling {
+                if let Some(red) = remote_red {
+                    if claimed.is_claimed(red) {
+                        if let Some(new_red) = claimed.find_unclaimed(PREFERED_RANGES, unlocked) {
+                            debug!("Remapped conflicting RED PT {:?} => {}", red, new_red);
+                            remote_red = Some(new_red);
+                            unlocked.remove(&new_red);
+                        } else {
+                            // RED is opt-in; drop it rather than panic if no PT is free.
+                            debug!("No free PT for RED; dropping it");
+                            remote_red = None;
+                        }
+                    }
+                }
+            }
+            self.red = remote_red;
+            if let Some(red) = remote_red {
+                claimed.assert_claim_once(red);
+            }
+
             // This is now locked.
             self.locked = true;
         }
@@ -750,6 +796,59 @@ mod test {
 
     use super::*;
     use crate::format::{CodecSpec, FormatParams};
+
+    #[test]
+    fn payload_params_red_defaults_none() {
+        let spec = CodecSpec {
+            codec: Codec::Opus,
+            clock_rate: Frequency::NINETY_KHZ,
+            channels: Some(2),
+            format: FormatParams::default(),
+        };
+        let p = PayloadParams::new(Pt::new_with_value(111), None, spec);
+        assert_eq!(p.red(), None);
+    }
+
+    #[test]
+    fn red_pt_remapped_on_conflict() {
+        use std::collections::HashSet;
+
+        // When we control PT allocation (the remote is send-only) and the RED PT we would adopt
+        // from the remote is already taken, RED is remapped to a free PT rather than colliding
+        // or being dropped.
+        let spec = CodecSpec {
+            codec: Codec::Opus,
+            clock_rate: Frequency::FORTY_EIGHT_KHZ,
+            channels: Some(2),
+            format: FormatParams::default(),
+        };
+
+        let red_pt = Pt::new_with_value(63);
+
+        let mut local = PayloadParams::new(Pt::new_with_value(111), None, spec);
+        local.red = Some(red_pt);
+
+        let mut remote = PayloadParams::new(Pt::new_with_value(111), None, spec);
+        remote.red = Some(red_pt);
+
+        // Pre-claim the RED PT as if another payload already holds it.
+        let mut claimed = [false; 128];
+        claimed[*red_pt as usize] = true;
+        let mut unlocked = HashSet::new();
+
+        // local_is_controlling = true: we allocate PTs and may remap the conflict.
+        local.update_param(&[remote], &mut claimed, true, &mut unlocked);
+
+        let got = local.red.expect("RED is kept, remapped to a free PT");
+        assert_ne!(
+            got, red_pt,
+            "RED PT must be remapped away from the conflict"
+        );
+        assert!(
+            claimed.is_claimed(got),
+            "the remapped RED PT must be claimed"
+        );
+    }
 
     mod h264 {
         use super::*;

--- a/src/format/payload_params.rs
+++ b/src/format/payload_params.rs
@@ -85,6 +85,10 @@ pub struct PayloadParams {
     /// This is used to, via PT, separate RTX resend streams from the main stream.
     pub(crate) resend: Option<Pt>,
 
+    /// The RFC 2198 RED payload type that wraps this primary codec, if negotiated.
+    /// Like `resend`, this links a secondary PT to this primary via SDP.
+    pub(crate) red: Option<Pt>,
+
     /// The codec with settings for this group of parameters.
     pub(crate) spec: CodecSpec,
 
@@ -116,6 +120,7 @@ impl PartialEq for PayloadParams {
     fn eq(&self, other: &Self) -> bool {
         self.pt == other.pt
             && self.resend == other.resend
+            && self.red == other.red
             && self.spec == other.spec
             && self.fb_transport_cc == other.fb_transport_cc
             && self.fb_nack == other.fb_nack
@@ -155,6 +160,7 @@ impl PayloadParams {
         PayloadParams {
             pt,
             resend,
+            red: None,
 
             spec,
 
@@ -183,6 +189,7 @@ impl PayloadParams {
         PayloadParams {
             pt,
             resend: None,
+            red: None,
             spec: CodecSpec {
                 codec: Codec::Null,
                 clock_rate: Frequency::NINETY_KHZ,
@@ -207,6 +214,11 @@ impl PayloadParams {
     /// This is used to, via PT, separate RTX resend streams from the main stream.
     pub fn resend(&self) -> Option<Pt> {
         self.resend
+    }
+
+    /// The RFC 2198 RED payload type wrapping this primary codec, if negotiated.
+    pub fn red(&self) -> Option<Pt> {
+        self.red
     }
 
     /// The codec with settings for this group of parameters.
@@ -696,6 +708,13 @@ impl PayloadParams {
                     self.resend, remote_rtx
                 );
             }
+
+            if self.red != first.red {
+                warn!(
+                    "Ignore remote PT RED change {:?} => {:?}",
+                    self.red, first.red
+                );
+            }
         } else {
             // Before locking, check if the remote PT conflicts with an already locked PT.
             // If we're receiving, we control what PTs to use,
@@ -748,6 +767,33 @@ impl PayloadParams {
                 claimed.assert_claim_once(rtx);
             }
 
+            // RED is opt-in on our side and audio-only: keep it only if the matched remote also
+            // offers RED (`and`) and our codec is an audio codec. Adopt the remote's RED PT,
+            // remapping on conflict when we control it.
+            let mut remote_red = self
+                .red
+                .and(first.red)
+                .filter(|_| self.spec.codec.is_audio());
+            if local_is_controlling {
+                if let Some(red) = remote_red {
+                    if claimed.is_claimed(red) {
+                        if let Some(new_red) = claimed.find_unclaimed(PREFERED_RANGES, unlocked) {
+                            debug!("Remapped conflicting RED PT {:?} => {}", red, new_red);
+                            remote_red = Some(new_red);
+                            unlocked.remove(&new_red);
+                        } else {
+                            // RED is opt-in; drop it rather than panic if no PT is free.
+                            debug!("No free PT for RED; dropping it");
+                            remote_red = None;
+                        }
+                    }
+                }
+            }
+            self.red = remote_red;
+            if let Some(red) = remote_red {
+                claimed.assert_claim_once(red);
+            }
+
             // This is now locked.
             self.locked = true;
         }
@@ -760,6 +806,59 @@ mod test {
 
     use super::*;
     use crate::format::{CodecSpec, FormatParams};
+
+    #[test]
+    fn payload_params_red_defaults_none() {
+        let spec = CodecSpec {
+            codec: Codec::Opus,
+            clock_rate: Frequency::NINETY_KHZ,
+            channels: Some(2),
+            format: FormatParams::default(),
+        };
+        let p = PayloadParams::new(Pt::new_with_value(111), None, spec);
+        assert_eq!(p.red(), None);
+    }
+
+    #[test]
+    fn red_pt_remapped_on_conflict() {
+        use std::collections::HashSet;
+
+        // When we control PT allocation (the remote is send-only) and the RED PT we would adopt
+        // from the remote is already taken, RED is remapped to a free PT rather than colliding
+        // or being dropped.
+        let spec = CodecSpec {
+            codec: Codec::Opus,
+            clock_rate: Frequency::FORTY_EIGHT_KHZ,
+            channels: Some(2),
+            format: FormatParams::default(),
+        };
+
+        let red_pt = Pt::new_with_value(63);
+
+        let mut local = PayloadParams::new(Pt::new_with_value(111), None, spec);
+        local.red = Some(red_pt);
+
+        let mut remote = PayloadParams::new(Pt::new_with_value(111), None, spec);
+        remote.red = Some(red_pt);
+
+        // Pre-claim the RED PT as if another payload already holds it.
+        let mut claimed = [false; 128];
+        claimed[*red_pt as usize] = true;
+        let mut unlocked = HashSet::new();
+
+        // local_is_controlling = true: we allocate PTs and may remap the conflict.
+        local.update_param(&[remote], &mut claimed, true, &mut unlocked);
+
+        let got = local.red.expect("RED is kept, remapped to a free PT");
+        assert_ne!(
+            got, red_pt,
+            "RED PT must be remapped away from the conflict"
+        );
+        assert!(
+            claimed.is_claimed(got),
+            "the remapped RED PT must be claimed"
+        );
+    }
 
     mod h264 {
         use super::*;

--- a/src/format/payload_params.rs
+++ b/src/format/payload_params.rs
@@ -85,10 +85,6 @@ pub struct PayloadParams {
     /// This is used to, via PT, separate RTX resend streams from the main stream.
     pub(crate) resend: Option<Pt>,
 
-    /// The RFC 2198 RED payload type that wraps this primary codec, if negotiated.
-    /// Like `resend`, this links a secondary PT to this primary via SDP.
-    pub(crate) red: Option<Pt>,
-
     /// The codec with settings for this group of parameters.
     pub(crate) spec: CodecSpec,
 
@@ -107,6 +103,10 @@ pub struct PayloadParams {
     /// Whether the payload uses the REMB (Receiver Estimated Maximum Bitrate) mechanic.
     pub(crate) fb_remb: bool,
 
+    /// The RFC 2198 RED payload type that wraps this primary codec, if negotiated.
+    /// Like `resend`, this links a secondary PT to this primary via SDP.
+    pub(crate) red: Option<Pt>,
+
     /// Whether the payload is locked by negotiation or can still be debated.
     ///
     /// If we make an OFFER or ANSWER and the direction is sendrecv/recvonly, the parameters are locked
@@ -120,13 +120,13 @@ impl PartialEq for PayloadParams {
     fn eq(&self, other: &Self) -> bool {
         self.pt == other.pt
             && self.resend == other.resend
-            && self.red == other.red
             && self.spec == other.spec
             && self.fb_transport_cc == other.fb_transport_cc
             && self.fb_nack == other.fb_nack
             && self.fb_pli == other.fb_pli
             && self.fb_fir == other.fb_fir
             && self.fb_remb == other.fb_remb
+            && self.red == other.red
     }
 }
 
@@ -160,7 +160,6 @@ impl PayloadParams {
         PayloadParams {
             pt,
             resend,
-            red: None,
 
             spec,
 
@@ -173,6 +172,7 @@ impl PayloadParams {
             fb_pli: is_video,
             fb_remb: is_video,
 
+            red: None,
             locked: false,
         }
     }
@@ -189,7 +189,6 @@ impl PayloadParams {
         PayloadParams {
             pt,
             resend: None,
-            red: None,
             spec: CodecSpec {
                 codec: Codec::Null,
                 clock_rate: Frequency::NINETY_KHZ,
@@ -201,6 +200,7 @@ impl PayloadParams {
             fb_pli: false,
             fb_fir: false,
             fb_remb: false,
+            red: None,
             locked: false,
         }
     }
@@ -214,11 +214,6 @@ impl PayloadParams {
     /// This is used to, via PT, separate RTX resend streams from the main stream.
     pub fn resend(&self) -> Option<Pt> {
         self.resend
-    }
-
-    /// The RFC 2198 RED payload type wrapping this primary codec, if negotiated.
-    pub fn red(&self) -> Option<Pt> {
-        self.red
     }
 
     /// The codec with settings for this group of parameters.
@@ -274,6 +269,11 @@ impl PayloadParams {
     /// Whether the payload uses the REMB (Receiver Estimated Maximum Bitrate) mechanic.
     pub fn fb_remb(&self) -> bool {
         self.fb_remb
+    }
+
+    /// The RFC 2198 RED payload type wrapping this primary codec, if negotiated.
+    pub fn red(&self) -> Option<Pt> {
+        self.red
     }
 
     pub(crate) fn match_score(&self, o: &PayloadParams) -> Option<usize> {

--- a/src/format/payload_params.rs
+++ b/src/format/payload_params.rs
@@ -768,15 +768,18 @@ impl PayloadParams {
             }
 
             // RED is opt-in on our side and audio-only: keep it only if the matched remote also
-            // offers RED (`and`) and our codec is an audio codec. Adopt the remote's RED PT,
-            // remapping on conflict when we control it.
+            // offers RED (`and`) and our codec is an audio codec. A RED PT can still collide (two
+            // codecs mapped to the same PT), so resolve any collision before claiming it. The
+            // collision check runs regardless of who controls PT allocation: only the resolution
+            // differs, and claiming the same PT twice would panic.
             let mut remote_red = self
                 .red
                 .and(first.red)
                 .filter(|_| self.spec.codec.is_audio());
-            if local_is_controlling {
-                if let Some(red) = remote_red {
-                    if claimed.is_claimed(red) {
+            if let Some(red) = remote_red {
+                if claimed.is_claimed(red) {
+                    if local_is_controlling {
+                        // We control PT allocation: remap the conflicting RED to a free PT.
                         if let Some(new_red) = claimed.find_unclaimed(PREFERED_RANGES, unlocked) {
                             debug!("Remapped conflicting RED PT {:?} => {}", red, new_red);
                             remote_red = Some(new_red);
@@ -786,6 +789,12 @@ impl PayloadParams {
                             debug!("No free PT for RED; dropping it");
                             remote_red = None;
                         }
+                    } else {
+                        // The remote dictated the PTs and mapped a RED PT that is already taken.
+                        // We can't reassign PTs the remote controls, and RED is opt-in, so drop it
+                        // rather than claim the same PT twice (which would panic).
+                        debug!("Conflicting remote RED PT {:?}; dropping it", red);
+                        remote_red = None;
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -783,7 +783,8 @@ pub mod rtp {
     pub use crate::rtp_::{Extension, ExtensionMap, ExtensionSerializer};
 
     pub use crate::packet::{
-        Vp8Descriptor, Vp8DescriptorError, Vp8Patch, Vp8PatchBuilder, Vp8PatchError,
+        RedBlock, RedDecoder, RedEncoder, RedundantBlock, Vp8Descriptor, Vp8DescriptorError,
+        Vp8Patch, Vp8PatchBuilder, Vp8PatchError,
     };
     pub use crate::rtp_::{RtpHeader, SeqNo, Ssrc, VideoOrientation};
     pub use crate::streams::{RtpPacket, RtpWrite, StreamPaused, StreamRx, StreamTx};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -783,7 +783,8 @@ pub mod rtp {
     pub use crate::rtp_::{Extension, ExtensionMap, ExtensionSerializer};
 
     pub use crate::packet::{
-        Vp8Descriptor, Vp8DescriptorError, Vp8Patch, Vp8PatchBuilder, Vp8PatchError,
+        RedBlock, RedDecoder, RedEncoder, RedundantBlock, Vp8Descriptor, Vp8DescriptorError,
+        Vp8Patch, Vp8PatchBuilder, Vp8PatchError,
     };
     pub use crate::rtp_::{RtpHeader, SeqNo, Ssrc, VideoOrientation};
     pub use crate::streams::{

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -442,11 +442,16 @@ impl Media {
         params: &[PayloadParams],
         vp9_mode: Vp9PacketizerMode,
     ) -> &mut Payloader {
-        self.payloaders.entry((pt, rid)).or_insert_with(|| {
+        let payloader = self.payloaders.entry((pt, rid)).or_insert_with(|| {
             // Unwrap is OK, the pt should be checked already when calling this function.
             let params = params.iter().find(|p| p.pt == pt).unwrap();
             Payloader::new(params.spec, vp9_mode)
-        })
+        });
+        // Keep the RED linkage current with the negotiated params so a remapped or dropped RED
+        // PT can't go stale in the cached payloader.
+        let red = params.iter().find(|p| p.pt == pt).and_then(|p| p.red);
+        payloader.set_red(red, pt);
+        payloader
     }
 
     fn set_to_payload(&mut self, to_payload: ToPayload) -> Result<(), RtcError> {

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -469,24 +469,12 @@ impl Media {
         rid: Option<Rid>,
         params: &[PayloadParams],
         vp9_mode: Vp9PacketizerMode,
-        red_distances: &[u32],
     ) -> &mut Payloader {
-        let payloader = self.payloaders.entry((pt, rid)).or_insert_with(|| {
+        self.payloaders.entry((pt, rid)).or_insert_with(|| {
             // Unwrap is OK, the pt should be checked already when calling this function.
             let params = params.iter().find(|p| p.pt == pt).unwrap();
             Payloader::new(params.spec, vp9_mode)
-        });
-        // Keep the RED linkage current with the negotiated params so a remapped or dropped RED
-        // PT can't go stale in the cached payloader. The runtime send toggle gates wrapping here:
-        // when RED sending is off we pass `None`, so packets go out as the plain codec PT even
-        // though RED stays negotiated on the m-line and can be turned back on with no renegotiation.
-        let red = if self.red_send_enabled {
-            params.iter().find(|p| p.pt == pt).and_then(|p| p.red)
-        } else {
-            None
-        };
-        payloader.set_red(red, pt, red_distances);
-        payloader
+        })
     }
 
     fn set_to_payload(&mut self, to_payload: ToPayload) -> Result<(), RtcError> {
@@ -533,7 +521,18 @@ impl Media {
 
         let pt = *pt;
 
-        let payloader = self.payloader_for(pt, *rid, params, vp9_mode, red_distances);
+        // Keep the RED linkage current with the negotiated params so a remapped or dropped RED PT
+        // can't go stale in the cached payloader. The runtime send toggle gates wrapping here: when
+        // RED sending is off we pass `None`, so packets go out as the plain codec PT even though RED
+        // stays negotiated on the m-line and can be turned back on with no renegotiation.
+        let red = if self.red_send_enabled {
+            params.iter().find(|p| p.pt == pt).and_then(|p| p.red)
+        } else {
+            None
+        };
+
+        let payloader = self.payloader_for(pt, *rid, params, vp9_mode);
+        payloader.set_red(red, pt, red_distances);
 
         let rtp_size: usize = mtu - SRTP_OVERHEAD;
         // align to SRTP block size to minimize padding needs

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -134,6 +134,11 @@ pub struct Media {
     /// Payloaders for outoing RTP packets.
     payloaders: HashMap<(Pt, Option<Rid>), Payloader>,
 
+    /// Whether outgoing packets are wrapped in RFC 2198 RED right now. RED availability is fixed at
+    /// negotiation (or set up via DirectAPI); this is the runtime send-side lever, toggled with no
+    /// renegotiation. Defaults to `true`, so a negotiated RED PT wraps unless it is turned off.
+    red_send_enabled: bool,
+
     /// Frames to payload. Should typically only be 0 or 1.
     to_payload: VecDeque<ToPayload>,
 
@@ -442,6 +447,17 @@ impl Media {
         self.dir = new_dir;
     }
 
+    /// Toggle RFC 2198 RED wrapping for outgoing packets. Takes effect on the next payloaded
+    /// packet; RED must be available (negotiated or set via DirectAPI) for `true` to wrap.
+    /// Returns whether the setting changed.
+    pub(crate) fn set_red_send(&mut self, enabled: bool) -> bool {
+        if self.red_send_enabled == enabled {
+            return false;
+        }
+        self.red_send_enabled = enabled;
+        true
+    }
+
     pub(crate) fn set_simulcast(&mut self, s: SdpSimulcast) {
         debug!("Set simulcast: {:?}", s);
         self.simulcast = Some(s);
@@ -453,12 +469,24 @@ impl Media {
         rid: Option<Rid>,
         params: &[PayloadParams],
         vp9_mode: Vp9PacketizerMode,
+        red_distances: &[u32],
     ) -> &mut Payloader {
-        self.payloaders.entry((pt, rid)).or_insert_with(|| {
+        let payloader = self.payloaders.entry((pt, rid)).or_insert_with(|| {
             // Unwrap is OK, the pt should be checked already when calling this function.
             let params = params.iter().find(|p| p.pt == pt).unwrap();
             Payloader::new(params.spec, vp9_mode)
-        })
+        });
+        // Keep the RED linkage current with the negotiated params so a remapped or dropped RED
+        // PT can't go stale in the cached payloader. The runtime send toggle gates wrapping here:
+        // when RED sending is off we pass `None`, so packets go out as the plain codec PT even
+        // though RED stays negotiated on the m-line and can be turned back on with no renegotiation.
+        let red = if self.red_send_enabled {
+            params.iter().find(|p| p.pt == pt).and_then(|p| p.red)
+        } else {
+            None
+        };
+        payloader.set_red(red, pt, red_distances);
+        payloader
     }
 
     fn set_to_payload(&mut self, to_payload: ToPayload) -> Result<(), RtcError> {
@@ -485,6 +513,7 @@ impl Media {
         params: &[PayloadParams],
         vp9_mode: Vp9PacketizerMode,
         mtu: usize,
+        red_distances: &[u32],
     ) -> Result<(), RtcError> {
         let Some(to_payload) = self.to_payload.pop_front() else {
             return Ok(());
@@ -504,7 +533,7 @@ impl Media {
 
         let pt = *pt;
 
-        let payloader = self.payloader_for(pt, *rid, params, vp9_mode);
+        let payloader = self.payloader_for(pt, *rid, params, vp9_mode, red_distances);
 
         let rtp_size: usize = mtu - SRTP_OVERHEAD;
         // align to SRTP block size to minimize padding needs
@@ -611,6 +640,7 @@ impl Default for Media {
             to_payload: VecDeque::default(),
             need_open_event: true,
             need_changed_event: false,
+            red_send_enabled: true,
         }
     }
 }

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -494,6 +494,22 @@ mod test {
     }
 
     #[test]
+    fn late_packet_in_front_of_waiting_frame() {
+        // Seq 3 is late. Seq 4 arrives first and waits for contiguity (it is depacketized ahead
+        // and cached). When 3 then arrives it is inserted in front of 4, and both must come out
+        // as themselves: 3 must not be emitted with 4's data.
+        test_n(
+            15,
+            &[
+                (1, 1, &[1, 1, 9], &[(1, &[1, 1, 9])]),
+                (2, 2, &[1, 2, 9], &[(2, &[1, 2, 9])]),
+                (4, 4, &[1, 4, 9], &[]),
+                (3, 3, &[1, 3, 9], &[(3, &[1, 3, 9]), (4, &[1, 4, 9])]),
+            ],
+        )
+    }
+
+    #[test]
     fn ext_vals_extracts_from_first_and_last_packet() {
         let first_time = Instant::now();
         let abs_capture_time = AbsCaptureTime {

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -210,6 +210,14 @@ impl DepacketizingBuffer {
                     tail,
                 };
                 self.queue.insert(i, entry);
+
+                // The depack cache is keyed by queue index. Inserting at or before the cached
+                // segment shifts it, so the cache would answer for the wrong packets.
+                if let Some((range, _)) = &self.depack_cache {
+                    if i <= range.end {
+                        self.depack_cache = None;
+                    }
+                }
             }
         }
     }

--- a/src/packet/error.rs
+++ b/src/packet/error.rs
@@ -18,6 +18,7 @@ pub enum PacketError {
     ErrVP8CorruptedPacket,
     ErrVP9CorruptedPacket,
     ErrAv1CorruptedPacket,
+    ErrRedCorruptedPacket,
 }
 
 impl fmt::Display for PacketError {
@@ -43,6 +44,7 @@ impl fmt::Display for PacketError {
             PacketError::ErrVP8CorruptedPacket => write!(f, "VP8 corrupted packet"),
             PacketError::ErrVP9CorruptedPacket => write!(f, "VP9 corrupted packet"),
             PacketError::ErrAv1CorruptedPacket => write!(f, "AV1 corrupted packet"),
+            PacketError::ErrRedCorruptedPacket => write!(f, "RED corrupted packet"),
         }
     }
 }

--- a/src/packet/error.rs
+++ b/src/packet/error.rs
@@ -19,6 +19,7 @@ pub enum PacketError {
     ErrVP8CorruptedPacket,
     ErrVP9CorruptedPacket,
     ErrAv1CorruptedPacket,
+    ErrRedCorruptedPacket,
 }
 
 impl fmt::Display for PacketError {
@@ -45,6 +46,7 @@ impl fmt::Display for PacketError {
             PacketError::ErrVP8CorruptedPacket => write!(f, "VP8 corrupted packet"),
             PacketError::ErrVP9CorruptedPacket => write!(f, "VP9 corrupted packet"),
             PacketError::ErrAv1CorruptedPacket => write!(f, "AV1 corrupted packet"),
+            PacketError::ErrRedCorruptedPacket => write!(f, "RED corrupted packet"),
         }
     }
 }

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -45,6 +45,10 @@ pub use h266_profile::{H266Level, H266Profile, H266ProfileTierLevel, H266Tier};
 mod opus;
 pub use opus::{OpusDepacketizer, OpusPacketizer};
 
+mod red;
+pub(crate) use red::red_recovery_blocks;
+pub use red::{RedBlock, RedDecoder, RedEncoder, RedundantBlock};
+
 mod vp8;
 pub use vp8::Vp8CodecExtra;
 pub use vp8::Vp8Descriptor;
@@ -320,6 +324,7 @@ impl CodecPacketizer {
             Codec::Av1 => CodecPacketizer::Av1(Av1Packetizer::default()),
             Codec::Null => CodecPacketizer::Null(NullPacketizer),
             Codec::Rtx => panic!("Cant instantiate packetizer for RTX codec"),
+            Codec::Red => panic!("Cant instantiate packetizer for RED codec"),
             Codec::Unknown => panic!("Cant instantiate packetizer for unknown codec"),
         }
     }
@@ -345,6 +350,7 @@ impl From<Codec> for CodecDepacketizer {
             Codec::Av1 => CodecDepacketizer::Av1(Av1Depacketizer::default()),
             Codec::Null => CodecDepacketizer::Null(NullDepacketizer),
             Codec::Rtx => panic!("Cant instantiate depacketizer for RTX codec"),
+            Codec::Red => panic!("Cant instantiate depacketizer for RED codec"),
             Codec::Unknown => panic!("Cant instantiate depacketizer for unknown codec"),
         }
     }

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -45,6 +45,10 @@ pub use h266_profile::{H266Level, H266Profile, H266ProfileTierLevel, H266Tier};
 mod opus;
 pub use opus::{OpusDepacketizer, OpusPacketizer};
 
+mod red;
+pub(crate) use red::{MAX_RED_RECOVERY_DEPTH, red_recovery_blocks};
+pub use red::{RedBlock, RedDecoder, RedEncoder, RedundantBlock};
+
 mod vp8;
 pub use vp8::Vp8CodecExtra;
 pub use vp8::Vp8Descriptor;
@@ -327,6 +331,7 @@ impl CodecPacketizer {
             Codec::Av1 => CodecPacketizer::Av1(Av1Packetizer::default()),
             Codec::Null => CodecPacketizer::Null(NullPacketizer),
             Codec::Rtx => panic!("Cant instantiate packetizer for RTX codec"),
+            Codec::Red => panic!("Cant instantiate packetizer for RED codec"),
             Codec::Unknown => panic!("Cant instantiate packetizer for unknown codec"),
         }
     }
@@ -354,6 +359,7 @@ impl From<Codec> for CodecDepacketizer {
             Codec::Av1 => CodecDepacketizer::Av1(Av1Depacketizer::default()),
             Codec::Null => CodecDepacketizer::Null(NullDepacketizer),
             Codec::Rtx => panic!("Cant instantiate depacketizer for RTX codec"),
+            Codec::Red => panic!("Cant instantiate depacketizer for RED codec"),
             Codec::Unknown => panic!("Cant instantiate depacketizer for unknown codec"),
         }
     }

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -46,7 +46,7 @@ mod opus;
 pub use opus::{OpusDepacketizer, OpusPacketizer};
 
 mod red;
-pub(crate) use red::{MAX_RED_RECOVERY_DEPTH, red_recovery_blocks};
+pub(crate) use red::{MAX_RED_RECOVERY_DEPTH, red_same_pt_blocks};
 pub use red::{RedBlock, RedDecoder, RedEncoder, RedundantBlock};
 
 mod vp8;

--- a/src/packet/payload.rs
+++ b/src/packet/payload.rs
@@ -2,16 +2,50 @@ use crate::format::CodecSpec;
 use crate::format::Vp9PacketizerMode;
 use crate::media::ToPayload;
 use crate::rtp::vla::VideoLayersAllocation;
-use crate::rtp_::Frequency;
+use crate::rtp_::{Frequency, Pt};
 use crate::streams::{RtpWrite, StreamTx};
 
 use super::PacketError;
-use super::{CodecPacketizer, Packetizer};
+use super::{CodecPacketizer, Packetizer, RedEncoder, RedundantBlock};
 
 #[derive(Debug)]
 pub struct Payloader {
     pack: CodecPacketizer,
     clock_rate: Frequency,
+    red: Option<RedState>,
+}
+
+/// Send-side RFC 2198 RED state: one level of redundancy carrying the previous payload.
+#[derive(Debug)]
+struct RedState {
+    red_pt: Pt,
+    primary_pt: Pt,
+    /// Previous packet's `(payload, rtp_time)`, used as the redundant block.
+    history: Option<(Vec<u8>, u32)>,
+}
+
+impl RedState {
+    /// Wrap the primary `payload` (at `rtp_time`) into a RED payload, prepending the previous
+    /// payload as one level of redundancy when it fits RFC 2198's field limits. Updates history.
+    fn wrap(&mut self, payload: Vec<u8>, rtp_time: u32) -> Vec<u8> {
+        let primary_pt = *self.primary_pt;
+        let redundant: Vec<RedundantBlock> = self
+            .history
+            .as_ref()
+            .and_then(|(prev, prev_time)| {
+                let block = RedundantBlock {
+                    pt: primary_pt,
+                    timestamp_offset: rtp_time.wrapping_sub(*prev_time),
+                    payload: prev.clone(),
+                };
+                block.fits().then_some(block)
+            })
+            .into_iter()
+            .collect();
+        let bytes = RedEncoder::encode(primary_pt, &payload, &redundant);
+        self.history = Some((payload, rtp_time));
+        bytes
+    }
 }
 
 impl Payloader {
@@ -35,6 +69,27 @@ impl Payloader {
         Payloader {
             pack,
             clock_rate: spec.clock_rate,
+            red: None,
+        }
+    }
+
+    /// Synchronise RED wrapping with the (possibly renegotiated) RED PT: enable it, update its
+    /// PT, or disable it, without discarding the codec packetizer or redundancy history. Called
+    /// on every payload so a remapped or dropped RED PT can't go stale in a cached payloader.
+    pub(crate) fn set_red(&mut self, red_pt: Option<Pt>, primary_pt: Pt) {
+        match (red_pt, &mut self.red) {
+            (Some(pt), Some(state)) => {
+                state.red_pt = pt;
+                state.primary_pt = primary_pt;
+            }
+            (Some(pt), None) => {
+                self.red = Some(RedState {
+                    red_pt: pt,
+                    primary_pt,
+                    history: None,
+                })
+            }
+            (None, _) => self.red = None,
         }
     }
 
@@ -84,20 +139,56 @@ impl Payloader {
                 pkt_ext_vals.video_timing = None;
             }
 
+            let rtp_time_u32 = rtp_time.rebase(self.clock_rate).numer() as u32;
+
+            // When RED is enabled, wrap the payload and swap to the RED PT. The primary
+            // stream's SSRC, sequence number and marker are preserved.
+            let (write_pt, write_payload) = match &mut self.red {
+                Some(red) => (red.red_pt, red.wrap(data, rtp_time_u32)),
+                None => (pt, data),
+            };
+
             stream.write_rtp(
-                RtpWrite::new(
-                    pt,
-                    seq_no,
-                    rtp_time.rebase(self.clock_rate).numer() as u32,
-                    wallclock,
-                    data,
-                )
-                .marker(marker)
-                .ext_vals(pkt_ext_vals)
-                .nackable(nackable),
+                RtpWrite::new(write_pt, seq_no, rtp_time_u32, wallclock, write_payload)
+                    .marker(marker)
+                    .ext_vals(pkt_ext_vals)
+                    .nackable(nackable),
             );
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::packet::RedDecoder;
+
+    #[test]
+    fn red_wrap_builds_redundancy_from_history() {
+        let mut red = RedState {
+            red_pt: Pt::new_with_value(63),
+            primary_pt: Pt::new_with_value(111),
+            history: None,
+        };
+
+        // First packet: primary-only RED (no history yet).
+        let first = red.wrap(vec![1, 2, 3], 1000);
+        let blocks = RedDecoder::decode(&first).unwrap();
+        assert_eq!(blocks.len(), 1);
+        assert!(blocks[0].is_primary);
+        assert_eq!(blocks[0].payload, &[1, 2, 3]);
+
+        // Second packet: carries the first frame as redundancy.
+        let second = red.wrap(vec![4, 5], 1960);
+        let blocks = RedDecoder::decode(&second).unwrap();
+        assert_eq!(blocks.len(), 2);
+        assert!(!blocks[0].is_primary);
+        assert_eq!(blocks[0].pt, 111);
+        assert_eq!(blocks[0].timestamp_offset, 960); // 1960 - 1000
+        assert_eq!(blocks[0].payload, &[1, 2, 3]);
+        assert!(blocks[1].is_primary);
+        assert_eq!(blocks[1].payload, &[4, 5]);
     }
 }

--- a/src/packet/payload.rs
+++ b/src/packet/payload.rs
@@ -1,18 +1,96 @@
+use std::collections::VecDeque;
+
 use crate::format::Vp9PacketizerMode;
 use crate::format::{Codec, CodecSpec};
 use crate::media::ToPayload;
 use crate::rtp::vla::VideoLayersAllocation;
-use crate::rtp_::Frequency;
+use crate::rtp_::{Frequency, Pt};
 use crate::streams::{RtpWrite, StreamTx};
 
 use super::PacketError;
-use super::{CodecPacketizer, Packetizer};
+use super::{CodecPacketizer, Packetizer, RedEncoder, RedundantBlock};
 
 #[derive(Debug)]
 pub struct Payloader {
     pack: CodecPacketizer,
     clock_rate: Frequency,
     allow_talkspurt_marker: bool,
+    red: Option<RedState>,
+}
+
+/// Send-side RFC 2198 RED state. `distances` lists how many packets back each redundant level
+/// carries (`[1]` = one level, the previous packet; `[1, 3, 5]` = three levels for higher loss),
+/// always sorted, distinct and >= 1. `history` keeps the most recent `max(distances)` payloads.
+#[derive(Debug)]
+struct RedState {
+    red_pt: Pt,
+    primary_pt: Pt,
+    distances: Box<[u32]>,
+    /// The most recent payloads as `(payload, rtp_time)`, oldest at the front, capped at the
+    /// deepest configured distance so it never grows without bound.
+    history: VecDeque<(Vec<u8>, u32)>,
+}
+
+impl RedState {
+    /// Wrap the primary `payload` (at `rtp_time`) into a RED payload, prepending one redundant
+    /// block per configured distance that has a matching history entry and fits RFC 2198's field
+    /// limits (a block over the 10-bit, 1023-byte length field does not fit and is dropped, so RED
+    /// adds no protection for audio frames that large). The most recent (shallowest, most valuable)
+    /// levels are added first and the deepest are dropped once the encoded packet would exceed
+    /// `budget` bytes. That size guard keeps the RED packet within the send MTU, which both avoids
+    /// IP fragmentation (a fragmented RED packet loses all its redundancy if any fragment drops) and
+    /// prevents overflowing the fixed datagram buffer downstream. Kept blocks are emitted
+    /// oldest-first as RFC 2198 requires, then the primary. Updates history.
+    fn wrap(&mut self, payload: Vec<u8>, rtp_time: u32, budget: usize) -> Vec<u8> {
+        let primary_pt = *self.primary_pt;
+        let len = self.history.len();
+
+        // Room for redundancy after the primary payload and its 1-byte RED header. `saturating_sub`
+        // gives 0 for a near-MTU primary, so we send it primary-only rather than overflow. RFC 2198
+        // headers: 1 byte for the primary block, 4 bytes for each redundant block.
+        let mut remaining = budget.saturating_sub(payload.len() + 1);
+
+        // Add the most recent levels first (distance 1 is the most valuable). Collected here
+        // shallowest-first, then reversed to oldest-first for the wire.
+        let mut kept: Vec<RedundantBlock> = Vec::new();
+        for &d in self.distances.iter() {
+            let Some((prev, prev_time)) = len
+                .checked_sub(d as usize)
+                .and_then(|i| self.history.get(i))
+            else {
+                continue;
+            };
+            let block = RedundantBlock {
+                pt: primary_pt,
+                timestamp_offset: rtp_time.wrapping_sub(*prev_time),
+                payload: prev.clone(),
+            };
+            // A distance whose offset or length overflows RFC 2198's fields is skipped, not sent
+            // malformed; the primary still goes out, so this only drops redundancy.
+            if !block.fits() {
+                continue;
+            }
+            let cost = 4 + block.payload.len();
+            if cost > remaining {
+                // Out of budget: stop so the kept (shallowest) levels stay contiguous. Redundancy
+                // never pushes the encoded RED past `budget`; only the 1-byte primary header can,
+                // and only for a primary that already fills the MTU — still far under the buffer.
+                break;
+            }
+            remaining -= cost;
+            kept.push(block);
+        }
+        // RFC 2198 requires redundant blocks oldest-first (largest distance first), then primary.
+        kept.reverse();
+
+        let bytes = RedEncoder::encode(primary_pt, &payload, &kept);
+        self.history.push_back((payload, rtp_time));
+        let max_distance = self.distances.last().copied().unwrap_or(1) as usize;
+        while self.history.len() > max_distance {
+            self.history.pop_front();
+        }
+        bytes
+    }
 }
 
 impl Payloader {
@@ -37,6 +115,38 @@ impl Payloader {
             pack,
             clock_rate: spec.rtp_clock_rate(),
             allow_talkspurt_marker: spec.codec != Codec::CN,
+            red: None,
+        }
+    }
+
+    /// Synchronise RED wrapping with the current RED PT and distance pattern: enable it, update
+    /// its PT/distances, or disable it, without discarding the codec packetizer. Called on every
+    /// payload so a remapped or dropped RED PT, a changed distance pattern, or a runtime on/off
+    /// toggle can't go stale in a cached payloader. `distances` must be sorted, distinct and >= 1.
+    pub(crate) fn set_red(&mut self, red_pt: Option<Pt>, primary_pt: Pt, distances: &[u32]) {
+        match (red_pt, &mut self.red) {
+            (Some(pt), Some(state)) => {
+                state.red_pt = pt;
+                state.primary_pt = primary_pt;
+                // Keep the redundancy history (a live talk-spurt) across a PT remap, but if the
+                // distance pattern changed, adopt it and trim history to the new deepest distance.
+                if *state.distances != *distances {
+                    state.distances = distances.into();
+                    let max_distance = distances.last().copied().unwrap_or(1) as usize;
+                    while state.history.len() > max_distance {
+                        state.history.pop_front();
+                    }
+                }
+            }
+            (Some(pt), None) => {
+                self.red = Some(RedState {
+                    red_pt: pt,
+                    primary_pt,
+                    distances: distances.into(),
+                    history: VecDeque::new(),
+                })
+            }
+            (None, _) => self.red = None,
         }
     }
 
@@ -86,20 +196,150 @@ impl Payloader {
                 pkt_ext_vals.video_timing = None;
             }
 
+            let rtp_time_u32 = rtp_time.rebase(self.clock_rate).numer() as u32;
+
+            // When RED is enabled, wrap the payload and swap to the RED PT. The primary
+            // stream's SSRC, sequence number and marker are preserved. `mtu` is the same
+            // aligned budget the chunk was packetized to, so RED redundancy is shed rather than
+            // pushing the packet over the MTU.
+            let (write_pt, write_payload) = match &mut self.red {
+                Some(red) => (red.red_pt, red.wrap(data, rtp_time_u32, mtu)),
+                None => (pt, data),
+            };
+
             stream.write_rtp(
-                RtpWrite::new(
-                    pt,
-                    seq_no,
-                    rtp_time.rebase(self.clock_rate).numer() as u32,
-                    wallclock,
-                    data,
-                )
-                .marker(marker)
-                .ext_vals(pkt_ext_vals)
-                .nackable(nackable),
+                RtpWrite::new(write_pt, seq_no, rtp_time_u32, wallclock, write_payload)
+                    .marker(marker)
+                    .ext_vals(pkt_ext_vals)
+                    .nackable(nackable),
             );
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::packet::RedDecoder;
+
+    // A budget large enough not to interfere with the small-payload tests below.
+    const BUDGET: usize = 1200;
+
+    fn red_state(distances: &[u32]) -> RedState {
+        RedState {
+            red_pt: Pt::new_with_value(63),
+            primary_pt: Pt::new_with_value(111),
+            distances: distances.into(),
+            history: VecDeque::new(),
+        }
+    }
+
+    #[test]
+    fn red_wrap_builds_redundancy_from_history() {
+        let mut red = red_state(&[1]);
+
+        // First packet: primary-only RED (no history yet).
+        let first = red.wrap(vec![1, 2, 3], 1000, BUDGET);
+        let blocks = RedDecoder::decode(&first).unwrap();
+        assert_eq!(blocks.len(), 1);
+        assert!(blocks[0].is_primary);
+        assert_eq!(blocks[0].payload, &[1, 2, 3]);
+
+        // Second packet: carries the first frame as redundancy.
+        let second = red.wrap(vec![4, 5], 1960, BUDGET);
+        let blocks = RedDecoder::decode(&second).unwrap();
+        assert_eq!(blocks.len(), 2);
+        assert!(!blocks[0].is_primary);
+        assert_eq!(blocks[0].pt, 111);
+        assert_eq!(blocks[0].timestamp_offset, 960); // 1960 - 1000
+        assert_eq!(blocks[0].payload, &[1, 2, 3]);
+        assert!(blocks[1].is_primary);
+        assert_eq!(blocks[1].payload, &[4, 5]);
+    }
+
+    #[test]
+    fn red_wrap_multi_distance_emits_levels_oldest_first() {
+        // A [1, 3] pattern: once enough history exists, each packet carries the previous frame
+        // (distance 1) and the frame three back (distance 3), emitted oldest-first before primary.
+        let mut red = red_state(&[1, 3]);
+
+        // Feed frames 0..=3 at 960-tick spacing. Only from the 4th packet is distance 3 available.
+        for i in 0..4u32 {
+            red.wrap(vec![i as u8], i * 960, BUDGET);
+        }
+        let fifth = red.wrap(vec![42], 4 * 960, BUDGET);
+        let blocks = RedDecoder::decode(&fifth).unwrap();
+
+        // Oldest-first: distance 3 (frame at 960), distance 1 (frame at 3*960), then primary.
+        assert_eq!(blocks.len(), 3);
+        assert!(!blocks[0].is_primary);
+        assert_eq!(blocks[0].timestamp_offset, 3 * 960); // 4*960 - 1*960
+        assert_eq!(blocks[0].payload, &[1]);
+        assert!(!blocks[1].is_primary);
+        assert_eq!(blocks[1].timestamp_offset, 960); // 4*960 - 3*960
+        assert_eq!(blocks[1].payload, &[3]);
+        assert!(blocks[2].is_primary);
+        assert_eq!(blocks[2].payload, &[42]);
+    }
+
+    #[test]
+    fn red_wrap_skips_redundancy_that_overflows_rfc_fields() {
+        // A distance whose timestamp offset exceeds RFC 2198's 14-bit field is dropped, not sent
+        // malformed; the primary and any in-range level still go out.
+        let mut red = red_state(&[1]);
+        red.wrap(vec![1], 0, BUDGET);
+        // Next frame is 0x4000 ticks later: offset 16384 overflows the 14-bit field, so no
+        // redundant block, just the primary.
+        let out = red.wrap(vec![2], 0x4000, BUDGET);
+        let blocks = RedDecoder::decode(&out).unwrap();
+        assert_eq!(blocks.len(), 1);
+        assert!(blocks[0].is_primary);
+    }
+
+    #[test]
+    fn red_wrap_sheds_deepest_redundancy_to_fit_budget() {
+        // Large frames whose redundancy cannot all fit the budget. Without this guard the encoded
+        // RED payload (primary + every redundant copy) overflows the fixed downstream datagram
+        // buffer and panics; with it, the deepest (oldest) levels are shed and the packet fits.
+        let mut red = red_state(&[1, 2]);
+        let budget = 300;
+        let frame = |b: u8| vec![b; 100];
+
+        red.wrap(frame(0xAA), 0, budget); // distance-2 source
+        red.wrap(frame(0xBB), 960, budget); // distance-1 source
+        let out = red.wrap(frame(0xCC), 1920, budget);
+
+        // Never exceeds the budget, which is the property that prevents the downstream overflow.
+        assert!(
+            out.len() <= budget,
+            "encoded RED {} > budget {budget}",
+            out.len()
+        );
+
+        let blocks = RedDecoder::decode(&out).unwrap();
+        // primary (0xCC) = 101 bytes; distance 1 (0xBB) = 104; together 205 <= 300, but adding
+        // distance 2 (0xAA, another 104) would be 309 > 300, so the deepest level is shed.
+        assert_eq!(blocks.len(), 2, "distance 2 shed to fit budget");
+        assert!(!blocks[0].is_primary);
+        assert_eq!(
+            blocks[0].payload,
+            &frame(0xBB)[..],
+            "kept the shallowest (distance 1)"
+        );
+        assert!(blocks[1].is_primary);
+        assert_eq!(blocks[1].payload, &frame(0xCC)[..]);
+
+        // With ample budget the same state keeps both levels, confirming the guard is what sheds.
+        let mut red = red_state(&[1, 2]);
+        red.wrap(frame(0xAA), 0, BUDGET);
+        red.wrap(frame(0xBB), 960, BUDGET);
+        let out = red.wrap(frame(0xCC), 1920, BUDGET);
+        assert_eq!(
+            RedDecoder::decode(&out).unwrap().len(),
+            3,
+            "all levels fit a large budget"
+        );
     }
 }

--- a/src/packet/payload.rs
+++ b/src/packet/payload.rs
@@ -45,10 +45,20 @@ impl RedState {
         let primary_pt = *self.primary_pt;
         let len = self.history.len();
 
-        // Room for redundancy after the primary payload and its 1-byte RED header. `saturating_sub`
-        // gives 0 for a near-MTU primary, so we send it primary-only rather than overflow. RFC 2198
-        // headers: 1 byte for the primary block, 4 bytes for each redundant block.
-        let mut remaining = budget.saturating_sub(payload.len() + 1);
+        // Even the mandatory 1-byte primary RED header must fit the budget. When it cannot (a
+        // primary that already fills the MTU), emit the payload unwrapped so RED never pushes the
+        // packet past `budget`. `push_sample` reserves this header byte when packetizing for RED,
+        // so in normal operation the primary always leaves room and this only guards a direct call
+        // or pathological input.
+        if payload.len() + 1 > budget {
+            self.history.push_back((payload.clone(), rtp_time));
+            self.trim_history();
+            return payload;
+        }
+
+        // Room for redundancy after the primary payload and its 1-byte RED header. The guard above
+        // makes the subtraction safe. RFC 2198 headers: 1 byte primary, 4 bytes per redundant block.
+        let mut remaining = budget - payload.len() - 1;
 
         // Add the most recent levels first (distance 1 is the most valuable). Collected here
         // shallowest-first, then reversed to oldest-first for the wire.
@@ -72,9 +82,9 @@ impl RedState {
             }
             let cost = 4 + block.payload.len();
             if cost > remaining {
-                // Out of budget: stop so the kept (shallowest) levels stay contiguous. Redundancy
-                // never pushes the encoded RED past `budget`; only the 1-byte primary header can,
-                // and only for a primary that already fills the MTU — still far under the buffer.
+                // Out of budget: stop so the kept (shallowest) levels stay contiguous. The primary
+                // and its header are already guaranteed to fit, so the encoded RED stays within
+                // `budget`.
                 break;
             }
             remaining -= cost;
@@ -85,11 +95,16 @@ impl RedState {
 
         let bytes = RedEncoder::encode(primary_pt, &payload, &kept);
         self.history.push_back((payload, rtp_time));
+        self.trim_history();
+        bytes
+    }
+
+    /// Cap history at the deepest configured distance so it never grows without bound.
+    fn trim_history(&mut self) {
         let max_distance = self.distances.last().copied().unwrap_or(1) as usize;
         while self.history.len() > max_distance {
             self.history.pop_front();
         }
-        bytes
     }
 }
 
@@ -167,7 +182,14 @@ impl Payloader {
             ..
         } = to_payload;
 
-        let chunks = self.pack.packetize(mtu, data.as_ref())?;
+        // When RED is on, reserve the 1-byte RED primary header so the wrapped packet still fits
+        // the MTU (the primary chunk plus that header must not exceed `mtu`).
+        let packetize_mtu = if self.red.is_some() {
+            mtu.saturating_sub(1)
+        } else {
+            mtu
+        };
+        let chunks = self.pack.packetize(packetize_mtu, data.as_ref())?;
         let len = chunks.len();
 
         for (idx, data) in chunks.into_iter().enumerate() {

--- a/src/packet/payload.rs
+++ b/src/packet/payload.rs
@@ -342,4 +342,18 @@ mod test {
             "all levels fit a large budget"
         );
     }
+
+    #[test]
+    fn red_primary_header_does_not_exceed_payload_budget() {
+        let mut red = red_state(&[1]);
+        let payload = vec![0xAA; BUDGET];
+
+        let out = red.wrap(payload, 960, BUDGET);
+
+        assert!(
+            out.len() <= BUDGET,
+            "RED payload is {} bytes for a {BUDGET}-byte budget",
+            out.len()
+        );
+    }
 }

--- a/src/packet/red.rs
+++ b/src/packet/red.rs
@@ -1,0 +1,330 @@
+//! RFC 2198 "RTP Payload for Redundant Audio Data" (RED) encode/decode.
+//!
+//! The RED structure is part of the RTP payload (so it is fully covered by SRTP): N redundant
+//! block headers (4 bytes each, F=1: 7-bit PT, 14-bit timestamp offset, 10-bit length), then the
+//! primary block header (1 byte, F=0: 7-bit PT), then all block payloads in the same order.
+
+use super::PacketError;
+
+const F_BIT: u8 = 0x80;
+
+/// Largest representable timestamp offset (14-bit field).
+const MAX_TS_OFFSET: u32 = 0x3fff;
+
+/// Largest representable redundant block length (10-bit field).
+const MAX_BLOCK_LEN: usize = 0x3ff;
+
+/// Maximum redundant blocks accepted in one RED payload. RFC 2198 sets no limit, but real
+/// Opus-RED senders use a single level of redundancy (str0m sends one; libwebrtc defaults to one
+/// and its receiver caps at 32). A 4-byte redundant header can otherwise pack hundreds of blocks
+/// into one datagram, so reject more than this to bound the parse work a malformed or hostile
+/// peer can trigger.
+const MAX_REDUNDANT_BLOCKS: usize = 32;
+
+/// How many levels of redundancy we recover from on receive. str0m sends one; this leaves a small
+/// margin for shallow multi-level senders while bounding the per-packet recovery work (decode +
+/// depayload) a hostile peer can trigger, independent of how many blocks the payload carries.
+const MAX_RED_RECOVERY_DEPTH: u64 = 2;
+
+/// A redundant block to prepend to the primary payload (older media).
+#[derive(Debug, Clone)]
+pub struct RedundantBlock {
+    /// Block payload type (7-bit).
+    pub pt: u8,
+    /// `primary_rtp_timestamp - block_timestamp`, 14-bit (max 16383).
+    pub timestamp_offset: u32,
+    /// Block payload bytes, 10-bit length (max 1023).
+    pub payload: Vec<u8>,
+}
+
+impl RedundantBlock {
+    /// Whether this block fits RFC 2198's 14-bit offset and 10-bit length fields.
+    pub fn fits(&self) -> bool {
+        self.timestamp_offset <= MAX_TS_OFFSET && self.payload.len() <= MAX_BLOCK_LEN
+    }
+}
+
+/// A block parsed out of a RED payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RedBlock<'a> {
+    /// Block payload type (7-bit).
+    pub pt: u8,
+    /// Timestamp offset from the primary (0 for the primary block).
+    pub timestamp_offset: u32,
+    /// Block payload bytes (no header).
+    pub payload: &'a [u8],
+    /// Whether this is the primary (final) block.
+    pub is_primary: bool,
+}
+
+/// Encoder for RFC 2198 RED payloads.
+pub struct RedEncoder;
+
+impl RedEncoder {
+    /// Encode a RED payload: redundant blocks (oldest first) followed by the primary block.
+    ///
+    /// Redundant blocks whose offset or length do not fit RFC 2198's 14-bit / 10-bit fields are
+    /// skipped (see [`RedundantBlock::fits`]) so the output is always a valid RED payload, never
+    /// silently truncated.
+    pub fn encode(primary_pt: u8, primary: &[u8], redundant: &[RedundantBlock]) -> Vec<u8> {
+        let blocks: Vec<&RedundantBlock> = redundant.iter().filter(|b| b.fits()).collect();
+
+        let mut out = Vec::with_capacity(primary.len() + blocks.len() * 4 + 1);
+
+        for b in &blocks {
+            // `fits()` guarantees ts <= 0x3fff and len <= 0x3ff, so no masking is needed.
+            let ts = b.timestamp_offset;
+            let len = b.payload.len() as u32;
+            out.push(F_BIT | (b.pt & 0x7f));
+            out.push((ts >> 6) as u8);
+            out.push((((ts & 0x3f) << 2) | (len >> 8)) as u8);
+            out.push((len & 0xff) as u8);
+        }
+
+        // Primary header, F=0.
+        out.push(primary_pt & 0x7f);
+
+        for b in &blocks {
+            out.extend_from_slice(&b.payload);
+        }
+        out.extend_from_slice(primary);
+
+        out
+    }
+}
+
+/// Decoder for RFC 2198 RED payloads.
+pub struct RedDecoder;
+
+impl RedDecoder {
+    /// Parse a RED payload into its blocks (redundant first, primary last).
+    ///
+    /// Never panics; returns `Err` on any malformed input. RED payloads come from untrusted
+    /// remote peers, so this strictly validates header chaining and block lengths.
+    pub fn decode(data: &[u8]) -> Result<Vec<RedBlock<'_>>, PacketError> {
+        struct Hdr {
+            pt: u8,
+            ts_offset: u32,
+            len: Option<usize>,
+        }
+
+        // Phase 1: parse headers up to and including the primary (F=0) header.
+        let mut hdrs: Vec<Hdr> = Vec::new();
+        let mut i = 0;
+        loop {
+            let first = *data.get(i).ok_or(PacketError::ErrRedCorruptedPacket)?;
+            if first & F_BIT == 0 {
+                hdrs.push(Hdr {
+                    pt: first & 0x7f,
+                    ts_offset: 0,
+                    len: None,
+                });
+                i += 1;
+                break;
+            }
+            // Bound the redundant blocks (untrusted input) before parsing/allocating more. At this
+            // point `hdrs` holds only redundant headers, since the primary (F=0) breaks the loop.
+            if hdrs.len() >= MAX_REDUNDANT_BLOCKS {
+                return Err(PacketError::ErrRedCorruptedPacket);
+            }
+            let h = data
+                .get(i..i + 4)
+                .ok_or(PacketError::ErrRedCorruptedPacket)?;
+            let ts_offset = ((h[1] as u32) << 6) | ((h[2] as u32) >> 2);
+            let len = (((h[2] as usize) & 0x03) << 8) | (h[3] as usize);
+            hdrs.push(Hdr {
+                pt: h[0] & 0x7f,
+                ts_offset,
+                len: Some(len),
+            });
+            i += 4;
+        }
+
+        // Phase 2: slice the payloads in the same order as the headers.
+        let mut out = Vec::with_capacity(hdrs.len());
+        for h in &hdrs {
+            match h.len {
+                Some(len) => {
+                    let payload = data
+                        .get(i..i + len)
+                        .ok_or(PacketError::ErrRedCorruptedPacket)?;
+                    out.push(RedBlock {
+                        pt: h.pt,
+                        timestamp_offset: h.ts_offset,
+                        payload,
+                        is_primary: false,
+                    });
+                    i += len;
+                }
+                None => {
+                    // Primary block takes the remaining bytes (may be empty).
+                    out.push(RedBlock {
+                        pt: h.pt,
+                        timestamp_offset: 0,
+                        payload: &data[i..],
+                        is_primary: true,
+                    });
+                }
+            }
+        }
+
+        Ok(out)
+    }
+}
+
+/// Select the redundant blocks to attempt recovery from, given the decoded redundant blocks
+/// (oldest first) and the primary payload type.
+///
+/// Returns `(distance_back, block)` pairs, where `distance_back` is how many sequence numbers
+/// before the primary the block sits (1 = the immediately preceding packet). Only the most-recent
+/// [`MAX_RED_RECOVERY_DEPTH`] blocks that carry `primary_pt` are returned: RFC 2198 allows a
+/// redundant block to use a different PT, and str0m only recovers the primary (Opus) codec, so
+/// blocks of another PT are skipped; bounding the depth caps the recovery work a hostile peer can
+/// trigger regardless of how many blocks the payload packs.
+pub(crate) fn red_recovery_blocks<'a>(
+    redundant: &'a [RedBlock<'a>],
+    primary_pt: u8,
+) -> Vec<(u64, &'a RedBlock<'a>)> {
+    let n = redundant.len() as u64;
+    redundant
+        .iter()
+        .enumerate()
+        .map(|(i, b)| (n - i as u64, b))
+        .filter(|(back, b)| *back <= MAX_RED_RECOVERY_DEPTH && b.pt == primary_pt)
+        .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn primary_only_roundtrip() {
+        let bytes = RedEncoder::encode(96, &[1, 2, 3], &[]);
+        assert_eq!(bytes, vec![96, 1, 2, 3]);
+
+        let blocks = RedDecoder::decode(&bytes).unwrap();
+        assert_eq!(blocks.len(), 1);
+        assert!(blocks[0].is_primary);
+        assert_eq!(blocks[0].pt, 96);
+        assert_eq!(blocks[0].timestamp_offset, 0);
+        assert_eq!(blocks[0].payload, &[1, 2, 3]);
+    }
+
+    #[test]
+    fn one_redundant_block_roundtrip() {
+        let red = [RedundantBlock {
+            pt: 96,
+            timestamp_offset: 960,
+            payload: vec![9, 9],
+        }];
+        let bytes = RedEncoder::encode(96, &[1, 2, 3], &red);
+
+        // Redundant header for ts_offset=960, len=2: F|pt=0xE0; 960>>6=15, low-6 ts bits and the
+        // 2 high len bits are 0, len low byte = 2.
+        assert_eq!(&bytes[..4], &[0xE0, 15, 0, 2]);
+        assert_eq!(bytes[4], 96); // primary header, F=0
+        assert_eq!(&bytes[5..], &[9, 9, 1, 2, 3]); // redundant payload then primary
+
+        let blocks = RedDecoder::decode(&bytes).unwrap();
+        assert_eq!(blocks.len(), 2);
+        assert!(!blocks[0].is_primary);
+        assert_eq!(blocks[0].timestamp_offset, 960);
+        assert_eq!(blocks[0].payload, &[9, 9]);
+        assert!(blocks[1].is_primary);
+        assert_eq!(blocks[1].payload, &[1, 2, 3]);
+    }
+
+    #[test]
+    fn encode_skips_oversized_blocks() {
+        // A block whose offset (>14 bits) or length (>10 bits) does not fit is dropped, so the
+        // wire payload is never silently corrupted — even in release builds.
+        let bad_offset = RedundantBlock {
+            pt: 96,
+            timestamp_offset: 0x4000, // > 0x3fff
+            payload: vec![1, 2],
+        };
+        let bad_len = RedundantBlock {
+            pt: 96,
+            timestamp_offset: 100,
+            payload: vec![0u8; 2000], // > 0x3ff
+        };
+        let bytes = RedEncoder::encode(96, &[7, 7], &[bad_offset, bad_len]);
+
+        let blocks = RedDecoder::decode(&bytes).unwrap();
+        assert_eq!(blocks.len(), 1, "oversized blocks must be skipped");
+        assert!(blocks[0].is_primary);
+        assert_eq!(blocks[0].payload, &[7, 7]);
+    }
+
+    #[test]
+    fn truncated_header_is_error_not_panic() {
+        assert!(RedDecoder::decode(&[0x80, 0x00]).is_err()); // F=1 but < 4 header bytes
+        assert!(RedDecoder::decode(&[]).is_err()); // empty
+    }
+
+    #[test]
+    fn block_length_past_end_is_error() {
+        // redundant header claims len=200 (len hi byte 0, lo byte 200) but no payload follows
+        let b = [0x80 | 96, 0, 0, 200, 96];
+        assert!(RedDecoder::decode(&b).is_err());
+    }
+
+    #[test]
+    fn never_panics_on_arbitrary_input() {
+        // Exhaustively poke short inputs; the decoder must only ever return Ok/Err.
+        for a in 0u16..=255 {
+            for b in 0u16..=255 {
+                let _ = RedDecoder::decode(&[a as u8, b as u8]);
+            }
+        }
+    }
+
+    #[test]
+    fn decode_rejects_too_many_redundant_blocks() {
+        // One 4-byte redundant header per block lets a single datagram pack hundreds of blocks.
+        // The decoder must bound this so a hostile peer can't expand one packet into an unbounded
+        // number of recovered packets. `n` zero-length redundant blocks, then an empty primary.
+        fn red_with_redundant_blocks(n: usize) -> Vec<u8> {
+            let mut data = Vec::with_capacity(n * 4 + 1);
+            for _ in 0..n {
+                data.extend_from_slice(&[F_BIT | 96, 0, 0, 0]); // F=1, pt=96, ts=0, len=0
+            }
+            data.push(96); // primary header, F=0
+            data
+        }
+
+        // At the limit: MAX redundant + 1 primary still decodes.
+        let ok = red_with_redundant_blocks(MAX_REDUNDANT_BLOCKS);
+        let blocks = RedDecoder::decode(&ok).expect("max redundant blocks is allowed");
+        assert_eq!(blocks.len(), MAX_REDUNDANT_BLOCKS + 1);
+
+        // One over the limit, and a pathological count, are rejected (not decoded).
+        assert!(RedDecoder::decode(&red_with_redundant_blocks(MAX_REDUNDANT_BLOCKS + 1)).is_err());
+        assert!(RedDecoder::decode(&red_with_redundant_blocks(360)).is_err());
+    }
+
+    #[test]
+    fn recovery_blocks_caps_depth_and_filters_pt() {
+        // Oldest-first redundant blocks; primary PT is 111. Index 1 carries a different PT and
+        // must be skipped; only the most-recent MAX_RED_RECOVERY_DEPTH same-PT blocks are kept,
+        // each with the correct distance-back (1 = immediately preceding packet).
+        let block = |pt| RedBlock {
+            pt,
+            timestamp_offset: 0,
+            payload: &[0u8],
+            is_primary: false,
+        };
+        let redundant = vec![block(111), block(96), block(111), block(111), block(111)];
+
+        let got = red_recovery_blocks(&redundant, 111);
+
+        let backs: Vec<u64> = got.iter().map(|(back, _)| *back).collect();
+        assert_eq!(backs, vec![2, 1], "only the two most-recent same-PT blocks");
+        assert!(got.iter().all(|(_, b)| b.pt == 111));
+
+        // A block list whose recent blocks are all a foreign PT yields nothing to recover.
+        let foreign = vec![block(111), block(96), block(96)];
+        assert!(red_recovery_blocks(&foreign, 111).is_empty());
+    }
+}

--- a/src/packet/red.rs
+++ b/src/packet/red.rs
@@ -23,8 +23,8 @@ const MAX_REDUNDANT_BLOCKS: usize = 32;
 
 /// How many packets back we recover from on receive, and the deepest distance a sender may be
 /// configured to send (see `CodecConfig::set_red_distances`). This covers realistic multi-level
-/// patterns such as `[1, 3, 5]` while bounding the per-packet recovery work (decode + depayload) a
-/// hostile peer can trigger, independent of how many blocks the payload carries.
+/// patterns such as `[1, 3, 5]` while bounding the per-packet recovery work (decode + depayload +
+/// seq lookup) a hostile peer can trigger, independent of how many blocks the payload carries.
 pub(crate) const MAX_RED_RECOVERY_DEPTH: u64 = 8;
 
 /// A redundant block to prepend to the primary payload (older media).
@@ -181,54 +181,19 @@ impl RedDecoder {
     }
 }
 
-/// Select the redundant blocks to attempt recovery from, given the decoded redundant blocks
-/// (oldest first) and the primary payload type.
+/// The redundant blocks that carry `primary_pt` and sit strictly before the primary.
 ///
-/// Returns `(distance_back, block)` pairs, where `distance_back` is how many sequence numbers
-/// before the primary the block sits (1 = the immediately preceding packet). Only the most-recent
-/// [`MAX_RED_RECOVERY_DEPTH`] blocks that carry `primary_pt` are returned: RFC 2198 allows a
-/// redundant block to use a different PT, and str0m only recovers the primary (Opus) codec, so
-/// blocks of another PT are skipped; bounding the depth caps the recovery work a hostile peer can
-/// trigger regardless of how many blocks the payload packs.
-pub(crate) fn red_recovery_blocks<'a>(
+/// RFC 2198 allows a redundant block to use a different PT than the primary; str0m only
+/// recovers the negotiated codec, so blocks of another PT are skipped. Which sequence number a
+/// block belongs to is decided by the receiving stream (it needs the surrounding received
+/// packets, see `StreamRx::red_locate_seq`), not from the offsets alone.
+pub(crate) fn red_same_pt_blocks<'a>(
     redundant: &'a [RedBlock<'a>],
     primary_pt: u8,
-) -> Vec<(u64, &'a RedBlock<'a>)> {
-    // A redundant block carries only a timestamp offset, not a sequence number, so how many
-    // packets back it sits is derived from the offset: `distance = offset / frame`, where `frame`
-    // is the RTP ticks per packet. That frame size is not reliably signalled (Opus `minptime` is a
-    // minimum, not the actual value), so we estimate it from the closest same-PT block, which is
-    // one packet back for every real sender (browsers and str0m both include main-1). The estimate
-    // is only trustworthy if every same-PT offset is an exact multiple of it; otherwise the packet
-    // duration cannot be established from offsets alone and we recover nothing. This keeps recovery
-    // best effort and never fabricates a packet at the wrong seq.
-    let same_pt = |b: &&RedBlock<'_>| b.pt == primary_pt && b.timestamp_offset > 0;
-    let Some(frame) = redundant
-        .iter()
-        .filter(same_pt)
-        .map(|b| b.timestamp_offset)
-        .min()
-    else {
-        return Vec::new();
-    };
-    // If any same-PT offset is not a multiple of the smallest one, the smallest is not reliably
-    // distance 1 (e.g. a [3, 5] pattern with no main-1 block), so recover nothing rather than map
-    // it to distance 1 and inject a frame at the wrong sequence number.
-    if redundant
-        .iter()
-        .filter(same_pt)
-        .any(|b| b.timestamp_offset % frame != 0)
-    {
-        return Vec::new();
-    }
+) -> impl Iterator<Item = &'a RedBlock<'a>> {
     redundant
         .iter()
-        .filter(same_pt)
-        .filter_map(|b| {
-            let back = (b.timestamp_offset / frame) as u64;
-            (back <= MAX_RED_RECOVERY_DEPTH).then_some((back, b))
-        })
-        .collect()
+        .filter(move |b| b.pt == primary_pt && b.timestamp_offset > 0)
 }
 
 #[cfg(test)]
@@ -342,6 +307,26 @@ mod test {
     }
 
     #[test]
+    fn same_pt_blocks_skip_foreign_pt_and_primary_offset() {
+        let block = |pt, ts| RedBlock {
+            pt,
+            timestamp_offset: ts,
+            payload: &[0u8],
+            is_primary: false,
+        };
+        let redundant = vec![
+            block(111, 1920),
+            block(96, 960),
+            block(111, 0),
+            block(111, 960),
+        ];
+        let offsets: Vec<u32> = red_same_pt_blocks(&redundant, 111)
+            .map(|b| b.timestamp_offset)
+            .collect();
+        assert_eq!(offsets, vec![1920, 960]);
+    }
+
+    #[test]
     fn public_encoder_output_is_accepted_by_public_decoder() {
         let redundant: Vec<_> = (0..33)
             .map(|i| RedundantBlock {
@@ -355,83 +340,6 @@ mod test {
         assert!(
             RedDecoder::decode(&encoded).is_ok(),
             "the public decoder must accept packets produced by the public encoder"
-        );
-    }
-
-    #[test]
-    fn recovery_blocks_derive_distance_from_offset_and_cap_depth() {
-        // Oldest-first, frame = 960 (Opus 20 ms @ 48 kHz), so the closest same-PT block (offset
-        // 960) is one packet back. Index 1 carries a different PT and must be skipped. Distance is
-        // derived from the offset, and only same-PT blocks within MAX_RED_RECOVERY_DEPTH are kept.
-        let block = |pt, ts| RedBlock {
-            pt,
-            timestamp_offset: ts,
-            payload: &[0u8],
-            is_primary: false,
-        };
-        // oldest-first: distance 9 (over cap), foreign PT, distance 8, distance 1.
-        let redundant = vec![
-            block(111, 960 * 9),
-            block(96, 960 * 7),
-            block(111, 960 * 8),
-            block(111, 960),
-        ];
-
-        let got = red_recovery_blocks(&redundant, 111);
-        let backs: Vec<u64> = got.iter().map(|(back, _)| *back).collect();
-        // Distances 1 and 8 are within depth; distance 9 is capped out, the foreign PT is skipped.
-        assert_eq!(backs, vec![8, 1]);
-        assert!(got.iter().all(|(_, b)| b.pt == 111));
-
-        // A block list whose only same-PT block is the primary (offset 0) yields nothing.
-        let foreign = vec![block(111, 0), block(96, 960), block(96, 1920)];
-        assert!(red_recovery_blocks(&foreign, 111).is_empty());
-    }
-
-    #[test]
-    fn recovery_blocks_handle_non_contiguous_offsets() {
-        // A non-contiguous [1,3,5] pattern: frame = 960 (the closest block), so distances 1, 3, 5
-        // are derived from the offsets. All are within MAX_RED_RECOVERY_DEPTH and each maps to its
-        // true distance from the offset, never to a wrong seq the way a positional index would.
-        let block = |ts| RedBlock {
-            pt: 111,
-            timestamp_offset: ts,
-            payload: &[0u8],
-            is_primary: false,
-        };
-        let redundant = vec![block(4800), block(2880), block(960)]; // main-5, main-3, main-1
-        let backs: Vec<u64> = red_recovery_blocks(&redundant, 111)
-            .iter()
-            .map(|(b, _)| *b)
-            .collect();
-        assert_eq!(
-            backs,
-            vec![5, 3, 1],
-            "distances derived from offsets, never mis-mapped"
-        );
-
-        // If any offset is not a clean multiple of the smallest, the packet duration can't be
-        // established, so the whole set is skipped rather than mis-mapped.
-        let irregular = vec![block(960), block(1441)];
-        assert!(red_recovery_blocks(&irregular, 111).is_empty());
-    }
-
-    #[test]
-    fn recovery_blocks_without_main_minus_one_do_not_fabricate_sequence_numbers() {
-        let block = |ts| RedBlock {
-            pt: 111,
-            timestamp_offset: ts,
-            payload: &[0u8],
-            is_primary: false,
-        };
-
-        // The public send configuration permits [3, 5]. Without a main-1 block, the receiver
-        // cannot infer the duration of one packet from timestamp offsets alone. Treating the
-        // smallest offset as one packet would inject main-3 at sequence main-1.
-        let redundant = vec![block(4800), block(2880)];
-        assert!(
-            red_recovery_blocks(&redundant, 111).is_empty(),
-            "recovery must skip blocks when their sequence distance cannot be established"
         );
     }
 }

--- a/src/packet/red.rs
+++ b/src/packet/red.rs
@@ -68,7 +68,15 @@ impl RedEncoder {
     /// skipped (see [`RedundantBlock::fits`]) so the output is always a valid RED payload, never
     /// silently truncated.
     pub fn encode(primary_pt: u8, primary: &[u8], redundant: &[RedundantBlock]) -> Vec<u8> {
-        let blocks: Vec<&RedundantBlock> = redundant.iter().filter(|b| b.fits()).collect();
+        // Cap at the decoder's bound so encoder output always round-trips: `RedDecoder::decode`
+        // rejects more than `MAX_REDUNDANT_BLOCKS` redundant blocks as a DoS guard. The internal
+        // sender never approaches this (at most `MAX_RED_RECOVERY_DEPTH` levels), so this only
+        // clamps public-API misuse.
+        let blocks: Vec<&RedundantBlock> = redundant
+            .iter()
+            .filter(|b| b.fits())
+            .take(MAX_REDUNDANT_BLOCKS)
+            .collect();
 
         let mut out = Vec::with_capacity(primary.len() + blocks.len() * 4 + 1);
 
@@ -189,11 +197,11 @@ pub(crate) fn red_recovery_blocks<'a>(
     // A redundant block carries only a timestamp offset, not a sequence number, so how many
     // packets back it sits is derived from the offset: `distance = offset / frame`, where `frame`
     // is the RTP ticks per packet. That frame size is not reliably signalled (Opus `minptime` is a
-    // minimum, not the actual value), so we take it from the closest same-PT block, which is one
-    // packet back for every real sender (browsers and str0m both include main-1). Blocks whose
-    // offset is not a clean multiple of that frame (irregular packetization) are skipped rather
-    // than mapped to a wrong sequence number, so recovery is best effort and never fabricates a
-    // packet at the wrong seq from a well-formed but unexpected payload.
+    // minimum, not the actual value), so we estimate it from the closest same-PT block, which is
+    // one packet back for every real sender (browsers and str0m both include main-1). The estimate
+    // is only trustworthy if every same-PT offset is an exact multiple of it; otherwise the packet
+    // duration cannot be established from offsets alone and we recover nothing. This keeps recovery
+    // best effort and never fabricates a packet at the wrong seq.
     let same_pt = |b: &&RedBlock<'_>| b.pt == primary_pt && b.timestamp_offset > 0;
     let Some(frame) = redundant
         .iter()
@@ -203,13 +211,20 @@ pub(crate) fn red_recovery_blocks<'a>(
     else {
         return Vec::new();
     };
+    // If any same-PT offset is not a multiple of the smallest one, the smallest is not reliably
+    // distance 1 (e.g. a [3, 5] pattern with no main-1 block), so recover nothing rather than map
+    // it to distance 1 and inject a frame at the wrong sequence number.
+    if redundant
+        .iter()
+        .filter(same_pt)
+        .any(|b| b.timestamp_offset % frame != 0)
+    {
+        return Vec::new();
+    }
     redundant
         .iter()
         .filter(same_pt)
         .filter_map(|b| {
-            if b.timestamp_offset % frame != 0 {
-                return None;
-            }
             let back = (b.timestamp_offset / frame) as u64;
             (back <= MAX_RED_RECOVERY_DEPTH).then_some((back, b))
         })
@@ -395,13 +410,10 @@ mod test {
             "distances derived from offsets, never mis-mapped"
         );
 
-        // An offset that is not a clean multiple of the frame is skipped, not mis-mapped.
+        // If any offset is not a clean multiple of the smallest, the packet duration can't be
+        // established, so the whole set is skipped rather than mis-mapped.
         let irregular = vec![block(960), block(1441)];
-        let backs: Vec<u64> = red_recovery_blocks(&irregular, 111)
-            .iter()
-            .map(|(b, _)| *b)
-            .collect();
-        assert_eq!(backs, vec![1]);
+        assert!(red_recovery_blocks(&irregular, 111).is_empty());
     }
 
     #[test]

--- a/src/packet/red.rs
+++ b/src/packet/red.rs
@@ -327,6 +327,23 @@ mod test {
     }
 
     #[test]
+    fn public_encoder_output_is_accepted_by_public_decoder() {
+        let redundant: Vec<_> = (0..33)
+            .map(|i| RedundantBlock {
+                pt: 111,
+                timestamp_offset: i + 1,
+                payload: vec![i as u8],
+            })
+            .collect();
+
+        let encoded = RedEncoder::encode(111, &[0xAA], &redundant);
+        assert!(
+            RedDecoder::decode(&encoded).is_ok(),
+            "the public decoder must accept packets produced by the public encoder"
+        );
+    }
+
+    #[test]
     fn recovery_blocks_derive_distance_from_offset_and_cap_depth() {
         // Oldest-first, frame = 960 (Opus 20 ms @ 48 kHz), so the closest same-PT block (offset
         // 960) is one packet back. Index 1 carries a different PT and must be skipped. Distance is
@@ -385,5 +402,24 @@ mod test {
             .map(|(b, _)| *b)
             .collect();
         assert_eq!(backs, vec![1]);
+    }
+
+    #[test]
+    fn recovery_blocks_without_main_minus_one_do_not_fabricate_sequence_numbers() {
+        let block = |ts| RedBlock {
+            pt: 111,
+            timestamp_offset: ts,
+            payload: &[0u8],
+            is_primary: false,
+        };
+
+        // The public send configuration permits [3, 5]. Without a main-1 block, the receiver
+        // cannot infer the duration of one packet from timestamp offsets alone. Treating the
+        // smallest offset as one packet would inject main-3 at sequence main-1.
+        let redundant = vec![block(4800), block(2880)];
+        assert!(
+            red_recovery_blocks(&redundant, 111).is_empty(),
+            "recovery must skip blocks when their sequence distance cannot be established"
+        );
     }
 }

--- a/src/packet/red.rs
+++ b/src/packet/red.rs
@@ -1,0 +1,389 @@
+//! RFC 2198 "RTP Payload for Redundant Audio Data" (RED) encode/decode.
+//!
+//! The RED structure is part of the RTP payload (so it is fully covered by SRTP): N redundant
+//! block headers (4 bytes each, F=1: 7-bit PT, 14-bit timestamp offset, 10-bit length), then the
+//! primary block header (1 byte, F=0: 7-bit PT), then all block payloads in the same order.
+
+use super::PacketError;
+
+const F_BIT: u8 = 0x80;
+
+/// Largest representable timestamp offset (14-bit field).
+const MAX_TS_OFFSET: u32 = 0x3fff;
+
+/// Largest representable redundant block length (10-bit field).
+const MAX_BLOCK_LEN: usize = 0x3ff;
+
+/// Maximum redundant blocks accepted in one RED payload. RFC 2198 sets no limit, but real
+/// Opus-RED senders use a single level of redundancy (str0m sends one; libwebrtc defaults to one
+/// and its receiver caps at 32). A 4-byte redundant header can otherwise pack hundreds of blocks
+/// into one datagram, so reject more than this to bound the parse work a malformed or hostile
+/// peer can trigger.
+const MAX_REDUNDANT_BLOCKS: usize = 32;
+
+/// How many packets back we recover from on receive, and the deepest distance a sender may be
+/// configured to send (see `CodecConfig::set_red_distances`). This covers realistic multi-level
+/// patterns such as `[1, 3, 5]` while bounding the per-packet recovery work (decode + depayload) a
+/// hostile peer can trigger, independent of how many blocks the payload carries.
+pub(crate) const MAX_RED_RECOVERY_DEPTH: u64 = 8;
+
+/// A redundant block to prepend to the primary payload (older media).
+#[derive(Debug, Clone)]
+pub struct RedundantBlock {
+    /// Block payload type (7-bit).
+    pub pt: u8,
+    /// `primary_rtp_timestamp - block_timestamp`, 14-bit (max 16383).
+    pub timestamp_offset: u32,
+    /// Block payload bytes, 10-bit length (max 1023).
+    pub payload: Vec<u8>,
+}
+
+impl RedundantBlock {
+    /// Whether this block fits RFC 2198's 14-bit offset and 10-bit length fields.
+    pub fn fits(&self) -> bool {
+        self.timestamp_offset <= MAX_TS_OFFSET && self.payload.len() <= MAX_BLOCK_LEN
+    }
+}
+
+/// A block parsed out of a RED payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RedBlock<'a> {
+    /// Block payload type (7-bit).
+    pub pt: u8,
+    /// Timestamp offset from the primary (0 for the primary block).
+    pub timestamp_offset: u32,
+    /// Block payload bytes (no header).
+    pub payload: &'a [u8],
+    /// Whether this is the primary (final) block.
+    pub is_primary: bool,
+}
+
+/// Encoder for RFC 2198 RED payloads.
+pub struct RedEncoder;
+
+impl RedEncoder {
+    /// Encode a RED payload: redundant blocks (oldest first) followed by the primary block.
+    ///
+    /// Redundant blocks whose offset or length do not fit RFC 2198's 14-bit / 10-bit fields are
+    /// skipped (see [`RedundantBlock::fits`]) so the output is always a valid RED payload, never
+    /// silently truncated.
+    pub fn encode(primary_pt: u8, primary: &[u8], redundant: &[RedundantBlock]) -> Vec<u8> {
+        let blocks: Vec<&RedundantBlock> = redundant.iter().filter(|b| b.fits()).collect();
+
+        let mut out = Vec::with_capacity(primary.len() + blocks.len() * 4 + 1);
+
+        for b in &blocks {
+            // `fits()` guarantees ts <= 0x3fff and len <= 0x3ff, so no masking is needed.
+            let ts = b.timestamp_offset;
+            let len = b.payload.len() as u32;
+            out.push(F_BIT | (b.pt & 0x7f));
+            out.push((ts >> 6) as u8);
+            out.push((((ts & 0x3f) << 2) | (len >> 8)) as u8);
+            out.push((len & 0xff) as u8);
+        }
+
+        // Primary header, F=0.
+        out.push(primary_pt & 0x7f);
+
+        for b in &blocks {
+            out.extend_from_slice(&b.payload);
+        }
+        out.extend_from_slice(primary);
+
+        out
+    }
+}
+
+/// Decoder for RFC 2198 RED payloads.
+pub struct RedDecoder;
+
+impl RedDecoder {
+    /// Parse a RED payload into its blocks (redundant first, primary last).
+    ///
+    /// Never panics; returns `Err` on any malformed input. RED payloads come from untrusted
+    /// remote peers, so this strictly validates header chaining and block lengths.
+    pub fn decode(data: &[u8]) -> Result<Vec<RedBlock<'_>>, PacketError> {
+        struct Hdr {
+            pt: u8,
+            ts_offset: u32,
+            len: Option<usize>,
+        }
+
+        // Phase 1: parse headers up to and including the primary (F=0) header.
+        let mut hdrs: Vec<Hdr> = Vec::new();
+        let mut i = 0;
+        loop {
+            let first = *data.get(i).ok_or(PacketError::ErrRedCorruptedPacket)?;
+            if first & F_BIT == 0 {
+                hdrs.push(Hdr {
+                    pt: first & 0x7f,
+                    ts_offset: 0,
+                    len: None,
+                });
+                i += 1;
+                break;
+            }
+            // Bound the redundant blocks (untrusted input) before parsing/allocating more. At this
+            // point `hdrs` holds only redundant headers, since the primary (F=0) breaks the loop.
+            if hdrs.len() >= MAX_REDUNDANT_BLOCKS {
+                return Err(PacketError::ErrRedCorruptedPacket);
+            }
+            let h = data
+                .get(i..i + 4)
+                .ok_or(PacketError::ErrRedCorruptedPacket)?;
+            let ts_offset = ((h[1] as u32) << 6) | ((h[2] as u32) >> 2);
+            let len = (((h[2] as usize) & 0x03) << 8) | (h[3] as usize);
+            hdrs.push(Hdr {
+                pt: h[0] & 0x7f,
+                ts_offset,
+                len: Some(len),
+            });
+            i += 4;
+        }
+
+        // Phase 2: slice the payloads in the same order as the headers.
+        let mut out = Vec::with_capacity(hdrs.len());
+        for h in &hdrs {
+            match h.len {
+                Some(len) => {
+                    let payload = data
+                        .get(i..i + len)
+                        .ok_or(PacketError::ErrRedCorruptedPacket)?;
+                    out.push(RedBlock {
+                        pt: h.pt,
+                        timestamp_offset: h.ts_offset,
+                        payload,
+                        is_primary: false,
+                    });
+                    i += len;
+                }
+                None => {
+                    // Primary block takes the remaining bytes (may be empty).
+                    out.push(RedBlock {
+                        pt: h.pt,
+                        timestamp_offset: 0,
+                        payload: &data[i..],
+                        is_primary: true,
+                    });
+                }
+            }
+        }
+
+        Ok(out)
+    }
+}
+
+/// Select the redundant blocks to attempt recovery from, given the decoded redundant blocks
+/// (oldest first) and the primary payload type.
+///
+/// Returns `(distance_back, block)` pairs, where `distance_back` is how many sequence numbers
+/// before the primary the block sits (1 = the immediately preceding packet). Only the most-recent
+/// [`MAX_RED_RECOVERY_DEPTH`] blocks that carry `primary_pt` are returned: RFC 2198 allows a
+/// redundant block to use a different PT, and str0m only recovers the primary (Opus) codec, so
+/// blocks of another PT are skipped; bounding the depth caps the recovery work a hostile peer can
+/// trigger regardless of how many blocks the payload packs.
+pub(crate) fn red_recovery_blocks<'a>(
+    redundant: &'a [RedBlock<'a>],
+    primary_pt: u8,
+) -> Vec<(u64, &'a RedBlock<'a>)> {
+    // A redundant block carries only a timestamp offset, not a sequence number, so how many
+    // packets back it sits is derived from the offset: `distance = offset / frame`, where `frame`
+    // is the RTP ticks per packet. That frame size is not reliably signalled (Opus `minptime` is a
+    // minimum, not the actual value), so we take it from the closest same-PT block, which is one
+    // packet back for every real sender (browsers and str0m both include main-1). Blocks whose
+    // offset is not a clean multiple of that frame (irregular packetization) are skipped rather
+    // than mapped to a wrong sequence number, so recovery is best effort and never fabricates a
+    // packet at the wrong seq from a well-formed but unexpected payload.
+    let same_pt = |b: &&RedBlock<'_>| b.pt == primary_pt && b.timestamp_offset > 0;
+    let Some(frame) = redundant
+        .iter()
+        .filter(same_pt)
+        .map(|b| b.timestamp_offset)
+        .min()
+    else {
+        return Vec::new();
+    };
+    redundant
+        .iter()
+        .filter(same_pt)
+        .filter_map(|b| {
+            if b.timestamp_offset % frame != 0 {
+                return None;
+            }
+            let back = (b.timestamp_offset / frame) as u64;
+            (back <= MAX_RED_RECOVERY_DEPTH).then_some((back, b))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn primary_only_roundtrip() {
+        let bytes = RedEncoder::encode(96, &[1, 2, 3], &[]);
+        assert_eq!(bytes, vec![96, 1, 2, 3]);
+
+        let blocks = RedDecoder::decode(&bytes).unwrap();
+        assert_eq!(blocks.len(), 1);
+        assert!(blocks[0].is_primary);
+        assert_eq!(blocks[0].pt, 96);
+        assert_eq!(blocks[0].timestamp_offset, 0);
+        assert_eq!(blocks[0].payload, &[1, 2, 3]);
+    }
+
+    #[test]
+    fn one_redundant_block_roundtrip() {
+        let red = [RedundantBlock {
+            pt: 96,
+            timestamp_offset: 960,
+            payload: vec![9, 9],
+        }];
+        let bytes = RedEncoder::encode(96, &[1, 2, 3], &red);
+
+        // Redundant header for ts_offset=960, len=2: F|pt=0xE0; 960>>6=15, low-6 ts bits and the
+        // 2 high len bits are 0, len low byte = 2.
+        assert_eq!(&bytes[..4], &[0xE0, 15, 0, 2]);
+        assert_eq!(bytes[4], 96); // primary header, F=0
+        assert_eq!(&bytes[5..], &[9, 9, 1, 2, 3]); // redundant payload then primary
+
+        let blocks = RedDecoder::decode(&bytes).unwrap();
+        assert_eq!(blocks.len(), 2);
+        assert!(!blocks[0].is_primary);
+        assert_eq!(blocks[0].timestamp_offset, 960);
+        assert_eq!(blocks[0].payload, &[9, 9]);
+        assert!(blocks[1].is_primary);
+        assert_eq!(blocks[1].payload, &[1, 2, 3]);
+    }
+
+    #[test]
+    fn encode_skips_oversized_blocks() {
+        // A block whose offset (>14 bits) or length (>10 bits) does not fit is dropped, so the
+        // wire payload is never silently corrupted — even in release builds.
+        let bad_offset = RedundantBlock {
+            pt: 96,
+            timestamp_offset: 0x4000, // > 0x3fff
+            payload: vec![1, 2],
+        };
+        let bad_len = RedundantBlock {
+            pt: 96,
+            timestamp_offset: 100,
+            payload: vec![0u8; 2000], // > 0x3ff
+        };
+        let bytes = RedEncoder::encode(96, &[7, 7], &[bad_offset, bad_len]);
+
+        let blocks = RedDecoder::decode(&bytes).unwrap();
+        assert_eq!(blocks.len(), 1, "oversized blocks must be skipped");
+        assert!(blocks[0].is_primary);
+        assert_eq!(blocks[0].payload, &[7, 7]);
+    }
+
+    #[test]
+    fn truncated_header_is_error_not_panic() {
+        assert!(RedDecoder::decode(&[0x80, 0x00]).is_err()); // F=1 but < 4 header bytes
+        assert!(RedDecoder::decode(&[]).is_err()); // empty
+    }
+
+    #[test]
+    fn block_length_past_end_is_error() {
+        // redundant header claims len=200 (len hi byte 0, lo byte 200) but no payload follows
+        let b = [0x80 | 96, 0, 0, 200, 96];
+        assert!(RedDecoder::decode(&b).is_err());
+    }
+
+    #[test]
+    fn never_panics_on_arbitrary_input() {
+        // Exhaustively poke short inputs; the decoder must only ever return Ok/Err.
+        for a in 0u16..=255 {
+            for b in 0u16..=255 {
+                let _ = RedDecoder::decode(&[a as u8, b as u8]);
+            }
+        }
+    }
+
+    #[test]
+    fn decode_rejects_too_many_redundant_blocks() {
+        // One 4-byte redundant header per block lets a single datagram pack hundreds of blocks.
+        // The decoder must bound this so a hostile peer can't expand one packet into an unbounded
+        // number of recovered packets. `n` zero-length redundant blocks, then an empty primary.
+        fn red_with_redundant_blocks(n: usize) -> Vec<u8> {
+            let mut data = Vec::with_capacity(n * 4 + 1);
+            for _ in 0..n {
+                data.extend_from_slice(&[F_BIT | 96, 0, 0, 0]); // F=1, pt=96, ts=0, len=0
+            }
+            data.push(96); // primary header, F=0
+            data
+        }
+
+        // At the limit: MAX redundant + 1 primary still decodes.
+        let ok = red_with_redundant_blocks(MAX_REDUNDANT_BLOCKS);
+        let blocks = RedDecoder::decode(&ok).expect("max redundant blocks is allowed");
+        assert_eq!(blocks.len(), MAX_REDUNDANT_BLOCKS + 1);
+
+        // One over the limit, and a pathological count, are rejected (not decoded).
+        assert!(RedDecoder::decode(&red_with_redundant_blocks(MAX_REDUNDANT_BLOCKS + 1)).is_err());
+        assert!(RedDecoder::decode(&red_with_redundant_blocks(360)).is_err());
+    }
+
+    #[test]
+    fn recovery_blocks_derive_distance_from_offset_and_cap_depth() {
+        // Oldest-first, frame = 960 (Opus 20 ms @ 48 kHz), so the closest same-PT block (offset
+        // 960) is one packet back. Index 1 carries a different PT and must be skipped. Distance is
+        // derived from the offset, and only same-PT blocks within MAX_RED_RECOVERY_DEPTH are kept.
+        let block = |pt, ts| RedBlock {
+            pt,
+            timestamp_offset: ts,
+            payload: &[0u8],
+            is_primary: false,
+        };
+        // oldest-first: distance 9 (over cap), foreign PT, distance 8, distance 1.
+        let redundant = vec![
+            block(111, 960 * 9),
+            block(96, 960 * 7),
+            block(111, 960 * 8),
+            block(111, 960),
+        ];
+
+        let got = red_recovery_blocks(&redundant, 111);
+        let backs: Vec<u64> = got.iter().map(|(back, _)| *back).collect();
+        // Distances 1 and 8 are within depth; distance 9 is capped out, the foreign PT is skipped.
+        assert_eq!(backs, vec![8, 1]);
+        assert!(got.iter().all(|(_, b)| b.pt == 111));
+
+        // A block list whose only same-PT block is the primary (offset 0) yields nothing.
+        let foreign = vec![block(111, 0), block(96, 960), block(96, 1920)];
+        assert!(red_recovery_blocks(&foreign, 111).is_empty());
+    }
+
+    #[test]
+    fn recovery_blocks_handle_non_contiguous_offsets() {
+        // A non-contiguous [1,3,5] pattern: frame = 960 (the closest block), so distances 1, 3, 5
+        // are derived from the offsets. All are within MAX_RED_RECOVERY_DEPTH and each maps to its
+        // true distance from the offset, never to a wrong seq the way a positional index would.
+        let block = |ts| RedBlock {
+            pt: 111,
+            timestamp_offset: ts,
+            payload: &[0u8],
+            is_primary: false,
+        };
+        let redundant = vec![block(4800), block(2880), block(960)]; // main-5, main-3, main-1
+        let backs: Vec<u64> = red_recovery_blocks(&redundant, 111)
+            .iter()
+            .map(|(b, _)| *b)
+            .collect();
+        assert_eq!(
+            backs,
+            vec![5, 3, 1],
+            "distances derived from offsets, never mis-mapped"
+        );
+
+        // An offset that is not a clean multiple of the frame is skipped, not mis-mapped.
+        let irregular = vec![block(960), block(1441)];
+        let backs: Vec<u64> = red_recovery_blocks(&irregular, 111)
+            .iter()
+            .map(|(b, _)| *b)
+            .collect();
+        assert_eq!(backs, vec![1]);
+    }
+}

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -380,6 +380,23 @@ impl MediaLine {
                         }
                     }
                 }
+
+                // find red pt, if there is one (RFC 2198). The red fmtp's primary PT
+                // points back to this codec, mirroring how `apt` links RTX. str0m only
+                // supports RED for Opus, so never fold it onto any other codec.
+                for fp in values.iter() {
+                    if let FormatParam::Red(primary) = fp {
+                        if *primary == p.pt {
+                            // ensure the owning rtpmap is actually red
+                            let is_red = rtp_maps
+                                .iter()
+                                .any(|(cpt, c)| cpt == *pt && c.codec == Codec::Red);
+                            if is_red && p.spec.codec == Codec::Opus {
+                                p.red = Some(**pt);
+                            }
+                        }
+                    }
+                }
             }
 
             // rtcp feedback mechanisms
@@ -977,6 +994,10 @@ pub enum FormatParam {
     /// RTX (resend) codecs, which PT it concerns.
     Apt(Pt),
 
+    /// RFC 2198 RED redundancy. Carries the primary PT this RED stream wraps
+    /// (the first entry of the `<primary>/<redundant>...` fmtp payload-type list).
+    Red(Pt),
+
     /// Unrecognized fmtp.
     Unknown,
 }
@@ -1093,6 +1114,7 @@ impl fmt::Display for FormatParam {
             }
             SpropMaxDonDiff(v) => write!(f, "sprop-max-don-diff={}", *v),
             Apt(v) => write!(f, "apt={v}"),
+            Red(v) => write!(f, "{v}/{v}"),
             Unknown => Ok(()),
         }
     }
@@ -1156,6 +1178,21 @@ impl PayloadParams {
             attrs.push(MediaAttribute::Fmtp {
                 pt,
                 values: vec![FormatParam::Apt(self.pt)],
+            });
+        }
+
+        if let Some(pt) = self.red {
+            attrs.push(MediaAttribute::RtpMap {
+                pt,
+                value: RtpMap {
+                    codec: Codec::Red,
+                    clock_rate: self.spec.clock_rate,
+                    channels: self.spec.channels,
+                },
+            });
+            attrs.push(MediaAttribute::Fmtp {
+                pt,
+                values: vec![FormatParam::Red(self.pt)],
             });
         }
     }
@@ -2282,6 +2319,203 @@ f78dde68-7055-4e20-bb37-433803dd1ed1\r\n\
 
             // Check RTX
             assert_eq!(h265_payload.resend, Some(97.into()));
+        }
+
+        #[test]
+        fn red_fmtp_parses_and_displays() {
+            // Single-level same-codec RED renders as "<primary>/<primary>".
+            assert_eq!(FormatParam::Red(111.into()).to_string(), "111/111");
+
+            let input = "v=0\r\n\
+            o=- 1 2 IN IP4 127.0.0.1\r\n\
+            s=-\r\n\
+            t=0 0\r\n\
+            a=group:BUNDLE 0\r\n\
+            m=audio 9 UDP/TLS/RTP/SAVPF 111 63\r\n\
+            c=IN IP4 0.0.0.0\r\n\
+            a=mid:0\r\n\
+            a=sendrecv\r\n\
+            a=rtpmap:111 opus/48000/2\r\n\
+            a=rtpmap:63 red/48000/2\r\n\
+            a=fmtp:63 111/111\r\n\
+            a=setup:actpass\r\n\
+            a=ice-ufrag:test\r\n\
+            a=ice-pwd:testpassword\r\n\
+            ";
+            let sdp = Sdp::parse(input).expect("should parse");
+            let has_red = sdp.media_lines[0].attrs.iter().any(|a| {
+                matches!(a, MediaAttribute::Fmtp { pt, values }
+                    if *pt == 63.into() && values == &vec![FormatParam::Red(111.into())])
+            });
+            assert!(
+                has_red,
+                "red fmtp should parse to FormatParam::Red(primary)"
+            );
+        }
+
+        #[test]
+        fn red_folds_onto_opus_and_emits() {
+            let input = "v=0\r\n\
+            o=- 1 2 IN IP4 127.0.0.1\r\n\
+            s=-\r\n\
+            t=0 0\r\n\
+            a=group:BUNDLE 0\r\n\
+            m=audio 9 UDP/TLS/RTP/SAVPF 111 63\r\n\
+            c=IN IP4 0.0.0.0\r\n\
+            a=mid:0\r\n\
+            a=sendrecv\r\n\
+            a=rtpmap:111 opus/48000/2\r\n\
+            a=rtpmap:63 red/48000/2\r\n\
+            a=fmtp:63 111/111\r\n\
+            a=setup:actpass\r\n\
+            a=ice-ufrag:test\r\n\
+            a=ice-pwd:testpassword\r\n\
+            ";
+            let sdp = Sdp::parse(input).expect("should parse");
+            let params = sdp.media_lines[0].rtp_params();
+
+            let opus = params
+                .iter()
+                .find(|p| p.spec.codec == Codec::Opus)
+                .expect("opus");
+            assert_eq!(opus.red, Some(63.into()));
+            // RED is folded onto the primary, never a standalone payload.
+            assert!(!params.iter().any(|p| p.pt == 63.into()));
+
+            // Emit: opus re-emits the red rtpmap + fmtp.
+            let mut attrs = Vec::new();
+            opus.as_media_attrs(&mut attrs);
+            let has_red_rtpmap = attrs.iter().any(|a| {
+                matches!(a, MediaAttribute::RtpMap { pt, value }
+                    if *pt == 63.into() && value.codec == Codec::Red && value.channels == Some(2))
+            });
+            let has_red_fmtp = attrs.iter().any(|a| {
+                matches!(a, MediaAttribute::Fmtp { pt, values }
+                    if *pt == 63.into() && values == &vec![FormatParam::Red(111.into())])
+            });
+            assert!(has_red_rtpmap, "should emit red rtpmap");
+            assert!(has_red_fmtp, "should emit red fmtp");
+        }
+
+        #[test]
+        fn red_folds_in_real_chrome_audio_mline() {
+            // Real captured Chrome offer audio section (see docs/chrome-sdp.json): RED (63) sits in
+            // the m-line fmt list right after Opus (111), among 16 payload types.
+            let input = "v=0\r\n\
+            o=- 2954344436352400798 4 IN IP4 127.0.0.1\r\n\
+            s=-\r\n\
+            t=0 0\r\n\
+            a=group:BUNDLE 0\r\n\
+            m=audio 9 UDP/TLS/RTP/SAVPF 111 63 103 104 9 0 8 106 105 13 110 112 113 126\r\n\
+            c=IN IP4 0.0.0.0\r\n\
+            a=mid:0\r\n\
+            a=sendrecv\r\n\
+            a=rtcp-mux\r\n\
+            a=rtpmap:111 opus/48000/2\r\n\
+            a=rtcp-fb:111 transport-cc\r\n\
+            a=fmtp:111 minptime=10;useinbandfec=1\r\n\
+            a=rtpmap:63 red/48000/2\r\n\
+            a=fmtp:63 111/111\r\n\
+            a=rtpmap:103 ISAC/16000\r\n\
+            a=rtpmap:104 ISAC/32000\r\n\
+            a=rtpmap:9 G722/8000\r\n\
+            a=rtpmap:0 PCMU/8000\r\n\
+            a=rtpmap:8 PCMA/8000\r\n\
+            a=rtpmap:106 CN/32000\r\n\
+            a=rtpmap:105 CN/16000\r\n\
+            a=rtpmap:13 CN/8000\r\n\
+            a=rtpmap:110 telephone-event/48000\r\n\
+            a=rtpmap:112 telephone-event/32000\r\n\
+            a=rtpmap:113 telephone-event/16000\r\n\
+            a=rtpmap:126 telephone-event/8000\r\n\
+            a=setup:actpass\r\n\
+            a=ice-ufrag:test\r\n\
+            a=ice-pwd:testpassword\r\n\
+            ";
+            let sdp = Sdp::parse(input).expect("parse real chrome audio m-line");
+            let params = sdp.media_lines[0].rtp_params();
+
+            let opus = params
+                .iter()
+                .find(|p| p.spec.codec == Codec::Opus)
+                .expect("opus");
+            assert_eq!(
+                opus.red,
+                Some(63.into()),
+                "RED must fold onto Opus among real Chrome PTs"
+            );
+            assert!(
+                !params.iter().any(|p| p.pt == 63.into()),
+                "RED is folded, not a standalone payload"
+            );
+            // Opus fmtp is not clobbered by the RED fold.
+            assert_eq!(opus.spec.format.use_inband_fec, Some(true));
+            // Real-world neighbours still parse alongside.
+            assert!(params.iter().any(|p| p.spec.codec == Codec::PCMU));
+            assert!(params.iter().any(|p| p.spec.codec == Codec::PCMA));
+        }
+
+        #[test]
+        fn red_not_folded_onto_video() {
+            // str0m supports RED only for Opus. A video m-line that links red to a video codec
+            // must not have red folded onto it; the video param's `red` stays None.
+            let input = "v=0\r\n\
+            o=- 1 2 IN IP4 127.0.0.1\r\n\
+            s=-\r\n\
+            t=0 0\r\n\
+            a=group:BUNDLE 0\r\n\
+            m=video 9 UDP/TLS/RTP/SAVPF 96 116\r\n\
+            c=IN IP4 0.0.0.0\r\n\
+            a=mid:0\r\n\
+            a=sendrecv\r\n\
+            a=rtpmap:96 VP8/90000\r\n\
+            a=rtpmap:116 red/90000\r\n\
+            a=fmtp:116 96/96\r\n\
+            a=setup:actpass\r\n\
+            a=ice-ufrag:test\r\n\
+            a=ice-pwd:testpassword\r\n\
+            ";
+            let sdp = Sdp::parse(input).expect("parse video m-line with red");
+            let params = sdp.media_lines[0].rtp_params();
+
+            let vp8 = params
+                .iter()
+                .find(|p| p.spec.codec == Codec::Vp8)
+                .expect("vp8");
+            assert_eq!(vp8.red, None, "RED must not fold onto a video codec");
+        }
+
+        #[test]
+        fn red_not_folded_onto_non_opus_audio() {
+            // str0m supports RED only for Opus. A remote that links red to a non-Opus audio
+            // codec (PCMU) must not have red folded onto it; the PCMU param's `red` stays None.
+            let input = "v=0\r\n\
+            o=- 1 2 IN IP4 127.0.0.1\r\n\
+            s=-\r\n\
+            t=0 0\r\n\
+            a=group:BUNDLE 0\r\n\
+            m=audio 9 UDP/TLS/RTP/SAVPF 0 63\r\n\
+            c=IN IP4 0.0.0.0\r\n\
+            a=mid:0\r\n\
+            a=sendrecv\r\n\
+            a=rtpmap:0 PCMU/8000\r\n\
+            a=rtpmap:63 red/8000\r\n\
+            a=fmtp:63 0/0\r\n\
+            a=setup:actpass\r\n\
+            a=ice-ufrag:test\r\n\
+            a=ice-pwd:testpassword\r\n\
+            ";
+            let sdp = Sdp::parse(input).expect("parse audio m-line with red on PCMU");
+            let params = sdp.media_lines[0].rtp_params();
+
+            let pcmu = params
+                .iter()
+                .find(|p| p.spec.codec == Codec::PCMU)
+                .expect("pcmu");
+            assert_eq!(
+                pcmu.red, None,
+                "RED must fold only onto Opus, not other audio codecs"
+            );
         }
     }
 

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -388,6 +388,23 @@ impl MediaLine {
                         }
                     }
                 }
+
+                // find red pt, if there is one (RFC 2198). The red fmtp's primary PT
+                // points back to this codec, mirroring how `apt` links RTX. str0m folds RED
+                // onto audio codecs only (the is_audio() gate below), never video.
+                for fp in values.iter() {
+                    if let FormatParam::Red(primary) = fp {
+                        if *primary == p.pt {
+                            // ensure the owning rtpmap is actually red
+                            let is_red = rtp_maps
+                                .iter()
+                                .any(|(cpt, c)| cpt == *pt && c.codec == Codec::Red);
+                            if is_red && p.spec.codec.is_audio() {
+                                p.red = Some(**pt);
+                            }
+                        }
+                    }
+                }
             }
 
             // rtcp feedback mechanisms
@@ -985,6 +1002,10 @@ pub enum FormatParam {
     /// RTX (resend) codecs, which PT it concerns.
     Apt(Pt),
 
+    /// RFC 2198 RED redundancy. Carries the primary PT this RED stream wraps
+    /// (the first entry of the `<primary>/<redundant>...` fmtp payload-type list).
+    Red(Pt),
+
     /// Unrecognized fmtp.
     Unknown,
 }
@@ -1101,6 +1122,7 @@ impl fmt::Display for FormatParam {
             }
             SpropMaxDonDiff(v) => write!(f, "sprop-max-don-diff={}", *v),
             Apt(v) => write!(f, "apt={v}"),
+            Red(v) => write!(f, "{v}/{v}"),
             Unknown => Ok(()),
         }
     }
@@ -1164,6 +1186,21 @@ impl PayloadParams {
             attrs.push(MediaAttribute::Fmtp {
                 pt,
                 values: vec![FormatParam::Apt(self.pt)],
+            });
+        }
+
+        if let Some(pt) = self.red {
+            attrs.push(MediaAttribute::RtpMap {
+                pt,
+                value: RtpMap {
+                    codec: Codec::Red,
+                    clock_rate: self.spec.rtp_clock_rate(),
+                    channels: self.spec.channels,
+                },
+            });
+            attrs.push(MediaAttribute::Fmtp {
+                pt,
+                values: vec![FormatParam::Red(self.pt)],
             });
         }
     }
@@ -2306,6 +2343,248 @@ f78dde68-7055-4e20-bb37-433803dd1ed1\r\n\
 
             // Check RTX
             assert_eq!(h265_payload.resend, Some(97.into()));
+        }
+
+        #[test]
+        fn red_fmtp_parses_and_displays() {
+            // Single-level same-codec RED renders as "<primary>/<primary>".
+            assert_eq!(FormatParam::Red(111.into()).to_string(), "111/111");
+
+            let input = "v=0\r\n\
+            o=- 1 2 IN IP4 127.0.0.1\r\n\
+            s=-\r\n\
+            t=0 0\r\n\
+            a=group:BUNDLE 0\r\n\
+            m=audio 9 UDP/TLS/RTP/SAVPF 111 63\r\n\
+            c=IN IP4 0.0.0.0\r\n\
+            a=mid:0\r\n\
+            a=sendrecv\r\n\
+            a=rtpmap:111 opus/48000/2\r\n\
+            a=rtpmap:63 red/48000/2\r\n\
+            a=fmtp:63 111/111\r\n\
+            a=setup:actpass\r\n\
+            a=ice-ufrag:test\r\n\
+            a=ice-pwd:testpassword\r\n\
+            ";
+            let sdp = Sdp::parse(input).expect("should parse");
+            let has_red = sdp.media_lines[0].attrs.iter().any(|a| {
+                matches!(a, MediaAttribute::Fmtp { pt, values }
+                    if *pt == 63.into() && values == &vec![FormatParam::Red(111.into())])
+            });
+            assert!(
+                has_red,
+                "red fmtp should parse to FormatParam::Red(primary)"
+            );
+        }
+
+        #[test]
+        fn red_folds_onto_opus_and_emits() {
+            let input = "v=0\r\n\
+            o=- 1 2 IN IP4 127.0.0.1\r\n\
+            s=-\r\n\
+            t=0 0\r\n\
+            a=group:BUNDLE 0\r\n\
+            m=audio 9 UDP/TLS/RTP/SAVPF 111 63\r\n\
+            c=IN IP4 0.0.0.0\r\n\
+            a=mid:0\r\n\
+            a=sendrecv\r\n\
+            a=rtpmap:111 opus/48000/2\r\n\
+            a=rtpmap:63 red/48000/2\r\n\
+            a=fmtp:63 111/111\r\n\
+            a=setup:actpass\r\n\
+            a=ice-ufrag:test\r\n\
+            a=ice-pwd:testpassword\r\n\
+            ";
+            let sdp = Sdp::parse(input).expect("should parse");
+            let params = sdp.media_lines[0].rtp_params();
+
+            let opus = params
+                .iter()
+                .find(|p| p.spec.codec == Codec::Opus)
+                .expect("opus");
+            assert_eq!(opus.red, Some(63.into()));
+            // RED is folded onto the primary, never a standalone payload.
+            assert!(!params.iter().any(|p| p.pt == 63.into()));
+
+            // Emit: opus re-emits the red rtpmap + fmtp.
+            let mut attrs = Vec::new();
+            opus.as_media_attrs(&mut attrs);
+            let has_red_rtpmap = attrs.iter().any(|a| {
+                matches!(a, MediaAttribute::RtpMap { pt, value }
+                    if *pt == 63.into() && value.codec == Codec::Red && value.channels == Some(2))
+            });
+            let has_red_fmtp = attrs.iter().any(|a| {
+                matches!(a, MediaAttribute::Fmtp { pt, values }
+                    if *pt == 63.into() && values == &vec![FormatParam::Red(111.into())])
+            });
+            assert!(has_red_rtpmap, "should emit red rtpmap");
+            assert!(has_red_fmtp, "should emit red fmtp");
+        }
+
+        #[test]
+        fn red_folds_in_real_chrome_audio_mline() {
+            // Real captured Chrome offer audio section (see docs/chrome-sdp.json): RED (63) sits in
+            // the m-line fmt list right after Opus (111), among 16 payload types.
+            let input = "v=0\r\n\
+            o=- 2954344436352400798 4 IN IP4 127.0.0.1\r\n\
+            s=-\r\n\
+            t=0 0\r\n\
+            a=group:BUNDLE 0\r\n\
+            m=audio 9 UDP/TLS/RTP/SAVPF 111 63 103 104 9 0 8 106 105 13 110 112 113 126\r\n\
+            c=IN IP4 0.0.0.0\r\n\
+            a=mid:0\r\n\
+            a=sendrecv\r\n\
+            a=rtcp-mux\r\n\
+            a=rtpmap:111 opus/48000/2\r\n\
+            a=rtcp-fb:111 transport-cc\r\n\
+            a=fmtp:111 minptime=10;useinbandfec=1\r\n\
+            a=rtpmap:63 red/48000/2\r\n\
+            a=fmtp:63 111/111\r\n\
+            a=rtpmap:103 ISAC/16000\r\n\
+            a=rtpmap:104 ISAC/32000\r\n\
+            a=rtpmap:9 G722/8000\r\n\
+            a=rtpmap:0 PCMU/8000\r\n\
+            a=rtpmap:8 PCMA/8000\r\n\
+            a=rtpmap:106 CN/32000\r\n\
+            a=rtpmap:105 CN/16000\r\n\
+            a=rtpmap:13 CN/8000\r\n\
+            a=rtpmap:110 telephone-event/48000\r\n\
+            a=rtpmap:112 telephone-event/32000\r\n\
+            a=rtpmap:113 telephone-event/16000\r\n\
+            a=rtpmap:126 telephone-event/8000\r\n\
+            a=setup:actpass\r\n\
+            a=ice-ufrag:test\r\n\
+            a=ice-pwd:testpassword\r\n\
+            ";
+            let sdp = Sdp::parse(input).expect("parse real chrome audio m-line");
+            let params = sdp.media_lines[0].rtp_params();
+
+            let opus = params
+                .iter()
+                .find(|p| p.spec.codec == Codec::Opus)
+                .expect("opus");
+            assert_eq!(
+                opus.red,
+                Some(63.into()),
+                "RED must fold onto Opus among real Chrome PTs"
+            );
+            assert!(
+                !params.iter().any(|p| p.pt == 63.into()),
+                "RED is folded, not a standalone payload"
+            );
+            // Opus fmtp is not clobbered by the RED fold.
+            assert_eq!(opus.spec.format.use_inband_fec, Some(true));
+            // Real-world neighbours still parse alongside.
+            assert!(params.iter().any(|p| p.spec.codec == Codec::PCMU));
+            assert!(params.iter().any(|p| p.spec.codec == Codec::PCMA));
+        }
+
+        #[test]
+        fn red_not_folded_onto_video() {
+            // str0m supports RED only for Opus. A video m-line that links red to a video codec
+            // must not have red folded onto it; the video param's `red` stays None.
+            let input = "v=0\r\n\
+            o=- 1 2 IN IP4 127.0.0.1\r\n\
+            s=-\r\n\
+            t=0 0\r\n\
+            a=group:BUNDLE 0\r\n\
+            m=video 9 UDP/TLS/RTP/SAVPF 96 116\r\n\
+            c=IN IP4 0.0.0.0\r\n\
+            a=mid:0\r\n\
+            a=sendrecv\r\n\
+            a=rtpmap:96 VP8/90000\r\n\
+            a=rtpmap:116 red/90000\r\n\
+            a=fmtp:116 96/96\r\n\
+            a=setup:actpass\r\n\
+            a=ice-ufrag:test\r\n\
+            a=ice-pwd:testpassword\r\n\
+            ";
+            let sdp = Sdp::parse(input).expect("parse video m-line with red");
+            let params = sdp.media_lines[0].rtp_params();
+
+            let vp8 = params
+                .iter()
+                .find(|p| p.spec.codec == Codec::Vp8)
+                .expect("vp8");
+            assert_eq!(vp8.red, None, "RED must not fold onto a video codec");
+        }
+
+        #[test]
+        fn red_folds_onto_non_opus_audio() {
+            // RED is audio-agnostic: a remote that links red to any audio codec (here PCMU)
+            // has red folded onto that codec's params.
+            let input = "v=0\r\n\
+            o=- 1 2 IN IP4 127.0.0.1\r\n\
+            s=-\r\n\
+            t=0 0\r\n\
+            a=group:BUNDLE 0\r\n\
+            m=audio 9 UDP/TLS/RTP/SAVPF 0 63\r\n\
+            c=IN IP4 0.0.0.0\r\n\
+            a=mid:0\r\n\
+            a=sendrecv\r\n\
+            a=rtpmap:0 PCMU/8000\r\n\
+            a=rtpmap:63 red/8000\r\n\
+            a=fmtp:63 0/0\r\n\
+            a=setup:actpass\r\n\
+            a=ice-ufrag:test\r\n\
+            a=ice-pwd:testpassword\r\n\
+            ";
+            let sdp = Sdp::parse(input).expect("parse audio m-line with red on PCMU");
+            let params = sdp.media_lines[0].rtp_params();
+
+            let pcmu = params
+                .iter()
+                .find(|p| p.spec.codec == Codec::PCMU)
+                .expect("pcmu");
+            assert_eq!(
+                pcmu.red,
+                Some(63.into()),
+                "RED folds onto any audio codec, not just Opus"
+            );
+        }
+
+        #[test]
+        fn g722_red_emits_wire_clock_rate() {
+            // G722 has a 16 kHz media clock but an 8 kHz RTP clock (RFC 3551). Its RED rtpmap
+            // must advertise 8000 (the wire rate), not 16000, or the peer derives the wrong
+            // timestamps.
+            let input = "v=0\r\n\
+            o=- 1 2 IN IP4 127.0.0.1\r\n\
+            s=-\r\n\
+            t=0 0\r\n\
+            a=group:BUNDLE 0\r\n\
+            m=audio 9 UDP/TLS/RTP/SAVPF 9 63\r\n\
+            c=IN IP4 0.0.0.0\r\n\
+            a=mid:0\r\n\
+            a=sendrecv\r\n\
+            a=rtpmap:9 G722/8000\r\n\
+            a=rtpmap:63 red/8000\r\n\
+            a=fmtp:63 9/9\r\n\
+            a=setup:actpass\r\n\
+            a=ice-ufrag:test\r\n\
+            a=ice-pwd:testpassword\r\n\
+            ";
+            let sdp = Sdp::parse(input).expect("parse G722 + red");
+            let params = sdp.media_lines[0].rtp_params();
+            let g722 = params
+                .iter()
+                .find(|p| p.spec.codec == Codec::G722)
+                .expect("g722");
+            assert_eq!(g722.red, Some(63.into()), "RED folds onto G722");
+
+            let mut attrs = Vec::new();
+            g722.as_media_attrs(&mut attrs);
+            let red_clock = attrs.iter().find_map(|a| match a {
+                MediaAttribute::RtpMap { value, .. } if value.codec == Codec::Red => {
+                    Some(value.clock_rate)
+                }
+                _ => None,
+            });
+            assert_eq!(
+                red_clock,
+                Some(Frequency::EIGHT_KHZ),
+                "G722 RED rtpmap must advertise the 8 kHz wire clock"
+            );
         }
     }
 

--- a/src/sdp/parser.rs
+++ b/src/sdp/parser.rs
@@ -608,6 +608,27 @@ where
     let fmtp1 = attribute_line("fmtp", (pt(), token(' '), fmtp_param))
         .map(|(pt, _, values)| MediaAttribute::Fmtp { pt, values });
 
+    // a=fmtp:63 111/111   (RFC 2198 RED: "<primary>/<redundant>[/...]" payload-type list)
+    // `pt()` grabs the whole non-space token, so split the slash-list ourselves. We keep only
+    // the primary PT (the first entry); failing here lets the parser fall through to `fmtp2`.
+    let fmtp_red = attribute_line("fmtp", (pt(), token(' '), not_sp())).and_then(
+        |(red_pt, _, value): (Pt, _, String)| {
+            let parts: Vec<&str> = value.split('/').collect();
+            let pts: Option<Vec<u8>> = if parts.len() >= 2 {
+                parts.iter().map(|p| p.parse::<u8>().ok()).collect()
+            } else {
+                None
+            };
+            match pts.and_then(|v| v.first().copied()) {
+                Some(primary) => Ok(MediaAttribute::Fmtp {
+                    pt: red_pt,
+                    values: vec![FormatParam::Red(Pt::from(primary))],
+                }),
+                None => Err(StreamErrorFor::<Input>::message_format("not a RED fmtp")),
+            }
+        },
+    );
+
     // a=fmtp:101 0-15
     let fmtp2 = attribute_line("fmtp", (pt(), token(' '), not_sp())).map(|(pt, _, _value)| {
         MediaAttribute::Fmtp {
@@ -616,7 +637,7 @@ where
         }
     });
 
-    let fmtp = choice((attempt(fmtp1), attempt(fmtp2)));
+    let fmtp = choice((attempt(fmtp1), attempt(fmtp_red), attempt(fmtp2)));
 
     // a=rid:<rid-id> <direction> [pt=<fmt-list>;]<restriction>=<value>
     let rid = attribute_line(

--- a/src/sdp/parser.rs
+++ b/src/sdp/parser.rs
@@ -608,26 +608,29 @@ where
     let fmtp1 = attribute_line("fmtp", (pt(), token(' '), fmtp_param))
         .map(|(pt, _, values)| MediaAttribute::Fmtp { pt, values });
 
-    // a=fmtp:63 111/111   (RFC 2198 RED: "<primary>/<redundant>[/...]" payload-type list)
-    // `pt()` grabs the whole non-space token, so split the slash-list ourselves. We keep only
-    // the primary PT (the first entry); failing here lets the parser fall through to `fmtp2`.
-    let fmtp_red = attribute_line("fmtp", (pt(), token(' '), not_sp())).and_then(
-        |(red_pt, _, value): (Pt, _, String)| {
-            let parts: Vec<&str> = value.split('/').collect();
-            let pts: Option<Vec<u8>> = if parts.len() >= 2 {
-                parts.iter().map(|p| p.parse::<u8>().ok()).collect()
-            } else {
-                None
-            };
-            match pts.and_then(|v| v.first().copied()) {
-                Some(primary) => Ok(MediaAttribute::Fmtp {
-                    pt: red_pt,
-                    values: vec![FormatParam::Red(Pt::from(primary))],
-                }),
-                None => Err(StreamErrorFor::<Input>::message_format("not a RED fmtp")),
-            }
-        },
-    );
+    // a=fmtp:63 111/111   (RFC 2198 RED: "<primary>/<redundant>[/...]" payload-type list). `pt()`
+    // reads the RED pt; from the slash list we keep only the primary (first) entry. Requiring at
+    // least one redundant entry lets a lone pt fall through to `fmtp2`. Each number is read the
+    // same combine way `rtpmap` reads its clock rate, rather than splitting the string by hand.
+    let red_pt_num = || {
+        many1::<String, _, _>(satisfy(|c| c != '/' && c != '\r' && c != '\n')).and_then(|s| {
+            s.parse::<u8>()
+                .map_err(StreamErrorFor::<Input>::message_format)
+        })
+    };
+    let fmtp_red = attribute_line(
+        "fmtp",
+        (
+            pt(),
+            token(' '),
+            red_pt_num(),
+            skip_many1((token('/'), red_pt_num())),
+        ),
+    )
+    .map(|(red_pt, _, primary, _)| MediaAttribute::Fmtp {
+        pt: red_pt,
+        values: vec![FormatParam::Red(Pt::from(primary))],
+    });
 
     // a=fmtp:101 0-15
     let fmtp2 = attribute_line("fmtp", (pt(), token(' '), not_sp())).map(|(pt, _, _value)| {

--- a/src/session.rs
+++ b/src/session.rs
@@ -19,8 +19,10 @@ use crate::media::{KeyframeRequestKind, MID_PROBE};
 use crate::media::{MediaAdded, MediaChanged};
 use crate::pacer::PacerControl;
 use crate::pacer::{Pacer, PacerImpl};
+use crate::packet::{RedBlock, RedDecoder, red_recovery_blocks};
 use crate::rtp::{Extension, RawPacket};
 use crate::rtp_::Direction;
+use crate::rtp_::MediaTime;
 use crate::rtp_::MidRid;
 use crate::rtp_::Pt;
 use crate::rtp_::SRTCP_OVERHEAD;
@@ -428,10 +430,11 @@ impl Session {
         };
 
         // Figure out which payload the PT maps to. Either main or RTX.
-        let maybe_payload = self
-            .codec_config
-            .iter()
-            .find(|p| p.pt() == header.payload_type || p.resend() == Some(header.payload_type));
+        let maybe_payload = self.codec_config.iter().find(|p| {
+            p.pt() == header.payload_type
+                || p.resend() == Some(header.payload_type)
+                || p.red() == Some(header.payload_type)
+        });
 
         // If we don't find it, bail out.
         let Some(payload) = maybe_payload else {
@@ -447,8 +450,10 @@ impl Session {
             self.streams
                 .map_dynamic_by_rid(header.ssrc, midrid, media, *payload, is_main);
         } else {
-            // Case B - the payload type identifies RTX.
-            let is_main = payload.pt() == header.payload_type;
+            // Case B - the payload type identifies RTX. RED rides the main SSRC, so a RED
+            // PT is also "main".
+            let is_main =
+                payload.pt() == header.payload_type || payload.red() == Some(header.payload_type);
 
             let midrid = MidRid(mid, None);
 
@@ -499,7 +504,8 @@ impl Session {
         };
         let clock_rate = params.spec().clock_rate;
         let pt = params.pt();
-        let is_repair = pt != header.payload_type;
+        let is_red = params.red() == Some(header.payload_type);
+        let is_repair = !is_red && pt != header.payload_type;
 
         let max_seq_lookup = make_max_seq_lookup(&self.max_rx_seq_lookup);
 
@@ -567,6 +573,10 @@ impl Session {
         // Register reception in nack registers.
         let receipt_outer = stream.update_register(now, &header, clock_rate, is_repair, seq_no);
 
+        // RED-recovered packets (frame mode) are collected here and delivered after the
+        // primary, filling single-packet losses from the next packet's redundancy.
+        let mut red_recovered: Vec<(RtpHeader, Arc<[u8]>, SeqNo, MediaTime)> = Vec::new();
+
         // RTX packets must be rewritten to be a normal packet. This only changes the
         // the seq_no, however MediaTime might be different when interpreted against the
         // the "main" register.
@@ -594,6 +604,47 @@ impl Session {
             // Now update the "main" register with the repaired packet info.
             let receipt = stream.update_register(now, &header, clock_rate, false, seq_no);
             (receipt, data)
+        } else if is_red && !self.rtp_mode {
+            // Frame mode: RED rides the main SSRC/seq. Decode to the primary (Opus) payload
+            // and rewrite the header PT; drop the packet if the RED structure is malformed.
+            let Some(un) = un_red(&mut header, data, pt) else {
+                return;
+            };
+            // Each redundant block carries an earlier frame. If that sequence number is still
+            // missing, deliver it as a recovered packet so a single loss is filled without a
+            // retransmission. is_new_packet is side-effect free and only true for a real gap.
+            // `red_recovery_blocks` bounds this to the most-recent few same-PT blocks, so a hostile
+            // peer can't turn one packet into unbounded recovery work, and a block whose codec
+            // differs from the primary (RFC 2198 permits that) is never fed to the depayloader.
+            for (back, b) in red_recovery_blocks(&un.redundant, *pt) {
+                let Some(rec_seq_val) = (*seq_no).checked_sub(back) else {
+                    continue;
+                };
+                let rec_seq: SeqNo = rec_seq_val.into();
+                // Recover only a still-missing sequence number. Recovered packets are not added to
+                // the receiver register (they were lost on the wire and rebuilt from FEC, so the
+                // real loss is still reported); the jitter buffer dedups any later real arrival.
+                if !stream.is_new_packet(false, rec_seq) {
+                    continue;
+                }
+                // Skip recovery (rather than inject a bad timestamp) if the offset somehow
+                // exceeds the primary's extended media time, mirroring the seq-no guard above.
+                let Some(numer) = receipt_outer
+                    .time
+                    .numer()
+                    .checked_sub(b.timestamp_offset as u64)
+                else {
+                    continue;
+                };
+                let rec_time = MediaTime::new(numer, clock_rate);
+                let mut rec_header = header.clone();
+                rec_header.sequence_number = *rec_seq as u16;
+                // RFC 2198: the marker bit is not carried for redundant blocks. Clearing it also
+                // stops a recovered (historical) audio frame being seen as a start-of-talkspurt.
+                rec_header.marker = false;
+                red_recovered.push((rec_header, Arc::from(b.payload), rec_seq, rec_time));
+            }
+            (receipt_outer, un.primary)
         } else {
             // This is not RTX, the outer seq and time is what we use. The first
             // stream.update will have updated the main register.
@@ -627,6 +678,22 @@ impl Session {
             media.depayload(
                 stream.rid(),
                 packet,
+                self.reordering_size_audio,
+                self.reordering_size_video,
+                &self.codec_config,
+            );
+        }
+
+        // Deliver any RED-recovered packets (frame mode only) through the same depayload
+        // path. The jitter buffer orders them and dedups against any later real arrival.
+        for (rec_header, rec_payload, rec_seq, rec_time) in red_recovered {
+            // make_rtp_packet (not handle_rtp): recovered packets must not inflate RX stats.
+            let rec_packet =
+                stream.make_rtp_packet(now, rec_header, rec_payload, rec_seq, rec_time);
+            let media = self.medias.iter_mut().find(|m| m.mid() == mid).unwrap();
+            media.depayload(
+                stream.rid(),
+                rec_packet,
                 self.reordering_size_audio,
                 self.reordering_size_video,
                 &self.codec_config,
@@ -1165,7 +1232,34 @@ pub struct PacketReceipt {
 /// Find the PayloadParams for the given Pt, either when the Pt is the main Pt for the Codec or
 /// when it's the RTX Pt.
 fn main_payload_params(c: &CodecConfig, pt: Pt) -> Option<&PayloadParams> {
-    c.iter().find(|p| p.pt == pt || p.resend == Some(pt))
+    c.iter()
+        .find(|p| p.pt == pt || p.resend == Some(pt) || p.red == Some(pt))
+}
+
+/// A decoded RED (RFC 2198) packet: the primary block plus any redundant (older) blocks.
+struct UnRed<'a> {
+    primary: &'a [u8],
+    redundant: Vec<RedBlock<'a>>,
+}
+
+/// Decode a RED packet, rewrite the header to the primary PT, and return the primary payload
+/// plus the redundant blocks. Returns `None` (drop) when the RED structure is malformed.
+fn un_red<'a>(header: &mut RtpHeader, data: &'a [u8], pt: Pt) -> Option<UnRed<'a>> {
+    let blocks = RedDecoder::decode(data).ok()?;
+    let mut primary = None;
+    let mut redundant = Vec::new();
+    for b in blocks {
+        if b.is_primary {
+            primary = Some(b.payload);
+        } else {
+            redundant.push(b);
+        }
+    }
+    header.payload_type = pt;
+    Some(UnRed {
+        primary: primary?,
+        redundant,
+    })
 }
 
 fn make_max_seq_lookup(map: &HashMap<Ssrc, SeqNo>) -> impl Fn(Ssrc) -> Option<SeqNo> + '_ {

--- a/src/session.rs
+++ b/src/session.rs
@@ -1427,6 +1427,7 @@ mod tests {
     use super::*;
     use crate::RtcConfig;
     use crate::io::DATAGRAM_MTU_TARGET;
+    use crate::packet::RedEncoder;
 
     #[test]
     fn session_mtu_matches_config() {
@@ -1437,5 +1438,17 @@ mod tests {
         let cfg = RtcConfig::default().set_mtu(900..=1280);
         let s = Session::new(&cfg);
         assert_eq!(s.mtu(), 900);
+    }
+
+    #[test]
+    fn un_red_rejects_a_primary_payload_type_mismatch() {
+        let expected_primary_pt = Pt::new_with_value(111);
+        let data = RedEncoder::encode(0, &[1, 2, 3], &[]);
+        let mut header = RtpHeader::default();
+
+        assert!(
+            un_red(&mut header, &data, expected_primary_pt).is_none(),
+            "RED associated with Opus must not reinterpret a PCMU primary block as Opus"
+        );
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -23,6 +23,7 @@ use crate::pacer::{Pacer, PacerImpl};
 use crate::packet::{RedBlock, RedDecoder, red_recovery_blocks};
 use crate::rtp::{Extension, RawPacket};
 use crate::rtp_::Direction;
+use crate::rtp_::ExtensionValues;
 use crate::rtp_::MediaTime;
 use crate::rtp_::MidRid;
 use crate::rtp_::Pli;
@@ -656,6 +657,10 @@ impl Session {
         // primary, filling single-packet losses from the next packet's redundancy.
         let mut red_recovered: Vec<(RtpHeader, Arc<[u8]>, SeqNo, MediaTime)> = Vec::new();
 
+        // Capture the full wire payload length before RED unwrapping narrows `data` to the primary
+        // block. The sender counts the whole RED-wrapped payload, so receive stats must too.
+        let wire_payload_len = data.len();
+
         // RTX packets must be rewritten to be a normal packet. This only changes the
         // the seq_no, however MediaTime might be different when interpreted against the
         // the "main" register.
@@ -728,6 +733,10 @@ impl Session {
                 // RFC 2198: the marker bit is not carried for redundant blocks. Clearing it also
                 // stops a recovered (historical) audio frame being seen as a start-of-talkspurt.
                 rec_header.marker = false;
+                // Redundant blocks carry no header extensions, so a recovered frame cannot carry
+                // its own (e.g. audio level). Clear the carrier's extensions rather than let the
+                // recovered frame inherit the current packet's metadata.
+                rec_header.ext_vals = ExtensionValues::default();
                 red_recovered.push((rec_header, Arc::from(b.payload), rec_seq, rec_time));
             }
             (receipt_outer, un.primary)
@@ -742,7 +751,14 @@ impl Session {
             return;
         }
 
-        self.media_bytes_rx += data.len() as u64;
+        // For RED (frame mode) `data` is now just the unwrapped primary; count the full RED wire
+        // payload instead so receive accounting matches the sender's byte count.
+        let rx_bytes = if is_red && !self.rtp_mode {
+            wire_payload_len
+        } else {
+            data.len()
+        };
+        self.media_bytes_rx += rx_bytes as u64;
 
         // One-shot conversion to Arc<[u8]>: a single allocation that copies
         // only the trimmed payload bytes out of the SRTP scratch buffer.
@@ -1399,6 +1415,13 @@ fn un_red<'a>(header: &mut RtpHeader, data: &'a [u8], pt: Pt) -> Option<UnRed<'a
     let mut redundant = Vec::new();
     for b in blocks {
         if b.is_primary {
+            // RFC 2198 lets redundant blocks use a different PT, but the primary block must carry
+            // the codec this RED stream negotiated (`pt`, e.g. Opus). A mismatch means this is not
+            // the primary we expect, so drop the packet rather than mislabel a foreign codec (e.g.
+            // reinterpret a PCMU primary as Opus).
+            if b.pt != *pt {
+                return None;
+            }
             primary = Some(b.payload);
         } else {
             redundant.push(b);

--- a/src/session.rs
+++ b/src/session.rs
@@ -20,7 +20,7 @@ use crate::media::{KeyframeRequestKind, MID_PROBE};
 use crate::media::{MediaAdded, MediaChanged};
 use crate::pacer::PacerControl;
 use crate::pacer::{Pacer, PacerImpl};
-use crate::packet::{RedBlock, RedDecoder, red_recovery_blocks};
+use crate::packet::{RedBlock, RedDecoder, red_same_pt_blocks};
 use crate::rtp::{Extension, RawPacket};
 use crate::rtp_::Direction;
 use crate::rtp_::ExtensionValues;
@@ -694,32 +694,15 @@ impl Session {
             let Some(un) = un_red(&mut header, data, pt) else {
                 return;
             };
-            // Each redundant block carries an earlier frame. If that sequence number is still
-            // missing, deliver it as a recovered packet so a single loss is filled without a
-            // retransmission. is_new_packet is side-effect free and only true for a real gap.
-            // `red_recovery_blocks` bounds this to the most-recent few same-PT blocks, so a hostile
-            // peer can't turn one packet into unbounded recovery work, and a block whose codec
-            // differs from the primary (RFC 2198 permits that) is never fed to the depayloader.
-            for (back, b) in red_recovery_blocks(&un.redundant, *pt) {
-                let Some(rec_seq_val) = (*seq_no).checked_sub(back) else {
-                    continue;
-                };
-                let rec_seq: SeqNo = rec_seq_val.into();
-                // Two blocks in the same RED packet must never rebuild the same seq_no. That can
-                // only happen if a malformed packet repeats an offset (well-formed senders don't),
-                // but `is_new_packet` below is side-effect free, so without this guard both blocks
-                // would pass it and inject a duplicate.
-                if red_recovered.iter().any(|(_, _, s, _)| *s == rec_seq) {
-                    continue;
-                }
-                // Recover only a still-missing sequence number. Recovered packets are not added to
-                // the receiver register (they were lost on the wire and rebuilt from FEC, so the
-                // real loss is still reported); the jitter buffer dedups any later real arrival.
-                if !stream.is_new_packet(false, rec_seq) {
-                    continue;
-                }
+            // Each redundant block carries an earlier frame. Place it at the sequence number it
+            // belongs to (derived from its timestamp and the packets received around it, see
+            // `StreamRx::red_locate_seq`) and, if that is still missing, deliver it as a
+            // recovered packet so a loss is filled without a retransmission. Only same-PT blocks
+            // are considered: RFC 2198 permits a redundant block of another codec, which must
+            // never be fed to this depayloader.
+            for b in red_same_pt_blocks(&un.redundant, *pt) {
                 // Skip recovery (rather than inject a bad timestamp) if the offset somehow
-                // exceeds the primary's extended media time, mirroring the seq-no guard above.
+                // exceeds the primary's extended media time.
                 let Some(numer) = receipt_outer
                     .time
                     .numer()
@@ -727,6 +710,17 @@ impl Session {
                 else {
                     continue;
                 };
+                // Correct-or-skip: `None` when the block can't be proven to belong to a missing
+                // seq no, or when that seq no was already received or recovered.
+                let Some(rec_seq) = stream.red_locate_seq(seq_no, numer) else {
+                    continue;
+                };
+                // Mark it so the seq is neither NACKed nor recovered again from a later packet.
+                // It is not counted as received (it was lost on the wire), so reception reports
+                // still carry the real loss. `red_locate_seq` now rejects this seq, which also
+                // dedups a malformed packet repeating the same offset.
+                stream.mark_red_recovered(rec_seq, numer);
+
                 let rec_time = MediaTime::new(numer, clock_rate);
                 let mut rec_header = header.clone();
                 rec_header.sequence_number = *rec_seq as u16;
@@ -764,7 +758,7 @@ impl Session {
         // only the trimmed payload bytes out of the SRTP scratch buffer.
         let payload: Arc<[u8]> = Arc::from(data);
 
-        let packet = stream.handle_rtp(now, header, payload, seq_no, receipt.time);
+        let packet = stream.handle_rtp(now, header, payload, seq_no, receipt.time, rx_bytes);
 
         if self.rtp_mode {
             // In RTP mode, we store the packet temporarily here for the next poll_output().

--- a/src/session.rs
+++ b/src/session.rs
@@ -710,8 +710,9 @@ impl Session {
                 else {
                     continue;
                 };
-                // Correct-or-skip: `None` when the block can't be proven to belong to a missing
-                // seq no, or when that seq no was already received or recovered.
+                // `None` when the block can't be tied to a currently-missing seq no (see
+                // `red_locate_seq` for the exact vs. best-effort cases), or when that seq no
+                // was already received or recovered. Recovery only ever fills a hole.
                 let Some(rec_seq) = stream.red_locate_seq(seq_no, numer) else {
                     continue;
                 };

--- a/src/session.rs
+++ b/src/session.rs
@@ -20,8 +20,10 @@ use crate::media::{KeyframeRequestKind, MID_PROBE};
 use crate::media::{MediaAdded, MediaChanged};
 use crate::pacer::PacerControl;
 use crate::pacer::{Pacer, PacerImpl};
+use crate::packet::{RedBlock, RedDecoder, red_recovery_blocks};
 use crate::rtp::{Extension, RawPacket};
 use crate::rtp_::Direction;
+use crate::rtp_::MediaTime;
 use crate::rtp_::MidRid;
 use crate::rtp_::Pli;
 use crate::rtp_::Pt;
@@ -507,10 +509,11 @@ impl Session {
         };
 
         // Figure out which payload the PT maps to. Either main or RTX.
-        let maybe_payload = self
-            .codec_config
-            .iter()
-            .find(|p| p.pt() == header.payload_type || p.resend() == Some(header.payload_type));
+        let maybe_payload = self.codec_config.iter().find(|p| {
+            p.pt() == header.payload_type
+                || p.resend() == Some(header.payload_type)
+                || p.red() == Some(header.payload_type)
+        });
 
         // If we don't find it, bail out.
         let Some(payload) = maybe_payload else {
@@ -526,8 +529,10 @@ impl Session {
             self.streams
                 .map_dynamic_by_rid(header.ssrc, midrid, media, *payload, is_main);
         } else {
-            // Case B - the payload type identifies RTX.
-            let is_main = payload.pt() == header.payload_type;
+            // Case B - the payload type identifies RTX. RED rides the main SSRC, so a RED
+            // PT is also "main".
+            let is_main =
+                payload.pt() == header.payload_type || payload.red() == Some(header.payload_type);
 
             let midrid = MidRid(mid, None);
 
@@ -578,7 +583,8 @@ impl Session {
         };
         let clock_rate = params.spec().rtp_clock_rate();
         let pt = params.pt();
-        let is_repair = pt != header.payload_type;
+        let is_red = params.red() == Some(header.payload_type);
+        let is_repair = !is_red && pt != header.payload_type;
 
         let max_seq_lookup = make_max_seq_lookup(&self.max_rx_seq_lookup);
 
@@ -646,6 +652,10 @@ impl Session {
         // Register reception in nack registers.
         let receipt_outer = stream.update_register(now, &header, clock_rate, is_repair, seq_no);
 
+        // RED-recovered packets (frame mode) are collected here and delivered after the
+        // primary, filling single-packet losses from the next packet's redundancy.
+        let mut red_recovered: Vec<(RtpHeader, Arc<[u8]>, SeqNo, MediaTime)> = Vec::new();
+
         // RTX packets must be rewritten to be a normal packet. This only changes the
         // the seq_no, however MediaTime might be different when interpreted against the
         // the "main" register.
@@ -673,6 +683,54 @@ impl Session {
             // Now update the "main" register with the repaired packet info.
             let receipt = stream.update_register(now, &header, clock_rate, false, seq_no);
             (receipt, data)
+        } else if is_red && !self.rtp_mode {
+            // Frame mode: RED rides the main SSRC/seq. Decode to the primary (Opus) payload
+            // and rewrite the header PT; drop the packet if the RED structure is malformed.
+            let Some(un) = un_red(&mut header, data, pt) else {
+                return;
+            };
+            // Each redundant block carries an earlier frame. If that sequence number is still
+            // missing, deliver it as a recovered packet so a single loss is filled without a
+            // retransmission. is_new_packet is side-effect free and only true for a real gap.
+            // `red_recovery_blocks` bounds this to the most-recent few same-PT blocks, so a hostile
+            // peer can't turn one packet into unbounded recovery work, and a block whose codec
+            // differs from the primary (RFC 2198 permits that) is never fed to the depayloader.
+            for (back, b) in red_recovery_blocks(&un.redundant, *pt) {
+                let Some(rec_seq_val) = (*seq_no).checked_sub(back) else {
+                    continue;
+                };
+                let rec_seq: SeqNo = rec_seq_val.into();
+                // Two blocks in the same RED packet must never rebuild the same seq_no. That can
+                // only happen if a malformed packet repeats an offset (well-formed senders don't),
+                // but `is_new_packet` below is side-effect free, so without this guard both blocks
+                // would pass it and inject a duplicate.
+                if red_recovered.iter().any(|(_, _, s, _)| *s == rec_seq) {
+                    continue;
+                }
+                // Recover only a still-missing sequence number. Recovered packets are not added to
+                // the receiver register (they were lost on the wire and rebuilt from FEC, so the
+                // real loss is still reported); the jitter buffer dedups any later real arrival.
+                if !stream.is_new_packet(false, rec_seq) {
+                    continue;
+                }
+                // Skip recovery (rather than inject a bad timestamp) if the offset somehow
+                // exceeds the primary's extended media time, mirroring the seq-no guard above.
+                let Some(numer) = receipt_outer
+                    .time
+                    .numer()
+                    .checked_sub(b.timestamp_offset as u64)
+                else {
+                    continue;
+                };
+                let rec_time = MediaTime::new(numer, clock_rate);
+                let mut rec_header = header.clone();
+                rec_header.sequence_number = *rec_seq as u16;
+                // RFC 2198: the marker bit is not carried for redundant blocks. Clearing it also
+                // stops a recovered (historical) audio frame being seen as a start-of-talkspurt.
+                rec_header.marker = false;
+                red_recovered.push((rec_header, Arc::from(b.payload), rec_seq, rec_time));
+            }
+            (receipt_outer, un.primary)
         } else {
             // This is not RTX, the outer seq and time is what we use. The first
             // stream.update will have updated the main register.
@@ -706,6 +764,22 @@ impl Session {
             media.depayload(
                 stream.rid(),
                 packet,
+                self.reordering_size_audio,
+                self.reordering_size_video,
+                &self.codec_config,
+            );
+        }
+
+        // Deliver any RED-recovered packets (frame mode only) through the same depayload
+        // path. The jitter buffer orders them and dedups against any later real arrival.
+        for (rec_header, rec_payload, rec_seq, rec_time) in red_recovered {
+            // make_rtp_packet (not handle_rtp): recovered packets must not inflate RX stats.
+            let rec_packet =
+                stream.make_rtp_packet(now, rec_header, rec_payload, rec_seq, rec_time);
+            let media = self.medias.iter_mut().find(|m| m.mid() == mid).unwrap();
+            media.depayload(
+                stream.rid(),
+                rec_packet,
                 self.reordering_size_audio,
                 self.reordering_size_video,
                 &self.codec_config,
@@ -1226,10 +1300,21 @@ impl Session {
                 &self.codec_config,
                 self.vp9_packetizer_mode,
                 mtu,
+                self.codec_config.red_distances(),
             )?;
         }
 
         Ok(())
+    }
+
+    /// Toggle RFC 2198 RED wrapping on the send side at runtime. No renegotiation: RED availability
+    /// is fixed at negotiation (or via DirectAPI); this only decides whether we wrap right now.
+    /// Returns whether the setting changed.
+    pub fn set_red_send(&mut self, mid: Mid, enabled: bool) -> bool {
+        let Some(media) = self.media_by_mid_mut(mid) else {
+            return false;
+        };
+        media.set_red_send(enabled)
     }
 
     pub fn set_direction(&mut self, mid: Mid, direction: Direction) -> bool {
@@ -1296,7 +1381,34 @@ pub struct PacketReceipt {
 /// Find the PayloadParams for the given Pt, either when the Pt is the main Pt for the Codec or
 /// when it's the RTX Pt.
 fn main_payload_params(c: &CodecConfig, pt: Pt) -> Option<&PayloadParams> {
-    c.iter().find(|p| p.pt == pt || p.resend == Some(pt))
+    c.iter()
+        .find(|p| p.pt == pt || p.resend == Some(pt) || p.red == Some(pt))
+}
+
+/// A decoded RED (RFC 2198) packet: the primary block plus any redundant (older) blocks.
+struct UnRed<'a> {
+    primary: &'a [u8],
+    redundant: Vec<RedBlock<'a>>,
+}
+
+/// Decode a RED packet, rewrite the header to the primary PT, and return the primary payload
+/// plus the redundant blocks. Returns `None` (drop) when the RED structure is malformed.
+fn un_red<'a>(header: &mut RtpHeader, data: &'a [u8], pt: Pt) -> Option<UnRed<'a>> {
+    let blocks = RedDecoder::decode(data).ok()?;
+    let mut primary = None;
+    let mut redundant = Vec::new();
+    for b in blocks {
+        if b.is_primary {
+            primary = Some(b.payload);
+        } else {
+            redundant.push(b);
+        }
+    }
+    header.payload_type = pt;
+    Some(UnRed {
+        primary: primary?,
+        redundant,
+    })
 }
 
 fn make_max_seq_lookup(map: &HashMap<Ssrc, SeqNo>) -> impl Fn(Ssrc) -> Option<SeqNo> + '_ {

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -453,6 +453,25 @@ impl StreamRx {
         seq_no: SeqNo,
         time: MediaTime,
     ) -> RtpPacket {
+        let packet = self.make_rtp_packet(now, header, payload, seq_no, time);
+
+        self.stats.bytes += packet.payload.len() as u64;
+        self.stats.packets += 1;
+
+        packet
+    }
+
+    /// Build an [`RtpPacket`] WITHOUT counting it in receive stats. Used for RFC 2198
+    /// FEC-recovered packets, which were never received on the wire (the carrying packet's
+    /// bytes are already counted by `handle_rtp`).
+    pub(crate) fn make_rtp_packet(
+        &mut self,
+        now: Instant,
+        header: RtpHeader,
+        payload: Arc<[u8]>,
+        seq_no: SeqNo,
+        time: MediaTime,
+    ) -> RtpPacket {
         trace!("Handle RTP: {:?}", header);
 
         let need_clock_rate = self.last_clock_rate.map(|(pt, _)| pt) != Some(header.payload_type);
@@ -465,7 +484,7 @@ impl StreamRx {
             }
         }
 
-        let packet = RtpPacket {
+        RtpPacket {
             seq_no,
             time,
             header,
@@ -474,12 +493,7 @@ impl StreamRx {
             nackable: false,
             last_sender_info: self.sender_info.as_ref().map(|l| l.info),
             timestamp: now,
-        };
-
-        self.stats.bytes += packet.payload.len() as u64;
-        self.stats.packets += 1;
-
-        packet
+        }
     }
 
     /// Rewrites the header to be the un-RTX'd original packet, and returns

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, Instant};
 
 use crate::config_mod::RtcpReportIntervals;
 use crate::media::KeyframeRequestKind;
+use crate::packet::MAX_RED_RECOVERY_DEPTH;
 use crate::rtp_::MidRid;
 use crate::rtp_::{Bitrate, DlrrItem, ExtendedReport, extend_u32};
 use crate::rtp_::{Fir, FirEntry, Frequency, MediaTime, Remb};
@@ -18,6 +19,10 @@ use crate::util::{already_happened, calculate_rtt};
 use super::RtpPacket;
 use super::StreamPaused;
 use super::register::ReceiverRegister;
+
+/// How many recent packets to remember for placing RED redundant blocks. Must cover the
+/// recovery depth plus some reordering slack.
+const RED_RECENT_PACKETS: usize = 32;
 
 /// Incoming encoded stream.
 ///
@@ -73,6 +78,11 @@ pub struct StreamRx {
     ///
     /// Set on first ever RTXpacket.
     register_rtx: Option<ReceiverRegister>,
+
+    /// The most recent main-stream packets as `(seq_no, extended rtp time)`, used to place
+    /// RFC 2198 RED redundant blocks (which carry a timestamp, not a seq no) at the right
+    /// sequence number. Bounded by `RED_RECENT_PACKETS`.
+    red_recent: VecDeque<(SeqNo, u64)>,
 
     /// Last observed media time in an RTP packet.
     last_time: Option<MediaTime>,
@@ -159,6 +169,7 @@ impl StreamRx {
             reset_roc: None,
             register: None,
             register_rtx: None,
+            red_recent: VecDeque::new(),
             last_time: None,
             pending_request_keyframe: None,
             pending_request_remb: None,
@@ -386,6 +397,103 @@ impl StreamRx {
         register_ref.unwrap().accepts(seq_no)
     }
 
+    fn remember_recent(&mut self, seq_no: SeqNo, time: u64) {
+        self.red_recent.push_back((seq_no, time));
+        while self.red_recent.len() > RED_RECENT_PACKETS {
+            self.red_recent.pop_front();
+        }
+    }
+
+    /// Work out which (still missing) sequence number a RED redundant block belongs to.
+    ///
+    /// RFC 2198 blocks carry a timestamp offset, not a sequence number, and the frame duration
+    /// is neither signalled nor constant (Opus 10/20/40/60 ms, DTX, CN interleaved on the same
+    /// SSRC). Rather than guess a duration from the offsets, bracket the block's time between the
+    /// nearest received packets `L` (latest with time before) and `U` (earliest with time after)
+    /// and look at the missing sequence numbers between them:
+    ///
+    /// * exactly one missing: that is the block, whatever the durations were;
+    /// * several missing: only if `L..U` is uniformly spaced and the block time lands exactly on
+    ///   one of the missing slots; otherwise give up.
+    ///
+    /// This is correct-or-skip: a block is never placed at a sequence number it cannot be
+    /// proven to belong to. `carrier` is the packet the block arrived in; recovery is limited to
+    /// `MAX_RED_RECOVERY_DEPTH` packets behind it.
+    pub(crate) fn red_locate_seq(&self, carrier: SeqNo, block_time: u64) -> Option<SeqNo> {
+        let register = self.register.as_ref()?;
+
+        // A packet (received or already recovered) at exactly this time: nothing to recover.
+        if self.red_recent.iter().any(|(_, t)| *t == block_time) {
+            return None;
+        }
+
+        let below = self
+            .red_recent
+            .iter()
+            .filter(|(_, t)| *t < block_time)
+            .max_by_key(|(s, _)| *s)?;
+        let above = self
+            .red_recent
+            .iter()
+            .filter(|(_, t)| *t > block_time)
+            .min_by_key(|(s, _)| *s)?;
+
+        let (l_seq, l_time) = (*below.0, below.1);
+        let (u_seq, u_time) = (*above.0, above.1);
+
+        // Bound the scan: the block must be within recovery depth of the carrier, which also
+        // keeps `l_seq..u_seq` small. `checked_sub` guards a stream whose timestamps don't
+        // follow its sequence numbers.
+        let depth_ok = (*carrier)
+            .checked_sub(l_seq)
+            .is_some_and(|d| d <= MAX_RED_RECOVERY_DEPTH + 1);
+        if u_seq <= l_seq + 1 || !depth_ok {
+            return None;
+        }
+
+        let mut missing = (l_seq + 1..u_seq)
+            .map(SeqNo::from)
+            .filter(|s| register.accepts(*s));
+
+        let first = missing.next()?;
+        let candidate = if missing.next().is_none() {
+            // Exactly one hole between two received packets that bracket the block in time.
+            first
+        } else {
+            // Several holes: only a uniformly spaced span lets us tell which one.
+            let span_seq = u_seq - l_seq;
+            let span_time = u_time - l_time;
+            if span_time % span_seq != 0 {
+                return None;
+            }
+            let d = span_time / span_seq;
+            let back = block_time - l_time;
+            if back % d != 0 {
+                return None;
+            }
+            let seq: SeqNo = (l_seq + back / d).into();
+            if !register.accepts(seq) {
+                return None;
+            }
+            seq
+        };
+
+        (*carrier)
+            .checked_sub(*candidate)
+            .is_some_and(|d| d <= MAX_RED_RECOVERY_DEPTH)
+            .then_some(candidate)
+    }
+
+    /// Record that `seq_no` was rebuilt from RED redundancy. It was never on the wire, so it is
+    /// not counted as received (reception reports still show the loss), but it must neither be
+    /// NACKed nor recovered again.
+    pub(crate) fn mark_red_recovered(&mut self, seq_no: SeqNo, time: u64) {
+        if let Some(register) = &mut self.register {
+            register.mark_recovered(seq_no);
+        }
+        self.remember_recent(seq_no, time);
+    }
+
     pub(crate) fn update_register(
         &mut self,
         now: Instant,
@@ -442,6 +550,9 @@ impl StreamRx {
 
         if !is_repair {
             self.last_time = Some(time);
+            if is_new_packet {
+                self.remember_recent(seq_no, time.numer());
+            }
         }
 
         RegisterUpdateReceipt {
@@ -458,10 +569,13 @@ impl StreamRx {
         payload: Arc<[u8]>,
         seq_no: SeqNo,
         time: MediaTime,
+        wire_payload_len: usize,
     ) -> RtpPacket {
         let packet = self.make_rtp_packet(now, header, payload, seq_no, time);
 
-        self.stats.bytes += packet.payload.len() as u64;
+        // `payload` may be narrower than what was on the wire (RED unwrapped to its primary
+        // block); count what was received, matching the sender's egress accounting.
+        self.stats.bytes += wire_payload_len as u64;
         self.stats.packets += 1;
 
         packet
@@ -769,6 +883,7 @@ impl StreamRx {
 
         // Reset all SSRC-specific state
         self.register = None;
+        self.red_recent.clear();
         self.last_time = None;
         self.last_clock_rate = None;
         self.sender_info = None;
@@ -818,6 +933,7 @@ impl StreamRx {
     pub fn reset_roc(&mut self, roc: u64) {
         self.register = None;
         self.register_rtx = None;
+        self.red_recent.clear();
         self.reset_roc = Some(roc);
     }
 
@@ -906,6 +1022,94 @@ mod tests {
             "expected repaired media time to move forward"
         );
         assert!(!stream.paused);
+    }
+
+    /// Feed packets `(seq, rtp_time)` into a fresh stream, as received on the wire.
+    fn stream_with(packets: &[(u16, u32)]) -> StreamRx {
+        let now = already_happened();
+        let mut stream = StreamRx::new(7.into(), MidRid("mid".into(), None), false);
+        for (seq, ts) in packets {
+            let header = RtpHeader {
+                payload_type: Pt::new_with_value(111),
+                sequence_number: *seq,
+                timestamp: *ts,
+                ssrc: 7.into(),
+                ..Default::default()
+            };
+            let seq_no = stream.extend_seq(&header, false, |_| None);
+            stream.update_register(now, &header, Frequency::FORTY_EIGHT_KHZ, false, seq_no);
+        }
+        stream
+    }
+
+    #[test]
+    fn red_locate_seq_single_hole_regardless_of_frame_duration() {
+        // 20 ms frames, then a 40 ms frame at seq 12, then 20 ms again. Seq 13 lost.
+        let stream = stream_with(&[(10, 0), (11, 960), (12, 1920), (14, 4800)]);
+
+        // Block at the time of seq 13 (1920 + 1920): the only hole between 12 and 14.
+        assert_eq!(stream.red_locate_seq(14.into(), 3840), Some(13.into()));
+    }
+
+    #[test]
+    fn red_locate_seq_several_holes_need_uniform_spacing() {
+        // Seq 11, 12, 13 lost; 10 and 14 bracket them 4 frames apart: unambiguous.
+        let stream = stream_with(&[(10, 0), (14, 3840)]);
+        assert_eq!(stream.red_locate_seq(14.into(), 960), Some(11.into()));
+        assert_eq!(stream.red_locate_seq(14.into(), 1920), Some(12.into()));
+        assert_eq!(stream.red_locate_seq(14.into(), 2880), Some(13.into()));
+        // Not on a slot: skip rather than guess.
+        assert_eq!(stream.red_locate_seq(14.into(), 1000), None);
+
+        // Same holes, but one of the lost frames was longer (span not a multiple): every block
+        // is skipped, none is misplaced.
+        let stream = stream_with(&[(10, 0), (14, 4800)]);
+        for t in [960, 1920, 2880, 3840] {
+            assert_eq!(stream.red_locate_seq(14.into(), t), None, "time {t}");
+        }
+    }
+
+    #[test]
+    fn red_locate_seq_rejects_known_and_recovered_frames() {
+        let mut stream = stream_with(&[(10, 0), (14, 3840)]);
+
+        // A block for a frame we already have is not a recovery.
+        assert_eq!(stream.red_locate_seq(14.into(), 0), None);
+
+        // Once recovered, the seq is neither a hole nor NACKed, and a later block for the same
+        // frame is rejected instead of being pushed into a neighbouring hole.
+        stream.mark_red_recovered(12.into(), 1920);
+        assert_eq!(stream.red_locate_seq(14.into(), 1920), None);
+        assert!(!stream.is_new_packet(false, 12.into()));
+        let nacked: Vec<SeqNo> = stream
+            .register
+            .as_mut()
+            .unwrap()
+            .nack_report()
+            .into_iter()
+            .flatten()
+            .flat_map(|n| {
+                n.reports
+                    .iter()
+                    .flat_map(|r| r.into_iter(10.into()))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        assert_eq!(nacked, vec![11.into(), 13.into()]);
+
+        // The remaining holes are still found (11 and 13 are single-hole brackets now).
+        assert_eq!(stream.red_locate_seq(14.into(), 960), Some(11.into()));
+        assert_eq!(stream.red_locate_seq(14.into(), 2880), Some(13.into()));
+    }
+
+    #[test]
+    fn red_locate_seq_limits_recovery_depth() {
+        let mut packets = vec![(10u16, 0u32)];
+        // Seq 11 lost, then 12..=30 received at 20 ms.
+        packets.extend((12..=30u16).map(|s| (s, (s as u32 - 10) * 960)));
+        let stream = stream_with(&packets);
+        assert_eq!(stream.red_locate_seq(30.into(), 960), None);
+        assert_eq!(stream.red_locate_seq(19.into(), 960), Some(11.into()));
     }
 
     #[test]

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -459,6 +459,25 @@ impl StreamRx {
         seq_no: SeqNo,
         time: MediaTime,
     ) -> RtpPacket {
+        let packet = self.make_rtp_packet(now, header, payload, seq_no, time);
+
+        self.stats.bytes += packet.payload.len() as u64;
+        self.stats.packets += 1;
+
+        packet
+    }
+
+    /// Build an [`RtpPacket`] WITHOUT counting it in receive stats. Used for RFC 2198
+    /// FEC-recovered packets, which were never received on the wire (the carrying packet's
+    /// bytes are already counted by `handle_rtp`).
+    pub(crate) fn make_rtp_packet(
+        &mut self,
+        now: Instant,
+        header: RtpHeader,
+        payload: Arc<[u8]>,
+        seq_no: SeqNo,
+        time: MediaTime,
+    ) -> RtpPacket {
         trace!("Handle RTP: {:?}", header);
 
         let need_clock_rate = self.last_clock_rate.map(|(pt, _)| pt) != Some(header.payload_type);
@@ -471,7 +490,7 @@ impl StreamRx {
             }
         }
 
-        let packet = RtpPacket {
+        RtpPacket {
             seq_no,
             time,
             header,
@@ -480,12 +499,7 @@ impl StreamRx {
             nackable: false,
             last_sender_info: self.sender_info.as_ref().map(|l| l.info),
             timestamp: now,
-        };
-
-        self.stats.bytes += packet.payload.len() as u64;
-        self.stats.packets += 1;
-
-        packet
+        }
     }
 
     /// Rewrites the header to be the un-RTX'd original packet, and returns

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -412,13 +412,20 @@ impl StreamRx {
     /// nearest received packets `L` (latest with time before) and `U` (earliest with time after)
     /// and look at the missing sequence numbers between them:
     ///
-    /// * exactly one missing: that is the block, whatever the durations were;
+    /// * exactly one missing: that is the block, whatever the durations were — this case is
+    ///   exact;
     /// * several missing: only if `L..U` is uniformly spaced and the block time lands exactly on
-    ///   one of the missing slots; otherwise give up.
+    ///   one of the missing slots; otherwise give up. This case *assumes* a constant frame
+    ///   duration across the gap, which holds for the fixed-ptime senders seen in practice
+    ///   (WebRTC uses 20 ms). Under variable Opus ptime the derived slot can be a neighbouring
+    ///   lost sequence number rather than the block's true one, so recovered audio may land one
+    ///   or two frames off.
     ///
-    /// This is correct-or-skip: a block is never placed at a sequence number it cannot be
-    /// proven to belong to. `carrier` is the packet the block arrived in; recovery is limited to
-    /// `MAX_RED_RECOVERY_DEPTH` packets behind it.
+    /// The bound this always keeps is that a candidate must be a currently *missing* sequence
+    /// number (`register.accepts`): recovery only ever fills a hole, and never overwrites a
+    /// correctly received frame — the worst case above only reorders audio among frames that
+    /// were all lost anyway. `carrier` is the packet the block arrived in; recovery is limited
+    /// to `MAX_RED_RECOVERY_DEPTH` packets behind it.
     pub(crate) fn red_locate_seq(&self, carrier: SeqNo, block_time: u64) -> Option<SeqNo> {
         let register = self.register.as_ref()?;
 

--- a/src/streams/register.rs
+++ b/src/streams/register.rs
@@ -81,6 +81,13 @@ impl ReceiverRegister {
         self.nack.accepts(seq)
     }
 
+    /// Mark `seq` as present without counting it as received: it was rebuilt from redundancy
+    /// (RFC 2198 RED) rather than arriving on the wire. It will no longer be NACKed or accepted
+    /// as new, while `count` (and thus the reception report loss) still reflects wire loss.
+    pub fn mark_recovered(&mut self, seq: SeqNo) {
+        self.nack.update(seq);
+    }
+
     pub fn update(&mut self, seq: SeqNo, arrival: Instant, rtp_time: u32, clock_rate: u32) -> bool {
         if self.first.is_none() {
             self.first = Some(seq);

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -479,8 +479,11 @@ impl StreamTx {
 
         let pt_main = header_ref.payload_type;
 
-        // The pt in next.pkt is the "main" pt.
-        let Some(param) = params.iter().find(|p| p.pt() == pt_main) else {
+        // The pt in next.pkt is the "main" pt, or a RED PT folded onto its primary codec.
+        let Some(param) = params
+            .iter()
+            .find(|p| p.pt() == pt_main || p.red() == Some(pt_main))
+        else {
             // PT does not exist in the connected media.
             warn!("Media is missing PT ({}) used in RTP packet", pt_main);
 

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -553,7 +553,12 @@ impl StreamTx {
 
         let mut header = match next.kind {
             NextPacketKind::Regular => {
-                let rtx_possible = param.resend().is_some();
+                // A RED-wrapped packet (pt_main is the RED PT) must not be nackable: an RTX
+                // resend carries the RTX PT with the primary codec's apt, so the peer would
+                // parse the RED bytes as raw primary codec. RED carries its own redundancy, so
+                // it does not need RTX anyway. Plain packets on this PT stay nackable.
+                let is_red_packet = param.red() == Some(pt_main);
+                let rtx_possible = param.resend().is_some() && !is_red_packet;
 
                 if rtx_possible {
                     // Remember PT We want to set these directly on `self` here, but can't

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -532,8 +532,11 @@ impl StreamTx {
 
         let pt_main = header_ref.payload_type;
 
-        // The pt in next.pkt is the "main" pt.
-        let Some(param) = params.iter().find(|p| p.pt() == pt_main) else {
+        // The pt in next.pkt is the "main" pt, or a RED PT folded onto its primary codec.
+        let Some(param) = params
+            .iter()
+            .find(|p| p.pt() == pt_main || p.red() == Some(pt_main))
+        else {
             // PT does not exist in the connected media.
             warn!("Media is missing PT ({}) used in RTP packet", pt_main);
 

--- a/tests/g722.rs
+++ b/tests/g722.rs
@@ -27,8 +27,9 @@ pub fn g722_media_mode_is_16khz_both_ways() -> Result<(), RtcError> {
     init_log();
     init_crypto_default();
 
-    let mut l = TestRtc::new_with_config(Peer::Left, |c| c.clear_codecs().enable_g722(true));
-    let mut r = TestRtc::new_with_config(Peer::Right, |c| c.clear_codecs().enable_g722(true));
+    let mut l = TestRtc::new_with_config(Peer::Left, |c| c.clear_codecs().enable_g722(true, false));
+    let mut r =
+        TestRtc::new_with_config(Peer::Right, |c| c.clear_codecs().enable_g722(true, false));
 
     l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
     r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
@@ -119,7 +120,7 @@ fn rtp_mode_g722(peer: Peer, now: Instant) -> Rtc {
         .set_rtp_mode(true)
         .enable_raw_packets(true)
         .clear_codecs()
-        .enable_g722(true);
+        .enable_g722(true, false);
     if let Some(crypto) = peer.crypto_provider() {
         b = b.set_crypto_provider(crypto);
     }
@@ -228,12 +229,15 @@ pub fn g722_sample_send_to_rtp_receive() -> Result<(), RtcError> {
 
     let now = Instant::now();
     // L writes via the sample/frame API (16 kHz media time).
-    let rtc_l = Rtc::builder().clear_codecs().enable_g722(true).build(now);
+    let rtc_l = Rtc::builder()
+        .clear_codecs()
+        .enable_g722(true, false)
+        .build(now);
     // R reads raw RTP packets (8 kHz wire clock).
     let rtc_r = Rtc::builder()
         .set_rtp_mode(true)
         .clear_codecs()
-        .enable_g722(true)
+        .enable_g722(true, false)
         .build(now);
 
     let (mut l, mut r) = connect_l_r_with_rtc(rtc_l, rtc_r);
@@ -324,13 +328,13 @@ pub fn g722_rtp_send_to_sample_receive() -> Result<(), RtcError> {
     let rtc_l = Rtc::builder()
         .set_rtp_mode(true)
         .clear_codecs()
-        .enable_g722(true)
+        .enable_g722(true, false)
         .build(now);
     // R reads frames via the sample API (16 kHz media time), no reorder hold-back.
     let rtc_r = Rtc::builder()
         .set_reordering_size_audio(0)
         .clear_codecs()
-        .enable_g722(true)
+        .enable_g722(true, false)
         .build(now);
 
     let (mut l, mut r) = connect_l_r_with_rtc(rtc_l, rtc_r);

--- a/tests/red.rs
+++ b/tests/red.rs
@@ -1,0 +1,293 @@
+use std::net::Ipv4Addr;
+use std::time::{Duration, Instant};
+
+use netem::{NetemConfig, Probability, RandomLoss};
+use str0m::format::Codec;
+use str0m::media::{Direction, MediaKind};
+use str0m::rtp::RedDecoder;
+use str0m::{Event, Rtc};
+
+mod common;
+use common::{Peer, TestRtc, init_crypto_default, init_log, progress};
+
+/// Build a `TestRtc` whose `Rtc` has RFC 2198 RED enabled, honouring the per-peer crypto
+/// provider env vars like `TestRtc::new` does.
+fn rtc_with_red(peer: Peer) -> TestRtc {
+    let now = Instant::now();
+    let mut builder = Rtc::builder().enable_red(true);
+    if let Some(crypto) = peer.crypto_provider() {
+        builder = builder.set_crypto_provider(crypto);
+    }
+    TestRtc::new_with_rtc(peer.span(), builder.build(now))
+}
+
+fn media_count(r: &TestRtc) -> usize {
+    r.events
+        .iter()
+        .filter(|(_, e)| matches!(e, Event::MediaData(_)))
+        .count()
+}
+
+/// Connect L and R for SendRecv audio, then send `secs` seconds of Opus frames. `red_l`/`red_r`
+/// enable RED on each side; `media_loss` is applied to R's incoming queue *after* the handshake
+/// so only the media phase is lossy. Returns both peers (with their collected events).
+fn run_audio(
+    red_l: bool,
+    red_r: bool,
+    media_loss: Option<NetemConfig>,
+    secs: u64,
+) -> (TestRtc, TestRtc) {
+    init_log();
+    init_crypto_default();
+
+    let mut l = if red_l {
+        rtc_with_red(Peer::Left)
+    } else {
+        TestRtc::new(Peer::Left)
+    };
+    let mut r = if red_r {
+        rtc_with_red(Peer::Right)
+    } else {
+        TestRtc::new(Peer::Right)
+    };
+
+    l.set_forced_time_advance(Duration::from_millis(1));
+    r.set_forced_time_advance(Duration::from_millis(1));
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    let mut change = l.sdp_api();
+    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+    let (offer, pending) = change.apply().unwrap();
+    let answer = r.rtc.sdp_api().accept_offer(offer).unwrap();
+    l.rtc.sdp_api().accept_answer(pending, answer).unwrap();
+
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r).unwrap();
+    }
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    // Apply loss only to the media phase, not the DTLS/ICE handshake.
+    if let Some(cfg) = media_loss {
+        r.set_netem(cfg);
+    }
+
+    let pt = l.params_opus().pt();
+    let data = vec![1_u8; 80];
+
+    let mut start_of_talk_spurt = true;
+    loop {
+        let wallclock = l.start + l.duration();
+        let time = l.duration().into();
+        l.writer(mid)
+            .unwrap()
+            .start_of_talkspurt(start_of_talk_spurt)
+            .write(pt, wallclock, time, data.clone())
+            .unwrap();
+        start_of_talk_spurt = false;
+
+        progress(&mut l, &mut r).unwrap();
+
+        if l.duration() > Duration::from_secs(secs) {
+            break;
+        }
+    }
+
+    (l, r)
+}
+
+/// With RED enabled on both peers, audio flows transparently: the application writes and reads
+/// plain Opus while RED wrapping/unwrapping happens on the wire.
+#[test]
+pub fn red_transparent_roundtrip() {
+    let (l, r) = run_audio(true, true, None, 5);
+
+    // RED must have been negotiated on both sides.
+    assert!(l.params_opus().red().is_some(), "L should negotiate RED");
+    assert!(r.params_opus().red().is_some(), "R should negotiate RED");
+
+    let media: Vec<_> = r
+        .events
+        .iter()
+        .filter_map(|(_, e)| match e {
+            Event::MediaData(m) => Some(m),
+            _ => None,
+        })
+        .collect();
+
+    // The app sees Opus, never RED, and the payload round-trips.
+    assert!(media.len() > 100, "Not enough MediaData: {}", media.len());
+    assert_eq!(media[0].params.spec().codec, Codec::Opus);
+    assert_eq!(media[0].pt, l.params_opus().pt());
+    assert_eq!(&media[0].data[..], &[1_u8; 80][..]);
+}
+
+/// The offer must list the RED payload type in the m-line `fmt` list, not only as an `a=rtpmap`.
+/// A strict peer (e.g. a browser) ignores an rtpmap whose PT is absent from the m-line, so this
+/// is required for RED to negotiate at all. Regression test: str0m-to-str0m is lenient and would
+/// otherwise hide the omission.
+#[test]
+pub fn red_offer_lists_red_pt_in_mline() {
+    init_log();
+    init_crypto_default();
+
+    let mut l = rtc_with_red(Peer::Left);
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+
+    let mut change = l.sdp_api();
+    change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+    let (offer, _pending) = change.apply().unwrap();
+
+    let red_pt = l.params_opus().red().expect("RED configured");
+    let sdp = offer.to_sdp_string();
+    let mline = sdp
+        .lines()
+        .find(|line| line.starts_with("m=audio"))
+        .expect("m=audio line");
+    // m=<media> <port> <proto> <fmt>...
+    let fmts: Vec<&str> = mline.split_whitespace().skip(3).collect();
+
+    assert!(
+        fmts.contains(&red_pt.to_string().as_str()),
+        "m-line fmt list must include the RED pt {red_pt}; got: {mline}"
+    );
+}
+
+/// Under independent (isolated) packet loss, RED recovers the lost frames from the next packet's
+/// redundancy. With the same loss seed, the RED receiver gets strictly more frames than a plain
+/// Opus receiver, which has no way to fill the gaps.
+#[test]
+pub fn red_recovers_single_loss() {
+    let loss = || {
+        NetemConfig::new()
+            .loss(RandomLoss::new(Probability::new(0.08)))
+            .seed(7)
+    };
+
+    let (_, r_red) = run_audio(true, true, Some(loss()), 4);
+    let (_, r_plain) = run_audio(false, false, Some(loss()), 4);
+
+    let red = media_count(&r_red);
+    let plain = media_count(&r_plain);
+
+    assert!(
+        red > plain,
+        "RED should recover isolated losses: red={red} plain={plain}"
+    );
+}
+
+/// If only one side enables RED, negotiation falls back to plain Opus (RED is opt-in and kept
+/// only when both peers offer it). Media still flows.
+#[test]
+pub fn red_interop_fallback() {
+    let (l, r) = run_audio(true, false, None, 2);
+
+    assert_eq!(
+        l.params_opus().red(),
+        None,
+        "L must drop RED when R does not offer it"
+    );
+    assert_eq!(r.params_opus().red(), None, "R never enabled RED");
+    assert!(media_count(&r) > 50, "media should still flow without RED");
+}
+
+/// Mirror of the fallback: the offerer has RED off and the answerer has it on. RED must still be
+/// dropped (it is kept only when the offer carries it), and media flows as plain Opus.
+#[test]
+pub fn red_interop_fallback_mirror() {
+    let (l, r) = run_audio(false, true, None, 2);
+
+    assert_eq!(l.params_opus().red(), None, "L never offered RED");
+    assert_eq!(
+        r.params_opus().red(),
+        None,
+        "R must drop RED when the offer does not carry it"
+    );
+    assert!(media_count(&r) > 50, "media should still flow without RED");
+}
+
+/// In RTP mode the RED packets are forwarded as-is: the receiver sees `Event::RtpPacket` carrying
+/// the RED payload type, and the RED structure is parseable with the public decoder.
+#[test]
+pub fn red_rtp_mode_passthrough() {
+    init_log();
+    init_crypto_default();
+
+    let mut l = rtc_with_red(Peer::Left); // frame mode, RED on: wraps outgoing Opus
+
+    let now = Instant::now();
+    let mut r_builder = Rtc::builder().set_rtp_mode(true).enable_red(true);
+    if let Some(crypto) = Peer::Right.crypto_provider() {
+        r_builder = r_builder.set_crypto_provider(crypto);
+    }
+    let mut r = TestRtc::new_with_rtc(Peer::Right.span(), r_builder.build(now));
+
+    l.set_forced_time_advance(Duration::from_millis(1));
+    r.set_forced_time_advance(Duration::from_millis(1));
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    let mut change = l.sdp_api();
+    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+    let (offer, pending) = change.apply().unwrap();
+    let answer = r.rtc.sdp_api().accept_offer(offer).unwrap();
+    l.rtc.sdp_api().accept_answer(pending, answer).unwrap();
+
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r).unwrap();
+    }
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    let red_pt = l.params_opus().red().expect("RED negotiated");
+    let pt = l.params_opus().pt();
+    let data = vec![1_u8; 80];
+
+    let mut start_of_talk_spurt = true;
+    loop {
+        let wallclock = l.start + l.duration();
+        let time = l.duration().into();
+        l.writer(mid)
+            .unwrap()
+            .start_of_talkspurt(start_of_talk_spurt)
+            .write(pt, wallclock, time, data.clone())
+            .unwrap();
+        start_of_talk_spurt = false;
+
+        progress(&mut l, &mut r).unwrap();
+
+        if l.duration() > Duration::from_secs(2) {
+            break;
+        }
+    }
+
+    // R is in RTP mode: it sees the raw RED packets (PT == red), not Opus MediaData.
+    let red_packets: Vec<_> = r
+        .events
+        .iter()
+        .filter_map(|(_, e)| match e {
+            Event::RtpPacket(p) if p.header.payload_type == red_pt => Some(p),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        !red_packets.is_empty(),
+        "R should receive raw RED RtpPackets in rtp mode"
+    );
+    // The RED payload is well-formed and parseable with the public decoder.
+    assert!(RedDecoder::decode(&red_packets[0].payload).is_ok());
+}

--- a/tests/red.rs
+++ b/tests/red.rs
@@ -453,3 +453,292 @@ pub fn red_rtp_mode_passthrough() {
     // The RED payload is well-formed and parseable with the public decoder.
     assert!(RedDecoder::decode(&red_packets[0].payload).is_ok());
 }
+
+// ---------------------------------------------------------------------------------------------
+// Hand-crafted RED on the wire.
+//
+// L runs in RTP mode and writes RED packets built with the public encoder, so the tests control
+// the exact redundancy pattern, the frame timing and which sequence numbers are lost. R runs in
+// frame mode and has to unwrap and recover. Frame `k` carries payload `[k; 80]` so every emitted
+// `MediaData` identifies which frame it is, and `seq_range`/`time` show where R placed it.
+// ---------------------------------------------------------------------------------------------
+
+mod raw {
+    use super::*;
+    use common::connect_l_r_with_rtc;
+    use str0m::Rtc;
+    use str0m::media::{Frequency, MediaData, Mid, Pt};
+    use str0m::rtp::rtcp::Rtcp;
+    use str0m::rtp::{RawPacket, RedEncoder, RedundantBlock, RtpWrite, SeqNo, Ssrc};
+
+    pub const BASE_SEQ: u64 = 47_000;
+    pub const BASE_TS: u32 = 10_000;
+    pub const FRAME: u32 = 960; // Opus 20 ms @ 48 kHz
+
+    pub struct RawRed {
+        pub l: TestRtc,
+        pub r: TestRtc,
+        pub mid: Mid,
+        pub ssrc: Ssrc,
+        pub opus_pt: Pt,
+        pub red_pt: Pt,
+    }
+
+    /// Connect L (RTP mode) and R (frame mode, `r_reordering` = `set_reordering_size_audio`)
+    /// with Opus + RED over DirectApi.
+    pub fn connect(r_reordering: Option<usize>) -> RawRed {
+        init_log();
+        init_crypto_default();
+        let now = Instant::now();
+
+        let mut lb = Rtc::builder()
+            .set_rtp_mode(true)
+            .enable_raw_packets(true)
+            .enable_opus(true, true);
+        if let Some(c) = Peer::Left.crypto_provider() {
+            lb = lb.set_crypto_provider(c);
+        }
+        let mut rb = Rtc::builder()
+            .enable_raw_packets(true)
+            .enable_opus(true, true);
+        if let Some(n) = r_reordering {
+            rb = rb.set_reordering_size_audio(n);
+        }
+        if let Some(c) = Peer::Right.crypto_provider() {
+            rb = rb.set_crypto_provider(c);
+        }
+
+        let (mut l, mut r) = connect_l_r_with_rtc(lb.build(now), rb.build(now));
+
+        let mid: Mid = "aud".into();
+        let ssrc: Ssrc = 42.into();
+
+        l.direct_api().declare_media(mid, MediaKind::Audio);
+        l.direct_api().declare_stream_tx(ssrc, None, mid, None);
+        r.direct_api().declare_media(mid, MediaKind::Audio);
+        r.direct_api().expect_stream_rx(ssrc, None, mid, None);
+
+        let max = l.last.max(r.last);
+        l.last = max;
+        r.last = max;
+
+        let opus = l.params_opus();
+        let red_pt = opus.red().expect("RED enabled on L");
+        assert!(r.params_opus().red().is_some(), "RED enabled on R");
+
+        RawRed {
+            l,
+            r,
+            mid,
+            ssrc,
+            opus_pt: opus.pt(),
+            red_pt,
+        }
+    }
+
+    impl RawRed {
+        /// Send frames `0..ts.len()` at the given RTP timestamps, seq `BASE_SEQ + k`. Each packet
+        /// carries, as redundancy, the frames `k - d` for every `d` in `distances` (oldest first).
+        /// Frames whose index is in `lost` are built (so their redundancy history is right) but
+        /// never written. Then lets everything settle.
+        pub fn send(&mut self, ts: &[u32], distances: &[u8], lost: &[u8]) {
+            let payload = |k: u8| vec![k; 80];
+            let n = ts.len() as u8;
+
+            for k in 0..n {
+                let mut blocks: Vec<RedundantBlock> = distances
+                    .iter()
+                    .filter_map(|&d| k.checked_sub(d))
+                    .map(|kk| RedundantBlock {
+                        pt: *self.opus_pt,
+                        timestamp_offset: ts[k as usize] - ts[kk as usize],
+                        payload: payload(kk),
+                    })
+                    .collect();
+                // RFC 2198: oldest first.
+                blocks.sort_by_key(|b| std::cmp::Reverse(b.timestamp_offset));
+
+                let red = RedEncoder::encode(*self.opus_pt, &payload(k), &blocks);
+
+                if !lost.contains(&k) {
+                    let wallclock = self.l.start + self.l.duration();
+                    let seq_no: SeqNo = (BASE_SEQ + k as u64).into();
+                    let mut direct = self.l.direct_api();
+                    let stream = direct.stream_tx(&self.ssrc).unwrap();
+                    stream.write_rtp(
+                        RtpWrite::new(self.red_pt, seq_no, ts[k as usize], wallclock, red)
+                            .marker(k == 0),
+                    );
+                }
+
+                progress(&mut self.l, &mut self.r).unwrap();
+            }
+
+            let settle = self.l.duration() + Duration::from_secs(2);
+            while self.l.duration() < settle {
+                progress(&mut self.l, &mut self.r).unwrap();
+            }
+        }
+
+        pub fn media(&self) -> Vec<&MediaData> {
+            self.r
+                .events
+                .iter()
+                .filter_map(|(_, e)| match e {
+                    Event::MediaData(m) if m.mid == self.mid => Some(m),
+                    _ => None,
+                })
+                .collect()
+        }
+
+        /// Every delivered frame must sit at its own sequence number and RTP time. A RED
+        /// recovery that maps a redundant block to the wrong seq shows up here.
+        pub fn assert_consistent(&self, ts: &[u32]) {
+            for m in self.media() {
+                let k = m.data[0];
+                let seq = *m.seq_range.start();
+                let time = m.time.rebase(Frequency::FORTY_EIGHT_KHZ).numer();
+                assert_eq!(
+                    *seq,
+                    BASE_SEQ + k as u64,
+                    "frame {k} delivered at seq {seq} (expected {})",
+                    BASE_SEQ + k as u64
+                );
+                assert_eq!(
+                    time, ts[k as usize] as u64,
+                    "frame {k} delivered at rtp time {time} (expected {})",
+                    ts[k as usize]
+                );
+            }
+        }
+
+        pub fn delivered(&self, k: u8) -> usize {
+            self.media().iter().filter(|m| m.data[0] == k).count()
+        }
+
+        /// Sequence numbers R asked to have retransmitted (extended against `BASE_SEQ`).
+        pub fn nacked_seqs(&self) -> Vec<u64> {
+            self.r
+                .events
+                .iter()
+                .filter_map(|(_, e)| match e.as_raw_packet() {
+                    Some(RawPacket::RtcpTx(Rtcp::Nack(n))) => Some(n),
+                    _ => None,
+                })
+                .flat_map(|n| {
+                    n.reports
+                        .iter()
+                        .flat_map(|r| r.into_iter(SeqNo::from(BASE_SEQ)).map(|s| *s))
+                })
+                .collect()
+        }
+    }
+
+    pub fn uniform(n: usize) -> Vec<u32> {
+        (0..n as u32).map(|k| BASE_TS + k * FRAME).collect()
+    }
+}
+
+use raw::{BASE_SEQ, FRAME};
+
+/// A remote sender is not bound by our `set_red_distances` sanitiser. With a `[2, 4]` pattern and
+/// no main-1 block, the receiver must not assume the closest block is one packet back: after
+/// losing frames 5 and 6, frame 7's closest block is frame 5, which must never be delivered as
+/// seq 6.
+#[test]
+fn red_recovery_never_misplaces_frames_for_a_pattern_without_main_minus_one() {
+    let mut t = raw::connect(None);
+    let ts = raw::uniform(24);
+
+    t.send(&ts, &[2, 4], &[5, 6]);
+
+    t.assert_consistent(&ts);
+}
+
+/// Opus frame duration is not constant (10/20/40/60 ms, adaptive ptime, DTX). Offsets alone then
+/// don't give a sequence distance: with a libwebrtc-like `[1, 2, 3]` pattern, where frame 4 is a
+/// 40 ms frame and frames 3..=6 are lost, frame 7's main-3 block (frame 4) sits 3840 ticks back,
+/// which looks like four 20 ms packets. It must not be delivered as seq 3.
+#[test]
+fn red_recovery_never_misplaces_frames_when_frame_duration_varies() {
+    let mut t = raw::connect(None);
+
+    let mut ts = raw::uniform(24);
+    // Frame 4 lasts 40 ms: everything after it shifts by one extra frame.
+    for v in ts.iter_mut().skip(5) {
+        *v += FRAME;
+    }
+
+    t.send(&ts, &[1, 2, 3], &[3, 4, 5, 6]);
+
+    t.assert_consistent(&ts);
+}
+
+/// A sequence number recovered from RED was never on the wire, but the receiver has the frame,
+/// so it must not ask for a retransmission of it. Frame 5 is recovered from frame 6. Frame 9 is
+/// lost together with frame 10 (which carried its redundancy) and is therefore genuinely
+/// missing: that one must still be NACKed, proving the NACK path is live.
+#[test]
+fn red_recovered_seq_no_is_not_nacked() {
+    let mut t = raw::connect(None);
+    let ts = raw::uniform(60);
+
+    t.send(&ts, &[1], &[5, 9, 10]);
+
+    assert_eq!(t.delivered(5), 1, "frame 5 recovered from RED");
+    assert_eq!(t.delivered(9), 0, "frame 9 had no surviving redundancy");
+
+    let nacked = t.nacked_seqs();
+    assert!(
+        nacked.contains(&(BASE_SEQ + 9)),
+        "genuinely lost seq must be NACKed: {nacked:?}"
+    );
+    assert!(
+        !nacked.contains(&(BASE_SEQ + 5)),
+        "RED-recovered seq must not be NACKed: {nacked:?}"
+    );
+}
+
+/// With multi-level redundancy the same lost frame is carried by several later packets. It must
+/// be delivered once, also when the application has turned the reordering buffer off
+/// (`set_reordering_size_audio(0)`), which is exactly the configuration that does not
+/// de-duplicate late arrivals.
+#[test]
+fn red_recovered_frame_is_delivered_once_without_reordering_buffer() {
+    let mut t = raw::connect(Some(0));
+    let ts = raw::uniform(30);
+
+    t.send(&ts, &[1, 3], &[5]);
+
+    t.assert_consistent(&ts);
+    assert_eq!(t.delivered(5), 1, "frame 5 delivered exactly once");
+    for k in 0..30u8 {
+        assert!(
+            t.delivered(k) <= 1,
+            "frame {k} delivered {} times",
+            t.delivered(k)
+        );
+    }
+}
+
+/// The per-mid ingress stats must count the full RED wire payload like the per-mid egress stats
+/// on the sender do (and like `PeerStats` already does), not just the unwrapped primary block.
+#[test]
+fn red_media_ingress_stats_match_media_egress_stats() {
+    let (l, r) = run_audio_options(true, true, None, 2, true, false);
+
+    let sent = l.events.iter().rev().find_map(|(_, e)| match e {
+        Event::MediaEgressStats(s) if s.bytes > 0 => Some(s.bytes),
+        _ => None,
+    });
+    let received = r.events.iter().rev().find_map(|(_, e)| match e {
+        Event::MediaIngressStats(s) if s.bytes > 0 => Some(s.bytes),
+        _ => None,
+    });
+
+    assert!(sent.is_some(), "egress stats emitted");
+    assert_eq!(
+        received, sent,
+        "RED ingress accounting must include the RED headers and redundant blocks"
+    );
+}

--- a/tests/red.rs
+++ b/tests/red.rs
@@ -14,7 +14,7 @@ use common::{Peer, TestRtc, init_crypto_default, init_log, progress};
 /// provider env vars like `TestRtc::new` does.
 fn rtc_with_red(peer: Peer) -> TestRtc {
     let now = Instant::now();
-    let mut builder = Rtc::builder().enable_red(true);
+    let mut builder = Rtc::builder().enable_opus(true, true);
     if let Some(crypto) = peer.crypto_provider() {
         builder = builder.set_crypto_provider(crypto);
     }
@@ -225,7 +225,7 @@ pub fn red_send_toggle_no_renegotiation() {
     let mut l = rtc_with_red(Peer::Left); // frame mode, RED on: wraps outgoing Opus
 
     let now = Instant::now();
-    let mut r_builder = Rtc::builder().set_rtp_mode(true).enable_red(true);
+    let mut r_builder = Rtc::builder().set_rtp_mode(true).enable_opus(true, true);
     if let Some(crypto) = Peer::Right.crypto_provider() {
         r_builder = r_builder.set_crypto_provider(crypto);
     }
@@ -275,7 +275,7 @@ pub fn red_send_toggle_no_renegotiation() {
         progress(&mut l, &mut r).unwrap();
 
         if !toggled && l.duration() > Duration::from_secs(1) {
-            l.rtc.sdp_api().set_red_send(mid, false);
+            l.rtc.direct_api().set_red_send(mid, false);
             toggled = true;
         }
         if l.duration() > Duration::from_secs(3) {
@@ -309,7 +309,7 @@ pub fn red_rtp_mode_passthrough() {
     let mut l = rtc_with_red(Peer::Left); // frame mode, RED on: wraps outgoing Opus
 
     let now = Instant::now();
-    let mut r_builder = Rtc::builder().set_rtp_mode(true).enable_red(true);
+    let mut r_builder = Rtc::builder().set_rtp_mode(true).enable_opus(true, true);
     if let Some(crypto) = Peer::Right.crypto_provider() {
         r_builder = r_builder.set_crypto_provider(crypto);
     }

--- a/tests/red.rs
+++ b/tests/red.rs
@@ -1,0 +1,379 @@
+use std::net::Ipv4Addr;
+use std::time::{Duration, Instant};
+
+use netem::{NetemConfig, Probability, RandomLoss};
+use str0m::format::Codec;
+use str0m::media::{Direction, MediaKind};
+use str0m::rtp::RedDecoder;
+use str0m::{Event, Rtc};
+
+mod common;
+use common::{Peer, TestRtc, init_crypto_default, init_log, progress};
+
+/// Build a `TestRtc` whose `Rtc` has RFC 2198 RED enabled, honouring the per-peer crypto
+/// provider env vars like `TestRtc::new` does.
+fn rtc_with_red(peer: Peer) -> TestRtc {
+    let now = Instant::now();
+    let mut builder = Rtc::builder().enable_red(true);
+    if let Some(crypto) = peer.crypto_provider() {
+        builder = builder.set_crypto_provider(crypto);
+    }
+    TestRtc::new_with_rtc(peer.span(), builder.build(now))
+}
+
+fn media_count(r: &TestRtc) -> usize {
+    r.events
+        .iter()
+        .filter(|(_, e)| matches!(e, Event::MediaData(_)))
+        .count()
+}
+
+/// Connect L and R for SendRecv audio, then send `secs` seconds of Opus frames. `red_l`/`red_r`
+/// enable RED on each side; `media_loss` is applied to R's incoming queue *after* the handshake
+/// so only the media phase is lossy. Returns both peers (with their collected events).
+fn run_audio(
+    red_l: bool,
+    red_r: bool,
+    media_loss: Option<NetemConfig>,
+    secs: u64,
+) -> (TestRtc, TestRtc) {
+    init_log();
+    init_crypto_default();
+
+    let mut l = if red_l {
+        rtc_with_red(Peer::Left)
+    } else {
+        TestRtc::new(Peer::Left)
+    };
+    let mut r = if red_r {
+        rtc_with_red(Peer::Right)
+    } else {
+        TestRtc::new(Peer::Right)
+    };
+
+    l.set_forced_time_advance(Duration::from_millis(1));
+    r.set_forced_time_advance(Duration::from_millis(1));
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    let mut change = l.sdp_api();
+    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+    let (offer, pending) = change.apply().unwrap();
+    let answer = r.rtc.sdp_api().accept_offer(offer).unwrap();
+    l.rtc.sdp_api().accept_answer(pending, answer).unwrap();
+
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r).unwrap();
+    }
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    // Apply loss only to the media phase, not the DTLS/ICE handshake.
+    if let Some(cfg) = media_loss {
+        r.set_netem(cfg);
+    }
+
+    let pt = l.params_opus().pt();
+    let data = vec![1_u8; 80];
+
+    let mut start_of_talk_spurt = true;
+    loop {
+        let wallclock = l.start + l.duration();
+        let time = l.duration().into();
+        l.writer(mid)
+            .unwrap()
+            .start_of_talkspurt(start_of_talk_spurt)
+            .write(pt, wallclock, time, data.clone())
+            .unwrap();
+        start_of_talk_spurt = false;
+
+        progress(&mut l, &mut r).unwrap();
+
+        if l.duration() > Duration::from_secs(secs) {
+            break;
+        }
+    }
+
+    (l, r)
+}
+
+/// With RED enabled on both peers, audio flows transparently: the application writes and reads
+/// plain Opus while RED wrapping/unwrapping happens on the wire.
+#[test]
+pub fn red_transparent_roundtrip() {
+    let (l, r) = run_audio(true, true, None, 5);
+
+    // RED must have been negotiated on both sides.
+    assert!(l.params_opus().red().is_some(), "L should negotiate RED");
+    assert!(r.params_opus().red().is_some(), "R should negotiate RED");
+
+    let media: Vec<_> = r
+        .events
+        .iter()
+        .filter_map(|(_, e)| match e {
+            Event::MediaData(m) => Some(m),
+            _ => None,
+        })
+        .collect();
+
+    // The app sees Opus, never RED, and the payload round-trips.
+    assert!(media.len() > 100, "Not enough MediaData: {}", media.len());
+    assert_eq!(media[0].params.spec().codec, Codec::Opus);
+    assert_eq!(media[0].pt, l.params_opus().pt());
+    assert_eq!(&media[0].data[..], &[1_u8; 80][..]);
+}
+
+/// The offer must list the RED payload type in the m-line `fmt` list, not only as an `a=rtpmap`.
+/// A strict peer (e.g. a browser) ignores an rtpmap whose PT is absent from the m-line, so this
+/// is required for RED to negotiate at all. Regression test: str0m-to-str0m is lenient and would
+/// otherwise hide the omission.
+#[test]
+pub fn red_offer_lists_red_pt_in_mline() {
+    init_log();
+    init_crypto_default();
+
+    let mut l = rtc_with_red(Peer::Left);
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+
+    let mut change = l.sdp_api();
+    change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+    let (offer, _pending) = change.apply().unwrap();
+
+    let red_pt = l.params_opus().red().expect("RED configured");
+    let sdp = offer.to_sdp_string();
+    let mline = sdp
+        .lines()
+        .find(|line| line.starts_with("m=audio"))
+        .expect("m=audio line");
+    // m=<media> <port> <proto> <fmt>...
+    let fmts: Vec<&str> = mline.split_whitespace().skip(3).collect();
+
+    assert!(
+        fmts.contains(&red_pt.to_string().as_str()),
+        "m-line fmt list must include the RED pt {red_pt}; got: {mline}"
+    );
+}
+
+/// Under independent (isolated) packet loss, RED recovers the lost frames from the next packet's
+/// redundancy. With the same loss seed, the RED receiver gets strictly more frames than a plain
+/// Opus receiver, which has no way to fill the gaps.
+#[test]
+pub fn red_recovers_single_loss() {
+    let loss = || {
+        NetemConfig::new()
+            .loss(RandomLoss::new(Probability::new(0.08)))
+            .seed(7)
+    };
+
+    let (_, r_red) = run_audio(true, true, Some(loss()), 4);
+    let (_, r_plain) = run_audio(false, false, Some(loss()), 4);
+
+    let red = media_count(&r_red);
+    let plain = media_count(&r_plain);
+
+    assert!(
+        red > plain,
+        "RED should recover isolated losses: red={red} plain={plain}"
+    );
+}
+
+/// If only one side enables RED, negotiation falls back to plain Opus (RED is opt-in and kept
+/// only when both peers offer it). Media still flows.
+#[test]
+pub fn red_interop_fallback() {
+    let (l, r) = run_audio(true, false, None, 2);
+
+    assert_eq!(
+        l.params_opus().red(),
+        None,
+        "L must drop RED when R does not offer it"
+    );
+    assert_eq!(r.params_opus().red(), None, "R never enabled RED");
+    assert!(media_count(&r) > 50, "media should still flow without RED");
+}
+
+/// Mirror of the fallback: the offerer has RED off and the answerer has it on. RED must still be
+/// dropped (it is kept only when the offer carries it), and media flows as plain Opus.
+#[test]
+pub fn red_interop_fallback_mirror() {
+    let (l, r) = run_audio(false, true, None, 2);
+
+    assert_eq!(l.params_opus().red(), None, "L never offered RED");
+    assert_eq!(
+        r.params_opus().red(),
+        None,
+        "R must drop RED when the offer does not carry it"
+    );
+    assert!(media_count(&r) > 50, "media should still flow without RED");
+}
+
+/// The runtime send-side toggle turns RED wrapping on and off with no renegotiation. With R in RTP
+/// mode we read the wire PT directly: RED-wrapped packets carry the RED PT, unwrapped packets carry
+/// the plain Opus PT. Toggling mid-session flips which PT R receives while RED stays negotiated the
+/// whole time, matching the SFU case of enabling redundancy on a lossy leg and disabling it later.
+#[test]
+pub fn red_send_toggle_no_renegotiation() {
+    init_log();
+    init_crypto_default();
+
+    let mut l = rtc_with_red(Peer::Left); // frame mode, RED on: wraps outgoing Opus
+
+    let now = Instant::now();
+    let mut r_builder = Rtc::builder().set_rtp_mode(true).enable_red(true);
+    if let Some(crypto) = Peer::Right.crypto_provider() {
+        r_builder = r_builder.set_crypto_provider(crypto);
+    }
+    let mut r = TestRtc::new_with_rtc(Peer::Right.span(), r_builder.build(now));
+
+    l.set_forced_time_advance(Duration::from_millis(1));
+    r.set_forced_time_advance(Duration::from_millis(1));
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    let mut change = l.sdp_api();
+    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+    let (offer, pending) = change.apply().unwrap();
+    let answer = r.rtc.sdp_api().accept_offer(offer).unwrap();
+    l.rtc.sdp_api().accept_answer(pending, answer).unwrap();
+
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r).unwrap();
+    }
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    let red_pt = l.params_opus().red().expect("RED negotiated");
+    let opus_pt = l.params_opus().pt();
+    let data = vec![1_u8; 80];
+
+    // Phase 1 (< 1s): RED on, wire carries the RED pt. At 1s, toggle RED sending off with no
+    // renegotiation. Phase 2 (1s..3s): the same media goes out as plain Opus.
+    let mut toggled = false;
+    let mut start_of_talk_spurt = true;
+    loop {
+        let wallclock = l.start + l.duration();
+        let time = l.duration().into();
+        l.writer(mid)
+            .unwrap()
+            .start_of_talkspurt(start_of_talk_spurt)
+            .write(opus_pt, wallclock, time, data.clone())
+            .unwrap();
+        start_of_talk_spurt = false;
+
+        progress(&mut l, &mut r).unwrap();
+
+        if !toggled && l.duration() > Duration::from_secs(1) {
+            l.rtc.sdp_api().set_red_send(mid, false);
+            toggled = true;
+        }
+        if l.duration() > Duration::from_secs(3) {
+            break;
+        }
+    }
+
+    // RED is still negotiated: the toggle never touched SDP.
+    assert!(l.params_opus().red().is_some(), "RED must stay negotiated");
+
+    let saw_red = r
+        .events
+        .iter()
+        .any(|(_, e)| matches!(e, Event::RtpPacket(p) if p.header.payload_type == red_pt));
+    let saw_opus = r
+        .events
+        .iter()
+        .any(|(_, e)| matches!(e, Event::RtpPacket(p) if p.header.payload_type == opus_pt));
+
+    assert!(saw_red, "phase 1 should wrap outgoing media in RED");
+    assert!(saw_opus, "phase 2 should send plain Opus after the toggle");
+}
+
+/// In RTP mode the RED packets are forwarded as-is: the receiver sees `Event::RtpPacket` carrying
+/// the RED payload type, and the RED structure is parseable with the public decoder.
+#[test]
+pub fn red_rtp_mode_passthrough() {
+    init_log();
+    init_crypto_default();
+
+    let mut l = rtc_with_red(Peer::Left); // frame mode, RED on: wraps outgoing Opus
+
+    let now = Instant::now();
+    let mut r_builder = Rtc::builder().set_rtp_mode(true).enable_red(true);
+    if let Some(crypto) = Peer::Right.crypto_provider() {
+        r_builder = r_builder.set_crypto_provider(crypto);
+    }
+    let mut r = TestRtc::new_with_rtc(Peer::Right.span(), r_builder.build(now));
+
+    l.set_forced_time_advance(Duration::from_millis(1));
+    r.set_forced_time_advance(Duration::from_millis(1));
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    let mut change = l.sdp_api();
+    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+    let (offer, pending) = change.apply().unwrap();
+    let answer = r.rtc.sdp_api().accept_offer(offer).unwrap();
+    l.rtc.sdp_api().accept_answer(pending, answer).unwrap();
+
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r).unwrap();
+    }
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    let red_pt = l.params_opus().red().expect("RED negotiated");
+    let pt = l.params_opus().pt();
+    let data = vec![1_u8; 80];
+
+    let mut start_of_talk_spurt = true;
+    loop {
+        let wallclock = l.start + l.duration();
+        let time = l.duration().into();
+        l.writer(mid)
+            .unwrap()
+            .start_of_talkspurt(start_of_talk_spurt)
+            .write(pt, wallclock, time, data.clone())
+            .unwrap();
+        start_of_talk_spurt = false;
+
+        progress(&mut l, &mut r).unwrap();
+
+        if l.duration() > Duration::from_secs(2) {
+            break;
+        }
+    }
+
+    // R is in RTP mode: it sees the raw RED packets (PT == red), not Opus MediaData.
+    let red_packets: Vec<_> = r
+        .events
+        .iter()
+        .filter_map(|(_, e)| match e {
+            Event::RtpPacket(p) if p.header.payload_type == red_pt => Some(p),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        !red_packets.is_empty(),
+        "R should receive raw RED RtpPackets in rtp mode"
+    );
+    // The RED payload is well-formed and parseable with the public decoder.
+    assert!(RedDecoder::decode(&red_packets[0].payload).is_ok());
+}

--- a/tests/red.rs
+++ b/tests/red.rs
@@ -118,6 +118,17 @@ fn run_audio_options(
         }
     }
 
+    // Drain (stats only): let every in-flight packet deliver and both peers emit a final stats
+    // snapshot that includes all of them, so cumulative tx/rx byte counters are compared at aligned
+    // points. Otherwise the last tx and rx snapshots (each on its own timer) can land a packet apart
+    // and the exact-equality check is off by one packet's worth of bytes.
+    if stats {
+        let drain_until = l.duration() + Duration::from_millis(300);
+        while l.duration() < drain_until {
+            progress(&mut l, &mut r).unwrap();
+        }
+    }
+
     (l, r)
 }
 
@@ -147,14 +158,17 @@ fn red_recovered_frames_do_not_inherit_the_carrier_audio_level() {
         .seed(7);
     let (_, r) = run_audio_options(true, true, Some(loss), 4, false, true);
 
+    // A RED-recovered frame carries no audio level of its own: RFC 2198 redundant blocks carry
+    // only codec payload, not RTP header extensions, so the frame's original audio level is not on
+    // the wire and is delivered as None. What it must never do is inherit the carrier packet's
+    // level, so flag only a frame that carries a level different from its own.
     let mismatched = r.events.iter().find_map(|(_, e)| match e {
         Event::MediaData(m) => {
             let expected = -(m.data[0] as i8);
-            (m.ext_vals.audio_level != Some(expected)).then_some((
-                m.data[0],
-                m.ext_vals.audio_level,
-                expected,
-            ))
+            m.ext_vals
+                .audio_level
+                .filter(|&lvl| lvl != expected)
+                .map(|lvl| (m.data[0], lvl, expected))
         }
         _ => None,
     });

--- a/tests/red.rs
+++ b/tests/red.rs
@@ -12,9 +12,12 @@ use common::{Peer, TestRtc, init_crypto_default, init_log, progress};
 
 /// Build a `TestRtc` whose `Rtc` has RFC 2198 RED enabled, honouring the per-peer crypto
 /// provider env vars like `TestRtc::new` does.
-fn rtc_with_red(peer: Peer) -> TestRtc {
+fn rtc_with_red(peer: Peer, stats: bool) -> TestRtc {
     let now = Instant::now();
     let mut builder = Rtc::builder().enable_opus(true, true);
+    if stats {
+        builder = builder.set_stats_interval(Some(Duration::from_millis(100)));
+    }
     if let Some(crypto) = peer.crypto_provider() {
         builder = builder.set_crypto_provider(crypto);
     }
@@ -37,16 +40,27 @@ fn run_audio(
     media_loss: Option<NetemConfig>,
     secs: u64,
 ) -> (TestRtc, TestRtc) {
+    run_audio_options(red_l, red_r, media_loss, secs, false, false)
+}
+
+fn run_audio_options(
+    red_l: bool,
+    red_r: bool,
+    media_loss: Option<NetemConfig>,
+    secs: u64,
+    stats: bool,
+    frame_metadata: bool,
+) -> (TestRtc, TestRtc) {
     init_log();
     init_crypto_default();
 
     let mut l = if red_l {
-        rtc_with_red(Peer::Left)
+        rtc_with_red(Peer::Left, stats)
     } else {
         TestRtc::new(Peer::Left)
     };
     let mut r = if red_r {
-        rtc_with_red(Peer::Right)
+        rtc_with_red(Peer::Right, stats)
     } else {
         TestRtc::new(Peer::Right)
     };
@@ -80,18 +94,22 @@ fn run_audio(
     }
 
     let pt = l.params_opus().pt();
-    let data = vec![1_u8; 80];
-
     let mut start_of_talk_spurt = true;
+    let mut frame_index = 0_u8;
     loop {
         let wallclock = l.start + l.duration();
         let time = l.duration().into();
-        l.writer(mid)
+        let value = if frame_metadata { frame_index % 100 } else { 1 };
+        let mut writer = l
+            .writer(mid)
             .unwrap()
-            .start_of_talkspurt(start_of_talk_spurt)
-            .write(pt, wallclock, time, data.clone())
-            .unwrap();
+            .start_of_talkspurt(start_of_talk_spurt);
+        if frame_metadata {
+            writer = writer.audio_level(-(value as i8), true);
+        }
+        writer.write(pt, wallclock, time, vec![value; 80]).unwrap();
         start_of_talk_spurt = false;
+        frame_index = frame_index.wrapping_add(1);
 
         progress(&mut l, &mut r).unwrap();
 
@@ -101,6 +119,50 @@ fn run_audio(
     }
 
     (l, r)
+}
+
+#[test]
+fn red_receive_stats_include_the_complete_wire_payload() {
+    let (l, r) = run_audio_options(true, true, None, 2, true, false);
+
+    let sent = l.events.iter().rev().find_map(|(_, e)| match e {
+        Event::PeerStats(s) if s.bytes_tx > 0 => Some(s.bytes_tx),
+        _ => None,
+    });
+    let received = r.events.iter().rev().find_map(|(_, e)| match e {
+        Event::PeerStats(s) if s.bytes_rx > 0 => Some(s.bytes_rx),
+        _ => None,
+    });
+
+    assert_eq!(
+        received, sent,
+        "RED receive accounting must include headers and redundant media counted by the sender"
+    );
+}
+
+#[test]
+fn red_recovered_frames_do_not_inherit_the_carrier_audio_level() {
+    let loss = NetemConfig::new()
+        .loss(RandomLoss::new(Probability::new(0.08)))
+        .seed(7);
+    let (_, r) = run_audio_options(true, true, Some(loss), 4, false, true);
+
+    let mismatched = r.events.iter().find_map(|(_, e)| match e {
+        Event::MediaData(m) => {
+            let expected = -(m.data[0] as i8);
+            (m.ext_vals.audio_level != Some(expected)).then_some((
+                m.data[0],
+                m.ext_vals.audio_level,
+                expected,
+            ))
+        }
+        _ => None,
+    });
+
+    assert!(
+        mismatched.is_none(),
+        "recovered frame inherited carrier metadata: {mismatched:?}"
+    );
 }
 
 /// With RED enabled on both peers, audio flows transparently: the application writes and reads
@@ -138,7 +200,7 @@ pub fn red_offer_lists_red_pt_in_mline() {
     init_log();
     init_crypto_default();
 
-    let mut l = rtc_with_red(Peer::Left);
+    let mut l = rtc_with_red(Peer::Left, false);
     l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
 
     let mut change = l.sdp_api();
@@ -222,7 +284,7 @@ pub fn red_send_toggle_no_renegotiation() {
     init_log();
     init_crypto_default();
 
-    let mut l = rtc_with_red(Peer::Left); // frame mode, RED on: wraps outgoing Opus
+    let mut l = rtc_with_red(Peer::Left, false); // frame mode, RED on: wraps outgoing Opus
 
     let now = Instant::now();
     let mut r_builder = Rtc::builder().set_rtp_mode(true).enable_opus(true, true);
@@ -306,7 +368,7 @@ pub fn red_rtp_mode_passthrough() {
     init_log();
     init_crypto_default();
 
-    let mut l = rtc_with_red(Peer::Left); // frame mode, RED on: wraps outgoing Opus
+    let mut l = rtc_with_red(Peer::Left, false); // frame mode, RED on: wraps outgoing Opus
 
     let now = Instant::now();
     let mut r_builder = Rtc::builder().set_rtp_mode(true).enable_opus(true, true);

--- a/tests/red.rs
+++ b/tests/red.rs
@@ -721,6 +721,23 @@ fn red_recovered_frame_is_delivered_once_without_reordering_buffer() {
     }
 }
 
+/// A burst of three losses under a `[1, 3, 5]` pattern is filled in over several later packets
+/// (8 and 10 from packet 11, then 9 from packet 12 once 8 and 10 are known). Each frame must be
+/// delivered exactly once, at its own sequence number, and nothing gets NACKed.
+#[test]
+fn red_recovers_a_burst_over_several_packets() {
+    let mut t = raw::connect(None);
+    let ts = raw::uniform(30);
+
+    t.send(&ts, &[1, 3, 5], &[8, 9, 10]);
+
+    t.assert_consistent(&ts);
+    for k in 0..30u8 {
+        assert_eq!(t.delivered(k), 1, "frame {k} delivered exactly once");
+    }
+    assert!(t.nacked_seqs().is_empty(), "nothing to NACK");
+}
+
 /// The per-mid ingress stats must count the full RED wire payload like the per-mid egress stats
 /// on the sender do (and like `PeerStats` already does), not just the unwrapped primary block.
 #[test]

--- a/tests/sdp-negotiation.rs
+++ b/tests/sdp-negotiation.rs
@@ -585,7 +585,7 @@ fn max_bundle_offer_accepted() {
         info_span!("R"),
         Rtc::builder()
             .clear_codecs()
-            .enable_opus(true)
+            .enable_opus(true, false)
             .enable_vp8(true)
             .build(Instant::now()),
     );


### PR DESCRIPTION
## What

Adds optional [RFC 2198](https://www.rfc-editor.org/rfc/rfc2198) RED (redundant audio) for all audio codecs (Opus, G722, PCMU, PCMA), off by default. Enable it per codec via the `use_red` argument of the audio enable fns (e.g. `RtcConfig::enable_opus(true, true)`). RED carries a redundant copy of one or more previous frames in each packet, letting the receiver recover isolated packet losses without retransmission, at the cost of extra audio payload size (roughly one primary's worth per redundancy level).

## Design

Modeled on the existing RTX support:

- A `Codec::Red` marker + `PayloadParams.red: Option<Pt>` linkage, folded onto the primary audio codec in SDP (`a=rtpmap:63 red/48000/2`, `a=fmtp:63 111/111`), mirroring how `apt` links RTX. Kept only when both peers offer it. Each audio codec gets its own RED PT, advertised with that codec's RTP clock rate (so G722's RED sits on 8000, its wire rate, not the 16000 it samples at).
- **Frame mode (default):** transparent — outgoing audio is wrapped with a configurable number of redundancy levels; incoming RED is unwrapped back to the primary codec and lost packets are recovered from later packets' redundancy via the existing depayload path.
- **RTP mode:** RED packets pass through unchanged; `RedEncoder` / `RedDecoder` are public for callers that want to build or parse RED themselves.
- A self-contained `packet::red` module does the byte-level RFC 2198 work and is fuzzed.

## Send-side control

RED availability is fixed at negotiation (or set up via DirectApi) and never renegotiated. On top of that:

- `RtcConfig::set_red_distances(&[u32])` sets the redundancy pattern — how many packets back each level carries. `[1]` (default) sends the previous frame, as browsers do; `[1, 3, 5]` sends three levels for higher loss. The pattern is sanitised (sorted, de-duped, capped at the receiver recovery depth) and always anchored on distance 1.
- `DirectApi::set_red_send(mid, bool)` toggles wrapping on and off at runtime with no renegotiation (reachable from an SDP-negotiated session too, via `rtc.direct_api()`), so an SFU can turn RED on for a leg that starts losing packets and off again when it's clean.
- If a redundant block would push the packet over the MTU, the deepest levels are shed so the wrapped packet still fits.

## Robustness

RED payloads are untrusted remote input, so the receive path is bounded:

- The decoder rejects payloads with more than 32 redundant blocks (matching libwebrtc's RED receiver limit; conformant Opus-RED senders use one, occasionally up to ~4).
- Recovery is limited to the most-recent `MAX_RED_RECOVERY_DEPTH` (8) packets and only to blocks carrying the primary PT, so one packet can't expand into unbounded recovery work, and a redundant block of a different codec (RFC 2198 permits mixed PTs) is never fed to the primary depayloader.
- A redundant block carries a timestamp offset, not a sequence number, so recovery places it by bracketing its time between the nearest received packets and filling the missing sequence number between them. This is exact for a single gap; for a multi-packet burst it assumes uniform frame duration (the fixed-ptime norm) and is otherwise best-effort. A recovered frame is only ever placed at a still-missing sequence number, so it never overwrites a correctly received frame. Recovered sequence numbers are marked so they are neither re-recovered nor NACKed, while reception reports still reflect the real wire loss.

## Tests

Unit (byte-level encode/decode round-trips, no-panic fuzz-style decode, block-count cap, send-side wrap/history/budget-shedding, and `red_locate_seq` placement across single-hole, uniform-burst, depth-limit and already-recovered cases) plus integration in `tests/red.rs`: transparent round-trip, single-loss and multi-packet-burst recovery vs. plain Opus under seeded loss, recovery correctness for patterns without a `main-1` block and under varying frame duration, recovered frames not inheriting the carrier's audio level, receive/ingress byte accounting matching the sender, the runtime send toggle, interop fallback when only one side enables RED (both directions), rtp-mode pass-through, and that the offer lists the RED PT in the m-line fmt list.

## Notes

- RED is *advertised* but not *preferred* (the primary codec stays first in the m-line). This is sufficient for str0m as a sender; a browser that gates RED sending on RED being the preferred codec would need the caller to reorder.
- Real-browser interop hasn't been exercised in-repo (no browser in the test harness) — a sanity check against Chrome/Firefox would be appreciated.
