### PR TITLE
Make DTLS client certs configurable

### DIFF
--- a/crates/proto/src/crypto/provider.rs
+++ b/crates/proto/src/crypto/provider.rs
@@ -150,12 +150,16 @@ pub trait DtlsProvider: CryptoSafe {
     ///
     /// mtu: Backends that can size their record layer according to the provided MTU should do so;
     /// backends that cannot ignore it. `None` means use the backend's default.
+    ///
+    /// client_certificate_required: Servers request and require a client certificate when true;
+    /// backends that cannot configure this behavior ignore it.
     fn new_dtls(
         &self,
         cert: &DtlsCert,
         now: Instant,
         dtls_version: DtlsVersion,
         mtu: Option<usize>,
+        client_certificate_required: bool,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError>;
 
     /// Whether the provider is used in a test context.

--- a/crypto/apple-crypto/src/dtls.rs
+++ b/crypto/apple-crypto/src/dtls.rs
@@ -91,6 +91,7 @@ impl DtlsProvider for AppleCryptoDtlsProvider {
         now: Instant,
         dtls_version: DtlsVersion,
         mtu: Option<usize>,
+        client_certificate_required: bool,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         let dimpl_cert = DtlsCertificate {
             certificate: cert.certificate.clone(),
@@ -99,7 +100,9 @@ impl DtlsProvider for AppleCryptoDtlsProvider {
 
         // Create a dimpl Config with Apple CommonCrypto crypto provider
         // ICE verifies return routability before DTLS, making server cookies redundant.
-        let mut builder = Config::builder().use_server_cookie(false);
+        let mut builder = Config::builder()
+            .use_server_cookie(false)
+            .require_client_certificate(client_certificate_required);
         if let Some(mtu) = mtu {
             builder = builder.mtu(mtu);
         }

--- a/crypto/aws-lc-rs/src/dtls.rs
+++ b/crypto/aws-lc-rs/src/dtls.rs
@@ -32,6 +32,7 @@ impl DtlsProvider for AwsLcRsDtlsProvider {
         now: Instant,
         dtls_version: DtlsVersion,
         mtu: Option<usize>,
+        client_certificate_required: bool,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         let dimpl_cert = dimpl::DtlsCertificate {
             certificate: cert.certificate.clone(),
@@ -40,7 +41,9 @@ impl DtlsProvider for AwsLcRsDtlsProvider {
 
         // Create a default dimpl Config with AWS-LC-RS crypto provider
         // ICE verifies return routability before DTLS, making server cookies redundant.
-        let mut builder = dimpl::Config::builder().use_server_cookie(false);
+        let mut builder = dimpl::Config::builder()
+            .use_server_cookie(false)
+            .require_client_certificate(client_certificate_required);
         if let Some(mtu) = mtu {
             builder = builder.mtu(mtu);
         }

--- a/crypto/openssl/src/dtls_dimpl.rs
+++ b/crypto/openssl/src/dtls_dimpl.rs
@@ -31,6 +31,7 @@ impl DtlsProvider for OsslDtlsProvider {
         now: Instant,
         dtls_version: DtlsVersion,
         mtu: Option<usize>,
+        client_certificate_required: bool,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         let dimpl_cert = dimpl::DtlsCertificate {
             certificate: cert.certificate.clone(),
@@ -38,7 +39,9 @@ impl DtlsProvider for OsslDtlsProvider {
         };
 
         // ICE verifies return routability before DTLS, making server cookies redundant.
-        let mut builder = dimpl::Config::builder().use_server_cookie(false);
+        let mut builder = dimpl::Config::builder()
+            .use_server_cookie(false)
+            .require_client_certificate(client_certificate_required);
         if let Some(mtu) = mtu {
             builder = builder.mtu(mtu);
         }

--- a/crypto/openssl/src/dtls_ossl.rs
+++ b/crypto/openssl/src/dtls_ossl.rs
@@ -685,6 +685,7 @@ impl DtlsProvider for OsslDtlsProvider {
         _now: Instant,
         dtls_version: DtlsVersion,
         mtu: Option<usize>,
+        _client_certificate_required: bool,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         let mtu = mtu.unwrap_or(DATAGRAM_MTU_TARGET);
         match dtls_version {

--- a/crypto/rust-crypto/src/dtls.rs
+++ b/crypto/rust-crypto/src/dtls.rs
@@ -32,6 +32,7 @@ impl DtlsProvider for RustCryptoDtlsProvider {
         now: Instant,
         dtls_version: DtlsVersion,
         mtu: Option<usize>,
+        client_certificate_required: bool,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         let dimpl_cert = dimpl::DtlsCertificate {
             certificate: cert.certificate.clone(),
@@ -40,7 +41,9 @@ impl DtlsProvider for RustCryptoDtlsProvider {
 
         // Create a default dimpl Config with RustCrypto crypto provider
         // ICE verifies return routability before DTLS, making server cookies redundant.
-        let mut builder = dimpl::Config::builder().use_server_cookie(false);
+        let mut builder = dimpl::Config::builder()
+            .use_server_cookie(false)
+            .require_client_certificate(client_certificate_required);
         if let Some(mtu) = mtu {
             builder = builder.mtu(mtu);
         }

--- a/crypto/wincrypto/src/dtls_dimpl.rs
+++ b/crypto/wincrypto/src/dtls_dimpl.rs
@@ -28,6 +28,7 @@ impl DtlsProvider for WinCryptoDtlsProvider {
         now: Instant,
         dtls_version: DtlsVersion,
         mtu: Option<usize>,
+        client_certificate_required: bool,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         let dimpl_cert = DtlsCertificate {
             certificate: cert.certificate.clone(),
@@ -35,7 +36,9 @@ impl DtlsProvider for WinCryptoDtlsProvider {
         };
 
         // ICE verifies return routability before DTLS, making server cookies redundant.
-        let mut builder = Config::builder().use_server_cookie(false);
+        let mut builder = Config::builder()
+            .use_server_cookie(false)
+            .require_client_certificate(client_certificate_required);
         if let Some(mtu) = mtu {
             builder = builder.mtu(mtu);
         }

--- a/crypto/wincrypto/src/dtls_schannel.rs
+++ b/crypto/wincrypto/src/dtls_schannel.rs
@@ -45,6 +45,7 @@ impl DtlsProvider for WinCryptoDtlsProvider {
         _now: Instant,
         dtls_version: DtlsVersion,
         mtu: Option<usize>,
+        _client_certificate_required: bool,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         if !matches!(dtls_version, DtlsVersion::Dtls12 | DtlsVersion::Auto) {
             return Err(CryptoError::Other(

--- a/crypto/wincrypto/src/sys/provider.rs
+++ b/crypto/wincrypto/src/sys/provider.rs
@@ -304,6 +304,7 @@ impl DtlsProvider for WinCryptoDtlsProvider {
         _now: Instant,
         dtls_version: DtlsVersion,
         mtu: Option<usize>,
+        _client_certificate_required: bool,
     ) -> Result<Box<dyn DtlsInstance>, CryptoError> {
         if dtls_version != DtlsVersion::Dtls12 {
             return Err(CryptoError::Other(

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,7 @@ pub struct RtcConfig {
     pub(crate) rtp_mode: bool,
     pub(crate) enable_raw_packets: bool,
     pub(crate) dtls_version: DtlsVersion,
+    pub(crate) dtls_client_certificate_required: bool,
     pub(crate) vp9_packetizer_mode: Vp9PacketizerMode,
     pub(crate) snap_enabled: bool,
     pub(crate) mtu: RangeInclusive<usize>,
@@ -596,6 +597,22 @@ impl RtcConfig {
         self.dtls_version
     }
 
+    /// Set whether passive DTLS endpoints request and require a client certificate.
+    ///
+    /// Dimpl-backed providers do not send `CertificateRequest` when this is disabled,
+    /// so the passive endpoint will not verify the client's DTLS certificate fingerprint.
+    ///
+    /// Defaults to `true`.
+    pub fn set_dtls_client_certificate_required(mut self, required: bool) -> Self {
+        self.dtls_client_certificate_required = required;
+        self
+    }
+
+    /// Get whether passive DTLS endpoints require a client certificate.
+    pub fn dtls_client_certificate_required(&self) -> bool {
+        self.dtls_client_certificate_required
+    }
+
     /// Set the MTU as a `target..=warn` inclusive range.
     ///
     /// * `*range.start()` is the **target** MTU: the size str0m aims for when
@@ -699,6 +716,7 @@ impl Default for RtcConfig {
             rtp_mode: false,
             enable_raw_packets: false,
             dtls_version: DtlsVersion::Dtls12,
+            dtls_client_certificate_required: true,
             vp9_packetizer_mode: Vp9PacketizerMode::default(),
             snap_enabled: false,
             mtu: DATAGRAM_MTU_TARGET..=DATAGRAM_MTU_WARN,
@@ -726,6 +744,15 @@ mod tests {
         let cfg = RtcConfig::default().set_mtu(900..=usize::MAX);
         assert_eq!(cfg.mtu(), 900);
         assert_eq!(cfg.mtu_warn(), usize::MAX);
+    }
+
+    #[test]
+    fn dtls_client_certificate_required_round_trips() {
+        let cfg = RtcConfig::default();
+        assert!(cfg.dtls_client_certificate_required());
+
+        let cfg = cfg.set_dtls_client_certificate_required(false);
+        assert!(!cfg.dtls_client_certificate_required());
     }
 
     #[test]

--- a/src/dtls.rs
+++ b/src/dtls.rs
@@ -61,9 +61,16 @@ impl Dtls {
         now: Instant,
         dtls_version: DtlsVersion,
         mtu: RangeInclusive<usize>,
+        client_certificate_required: bool,
     ) -> Result<Self, DtlsError> {
         let instance = dtls_provider
-            .new_dtls(cert, now, dtls_version, Some(*mtu.start()))
+            .new_dtls(
+                cert,
+                now,
+                dtls_version,
+                Some(*mtu.start()),
+                client_certificate_required,
+            )
             .map_err(DtlsError::CryptoError)?;
 
         // Compute fingerprint from the certificate DER bytes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1247,6 +1247,7 @@ impl Rtc {
                 start,
                 config.dtls_version,
                 mtu,
+                config.dtls_client_certificate_required,
             )
             .expect("DTLS to init without problem"),
             dtls_connected: false,


### PR DESCRIPTION
Make client certificate requests configurable for dimpl-backed DTLS.

Default stays true. This lets callers disable `CertificateRequest` when talking to Chrome/WebRTC over DTLS 1.3.
