### PR TITLE
Handle SCTP AssociationLost as closed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1715,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "sctp-proto"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8423ea59db998985015bc5d0145837eab48f60ec449a2dc01f5870499afe0a4"
+checksum = "5376eaf8a764118abd6bee29673c68eab91f0913b448fe2944e74488b63c37b5"
 dependencies = [
  "bytes",
  "crc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ _str0m_test = { path = "crates/_str0m_test" }
 # Core dependencies
 tracing = "0.1.37"
 fastrand = "2.0.1"
-sctp-proto = "0.9.1"
+sctp-proto = "0.10.0"
 combine = "4.6.6"
 subtle = "2.0.0"
 arrayvec = "0.7.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1030,6 +1030,11 @@ pub enum Event {
     /// We have received the DTLS close packet
     Closed,
 
+    /// The sctp association has been closed.
+    ///
+    /// Emitted when the peer emitted an SCTP abort packet.
+    SctpAssociationClosed,
+
     /// Debug output of incoming and outgoing RTCP/RTP packets.
     ///
     /// Enable using [`RtcConfig::enable_raw_packets()`].
@@ -1743,6 +1748,12 @@ impl Rtc {
                     };
                     self.chan.remove_channel(id, self.last_now);
                     return Ok(Output::Event(Event::ChannelClose(id)));
+                }
+                SctpEvent::AssociationLost => {
+                    // The SCTP association was lost. SCTP is the data-channel transport,
+                    // it is up to the user to keep the webrtc connection alive or
+                    // loosing the data-channel implies a close of the whole Rtc.
+                    return Ok(Output::Event(Event::SctpAssociationClosed));
                 }
                 SctpEvent::Data { id, binary, data } => {
                     let Some(id) = self.chan.channel_id_by_stream_id(id) else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1030,11 +1030,6 @@ pub enum Event {
     /// We have received the DTLS close packet
     Closed,
 
-    /// The sctp association has been closed.
-    ///
-    /// Emitted when the peer emitted an SCTP abort packet.
-    SctpAssociationClosed,
-
     /// Debug output of incoming and outgoing RTCP/RTP packets.
     ///
     /// Enable using [`RtcConfig::enable_raw_packets()`].
@@ -1750,10 +1745,7 @@ impl Rtc {
                     return Ok(Output::Event(Event::ChannelClose(id)));
                 }
                 SctpEvent::AssociationLost => {
-                    // The SCTP association was lost. SCTP is the data-channel transport,
-                    // it is up to the user to keep the webrtc connection alive or
-                    // loosing the data-channel implies a close of the whole Rtc.
-                    return Ok(Output::Event(Event::SctpAssociationClosed));
+                    return Ok(Output::Event(Event::Closed));
                 }
                 SctpEvent::Data { id, binary, data } => {
                     let Some(id) = self.chan.channel_id_by_stream_id(id) else {

--- a/src/sctp/mod.rs
+++ b/src/sctp/mod.rs
@@ -137,6 +137,7 @@ pub(crate) enum SctpEvent {
     BufferedAmountLow {
         id: u16,
     },
+    AssociationLost,
 }
 
 /// These are the possible paths:
@@ -713,7 +714,10 @@ impl RtcSctp {
                 return self.poll();
             }
 
-            // TODO: Do we need to handle AssociationLost?
+            if let Event::AssociationLost { ref reason } = e {
+                debug!("Association lost, reason: {}", reason);
+                return Some(SctpEvent::AssociationLost);
+            }
 
             if let Event::Stream(se) = e {
                 match se {
@@ -1087,6 +1091,7 @@ impl fmt::Debug for SctpEvent {
             Self::BufferedAmountLow { id } => {
                 f.debug_struct("BufferedAmountLow").field("id", id).finish()
             }
+            Self::AssociationLost => f.debug_struct("AssociationLost").finish(),
         }
     }
 }


### PR DESCRIPTION
Summary

- Normalize SCTP association loss to the existing `Event::Closed` event.
- Keep the top-level RTC event abstraction independent of whether closure came from DTLS or SCTP.
- Bump `sctp-proto` to 0.10.0.