### PR TITLE
fix(rtcp): prevent panics parsing malformed SDES/XR packets

### DIFF
--- a/src/rtp/rtcp/sdes.rs
+++ b/src/rtp/rtcp/sdes.rs
@@ -177,9 +177,18 @@ impl<'a> TryFrom<&'a [u8]> for Descriptions {
             let report: Sdes = buf.try_into()?;
 
             let len = report.word_size() * 4;
-            buf = &buf[len..];
 
             reports.push(report);
+
+            // word_size() pads up to a 32-bit boundary and may report more bytes
+            // than remain for a trailing or truncated chunk. Guard against slicing
+            // past the end (which would panic) and against a zero len that would
+            // otherwise spin forever.
+            if len == 0 || len >= buf.len() {
+                break;
+            }
+
+            buf = &buf[len..];
         }
 
         Ok(Descriptions {
@@ -203,6 +212,13 @@ impl<'a> TryFrom<&'a [u8]> for Sdes {
         let mut abs = 0;
 
         loop {
+            // SDES items are END-terminated rather than count-bounded, so a
+            // malformed chunk could contain more than the ReportList capacity.
+            // Stop at the cap rather than panicking on the 32nd push.
+            if values.is_full() {
+                break;
+            }
+
             // Per RFC 3550 Section 6.5:
             // "The list of items in each chunk MUST be terminated by one or more null octets,
             // the first of which is interpreted as an item type of end of list.

--- a/src/rtp/rtcp/xr.rs
+++ b/src/rtp/rtcp/xr.rs
@@ -192,6 +192,12 @@ impl<'a> TryFrom<&'a [u8]> for ExtendedReport {
             let block: ReportBlock = block;
             let len = block.len();
             blocks.push(block);
+            // A block's reported len may exceed the remaining bytes for a
+            // truncated/malformed packet. Guard against slicing past the end
+            // (panic) and against a zero len that would spin forever.
+            if len == 0 || len >= buf.len() {
+                break;
+            }
             buf = &buf[len..];
         }
 
@@ -226,6 +232,10 @@ impl<'a> TryFrom<&'a [u8]> for Rrtr {
     type Error = &'static str;
 
     fn try_from(buf: &'a [u8]) -> Result<Self, Self::Error> {
+        if buf.len() < 12 {
+            return Err("Less than 12 bytes for Rrtr");
+        }
+
         let ntp_time = u64::from_be_bytes(buf[4..4 + 8].try_into().unwrap());
         let ntp_time = SystemTime::from_ntp_64(ntp_time);
 
@@ -237,6 +247,10 @@ impl<'a> TryFrom<&'a [u8]> for Dlrr {
     type Error = &'static str;
 
     fn try_from(buf: &'a [u8]) -> Result<Self, Self::Error> {
+        if buf.len() < 4 {
+            return Err("Less than 4 bytes for Dlrr");
+        }
+
         let words_per_block = 3;
         let blocks = u16::from_be_bytes(buf[2..4].try_into().unwrap()) / words_per_block;
 
@@ -246,6 +260,12 @@ impl<'a> TryFrom<&'a [u8]> for Dlrr {
         let mut buf = &buf[4..];
 
         for _ in 0..blocks {
+            // Each DLRR item is 12 bytes. The block count comes from the
+            // (attacker-controlled) length field, so stop if there aren't
+            // enough bytes left for another item.
+            if buf.len() < 12 {
+                break;
+            }
             let ssrc = u32::from_be_bytes(buf[0..4].try_into().unwrap()).into();
             let last_rr_time = u32::from_be_bytes(buf[4..8].try_into().unwrap());
             let last_rr_delay = u32::from_be_bytes(buf[8..12].try_into().unwrap());


### PR DESCRIPTION
RTCP compound-packet parsing could panic on malformed input via out-of-bounds slicing and ReportList overflow. These parsers run on decrypted SRTCP plaintext, so a connected (authenticated) peer could crash the receiver with a malformed RTCP packet.

- sdes.rs: guard Descriptions::try_from slice when word_size() padding exceeds the remaining buffer; stop SDES item parsing at the ReportList capacity (31) instead of panicking on push.

- xr.rs: bounds-check Rrtr (needs 12 bytes), Dlrr (4-byte header + 12 bytes per attacker-controlled item count), and the ExtendedReport block loop.