### PR TITLE
[poc] binary timer heap

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -910,7 +910,6 @@ impl Session {
         let pacing_at = self.pacer.poll_timeout();
         let packetize_at = self.medias.iter().flat_map(|m| m.poll_timeout()).next();
         let paused_at = self.paused_at();
-        let send_stream_at = self.streams.send_stream();
 
         // Gives us built-in reason
         let bwe_at = self
@@ -926,7 +925,6 @@ impl Session {
             .soonest(pacing_at)
             .soonest((packetize_at, Reason::Packetize))
             .soonest((paused_at, Reason::PauseCheck))
-            .soonest((send_stream_at, Reason::SendStream))
             .soonest(bwe_at)
     }
 

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -55,7 +55,6 @@ struct StreamDeadline {
 
 impl Ord for StreamDeadline {
     fn cmp(&self, other: &Self) -> Ordering {
-        // Reverse comparison to turn BinaryHeap into a Min-Heap (earliest time first)
         other.deadline.cmp(&self.deadline)
     }
 }
@@ -478,22 +477,8 @@ impl Streams {
                     let get_media =
                         move || (medias.iter().find(|m| m.mid() == mid).unwrap(), config);
                     stream.handle_timeout(now, get_media);
-
-                    // --- LAZY VALIDATION FOR TX ---
-                    // If external packet actions pushed this deadline forward into the future,
-                    // re-enqueue it with its current updated schedule and skip handling now.
-                    if !stream.need_sr(now) {
-                        self.deadline_heap.push(StreamDeadline {
-                            deadline: stream.next_sr(),
-                            ssrc: entry.ssrc,
-                            is_tx: true,
-                        });
-                        continue;
-                    }
-
                     stream.create_sr_and_update(now, feedback);
 
-                    // Re-enqueue for its next predictable interval
                     self.deadline_heap.push(StreamDeadline {
                         deadline: stream.next_sr(),
                         ssrc: entry.ssrc,
@@ -503,18 +488,6 @@ impl Streams {
             } else {
                 if let Some(stream) = self.streams_rx.get_mut(&entry.ssrc) {
                     stream.handle_timeout(now);
-                    // --- LAZY VALIDATION FOR RX ---
-                    // If an incoming packet or explicit pull updated our timing,
-                    // we don't need a receiver report yet. Skip and re-enqueue.
-                    if !stream.need_rr(now) {
-                        self.deadline_heap.push(StreamDeadline {
-                            deadline: stream.next_rr(),
-                            ssrc: entry.ssrc,
-                            is_tx: false,
-                        });
-                        continue;
-                    }
-
                     stream.maybe_create_keyframe_request(sender_ssrc, feedback);
                     stream.maybe_create_remb_request(sender_ssrc, feedback);
                     stream.create_rr_and_update(now, sender_ssrc, feedback);
@@ -533,7 +506,6 @@ impl Streams {
             }
         }
 
-        // --- 3. COARSE TIME LOOKUP CLEANUP ---
         if now > self.rx_lookup_at() {
             self.rx_lookup
                 .retain(|_, l| now - l.last_used <= RX_LOOKUP_EXPIRY);
@@ -725,9 +697,7 @@ impl Streams {
 
             // Reinsert under new SSRC key.
             self.streams_rx.insert(ssrc_to, to_change);
-            // Register the stream under its new key tracker immediately.
-            // The old ghost entry for ssrc_from will simply float to the top later,
-            // get() a None value out of the HashMap, and dissolve gracefully.
+            // Ghost SSRC gets evicted lazily
             self.deadline_heap.push(StreamDeadline {
                 deadline: active_deadline,
                 ssrc: ssrc_to,

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -441,14 +441,6 @@ impl Streams {
         self.streams_rx.values().find_map(|s| s.paused_at())
     }
 
-    pub(crate) fn send_stream(&self) -> Option<Instant> {
-        if self.streams_tx.values().any(|s| s.need_timeout()) {
-            Some(already_happened())
-        } else {
-            None
-        }
-    }
-
     pub(crate) fn is_receiving(&self) -> bool {
         !self.streams_rx.is_empty()
     }
@@ -496,7 +488,6 @@ impl Streams {
                         stream.maybe_create_nack(sender_ssrc, feedback);
                     }
 
-                    // Re-enqueue for its next predictable interval
                     self.deadline_heap.push(StreamDeadline {
                         deadline: stream.next_rr(),
                         ssrc: entry.ssrc,

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -1,4 +1,5 @@
-use std::collections::{HashMap, VecDeque};
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap, VecDeque};
 use std::fmt::{self};
 use std::sync::Arc;
 use std::time::Duration;
@@ -42,6 +43,26 @@ fn rr_interval(audio: bool) -> Duration {
         RR_INTERVAL_AUDIO
     } else {
         RR_INTERVAL_VIDEO
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct StreamDeadline {
+    deadline: Instant,
+    ssrc: Ssrc,
+    is_tx: bool,
+}
+
+impl Ord for StreamDeadline {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Reverse comparison to turn BinaryHeap into a Min-Heap (earliest time first)
+        other.deadline.cmp(&self.deadline)
+    }
+}
+
+impl PartialOrd for StreamDeadline {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 
@@ -163,6 +184,8 @@ pub(crate) struct Streams {
     /// Threshold above which an outgoing RTP packet triggers an MTU warning. Used as a
     /// hard cap when selecting RTX cache entries for spurious padding.
     mtu_warn: usize,
+
+    deadline_heap: BinaryHeap<StreamDeadline>,
 }
 
 /// Delay between cleaning up the RxLookup.
@@ -190,6 +213,7 @@ impl Streams {
             any_nack_active: None,
             enable_stats,
             mtu_warn,
+            deadline_heap: BinaryHeap::new(),
         }
     }
 
@@ -315,10 +339,20 @@ impl Streams {
         // New stream might have enabled nacks.
         self.any_nack_active = None;
 
-        let stream = self
-            .streams_rx
-            .entry(ssrc)
-            .or_insert_with(|| StreamRx::new(ssrc, midrid, suppress_nack));
+        let mut was_inserted = false;
+        let stream = self.streams_rx.entry(ssrc).or_insert_with(|| {
+            was_inserted = true;
+            StreamRx::new(ssrc, midrid, suppress_nack)
+        });
+
+        // Bootstrap the heap if this stream was just newly created
+        if was_inserted {
+            self.deadline_heap.push(StreamDeadline {
+                deadline: stream.next_rr(),
+                ssrc,
+                is_tx: false,
+            });
+        }
 
         if let Some(rtx) = rtx {
             stream.maybe_reset_rtx(rtx);
@@ -342,9 +376,17 @@ impl Streams {
         rtx: Option<Ssrc>,
         midrid: MidRid,
     ) -> &mut StreamTx {
-        self.streams_tx
-            .entry(ssrc)
-            .or_insert_with(|| StreamTx::new(ssrc, rtx, midrid, self.enable_stats, self.mtu_warn))
+        self.streams_tx.entry(ssrc).or_insert_with(|| {
+            let stream = StreamTx::new(ssrc, rtx, midrid, self.enable_stats, self.mtu_warn);
+
+            self.deadline_heap.push(StreamDeadline {
+                deadline: stream.next_sr(),
+                ssrc,
+                is_tx: true,
+            });
+
+            stream
+        })
     }
 
     pub fn remove_stream_tx(&mut self, ssrc: Ssrc) -> bool {
@@ -423,52 +465,54 @@ impl Streams {
         config: &CodecConfig,
         feedback: &mut VecDeque<Rtcp>,
     ) {
-        self.mids_to_report.clear(); // Clear for checking StreamRx.
-        for stream in self.streams_rx.values() {
-            if stream.need_rr(now) {
-                self.mids_to_report.push(stream.mid());
+        self.mids_to_report.clear();
+
+        while let Some(entry) = self.deadline_heap.peek() {
+            if entry.deadline > now {
+                break; // Earliest scheduled track work is in the future. Exit immediately.
+            }
+
+            let entry = self.deadline_heap.pop().unwrap();
+
+            if entry.is_tx {
+                if let Some(stream) = self.streams_tx.get_mut(&entry.ssrc) {
+                    let mid = stream.mid();
+                    stream.create_sr_and_update(now, feedback);
+
+                    let get_media =
+                        move || (medias.iter().find(|m| m.mid() == mid).unwrap(), config);
+                    stream.handle_timeout(now, get_media);
+
+                    // Re-enqueue for its next predictable interval
+                    self.deadline_heap.push(StreamDeadline {
+                        deadline: stream.next_sr(),
+                        ssrc: entry.ssrc,
+                        is_tx: true,
+                    });
+                }
+            } else {
+                if let Some(stream) = self.streams_rx.get_mut(&entry.ssrc) {
+                    stream.maybe_create_keyframe_request(sender_ssrc, feedback);
+                    stream.maybe_create_remb_request(sender_ssrc, feedback);
+                    stream.create_rr_and_update(now, sender_ssrc, feedback);
+
+                    if do_nack {
+                        stream.maybe_create_nack(sender_ssrc, feedback);
+                    }
+
+                    stream.handle_timeout(now);
+
+                    // Re-enqueue for its next predictable interval
+                    self.deadline_heap.push(StreamDeadline {
+                        deadline: stream.next_rr(),
+                        ssrc: entry.ssrc,
+                        is_tx: false,
+                    });
+                }
             }
         }
 
-        for stream in self.streams_rx.values_mut() {
-            stream.maybe_create_keyframe_request(sender_ssrc, feedback);
-            stream.maybe_create_remb_request(sender_ssrc, feedback);
-
-            // All StreamRx belonging to the same Mid are reported together.
-            if self.mids_to_report.contains(&stream.mid()) {
-                stream.create_rr_and_update(now, sender_ssrc, feedback);
-            }
-
-            if do_nack {
-                stream.maybe_create_nack(sender_ssrc, feedback);
-            }
-
-            stream.handle_timeout(now);
-        }
-
-        self.mids_to_report.clear(); // start over for StreamTx.
-        for stream in self.streams_tx.values() {
-            if stream.need_sr(now) {
-                self.mids_to_report.push(stream.mid());
-            }
-        }
-
-        for stream in self.streams_tx.values_mut() {
-            let mid = stream.mid();
-
-            // All StreamTx belonging to the same Mid are reported together.
-            if self.mids_to_report.contains(&mid) {
-                stream.create_sr_and_update(now, feedback);
-            }
-
-            // Finding the first (main) PT that also has RTX for the Media is expensive,
-            // this closure is run only when needed.
-            // The unwrap is okay because we cannot have StreamTx with a Mid without the corresponding Media.
-            let get_media = move || (medias.iter().find(|m| m.mid() == mid).unwrap(), config);
-
-            stream.handle_timeout(now, get_media);
-        }
-
+        // --- 3. COARSE TIME LOOKUP CLEANUP ---
         if now > self.rx_lookup_at() {
             self.rx_lookup
                 .retain(|_, l| now - l.last_used <= RX_LOOKUP_EXPIRY);
@@ -656,9 +700,18 @@ impl Streams {
         if did_change {
             // Unwrap is OK, see above.
             let to_change = self.streams_rx.remove(&ssrc_from).unwrap();
+            let active_deadline = to_change.next_rr();
 
             // Reinsert under new SSRC key.
             self.streams_rx.insert(ssrc_to, to_change);
+            // Register the stream under its new key tracker immediately.
+            // The old ghost entry for ssrc_from will simply float to the top later,
+            // get() a None value out of the HashMap, and dissolve gracefully.
+            self.deadline_heap.push(StreamDeadline {
+                deadline: active_deadline,
+                ssrc: ssrc_to,
+                is_tx: false,
+            });
 
             // Remove previous mappings for the SSRC
             self.rx_lookup

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -348,7 +348,7 @@ impl Streams {
         // Bootstrap the heap if this stream was just newly created
         if was_inserted {
             self.deadline_heap.push(StreamDeadline {
-                deadline: stream.next_rr(),
+                deadline: already_happened(),
                 ssrc,
                 is_tx: false,
             });
@@ -380,7 +380,7 @@ impl Streams {
             let stream = StreamTx::new(ssrc, rtx, midrid, self.enable_stats, self.mtu_warn);
 
             self.deadline_heap.push(StreamDeadline {
-                deadline: stream.next_sr(),
+                deadline: already_happened(),
                 ssrc,
                 is_tx: true,
             });
@@ -435,9 +435,7 @@ impl Streams {
     }
 
     pub(crate) fn regular_feedback_at(&self) -> Option<Instant> {
-        let r = self.streams_rx.values().map(|s| s.receiver_report_at());
-        let s = self.streams_tx.values().map(|s| s.sender_report_at());
-        r.chain(s).min()
+        self.deadline_heap.peek().map(|entry| entry.deadline)
     }
 
     pub(crate) fn paused_at(&self) -> Option<Instant> {
@@ -477,11 +475,23 @@ impl Streams {
             if entry.is_tx {
                 if let Some(stream) = self.streams_tx.get_mut(&entry.ssrc) {
                     let mid = stream.mid();
-                    stream.create_sr_and_update(now, feedback);
-
                     let get_media =
                         move || (medias.iter().find(|m| m.mid() == mid).unwrap(), config);
                     stream.handle_timeout(now, get_media);
+
+                    // --- LAZY VALIDATION FOR TX ---
+                    // If external packet actions pushed this deadline forward into the future,
+                    // re-enqueue it with its current updated schedule and skip handling now.
+                    if !stream.need_sr(now) {
+                        self.deadline_heap.push(StreamDeadline {
+                            deadline: stream.next_sr(),
+                            ssrc: entry.ssrc,
+                            is_tx: true,
+                        });
+                        continue;
+                    }
+
+                    stream.create_sr_and_update(now, feedback);
 
                     // Re-enqueue for its next predictable interval
                     self.deadline_heap.push(StreamDeadline {
@@ -492,6 +502,19 @@ impl Streams {
                 }
             } else {
                 if let Some(stream) = self.streams_rx.get_mut(&entry.ssrc) {
+                    stream.handle_timeout(now);
+                    // --- LAZY VALIDATION FOR RX ---
+                    // If an incoming packet or explicit pull updated our timing,
+                    // we don't need a receiver report yet. Skip and re-enqueue.
+                    if !stream.need_rr(now) {
+                        self.deadline_heap.push(StreamDeadline {
+                            deadline: stream.next_rr(),
+                            ssrc: entry.ssrc,
+                            is_tx: false,
+                        });
+                        continue;
+                    }
+
                     stream.maybe_create_keyframe_request(sender_ssrc, feedback);
                     stream.maybe_create_remb_request(sender_ssrc, feedback);
                     stream.create_rr_and_update(now, sender_ssrc, feedback);
@@ -499,8 +522,6 @@ impl Streams {
                     if do_nack {
                         stream.maybe_create_nack(sender_ssrc, feedback);
                     }
-
-                    stream.handle_timeout(now);
 
                     // Re-enqueue for its next predictable interval
                     self.deadline_heap.push(StreamDeadline {

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -564,6 +564,10 @@ impl StreamRx {
         now >= self.receiver_report_at()
     }
 
+    pub(crate) fn next_rr(&self) -> Instant {
+        self.receiver_report_at()
+    }
+
     pub(crate) fn create_rr_and_update(
         &mut self,
         now: Instant,

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -928,6 +928,10 @@ impl StreamTx {
         now >= self.sender_report_at()
     }
 
+    pub(crate) fn next_sr(&self) -> Instant {
+        self.sender_report_at()
+    }
+
     pub(crate) fn create_sr_and_update(&mut self, now: Instant, feedback: &mut VecDeque<Rtcp>) {
         let sr = self.create_sender_report(now);
 

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -1119,8 +1119,6 @@ impl StreamTx {
             let (media, config) = get_media();
             self.on_first_timeout(media, config);
         }
-
-        self.send_queue.handle_timeout(now);
     }
 
     fn on_first_timeout(&mut self, media: &Media, config: &CodecConfig) {

--- a/src/streams/send_queue.rs
+++ b/src/streams/send_queue.rs
@@ -87,6 +87,7 @@ impl SendQueue {
     }
 
     pub(crate) fn snapshot(&mut self, now: Instant) -> QueueSnapshot {
+        self.handle_timeout(now);
         self.total.move_time_forward(now);
 
         QueueSnapshot {
@@ -232,11 +233,11 @@ mod test {
             queue.snapshot(snapshot_at),
             QueueSnapshot {
                 created_at: snapshot_at,
-                packet_count: 0,
+                packet_count: 1,
                 size: 0,
                 total_queue_time_origin: Duration::ZERO,
-                first_unsent: None,
-                priority: QueuePriority::Empty,
+                first_unsent: Some(snapshot_at),
+                priority: QueuePriority::Media,
                 ..Default::default()
             }
         );


### PR DESCRIPTION
WARNING: this is just a POC.

Issue: https://github.com/algesten/str0m/issues/922

The idea here is to reduce the amount of work per time update. Currently, we have to traverse every subsystem every time we get a newer time. If N is the number of subsystems (the number of streams and other fixed subsystems like DTLS, ICE, SCTP, etc), then we have to spend O(N) time each. 

Each of this system unlikely to have the same deadline. So, ideally, we should only do work when needed, aka bringing us closer to a constant time per time update (Polling -> Event Driven).

**Before:**

<img width="1876" height="1008" alt="Screenshot 2026-06-23 at 9 20 24 PM" src="https://github.com/user-attachments/assets/2968af84-3b0a-46f8-a2e8-5b18508a2e71" />

**After**

<img width="1876" height="1008" alt="Screenshot 2026-06-23 at 9 20 32 PM" src="https://github.com/user-attachments/assets/28f05057-076e-4f2b-917f-f9211e4563c2" />


**Result**

It's interesting to see how the number of spikes reduced on the profiler timelines.
The CPU usage reduction is marginal for now, from ~56% -> ~54%. But there is plenty of room for expansion.

Edit: With many rooms of 4 fully interactive participants, the CPU usage went down from ~72% to ~60% CPU. The above workload consisted of rooms with mostly idle participants.

<img width="1876" height="1008" alt="Screenshot 2026-06-23 at 9 25 12 PM" src="https://github.com/user-attachments/assets/681d6c25-051d-4f9d-87be-0351f1d4b564" />


