### PR TITLE
fix: reject SDP payload types > 127 instead of panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Reject SDP payload types > 127 instead of panicking when claiming PTs #983
   * Add H266/VVC RTP packetizer and depacketizer #971
   * Negotiate SCTP max message size for data channels #852
   * Expose the negotiated DTLS protocol version #979

--- a/src/sdp/parser.rs
+++ b/src/sdp/parser.rs
@@ -547,9 +547,17 @@ where
 
     let pt = || {
         not_sp().and_then(|s| {
-            s.parse::<u8>()
-                .map(Pt::from)
-                .map_err(StreamErrorFor::<Input>::message_format)
+            let pt = s
+                .parse::<u8>()
+                .map_err(StreamErrorFor::<Input>::message_format)?;
+            // RTP payload type is 7-bit; reject out-of-range values rather than panicking later
+            // when PTs are claimed against a 128-entry table.
+            if pt > 127 {
+                return Err(StreamErrorFor::<Input>::message_format(format!(
+                    "payload type out of range (0-127): {pt}"
+                )));
+            }
+            Ok(Pt::from(pt))
         })
     };
 
@@ -1005,6 +1013,23 @@ mod test {
                 ""
             ))
         );
+    }
+
+    #[test]
+    fn rtpmap_payload_type_over_127_is_rejected() {
+        // RTP payload type is 7-bit. An out-of-range PT in a=rtpmap must not be accepted as an
+        // RtpMap; otherwise it becomes a PayloadParams that panics when claimed against a
+        // 128-entry table. It instead falls through to Unused and is ignored (the m-line then
+        // fails its own "missing a=rtpmap" check). 127 is the largest valid PT.
+        let bad = media_attribute_line().parse("a=rtpmap:200 opus/48000/2");
+        assert!(
+            !matches!(bad, Ok((MediaAttribute::RtpMap { .. }, _))),
+            "out-of-range rtpmap PT must not parse as RtpMap: {bad:?}"
+        );
+        assert!(matches!(
+            media_attribute_line().parse("a=rtpmap:127 opus/48000/2"),
+            Ok((MediaAttribute::RtpMap { .. }, _))
+        ));
     }
 
     #[test]

--- a/tests/sdp-negotiation.rs
+++ b/tests/sdp-negotiation.rs
@@ -589,6 +589,44 @@ fn max_bundle_offer_accepted() {
     );
 }
 
+/// A remote offer advertising a codec at a payload type outside the 7-bit RTP range must be
+/// rejected, not panic. Before the fix the out-of-range PT was claimed against a 128-entry table
+/// and indexed out of bounds; now the malformed `a=rtpmap` is ignored, leaving the m-line PT
+/// without a codec, so the offer is rejected at parse instead.
+#[test]
+fn offer_with_out_of_range_pt_is_rejected() {
+    init_log();
+    init_crypto_default();
+
+    let offer = "\
+        v=0\r\n\
+        o=- 123456789 2 IN IP4 127.0.0.1\r\n\
+        s=-\r\n\
+        t=0 0\r\n\
+        a=group:BUNDLE 0\r\n\
+        a=msid-semantic:WMS *\r\n\
+        a=fingerprint:sha-256 00:00:00:00:00:00:00:00\
+        :00:00:00:00:00:00:00:00:00:00:00:00:00:00:00\
+        :00:00:00:00:00:00:00:00:00\r\n\
+        a=ice-ufrag:testufrag\r\n\
+        a=ice-pwd:testpassword12345678\r\n\
+        a=setup:actpass\r\n\
+        m=audio 9 UDP/TLS/RTP/SAVPF 200\r\n\
+        c=IN IP4 0.0.0.0\r\n\
+        a=mid:0\r\n\
+        a=sendrecv\r\n\
+        a=rtcp-mux\r\n\
+        a=rtpmap:200 opus/48000/2\r\n\
+        ";
+
+    // Before the fix this parsed and then panicked when the PT was claimed; now it is rejected.
+    let result = SdpOffer::from_sdp_string(offer);
+    assert!(
+        result.is_err(),
+        "offer with out-of-range PT must be rejected: {result:?}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // SNAP (SCTP Negotiation Acceleration Protocol) tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

A remote SDP offer that advertises a codec at a payload type outside the 7-bit RTP range (e.g. `a=rtpmap:200 opus/48000/2`) panics the `Rtc`: the out-of-range payload type parses into a `Pt`, and when it matches a locally-enabled codec it is claimed against a 128-entry table (`[bool; 128]`), indexing out of bounds.

This violates str0m's "never panic on user input" invariant — a single malformed or hostile offer crashes the instance. It is pre-existing and not specific to a codec (the main and RTX payload-type paths reach the same claim), so the fix is at the shared `a=rtpmap` parser.

## Fix

Bound the `a=rtpmap` payload-type parser to the valid `0..=127` range. An out-of-range payload type makes the `a=rtpmap` line fall through to `Unused` (ignored), so no `PayloadParams` with an out-of-range PT is ever created. The offer is then rejected gracefully at parse (the m-line PT has no matching rtpmap) instead of panicking later when PTs are claimed.

## Tests

- `rtpmap_payload_type_over_127_is_rejected` (unit): an out-of-range `a=rtpmap` PT does not parse as an `RtpMap`; PT 127 still does.
- `offer_with_out_of_range_pt_is_rejected` (integration): an offer advertising a codec at PT 200 is rejected, not a panic.

Both fail without the fix (the integration test previously panicked on the out-of-bounds index).
