### PR TITLE
Add support for AMR-WB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Support single-channel AMR-WB audio in octet-aligned and bandwidth-efficient modes
   * Expose the latest send queue information on `StreamTx` #1005
   * Fix VP9 non-flexible SS advertising a bogus R=0 GOF for single-layer streams #999
   * Support G722 audio codec (16 kHz codec with 8 kHz RTP clock per RFC 3551) #992

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Support single-channel AMR-WB audio in octet-aligned and bandwidth-efficient modes
   * Add RFC 2198 RED (redundant audio) support for all audio codecs #982
   * Preserve the RFC 6464 audio-level voice activity bit when serializing #1032
 

--- a/src/_internal_test_exports/fuzz.rs
+++ b/src/_internal_test_exports/fuzz.rs
@@ -79,7 +79,7 @@ pub fn sdp_answer(data: &[u8]) -> Option<()> {
 pub fn depack(data: &[u8]) -> Option<()> {
     let mut rng = Rng::new(data);
 
-    let codec = match rng.u8(9)? {
+    let codec = match rng.u8(10)? {
         0 => Codec::Opus,
         1 => Codec::Vp8,
         2 => Codec::Vp9,
@@ -90,10 +90,17 @@ pub fn depack(data: &[u8]) -> Option<()> {
         7 => Codec::PCMU,
         8 => Codec::PCMA,
         9 => Codec::G722,
+        10 => Codec::AmrWb,
         _ => unreachable!(),
     };
 
-    let mut depack = DepacketizingBuffer::new(codec.into(), rng.usize(300)?);
+    let mut cd: CodecDepacketizer = codec.into();
+    // AMR-WB has two on-the-wire layouts (RFC 4867); fuzz both.
+    if let CodecDepacketizer::AmrWb(ref mut amr) = cd {
+        *amr = amr.with_octet_align(rng.bool()?);
+    }
+
+    let mut depack = DepacketizingBuffer::new(cd, rng.usize(300)?);
 
     let exts = random_extmap(&mut rng, 10)?;
 
@@ -209,7 +216,7 @@ pub fn rtcp(data: &[u8]) -> Option<()> {
 pub fn depack_direct(data: &[u8]) -> Option<()> {
     let mut rng = Rng::new(data);
 
-    let codec = match rng.u8(9)? {
+    let codec = match rng.u8(10)? {
         0 => Codec::Opus,
         1 => Codec::Vp8,
         2 => Codec::Vp9,
@@ -220,10 +227,15 @@ pub fn depack_direct(data: &[u8]) -> Option<()> {
         7 => Codec::PCMU,
         8 => Codec::PCMA,
         9 => Codec::G722,
+        10 => Codec::AmrWb,
         _ => unreachable!(),
     };
 
     let mut depack: CodecDepacketizer = codec.into();
+    // AMR-WB has two on-the-wire layouts (RFC 4867); fuzz both.
+    if let CodecDepacketizer::AmrWb(ref mut amr) = depack {
+        *amr = amr.with_octet_align(rng.bool()?);
+    }
     let mut out = Vec::new();
     let mut extra = CodecExtra::None;
 

--- a/src/_internal_test_exports/fuzz.rs
+++ b/src/_internal_test_exports/fuzz.rs
@@ -79,7 +79,7 @@ pub fn sdp_answer(data: &[u8]) -> Option<()> {
 pub fn depack(data: &[u8]) -> Option<()> {
     let mut rng = Rng::new(data);
 
-    let codec = match rng.u8(10)? {
+    let codec = match rng.u8(11)? {
         0 => Codec::Opus,
         1 => Codec::Vp8,
         2 => Codec::Vp9,
@@ -91,10 +91,17 @@ pub fn depack(data: &[u8]) -> Option<()> {
         8 => Codec::PCMA,
         9 => Codec::G722,
         10 => Codec::CN,
+        11 => Codec::AmrWb,
         _ => unreachable!(),
     };
 
-    let mut depack = DepacketizingBuffer::new(codec.into(), rng.usize(300)?);
+    let mut cd: CodecDepacketizer = codec.into();
+    // AMR-WB has two on-the-wire layouts (RFC 4867); fuzz both.
+    if let CodecDepacketizer::AmrWb(ref mut amr) = cd {
+        *amr = amr.with_octet_align(rng.bool()?);
+    }
+
+    let mut depack = DepacketizingBuffer::new(cd, rng.usize(300)?);
 
     let exts = random_extmap(&mut rng, 10)?;
 
@@ -210,7 +217,7 @@ pub fn rtcp(data: &[u8]) -> Option<()> {
 pub fn depack_direct(data: &[u8]) -> Option<()> {
     let mut rng = Rng::new(data);
 
-    let codec = match rng.u8(10)? {
+    let codec = match rng.u8(11)? {
         0 => Codec::Opus,
         1 => Codec::Vp8,
         2 => Codec::Vp9,
@@ -222,10 +229,15 @@ pub fn depack_direct(data: &[u8]) -> Option<()> {
         8 => Codec::PCMA,
         9 => Codec::G722,
         10 => Codec::CN,
+        11 => Codec::AmrWb,
         _ => unreachable!(),
     };
 
     let mut depack: CodecDepacketizer = codec.into();
+    // AMR-WB has two on-the-wire layouts (RFC 4867); fuzz both.
+    if let CodecDepacketizer::AmrWb(ref mut amr) = depack {
+        *amr = amr.with_octet_align(rng.bool()?);
+    }
     let mut out = Vec::new();
     let mut extra = CodecExtra::None;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -257,6 +257,16 @@ impl RtcConfig {
         self
     }
 
+    /// Enable AMR-WB (Adaptive Multi-Rate Wideband) audio codec.
+    ///
+    /// 16 kHz mono telephony/IMS audio using the octet-aligned RFC 4867 layout.
+    /// Media writes must contain exactly one 3GPP IF frame per call.
+    /// Disabled by default.
+    pub fn enable_amr_wb(mut self, enabled: bool) -> Self {
+        self.codec_config.enable_amr_wb(enabled);
+        self
+    }
+
     /// Enable VP8 video codec.
     ///
     /// Enabled by default.

--- a/src/config.rs
+++ b/src/config.rs
@@ -301,6 +301,16 @@ impl RtcConfig {
         self
     }
 
+    /// Enable AMR-WB (Adaptive Multi-Rate Wideband) audio codec.
+    ///
+    /// 16 kHz mono telephony/IMS audio using the octet-aligned RFC 4867 layout.
+    /// Media writes must contain exactly one 3GPP IF frame per call.
+    /// Disabled by default.
+    pub fn enable_amr_wb(mut self, enabled: bool) -> Self {
+        self.codec_config.enable_amr_wb(enabled);
+        self
+    }
+
     /// Enable VP8 video codec.
     ///
     /// Enabled by default.

--- a/src/format/codec.rs
+++ b/src/format/codec.rs
@@ -53,6 +53,12 @@ pub enum Codec {
     PCMU,
     PCMA,
     G722,
+    /// AMR Wideband (RFC 4867), 16 kHz mono telephony/IMS audio.
+    ///
+    /// Each call to [`Writer::write`](crate::media::Writer::write) must contain
+    /// exactly one 3GPP IF frame. Concatenated frames are rejected because each
+    /// frame requires its own RTP timestamp.
+    AmrWb,
     H264,
     // TODO show this when we support h265.
     #[doc(hidden)]
@@ -82,7 +88,7 @@ impl Codec {
     /// Tells if codec is audio.
     pub fn is_audio(&self) -> bool {
         use Codec::*;
-        matches!(self, Opus | PCMU | PCMA | G722)
+        matches!(self, Opus | PCMU | PCMA | G722 | AmrWb)
     }
 
     /// Tells if codec is video.
@@ -109,6 +115,7 @@ impl<'a> From<&'a str> for Codec {
             "pcmu" => Codec::PCMU,
             "pcma" => Codec::PCMA,
             "g722" => Codec::G722,
+            "amr-wb" => Codec::AmrWb,
             "h264" => Codec::H264,
             "h265" => Codec::H265,
             "h266" => Codec::H266,
@@ -128,6 +135,7 @@ impl fmt::Display for Codec {
             Codec::PCMU => write!(f, "PCMU"),
             Codec::PCMA => write!(f, "PCMA"),
             Codec::G722 => write!(f, "G722"),
+            Codec::AmrWb => write!(f, "AMR-WB"),
             Codec::H264 => write!(f, "H264"),
             Codec::H265 => write!(f, "H265"),
             Codec::H266 => write!(f, "H266"),

--- a/src/format/codec.rs
+++ b/src/format/codec.rs
@@ -55,6 +55,7 @@ pub enum Codec {
     G722,
     /// Comfort Noise payload, per RFC 3389.
     CN,
+    AmrWb,
     H264,
     // TODO show this when we support h265.
     #[doc(hidden)]
@@ -88,7 +89,7 @@ impl Codec {
     /// Tells if codec is audio.
     pub fn is_audio(&self) -> bool {
         use Codec::*;
-        matches!(self, Opus | PCMU | PCMA | G722 | CN)
+        matches!(self, Opus | PCMU | PCMA | G722 | CN | AmrWb)
     }
 
     /// Tells if codec is video.
@@ -116,6 +117,7 @@ impl<'a> From<&'a str> for Codec {
             "pcma" => Codec::PCMA,
             "g722" => Codec::G722,
             "cn" => Codec::CN,
+            "amr-wb" => Codec::AmrWb,
             "h264" => Codec::H264,
             "h265" => Codec::H265,
             "h266" => Codec::H266,
@@ -137,6 +139,7 @@ impl fmt::Display for Codec {
             Codec::PCMA => write!(f, "PCMA"),
             Codec::G722 => write!(f, "G722"),
             Codec::CN => write!(f, "CN"),
+            Codec::AmrWb => write!(f, "AMR-WB"),
             Codec::H264 => write!(f, "H264"),
             Codec::H265 => write!(f, "H265"),
             Codec::H266 => write!(f, "H266"),

--- a/src/format/codec_config.rs
+++ b/src/format/codec_config.rs
@@ -52,6 +52,9 @@ pub(crate) const PT_H266_RTX: Pt = Pt::new_with_value(105);
 /// Default payload type for Opus.
 pub(crate) const PT_OPUS: Pt = Pt::new_with_value(111);
 
+/// Default payload type for AMR-WB (RFC 4867).
+pub(crate) const PT_AMR_WB: Pt = Pt::new_with_value(122);
+
 /// Session config for all codecs.
 #[derive(Debug, Clone, Default)]
 pub struct CodecConfig {
@@ -233,6 +236,32 @@ impl CodecConfig {
             Frequency::SIXTEEN_KHZ,
             None,
             Default::default(),
+        );
+    }
+
+    /// Enable the AMR-WB (Adaptive Multi-Rate Wideband) audio codec.
+    ///
+    /// Adds a 16 kHz mono AMR-WB payload type using the octet-aligned RFC 4867
+    /// layout with the parameters most commonly seen in IMS/VoLTE offers
+    /// (`octet-align=1;mode-change-capability=2;max-red=0`). Each media write
+    /// must contain exactly one 3GPP IF frame. Disabled by default.
+    pub fn enable_amr_wb(&mut self, enabled: bool) {
+        self.params.retain(|c| c.spec.codec != Codec::AmrWb);
+        if !enabled {
+            return;
+        }
+        self.add_config(
+            PT_AMR_WB,
+            None,
+            Codec::AmrWb,
+            Frequency::SIXTEEN_KHZ,
+            Some(1),
+            FormatParams {
+                octet_align: Some(true),
+                mode_change_capability: Some(2),
+                max_red: Some(0),
+                ..Default::default()
+            },
         );
     }
 
@@ -563,6 +592,7 @@ impl Codec {
             PCMA => Some(PT_PCMA),
             Vp8 => Some(PT_VP8),
             Vp9 => Some(PT_VP9),
+            AmrWb => Some(PT_AMR_WB),
             H265 => Some(PT_H265),
             _ => None,
         }
@@ -577,6 +607,42 @@ mod test {
 
     use super::*;
     use crate::format::{CodecSpec, FormatParams};
+
+    #[test]
+    fn enable_amr_wb_uses_default_pt() {
+        let mut config = CodecConfig::empty();
+
+        config.enable_amr_wb(true);
+
+        let amr_wb = config
+            .params()
+            .iter()
+            .find(|p| p.spec().codec == Codec::AmrWb)
+            .expect("AMR-WB should be enabled");
+        assert_eq!(amr_wb.pt(), PT_AMR_WB);
+    }
+
+    #[test]
+    fn enable_amr_wb_keeps_payload_types_unique_with_defaults() {
+        let mut config = CodecConfig::new_with_defaults();
+
+        config.enable_amr_wb(true);
+
+        let amr_wb = config
+            .params()
+            .iter()
+            .find(|p| p.spec().codec == Codec::AmrWb)
+            .expect("AMR-WB should be enabled");
+        assert_eq!(amr_wb.pt(), PT_AMR_WB);
+
+        let mut seen = std::collections::HashSet::new();
+        for param in config.params() {
+            assert!(seen.insert(param.pt()), "duplicate PT {}", param.pt());
+            if let Some(rtx) = param.resend() {
+                assert!(seen.insert(rtx), "duplicate PT {rtx}");
+            }
+        }
+    }
 
     #[test]
     fn test_pt_conflict_different_directions() {

--- a/src/format/codec_config.rs
+++ b/src/format/codec_config.rs
@@ -66,6 +66,9 @@ pub(crate) const PT_G722_RED: Pt = Pt::new_with_value(62);
 pub(crate) const PT_PCMU_RED: Pt = Pt::new_with_value(61);
 pub(crate) const PT_PCMA_RED: Pt = Pt::new_with_value(60);
 
+/// Default payload type for AMR-WB (RFC 4867).
+pub(crate) const PT_AMR_WB: Pt = Pt::new_with_value(122);
+
 /// Session config for all codecs.
 #[derive(Debug, Clone, Default)]
 pub struct CodecConfig {
@@ -272,6 +275,32 @@ impl CodecConfig {
             return;
         }
         self.add_static_config(PT_COMFORT_NOISE);
+    }
+
+    /// Enable the AMR-WB (Adaptive Multi-Rate Wideband) audio codec.
+    ///
+    /// Adds a 16 kHz mono AMR-WB payload type using the octet-aligned RFC 4867
+    /// layout without redundancy (`octet-align=1;max-red=0`). Each media write
+    /// must contain exactly one 3GPP IF frame. Mode-change capability stays
+    /// unset because str0m cannot enforce period-2 changes on application-supplied
+    /// frames. Disabled by default.
+    pub fn enable_amr_wb(&mut self, enabled: bool) {
+        self.params.retain(|c| c.spec.codec != Codec::AmrWb);
+        if !enabled {
+            return;
+        }
+        self.add_config(
+            PT_AMR_WB,
+            None,
+            Codec::AmrWb,
+            Frequency::SIXTEEN_KHZ,
+            Some(1),
+            FormatParams {
+                octet_align: Some(true),
+                max_red: Some(0),
+                ..Default::default()
+            },
+        );
     }
 
     /// Add a default OPUS payload type, optionally with RFC 2198 RED.
@@ -900,6 +929,42 @@ mod test {
         for (i, a) in pts.iter().enumerate() {
             for b in &pts[i + 1..] {
                 assert_ne!(a, b, "RED payload types must be distinct");
+            }
+        }
+    }
+
+    #[test]
+    fn enable_amr_wb_uses_default_pt() {
+        let mut config = CodecConfig::empty();
+
+        config.enable_amr_wb(true);
+
+        let amr_wb = config
+            .params()
+            .iter()
+            .find(|p| p.spec().codec == Codec::AmrWb)
+            .expect("AMR-WB should be enabled");
+        assert_eq!(amr_wb.pt(), PT_AMR_WB);
+    }
+
+    #[test]
+    fn enable_amr_wb_keeps_payload_types_unique_with_defaults() {
+        let mut config = CodecConfig::new_with_defaults();
+
+        config.enable_amr_wb(true);
+
+        let amr_wb = config
+            .params()
+            .iter()
+            .find(|p| p.spec().codec == Codec::AmrWb)
+            .expect("AMR-WB should be enabled");
+        assert_eq!(amr_wb.pt(), PT_AMR_WB);
+
+        let mut seen = std::collections::HashSet::new();
+        for param in config.params() {
+            assert!(seen.insert(param.pt()), "duplicate PT {}", param.pt());
+            if let Some(rtx) = param.resend() {
+                assert!(seen.insert(rtx), "duplicate PT {rtx}");
             }
         }
     }

--- a/src/format/format_params.rs
+++ b/src/format/format_params.rs
@@ -108,6 +108,68 @@ pub struct FormatParams {
     /// When > 0, DONL fields are included in H.265 RTP packets to support
     /// out-of-order NAL unit decoding.
     pub sprop_max_don_diff: Option<u16>,
+
+    /// AMR-WB specific parameter (RFC 4867).
+    ///
+    /// When `true` the payload is octet-aligned (`octet-align=1`); when absent
+    /// or `false` the bandwidth-efficient layout is used (the RFC default).
+    pub octet_align: Option<bool>,
+
+    /// AMR-WB specific parameter (RFC 4867).
+    ///
+    /// Restricts the active speech modes. Bits 0 through 8 correspond to the
+    /// nine AMR-WB speech frame types. str0m does not currently enforce this
+    /// encoder restriction and therefore declines configurations that set it.
+    pub mode_set: Option<u16>,
+
+    /// AMR-WB specific parameter (RFC 4867).
+    ///
+    /// Requires codec mode changes to be separated by one or two frame-blocks.
+    /// str0m declines the restrictive value `2` because the encoded frames are
+    /// supplied by the application.
+    pub mode_change_period: Option<u8>,
+
+    /// AMR-WB specific parameter (RFC 4867).
+    ///
+    /// Signals the sender's ability to restrict mode changes to every second
+    /// frame-block. `1` means incapable and `2` means capable.
+    pub mode_change_capability: Option<u8>,
+
+    /// AMR-WB specific parameter (RFC 4867).
+    ///
+    /// Requests changes only between neighboring codec modes. str0m declines
+    /// this restriction because encoded frames are supplied by the application.
+    pub mode_change_neighbor: Option<bool>,
+
+    /// AMR-WB specific parameter (RFC 4867).
+    ///
+    /// The maximum amount of frame redundancy, in milliseconds, the receiver
+    /// accepts. `0` disables redundancy.
+    pub max_red: Option<u16>,
+
+    /// AMR-WB specific parameter (RFC 4867).
+    ///
+    /// When `true` (`crc=1`) each frame carries a payload CRC. str0m can neither
+    /// generate nor decode that CRC, so it never offers `crc=1` and declines a
+    /// peer that requires it; this field exists only to recognise and reject it.
+    pub crc: Option<bool>,
+
+    /// AMR-WB specific parameter (RFC 4867).
+    ///
+    /// Its numeric value bounds the interleaving-group size. Presence enables a
+    /// payload layout str0m does not support, so such peers are declined.
+    pub interleaving: Option<u16>,
+
+    /// AMR-WB specific parameter (RFC 4867).
+    ///
+    /// When `true` (`robust-sorting=1`) the RTP payload uses a robust sorting
+    /// layout that str0m does not support, so peers requiring it are declined.
+    pub robust_sorting: Option<bool>,
+
+    /// Whether a recognized AMR-WB format parameter had an invalid value.
+    #[doc(hidden)]
+    #[serde(default)]
+    pub invalid_amr_wb: bool,
 }
 
 #[cfg(feature = "drv")]
@@ -156,6 +218,16 @@ impl FormatParams {
             H265ProfileTierLevel(v) => self.h265_profile_tier_level = Some(*v),
             H266ProfileTierLevel(v) => self.h266_profile_tier_level = Some(*v),
             SpropMaxDonDiff(v) => self.sprop_max_don_diff = Some(*v),
+            OctetAlign(v) => self.octet_align = Some(*v),
+            ModeSet(v) => self.mode_set = Some(*v),
+            ModeChangePeriod(v) => self.mode_change_period = Some(*v),
+            ModeChangeCapability(v) => self.mode_change_capability = Some(*v),
+            ModeChangeNeighbor(v) => self.mode_change_neighbor = Some(*v),
+            MaxRed(v) => self.max_red = Some(*v),
+            Crc(v) => self.crc = Some(*v),
+            Interleaving(v) => self.interleaving = Some(*v),
+            RobustSorting(v) => self.robust_sorting = Some(*v),
+            InvalidAmrWb => self.invalid_amr_wb = true,
             Apt(_) => {}
             Unknown => {}
         }
@@ -211,6 +283,34 @@ impl FormatParams {
         }
         if let Some(v) = self.sprop_max_don_diff {
             r.push(SpropMaxDonDiff(v));
+        }
+
+        if let Some(v) = self.octet_align {
+            r.push(OctetAlign(v));
+        }
+        if let Some(v) = self.mode_set {
+            r.push(ModeSet(v));
+        }
+        if let Some(v) = self.mode_change_period {
+            r.push(ModeChangePeriod(v));
+        }
+        if let Some(v) = self.mode_change_capability {
+            r.push(ModeChangeCapability(v));
+        }
+        if let Some(v) = self.mode_change_neighbor {
+            r.push(ModeChangeNeighbor(v));
+        }
+        if let Some(v) = self.max_red {
+            r.push(MaxRed(v));
+        }
+        if let Some(v) = self.crc {
+            r.push(Crc(v));
+        }
+        if let Some(v) = self.interleaving {
+            r.push(Interleaving(v));
+        }
+        if let Some(v) = self.robust_sorting {
+            r.push(RobustSorting(v));
         }
 
         r
@@ -312,5 +412,142 @@ mod test {
         let parsed = FormatParams::parse_line(&fmtp_str);
         assert_eq!(parsed.h266_profile_tier_level, Some(ptl));
         assert_eq!(parsed.sprop_max_don_diff, Some(32));
+    }
+
+    #[test]
+    fn amr_wb_default_fmtp_roundtrip() {
+        // The most common production AMR-WB offer.
+        let f = FormatParams {
+            octet_align: Some(true),
+            mode_change_capability: Some(2),
+            max_red: Some(0),
+            ..Default::default()
+        };
+
+        let fmtp_str = f.to_string();
+        assert_eq!(fmtp_str, "octet-align=1;mode-change-capability=2;max-red=0");
+
+        let parsed = FormatParams::parse_line(&fmtp_str);
+        assert_eq!(parsed, f);
+    }
+
+    #[test]
+    fn amr_wb_production_fmtp_variants_parse() {
+        // The variants seen most often across SIP, IMS, VoLTE and SBC deployments.
+        let cases: &[(&str, FormatParams)] = &[
+            (
+                "mode-change-capability=2",
+                FormatParams {
+                    mode_change_capability: Some(2),
+                    ..Default::default()
+                },
+            ),
+            (
+                "mode-change-capability=2;max-red=0",
+                FormatParams {
+                    mode_change_capability: Some(2),
+                    max_red: Some(0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "mode-change-capability=2;max-red=220",
+                FormatParams {
+                    mode_change_capability: Some(2),
+                    max_red: Some(220),
+                    ..Default::default()
+                },
+            ),
+            (
+                "octet-align=1;mode-change-capability=2",
+                FormatParams {
+                    octet_align: Some(true),
+                    mode_change_capability: Some(2),
+                    ..Default::default()
+                },
+            ),
+            (
+                "octet-align=1;mode-change-capability=2;max-red=0",
+                FormatParams {
+                    octet_align: Some(true),
+                    mode_change_capability: Some(2),
+                    max_red: Some(0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "octet-align=1;mode-change-capability=2;max-red=220",
+                FormatParams {
+                    octet_align: Some(true),
+                    mode_change_capability: Some(2),
+                    max_red: Some(220),
+                    ..Default::default()
+                },
+            ),
+            (
+                "octet-align=1;crc=1;mode-change-capability=2",
+                FormatParams {
+                    octet_align: Some(true),
+                    crc: Some(true),
+                    mode_change_capability: Some(2),
+                    ..Default::default()
+                },
+            ),
+            (
+                "octet-align=1;interleaving=30;robust-sorting=1",
+                FormatParams {
+                    octet_align: Some(true),
+                    interleaving: Some(30),
+                    robust_sorting: Some(true),
+                    ..Default::default()
+                },
+            ),
+        ];
+
+        for (line, expected) in cases {
+            let parsed = FormatParams::parse_line(line);
+            assert_eq!(&parsed, expected, "parsing AMR-WB fmtp line `{line}`");
+        }
+    }
+
+    #[test]
+    fn amr_wb_octet_align_zero_parses_false() {
+        let parsed = FormatParams::parse_line("octet-align=0;mode-change-capability=2");
+        assert_eq!(parsed.octet_align, Some(false));
+        assert_eq!(parsed.mode_change_capability, Some(2));
+    }
+
+    #[test]
+    fn amr_wb_mode_restrictions_and_interleaving_roundtrip() {
+        let line = "mode-set=0,2,8;mode-change-period=2;mode-change-capability=2;\
+                    mode-change-neighbor=1;interleaving=30";
+        let parsed = FormatParams::parse_line(line);
+
+        assert_eq!(parsed.mode_set, Some((1 << 0) | (1 << 2) | (1 << 8)));
+        assert_eq!(parsed.mode_change_period, Some(2));
+        assert_eq!(parsed.mode_change_capability, Some(2));
+        assert_eq!(parsed.mode_change_neighbor, Some(true));
+        assert_eq!(parsed.interleaving, Some(30));
+        assert_eq!(parsed.to_string(), line);
+    }
+
+    #[test]
+    fn invalid_amr_wb_values_are_retained_for_rejection() {
+        for line in [
+            "octet-align=2",
+            "mode-set=9",
+            "mode-change-period=3",
+            "mode-change-capability=0",
+            "mode-change-neighbor=2",
+            "max-red=65536",
+            "crc=2",
+            "interleaving=invalid",
+            "robust-sorting=2",
+        ] {
+            assert!(
+                FormatParams::parse_line(line).invalid_amr_wb,
+                "expected `{line}` to be marked invalid"
+            );
+        }
     }
 }

--- a/src/format/format_params.rs
+++ b/src/format/format_params.rs
@@ -108,6 +108,68 @@ pub struct FormatParams {
     /// When > 0, DONL fields are included in H.265 RTP packets to support
     /// out-of-order NAL unit decoding.
     pub sprop_max_don_diff: Option<u16>,
+
+    /// AMR-WB specific parameter (RFC 4867).
+    ///
+    /// When `true` the payload is octet-aligned (`octet-align=1`); when absent
+    /// or `false` the bandwidth-efficient layout is used (the RFC default).
+    pub octet_align: Option<bool>,
+
+    /// AMR-WB specific parameter (RFC 4867).
+    ///
+    /// Restricts the active speech modes. Bits 0 through 8 correspond to the
+    /// nine AMR-WB speech frame types. str0m does not currently enforce this
+    /// encoder restriction and therefore declines configurations that set it.
+    pub mode_set: Option<u16>,
+
+    /// AMR-WB specific parameter (RFC 4867).
+    ///
+    /// Requires codec mode changes to be separated by one or two frame-blocks.
+    /// str0m declines the restrictive value `2` because the encoded frames are
+    /// supplied by the application.
+    pub mode_change_period: Option<u8>,
+
+    /// AMR-WB specific parameter (RFC 4867).
+    ///
+    /// Signals the sender's ability to restrict mode changes to every second
+    /// frame-block. `1` means incapable and `2` means capable.
+    pub mode_change_capability: Option<u8>,
+
+    /// AMR-WB specific parameter (RFC 4867).
+    ///
+    /// Requests changes only between neighboring codec modes. str0m declines
+    /// this restriction because encoded frames are supplied by the application.
+    pub mode_change_neighbor: Option<bool>,
+
+    /// AMR-WB specific parameter (RFC 4867).
+    ///
+    /// Parsed and serialized for negotiation only; str0m does not implement
+    /// AMR-WB frame redundancy. `0` advertises that no redundancy is used.
+    pub max_red: Option<u16>,
+
+    /// AMR-WB specific parameter (RFC 4867).
+    ///
+    /// When `true` (`crc=1`) each frame carries a payload CRC. str0m can neither
+    /// generate nor decode that CRC, so it never offers `crc=1` and declines a
+    /// peer that requires it; this field exists only to recognise and reject it.
+    pub crc: Option<bool>,
+
+    /// AMR-WB specific parameter (RFC 4867).
+    ///
+    /// Its numeric value bounds the interleaving-group size. Presence enables a
+    /// payload layout str0m does not support, so such peers are declined.
+    pub interleaving: Option<u16>,
+
+    /// AMR-WB specific parameter (RFC 4867).
+    ///
+    /// When `true` (`robust-sorting=1`) the RTP payload uses a robust sorting
+    /// layout that str0m does not support, so peers requiring it are declined.
+    pub robust_sorting: Option<bool>,
+
+    /// Whether a recognized AMR-WB format parameter had an invalid value.
+    #[doc(hidden)]
+    #[serde(default)]
+    pub invalid_amr_wb: bool,
 }
 
 #[cfg(feature = "drv")]
@@ -156,6 +218,16 @@ impl FormatParams {
             H265ProfileTierLevel(v) => self.h265_profile_tier_level = Some(*v),
             H266ProfileTierLevel(v) => self.h266_profile_tier_level = Some(*v),
             SpropMaxDonDiff(v) => self.sprop_max_don_diff = Some(*v),
+            OctetAlign(v) => self.octet_align = Some(*v),
+            ModeSet(v) => self.mode_set = Some(*v),
+            ModeChangePeriod(v) => self.mode_change_period = Some(*v),
+            ModeChangeCapability(v) => self.mode_change_capability = Some(*v),
+            ModeChangeNeighbor(v) => self.mode_change_neighbor = Some(*v),
+            MaxRed(v) => self.max_red = Some(*v),
+            Crc(v) => self.crc = Some(*v),
+            Interleaving(v) => self.interleaving = Some(*v),
+            RobustSorting(v) => self.robust_sorting = Some(*v),
+            InvalidAmrWb => self.invalid_amr_wb = true,
             Apt(_) => {}
             Red(_) => {}
             Unknown => {}
@@ -212,6 +284,34 @@ impl FormatParams {
         }
         if let Some(v) = self.sprop_max_don_diff {
             r.push(SpropMaxDonDiff(v));
+        }
+
+        if let Some(v) = self.octet_align {
+            r.push(OctetAlign(v));
+        }
+        if let Some(v) = self.mode_set {
+            r.push(ModeSet(v));
+        }
+        if let Some(v) = self.mode_change_period {
+            r.push(ModeChangePeriod(v));
+        }
+        if let Some(v) = self.mode_change_capability {
+            r.push(ModeChangeCapability(v));
+        }
+        if let Some(v) = self.mode_change_neighbor {
+            r.push(ModeChangeNeighbor(v));
+        }
+        if let Some(v) = self.max_red {
+            r.push(MaxRed(v));
+        }
+        if let Some(v) = self.crc {
+            r.push(Crc(v));
+        }
+        if let Some(v) = self.interleaving {
+            r.push(Interleaving(v));
+        }
+        if let Some(v) = self.robust_sorting {
+            r.push(RobustSorting(v));
         }
 
         r
@@ -313,5 +413,142 @@ mod test {
         let parsed = FormatParams::parse_line(&fmtp_str);
         assert_eq!(parsed.h266_profile_tier_level, Some(ptl));
         assert_eq!(parsed.sprop_max_don_diff, Some(32));
+    }
+
+    #[test]
+    fn amr_wb_default_fmtp_roundtrip() {
+        // The most common production AMR-WB offer.
+        let f = FormatParams {
+            octet_align: Some(true),
+            mode_change_capability: Some(2),
+            max_red: Some(0),
+            ..Default::default()
+        };
+
+        let fmtp_str = f.to_string();
+        assert_eq!(fmtp_str, "octet-align=1;mode-change-capability=2;max-red=0");
+
+        let parsed = FormatParams::parse_line(&fmtp_str);
+        assert_eq!(parsed, f);
+    }
+
+    #[test]
+    fn amr_wb_production_fmtp_variants_parse() {
+        // The variants seen most often across SIP, IMS, VoLTE and SBC deployments.
+        let cases: &[(&str, FormatParams)] = &[
+            (
+                "mode-change-capability=2",
+                FormatParams {
+                    mode_change_capability: Some(2),
+                    ..Default::default()
+                },
+            ),
+            (
+                "mode-change-capability=2;max-red=0",
+                FormatParams {
+                    mode_change_capability: Some(2),
+                    max_red: Some(0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "mode-change-capability=2;max-red=220",
+                FormatParams {
+                    mode_change_capability: Some(2),
+                    max_red: Some(220),
+                    ..Default::default()
+                },
+            ),
+            (
+                "octet-align=1;mode-change-capability=2",
+                FormatParams {
+                    octet_align: Some(true),
+                    mode_change_capability: Some(2),
+                    ..Default::default()
+                },
+            ),
+            (
+                "octet-align=1;mode-change-capability=2;max-red=0",
+                FormatParams {
+                    octet_align: Some(true),
+                    mode_change_capability: Some(2),
+                    max_red: Some(0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "octet-align=1;mode-change-capability=2;max-red=220",
+                FormatParams {
+                    octet_align: Some(true),
+                    mode_change_capability: Some(2),
+                    max_red: Some(220),
+                    ..Default::default()
+                },
+            ),
+            (
+                "octet-align=1;crc=1;mode-change-capability=2",
+                FormatParams {
+                    octet_align: Some(true),
+                    crc: Some(true),
+                    mode_change_capability: Some(2),
+                    ..Default::default()
+                },
+            ),
+            (
+                "octet-align=1;interleaving=30;robust-sorting=1",
+                FormatParams {
+                    octet_align: Some(true),
+                    interleaving: Some(30),
+                    robust_sorting: Some(true),
+                    ..Default::default()
+                },
+            ),
+        ];
+
+        for (line, expected) in cases {
+            let parsed = FormatParams::parse_line(line);
+            assert_eq!(&parsed, expected, "parsing AMR-WB fmtp line `{line}`");
+        }
+    }
+
+    #[test]
+    fn amr_wb_octet_align_zero_parses_false() {
+        let parsed = FormatParams::parse_line("octet-align=0;mode-change-capability=2");
+        assert_eq!(parsed.octet_align, Some(false));
+        assert_eq!(parsed.mode_change_capability, Some(2));
+    }
+
+    #[test]
+    fn amr_wb_mode_restrictions_and_interleaving_roundtrip() {
+        let line = "mode-set=0,2,8;mode-change-period=2;mode-change-capability=2;\
+                    mode-change-neighbor=1;interleaving=30";
+        let parsed = FormatParams::parse_line(line);
+
+        assert_eq!(parsed.mode_set, Some((1 << 0) | (1 << 2) | (1 << 8)));
+        assert_eq!(parsed.mode_change_period, Some(2));
+        assert_eq!(parsed.mode_change_capability, Some(2));
+        assert_eq!(parsed.mode_change_neighbor, Some(true));
+        assert_eq!(parsed.interleaving, Some(30));
+        assert_eq!(parsed.to_string(), line);
+    }
+
+    #[test]
+    fn invalid_amr_wb_values_are_retained_for_rejection() {
+        for line in [
+            "octet-align=2",
+            "mode-set=9",
+            "mode-change-period=3",
+            "mode-change-capability=0",
+            "mode-change-neighbor=2",
+            "max-red=65536",
+            "crc=2",
+            "interleaving=invalid",
+            "robust-sorting=2",
+        ] {
+            assert!(
+                FormatParams::parse_line(line).invalid_amr_wb,
+                "expected `{line}` to be marked invalid"
+            );
+        }
     }
 }

--- a/src/format/payload_params.rs
+++ b/src/format/payload_params.rs
@@ -269,7 +269,7 @@ impl PayloadParams {
         let c0 = self.spec;
         let c1 = o.spec;
 
-        if c0 == c1 {
+        if c0 == c1 && c0.codec != Codec::AmrWb {
             // Exact match
             return Some(Self::EXACT_MATCH_SCORE);
         }
@@ -285,7 +285,7 @@ impl PayloadParams {
             return None;
         }
 
-        if c0.channels != c1.channels {
+        if !Self::channels_match(c0, c1) {
             // Channels must match
             return None;
         }
@@ -312,6 +312,10 @@ impl PayloadParams {
 
         if c0.codec == Codec::Av1 {
             return Self::match_av1_score(c0, c1);
+        }
+
+        if c0.codec == Codec::AmrWb {
+            return Self::match_amr_wb_score(c0, c1);
         }
 
         // TODO: Fuzzy matching for any other audio codecs
@@ -363,6 +367,18 @@ impl PayloadParams {
         score
     }
 
+    fn channels_match(c0: CodecSpec, c1: CodecSpec) -> bool {
+        if c0.channels == c1.channels {
+            return true;
+        }
+
+        if c0.codec == Codec::AmrWb && c1.codec == Codec::AmrWb {
+            return c0.channels.unwrap_or(1) == 1 && c1.channels.unwrap_or(1) == 1;
+        }
+
+        false
+    }
+
     fn match_vp9_score(c0: CodecSpec, c1: CodecSpec) -> Option<usize> {
         // Default profile_id is 0. https://datatracker.ietf.org/doc/html/draft-ietf-payload-vp9-16#section-6
         let c0_profile_id = c0.format.profile_id.unwrap_or(0);
@@ -403,6 +419,60 @@ impl PayloadParams {
             return None;
         }
 
+        Some(Self::EXACT_MATCH_SCORE)
+    }
+
+    fn match_amr_wb_score(c0: CodecSpec, c1: CodecSpec) -> Option<usize> {
+        if c0.format.invalid_amr_wb || c1.format.invalid_amr_wb {
+            return None;
+        }
+
+        if c0.channels.unwrap_or(1) != 1 || c1.channels.unwrap_or(1) != 1 {
+            return None;
+        }
+
+        // The octet-align mode selects the on-the-wire framing (RFC 4867 §4.3);
+        // octet-aligned and bandwidth-efficient payloads are not interchangeable,
+        // so the two sides must agree. The default (absent) is bandwidth-efficient.
+        let c0_octet_align = c0.format.octet_align.unwrap_or(false);
+        let c1_octet_align = c1.format.octet_align.unwrap_or(false);
+        if c0_octet_align != c1_octet_align {
+            return None;
+        }
+
+        // str0m can neither generate nor decode the per-frame payload CRC that
+        // crc=1 adds (RFC 4867 §4.3). Rather than agree to it and then mis-decode
+        // the stream, decline any peer that requires it. The default is no CRC.
+        if c0.format.crc.unwrap_or(false) || c1.format.crc.unwrap_or(false) {
+            return None;
+        }
+
+        // Presence of interleaving adds RTP payload fields that str0m does not
+        // implement, regardless of the advertised maximum group size.
+        if c0.format.interleaving.is_some() || c1.format.interleaving.is_some() {
+            return None;
+        }
+        if c0.format.robust_sorting.unwrap_or(false) || c1.format.robust_sorting.unwrap_or(false) {
+            return None;
+        }
+
+        // These parameters constrain an encoder's mode choices. str0m receives
+        // already encoded IF frames from the application and cannot guarantee
+        // compliance, so reject restrictive configurations.
+        if c0.format.mode_set.is_some() || c1.format.mode_set.is_some() {
+            return None;
+        }
+        if c0.format.mode_change_period == Some(2) || c1.format.mode_change_period == Some(2) {
+            return None;
+        }
+        if c0.format.mode_change_neighbor == Some(true)
+            || c1.format.mode_change_neighbor == Some(true)
+        {
+            return None;
+        }
+
+        // mode-change-capability and max-red are capability hints that do not
+        // affect interoperability, so they don't influence the match.
         Some(Self::EXACT_MATCH_SCORE)
     }
 
@@ -665,6 +735,17 @@ impl PayloadParams {
             if first.spec.format.sprop_max_don_diff.is_some() {
                 self.spec.format.sprop_max_don_diff = first.spec.format.sprop_max_don_diff;
             }
+        }
+
+        // RFC 4867 requires transport-format parameters and channels to be
+        // returned unmodified in an answer. Preserve both explicit zero values
+        // and omission so the generated answer has the same wire layout shape.
+        if self.spec.codec == Codec::AmrWb && first.spec.codec == Codec::AmrWb {
+            self.spec.channels = first.spec.channels;
+            self.spec.format.octet_align = first.spec.format.octet_align;
+            self.spec.format.crc = first.spec.format.crc;
+            self.spec.format.interleaving = first.spec.format.interleaving;
+            self.spec.format.robust_sorting = first.spec.format.robust_sorting;
         }
 
         let mut remote_pt = first.pt;
@@ -1843,6 +1924,230 @@ mod test {
                 nalu.len(),
                 "No DONL field when sprop-max-don-diff=0"
             );
+        }
+    }
+
+    mod amr_wb {
+        use super::*;
+
+        fn amr_wb_codec_spec(
+            octet_align: Option<bool>,
+            crc: Option<bool>,
+            mode_change_capability: Option<u8>,
+            max_red: Option<u16>,
+        ) -> CodecSpec {
+            amr_wb_codec_spec_with_channels(
+                Some(1),
+                octet_align,
+                crc,
+                mode_change_capability,
+                max_red,
+                None,
+                None,
+            )
+        }
+
+        fn amr_wb_codec_spec_with_channels(
+            channels: Option<u8>,
+            octet_align: Option<bool>,
+            crc: Option<bool>,
+            mode_change_capability: Option<u8>,
+            max_red: Option<u16>,
+            interleaving: Option<u16>,
+            robust_sorting: Option<bool>,
+        ) -> CodecSpec {
+            CodecSpec {
+                codec: Codec::AmrWb,
+                clock_rate: Frequency::SIXTEEN_KHZ,
+                channels,
+                format: FormatParams {
+                    octet_align,
+                    crc,
+                    mode_change_capability,
+                    max_red,
+                    interleaving,
+                    robust_sorting,
+                    ..Default::default()
+                },
+            }
+        }
+
+        #[test]
+        fn test_amr_wb_matching() {
+            struct Case {
+                c0: CodecSpec,
+                c1: CodecSpec,
+                must_match: bool,
+                msg: &'static str,
+            }
+
+            let cases = [
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), None, Some(2), Some(0)),
+                    c1: amr_wb_codec_spec(Some(true), None, Some(2), Some(0)),
+                    must_match: true,
+                    msg: "identical octet-aligned configs should match",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), None, Some(2), Some(0)),
+                    c1: amr_wb_codec_spec_with_channels(
+                        None,
+                        Some(true),
+                        None,
+                        Some(2),
+                        Some(0),
+                        None,
+                        None,
+                    ),
+                    must_match: true,
+                    msg: "AMR-WB /16000 and /16000/1 are both mono and should match",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(None, None, None, None),
+                    c1: amr_wb_codec_spec(None, None, None, None),
+                    must_match: true,
+                    msg: "both bandwidth-efficient (the RFC defaults) should match",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), None, Some(2), Some(0)),
+                    c1: amr_wb_codec_spec(Some(true), None, Some(1), Some(220)),
+                    must_match: true,
+                    msg: "mode-change-capability and max-red are hints; should still match",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), None, Some(2), None),
+                    c1: amr_wb_codec_spec(None, None, Some(2), None),
+                    must_match: false,
+                    msg: "octet-aligned vs bandwidth-efficient framings must not match",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), None, Some(2), Some(0)),
+                    c1: amr_wb_codec_spec(Some(true), Some(false), Some(2), Some(0)),
+                    must_match: true,
+                    msg: "an explicit crc=0 means no CRC and must match our (absent) default",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), Some(false), Some(2), Some(0)),
+                    c1: amr_wb_codec_spec(Some(true), Some(false), Some(2), Some(0)),
+                    must_match: true,
+                    msg: "crc=0 on both sides means no CRC and should match",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), None, Some(2), Some(0)),
+                    c1: amr_wb_codec_spec(Some(true), Some(true), Some(2), Some(0)),
+                    must_match: false,
+                    msg: "a peer requiring crc=1 must be declined; str0m cannot decode CRC",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), Some(true), Some(2), Some(0)),
+                    c1: amr_wb_codec_spec(Some(true), Some(true), Some(2), Some(0)),
+                    must_match: false,
+                    msg: "crc=1 is never agreed to, even if both sides signal it",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), None, Some(2), Some(0)),
+                    c1: amr_wb_codec_spec_with_channels(
+                        Some(1),
+                        Some(true),
+                        None,
+                        Some(2),
+                        Some(0),
+                        Some(30),
+                        None,
+                    ),
+                    must_match: false,
+                    msg: "interleaving=30 must be declined because it changes the RTP payload layout",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), None, Some(2), Some(0)),
+                    c1: amr_wb_codec_spec_with_channels(
+                        Some(1),
+                        Some(true),
+                        None,
+                        Some(2),
+                        Some(0),
+                        None,
+                        Some(true),
+                    ),
+                    must_match: false,
+                    msg: "robust-sorting=1 must be declined because it changes the RTP payload layout",
+                },
+            ];
+
+            for Case {
+                c0,
+                c1,
+                must_match,
+                msg,
+            } in cases.into_iter()
+            {
+                let matched = PayloadParams::match_amr_wb_score(c0, c1).is_some();
+                assert_eq!(matched, must_match, "{msg}\nc0: {c0:#?}\nc1: {c1:#?}");
+            }
+        }
+
+        #[test]
+        fn unsupported_amr_wb_restrictions_do_not_match() {
+            let supported = amr_wb_codec_spec(Some(true), None, Some(2), Some(0));
+
+            let mut restricted = supported;
+            restricted.format.mode_set = Some(1 << 2);
+            assert!(PayloadParams::match_amr_wb_score(supported, restricted).is_none());
+
+            restricted = supported;
+            restricted.format.mode_change_period = Some(2);
+            assert!(PayloadParams::match_amr_wb_score(supported, restricted).is_none());
+
+            restricted = supported;
+            restricted.format.mode_change_neighbor = Some(true);
+            assert!(PayloadParams::match_amr_wb_score(supported, restricted).is_none());
+
+            restricted = supported;
+            restricted.format.invalid_amr_wb = true;
+            assert!(PayloadParams::match_amr_wb_score(supported, restricted).is_none());
+
+            let multi_channel = amr_wb_codec_spec_with_channels(
+                Some(2),
+                Some(true),
+                None,
+                Some(2),
+                Some(0),
+                None,
+                None,
+            );
+            assert!(PayloadParams::match_amr_wb_score(multi_channel, multi_channel).is_none());
+        }
+
+        #[test]
+        fn exact_unsupported_amr_wb_configs_do_not_bypass_validation() {
+            let unsupported = amr_wb_codec_spec(Some(true), Some(true), Some(2), Some(0));
+            let params = PayloadParams::new(122.into(), None, unsupported);
+            assert_eq!(params.match_score(&params), None);
+        }
+
+        #[test]
+        fn update_param_mirrors_amr_wb_transport_shape() {
+            let local_spec = amr_wb_codec_spec(None, None, Some(2), Some(0));
+            let remote_spec = amr_wb_codec_spec_with_channels(
+                None,
+                Some(false),
+                Some(false),
+                Some(1),
+                Some(220),
+                None,
+                Some(false),
+            );
+            let mut local = PayloadParams::new(122.into(), None, local_spec);
+            let remote = PayloadParams::new(122.into(), None, remote_spec);
+            let mut claimed = [false; 128];
+            let mut unlocked = HashSet::new();
+
+            local.update_param(&[remote], &mut claimed, false, &mut unlocked);
+
+            assert_eq!(local.spec.channels, None);
+            assert_eq!(local.spec.format.octet_align, Some(false));
+            assert_eq!(local.spec.format.crc, Some(false));
+            assert_eq!(local.spec.format.robust_sorting, Some(false));
         }
     }
 }

--- a/src/format/payload_params.rs
+++ b/src/format/payload_params.rs
@@ -281,7 +281,7 @@ impl PayloadParams {
         let c0 = self.spec;
         let c1 = o.spec;
 
-        if c0 == c1 {
+        if c0 == c1 && c0.codec != Codec::AmrWb {
             // Exact match
             return Some(Self::EXACT_MATCH_SCORE);
         }
@@ -295,6 +295,12 @@ impl PayloadParams {
         if c0.clock_rate != c1.clock_rate {
             // Clock rates must match
             return None;
+        }
+
+        // AMR-WB defaults an omitted channel count to mono, so it must match
+        // before the generic channel comparison below.
+        if c0.codec == Codec::AmrWb {
+            return Self::match_amr_wb_score(c0, c1);
         }
 
         if c0.channels != c1.channels {
@@ -415,6 +421,60 @@ impl PayloadParams {
             return None;
         }
 
+        Some(Self::EXACT_MATCH_SCORE)
+    }
+
+    fn match_amr_wb_score(c0: CodecSpec, c1: CodecSpec) -> Option<usize> {
+        if c0.format.invalid_amr_wb || c1.format.invalid_amr_wb {
+            return None;
+        }
+
+        // Presence of interleaving adds RTP payload fields that str0m does not
+        // implement, regardless of the advertised maximum group size.
+        if c0.format.interleaving.is_some() || c1.format.interleaving.is_some() {
+            return None;
+        }
+        if c0.format.robust_sorting.unwrap_or(false) || c1.format.robust_sorting.unwrap_or(false) {
+            return None;
+        }
+
+        if c0.channels.unwrap_or(1) != 1 || c1.channels.unwrap_or(1) != 1 {
+            return None;
+        }
+
+        // The octet-align mode selects the on-the-wire framing (RFC 4867 §4.3);
+        // octet-aligned and bandwidth-efficient payloads are not interchangeable,
+        // so the two sides must agree. The default (absent) is bandwidth-efficient.
+        let c0_octet_align = c0.format.octet_align.unwrap_or(false);
+        let c1_octet_align = c1.format.octet_align.unwrap_or(false);
+        if c0_octet_align != c1_octet_align {
+            return None;
+        }
+
+        // str0m can neither generate nor decode the per-frame payload CRC that
+        // crc=1 adds (RFC 4867 §4.3). Rather than agree to it and then mis-decode
+        // the stream, decline any peer that requires it. The default is no CRC.
+        if c0.format.crc.unwrap_or(false) || c1.format.crc.unwrap_or(false) {
+            return None;
+        }
+
+        // These parameters constrain an encoder's mode choices. str0m receives
+        // already encoded IF frames from the application and cannot guarantee
+        // compliance, so reject restrictive configurations.
+        if c0.format.mode_set.is_some() || c1.format.mode_set.is_some() {
+            return None;
+        }
+        if c0.format.mode_change_period == Some(2) || c1.format.mode_change_period == Some(2) {
+            return None;
+        }
+        if c0.format.mode_change_neighbor == Some(true)
+            || c1.format.mode_change_neighbor == Some(true)
+        {
+            return None;
+        }
+
+        // mode-change-capability and max-red are capability hints that do not
+        // affect interoperability, so they don't influence the match.
         Some(Self::EXACT_MATCH_SCORE)
     }
 
@@ -686,6 +746,17 @@ impl PayloadParams {
         // narrowing it to `min(local, remote)`. Per RFC 6184 §8.2.2, when
         // `level-asymmetry-allowed` is not set the answer should use the lower
         // level.
+
+        // RFC 4867 requires transport-format parameters and channels to be
+        // returned unmodified in an answer. Preserve both explicit zero values
+        // and omission so the generated answer has the same wire layout shape.
+        if self.spec.codec == Codec::AmrWb && first.spec.codec == Codec::AmrWb {
+            self.spec.channels = first.spec.channels;
+            self.spec.format.octet_align = first.spec.format.octet_align;
+            self.spec.format.crc = first.spec.format.crc;
+            self.spec.format.interleaving = first.spec.format.interleaving;
+            self.spec.format.robust_sorting = first.spec.format.robust_sorting;
+        }
 
         let mut remote_pt = first.pt;
         let mut remote_rtx = first.resend;
@@ -1985,6 +2056,230 @@ mod test {
                 nalu.len(),
                 "No DONL field when sprop-max-don-diff=0"
             );
+        }
+    }
+
+    mod amr_wb {
+        use super::*;
+
+        fn amr_wb_codec_spec(
+            octet_align: Option<bool>,
+            crc: Option<bool>,
+            mode_change_capability: Option<u8>,
+            max_red: Option<u16>,
+        ) -> CodecSpec {
+            amr_wb_codec_spec_with_channels(
+                Some(1),
+                octet_align,
+                crc,
+                mode_change_capability,
+                max_red,
+                None,
+                None,
+            )
+        }
+
+        fn amr_wb_codec_spec_with_channels(
+            channels: Option<u8>,
+            octet_align: Option<bool>,
+            crc: Option<bool>,
+            mode_change_capability: Option<u8>,
+            max_red: Option<u16>,
+            interleaving: Option<u16>,
+            robust_sorting: Option<bool>,
+        ) -> CodecSpec {
+            CodecSpec {
+                codec: Codec::AmrWb,
+                clock_rate: Frequency::SIXTEEN_KHZ,
+                channels,
+                format: FormatParams {
+                    octet_align,
+                    crc,
+                    mode_change_capability,
+                    max_red,
+                    interleaving,
+                    robust_sorting,
+                    ..Default::default()
+                },
+            }
+        }
+
+        #[test]
+        fn test_amr_wb_matching() {
+            struct Case {
+                c0: CodecSpec,
+                c1: CodecSpec,
+                must_match: bool,
+                msg: &'static str,
+            }
+
+            let cases = [
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), None, Some(2), Some(0)),
+                    c1: amr_wb_codec_spec(Some(true), None, Some(2), Some(0)),
+                    must_match: true,
+                    msg: "identical octet-aligned configs should match",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), None, Some(2), Some(0)),
+                    c1: amr_wb_codec_spec_with_channels(
+                        None,
+                        Some(true),
+                        None,
+                        Some(2),
+                        Some(0),
+                        None,
+                        None,
+                    ),
+                    must_match: true,
+                    msg: "AMR-WB /16000 and /16000/1 are both mono and should match",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(None, None, None, None),
+                    c1: amr_wb_codec_spec(None, None, None, None),
+                    must_match: true,
+                    msg: "both bandwidth-efficient (the RFC defaults) should match",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), None, Some(2), Some(0)),
+                    c1: amr_wb_codec_spec(Some(true), None, Some(1), Some(220)),
+                    must_match: true,
+                    msg: "mode-change-capability and max-red are hints; should still match",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), None, Some(2), None),
+                    c1: amr_wb_codec_spec(None, None, Some(2), None),
+                    must_match: false,
+                    msg: "octet-aligned vs bandwidth-efficient framings must not match",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), None, Some(2), Some(0)),
+                    c1: amr_wb_codec_spec(Some(true), Some(false), Some(2), Some(0)),
+                    must_match: true,
+                    msg: "an explicit crc=0 means no CRC and must match our (absent) default",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), Some(false), Some(2), Some(0)),
+                    c1: amr_wb_codec_spec(Some(true), Some(false), Some(2), Some(0)),
+                    must_match: true,
+                    msg: "crc=0 on both sides means no CRC and should match",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), None, Some(2), Some(0)),
+                    c1: amr_wb_codec_spec(Some(true), Some(true), Some(2), Some(0)),
+                    must_match: false,
+                    msg: "a peer requiring crc=1 must be declined; str0m cannot decode CRC",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), Some(true), Some(2), Some(0)),
+                    c1: amr_wb_codec_spec(Some(true), Some(true), Some(2), Some(0)),
+                    must_match: false,
+                    msg: "crc=1 is never agreed to, even if both sides signal it",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), None, Some(2), Some(0)),
+                    c1: amr_wb_codec_spec_with_channels(
+                        Some(1),
+                        Some(true),
+                        None,
+                        Some(2),
+                        Some(0),
+                        Some(30),
+                        None,
+                    ),
+                    must_match: false,
+                    msg: "interleaving=30 must be declined because it changes the RTP payload layout",
+                },
+                Case {
+                    c0: amr_wb_codec_spec(Some(true), None, Some(2), Some(0)),
+                    c1: amr_wb_codec_spec_with_channels(
+                        Some(1),
+                        Some(true),
+                        None,
+                        Some(2),
+                        Some(0),
+                        None,
+                        Some(true),
+                    ),
+                    must_match: false,
+                    msg: "robust-sorting=1 must be declined because it changes the RTP payload layout",
+                },
+            ];
+
+            for Case {
+                c0,
+                c1,
+                must_match,
+                msg,
+            } in cases.into_iter()
+            {
+                let matched = PayloadParams::match_amr_wb_score(c0, c1).is_some();
+                assert_eq!(matched, must_match, "{msg}\nc0: {c0:#?}\nc1: {c1:#?}");
+            }
+        }
+
+        #[test]
+        fn unsupported_amr_wb_restrictions_do_not_match() {
+            let supported = amr_wb_codec_spec(Some(true), None, Some(2), Some(0));
+
+            let mut restricted = supported;
+            restricted.format.mode_set = Some(1 << 2);
+            assert!(PayloadParams::match_amr_wb_score(supported, restricted).is_none());
+
+            restricted = supported;
+            restricted.format.mode_change_period = Some(2);
+            assert!(PayloadParams::match_amr_wb_score(supported, restricted).is_none());
+
+            restricted = supported;
+            restricted.format.mode_change_neighbor = Some(true);
+            assert!(PayloadParams::match_amr_wb_score(supported, restricted).is_none());
+
+            restricted = supported;
+            restricted.format.invalid_amr_wb = true;
+            assert!(PayloadParams::match_amr_wb_score(supported, restricted).is_none());
+
+            let multi_channel = amr_wb_codec_spec_with_channels(
+                Some(2),
+                Some(true),
+                None,
+                Some(2),
+                Some(0),
+                None,
+                None,
+            );
+            assert!(PayloadParams::match_amr_wb_score(multi_channel, multi_channel).is_none());
+        }
+
+        #[test]
+        fn exact_unsupported_amr_wb_configs_do_not_bypass_validation() {
+            let unsupported = amr_wb_codec_spec(Some(true), Some(true), Some(2), Some(0));
+            let params = PayloadParams::new(122.into(), None, unsupported);
+            assert_eq!(params.match_score(&params), None);
+        }
+
+        #[test]
+        fn update_param_mirrors_amr_wb_transport_shape() {
+            let local_spec = amr_wb_codec_spec(None, None, Some(2), Some(0));
+            let remote_spec = amr_wb_codec_spec_with_channels(
+                None,
+                Some(false),
+                Some(false),
+                Some(1),
+                Some(220),
+                None,
+                Some(false),
+            );
+            let mut local = PayloadParams::new(122.into(), None, local_spec);
+            let remote = PayloadParams::new(122.into(), None, remote_spec);
+            let mut claimed = [false; 128];
+            let mut unlocked = HashSet::new();
+
+            local.update_param(&[remote], &mut claimed, false, &mut unlocked);
+
+            assert_eq!(local.spec.channels, None);
+            assert_eq!(local.spec.format.octet_align, Some(false));
+            assert_eq!(local.spec.format.crc, Some(false));
+            assert_eq!(local.spec.format.robust_sorting, Some(false));
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2221,7 +2221,9 @@ mod test {
     #[test]
     fn event_is_reasonably_sized() {
         let n = std::mem::size_of::<Event>();
-        assert!(n < 490); // Increased to accommodate abs-capture-time fields in ExtensionValues
+        // Bumped to 512 to accommodate the AMR-WB fmtp fields in FormatParams.
+        // Previously 490 for the abs-capture-time fields in ExtensionValues.
+        assert!(n < 512, "Event size is {n}");
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2238,7 +2238,9 @@ mod test {
     #[test]
     fn event_is_reasonably_sized() {
         let n = std::mem::size_of::<Event>();
-        assert!(n < 490); // Increased to accommodate abs-capture-time fields in ExtensionValues
+        // Bumped to 512 to accommodate the AMR-WB fmtp fields in FormatParams.
+        // Previously 490 for the abs-capture-time fields in ExtensionValues.
+        assert!(n < 512, "Event size is {n}");
     }
 }
 

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -404,6 +404,12 @@ impl Media {
                 }
             }
 
+            // Select the AMR-WB layout negotiated via the octet-align fmtp param
+            // (RFC 4867); absent means bandwidth-efficient.
+            if let CodecDepacketizer::AmrWb(ref mut amr) = depack {
+                *amr = amr.with_octet_align(params.spec.format.octet_align.unwrap_or(false));
+            }
+
             let buffer = DepacketizingBuffer::new(depack, hold_back);
 
             self.depayloaders.insert((pt, rid), buffer);

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -409,6 +409,12 @@ impl Media {
                 }
             }
 
+            // Select the AMR-WB layout negotiated via the octet-align fmtp param
+            // (RFC 4867); absent means bandwidth-efficient.
+            if let CodecDepacketizer::AmrWb(ref mut amr) = depack {
+                *amr = amr.with_octet_align(params.spec.format.octet_align.unwrap_or(false));
+            }
+
             let buffer = DepacketizingBuffer::new(depack, hold_back);
 
             self.depayloaders.insert((pt, rid), buffer);

--- a/src/media/writer.rs
+++ b/src/media/writer.rs
@@ -133,6 +133,10 @@ impl<'a> Writer<'a> {
     ///
     /// If you write media before `IceConnectionState` is `Connected` it will be dropped.
     ///
+    /// AMR-WB data must contain exactly one 3GPP IF frame per call. Concatenated
+    /// frames are rejected during packetization because each frame represents a
+    /// separate 20 ms RTP timestamp interval.
+    ///
     /// Panics if [`RtcConfig::set_rtp_mode()`][crate::RtcConfig::set_rtp_mode] is `true`.
     pub fn write(
         self,

--- a/src/packet/amr_wb.rs
+++ b/src/packet/amr_wb.rs
@@ -1,0 +1,569 @@
+//! RFC 4867 RTP payload (de)packetization for AMR-WB.
+//!
+//! AMR-WB is carried per [RFC 4867](https://datatracker.ietf.org/doc/html/rfc4867).
+//! A payload is a 4-bit Codec Mode Request (CMR), a table of contents (one entry
+//! per frame) and the speech bits for each frame, in either the octet-aligned
+//! (`octet-align=1`) or bandwidth-efficient (the SDP default) layout.
+//!
+//! str0m's application-facing byte stream uses the 3GPP IF / storage format: each
+//! frame is a 1-octet header `(FT << 3) | (Q << 2)` (the
+//! [RFC 4867 §5.3](https://datatracker.ietf.org/doc/html/rfc4867#section-5.3)
+//! frame header) followed by its speech bytes. The depacketizer turns an RTP
+//! payload into one or more concatenated IF frames. The packetizer accepts
+//! exactly one IF frame per call and turns it into one RTP payload. This is the
+//! layout an AMR-WB decoder/encoder consumes directly.
+//!
+//! Supported: octet-aligned and bandwidth-efficient single-channel payloads and
+//! the per-frame table of contents.
+//! Not supported (matching the codec's common use): frame interleaving, payload
+//! CRC (`crc=1`), robust sorting, and multiple channels.
+
+use super::{CodecExtra, Depacketizer, PacketError, Packetizer};
+
+/// Speech bits carried by each AMR-WB frame type (the `FT` field, 0..=15), per
+/// RFC 4867 Table 1a. `None` marks the reserved types FT 10..=13.
+const FRAME_TYPE_BITS: [Option<u16>; 16] = [
+    Some(132), // 0: 6.60 kbps
+    Some(177), // 1: 8.85 kbps
+    Some(253), // 2: 12.65 kbps
+    Some(285), // 3: 14.25 kbps
+    Some(317), // 4: 15.85 kbps
+    Some(365), // 5: 18.25 kbps
+    Some(397), // 6: 19.85 kbps
+    Some(461), // 7: 23.05 kbps
+    Some(477), // 8: 23.85 kbps
+    Some(40),  // 9: SID (comfort noise)
+    None,      // 10: reserved
+    None,      // 11: reserved
+    None,      // 12: reserved
+    None,      // 13: reserved
+    Some(0),   // 14: speech lost
+    Some(0),   // 15: no data
+];
+
+/// Codec Mode Request value meaning "no mode requested" (RFC 4867).
+const CMR_NO_REQUEST: u32 = 15;
+
+/// Packetizes AMR-WB RTP packets (RFC 4867).
+///
+/// Input is exactly one 3GPP IF frame: a `(FT << 3) | (Q << 2)` header octet
+/// followed by the speech bytes for that frame. Concatenated frames are rejected
+/// because each call supplies only one RTP timestamp, while every AMR-WB frame
+/// represents a distinct 20 ms interval. A standalone NO_DATA frame is also
+/// rejected, following RFC 4867's recommendation for non-interleaved payloads.
+///
+/// ## Unversioned API surface
+///
+/// This struct is not currently versioned according to semver rules.
+/// Breaking changes may be made in minor or patch releases.
+#[derive(Debug, Default, Copy, Clone)]
+pub struct AmrWbPacketizer {
+    /// Whether to emit the octet-aligned (`octet-align=1`) layout.
+    octet_align: bool,
+}
+
+impl AmrWbPacketizer {
+    /// Selects the octet-aligned (`true`) or bandwidth-efficient (`false`) layout.
+    pub fn with_octet_align(mut self, octet_align: bool) -> Self {
+        self.octet_align = octet_align;
+        self
+    }
+}
+
+impl Packetizer for AmrWbPacketizer {
+    fn packetize(&mut self, mtu: usize, payload: &[u8]) -> Result<Vec<Vec<u8>>, PacketError> {
+        if payload.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let header = payload[0];
+        if header & 0b1000_0011 != 0 {
+            return Err(PacketError::ErrAmrWbCorruptedPacket);
+        }
+
+        let frame_type = (header >> 3) & 0x0f;
+        let bits = FRAME_TYPE_BITS[frame_type as usize]
+            .map(usize::from)
+            .ok_or(PacketError::ErrAmrWbCorruptedPacket)?;
+        let expected_len = 1 + bits.div_ceil(8);
+        if payload.len() < expected_len {
+            return Err(PacketError::ErrShortPacket);
+        }
+        if payload.len() != expected_len || frame_type == 15 {
+            return Err(PacketError::ErrAmrWbCorruptedPacket);
+        }
+
+        let packet = build_payload(payload, self.octet_align);
+        if packet.len() > mtu {
+            return Err(PacketError::PacketSizeLargerThanMtu(packet.len(), mtu));
+        }
+
+        Ok(vec![packet])
+    }
+
+    fn is_marker(&mut self, _data: &[u8], _previous: Option<&[u8]>, _last: bool) -> bool {
+        false
+    }
+}
+
+/// Depacketizes AMR-WB RTP packets (RFC 4867).
+///
+/// Each RTP payload is turned into concatenated 3GPP IF frames written to `out`:
+/// per frame a `(FT << 3) | (Q << 2)` header octet followed by the speech bytes.
+///
+/// ## Unversioned API surface
+///
+/// This struct is not currently versioned according to semver rules.
+/// Breaking changes may be made in minor or patch releases.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct AmrWbDepacketizer {
+    /// Whether the payload uses the octet-aligned (`octet-align=1`) layout.
+    octet_align: bool,
+}
+
+impl AmrWbDepacketizer {
+    /// Selects the octet-aligned (`true`) or bandwidth-efficient (`false`) layout.
+    pub fn with_octet_align(mut self, octet_align: bool) -> Self {
+        self.octet_align = octet_align;
+        self
+    }
+}
+
+impl Depacketizer for AmrWbDepacketizer {
+    fn out_size_hint(&self, packets_size: usize) -> Option<usize> {
+        // Even a payload consisting entirely of zero-length frame types has a
+        // six-bit ToC entry for every one-byte IF header, so twice the packet size
+        // is a conservative allocation hint.
+        Some(packets_size.saturating_mul(2))
+    }
+
+    fn depacketize(
+        &mut self,
+        packet: &[u8],
+        out: &mut Vec<u8>,
+        _: &mut CodecExtra,
+    ) -> Result<(), PacketError> {
+        if packet.is_empty() {
+            return Ok(());
+        }
+
+        let mut reader = BitReader::new(packet);
+
+        // Payload header: CMR, plus 4 reserved bits when octet-aligned.
+        let _cmr = reader.get_bits(4)?;
+        if self.octet_align {
+            reader.get_bits(4)?;
+        }
+
+        // Table of contents: F (more frames follow), FT, Q for each frame. The
+        // packet length itself bounds the number of entries.
+        let mut toc = Vec::new();
+        loop {
+            let follows = reader.get_bits(1)? != 0;
+            let frame_type = reader.get_bits(4)? as u8;
+            let good = reader.get_bits(1)? != 0;
+            if self.octet_align {
+                reader.get_bits(2)?;
+            }
+            toc.push((frame_type, good));
+            if !follows {
+                break;
+            }
+        }
+
+        // Speech data: one block per ToC entry, written as an IF frame.
+        for (frame_type, good) in toc {
+            let bits = FRAME_TYPE_BITS[(frame_type & 0x0f) as usize]
+                .ok_or(PacketError::ErrAmrWbCorruptedPacket)?;
+
+            out.push((frame_type << 3) | (u8::from(good) << 2));
+            reader.get_frame_into(usize::from(bits), out)?;
+
+            if self.octet_align {
+                reader.align_to_byte();
+            }
+        }
+
+        // RFC 4867 section 4.5.1 recommends discarding a packet when its actual
+        // length differs from the length implied by the ToC. Bandwidth-efficient
+        // payloads may end in at most seven zero padding bits.
+        let remaining = reader.remaining();
+        if remaining >= 8 || (remaining > 0 && reader.get_bits(remaining)? != 0) {
+            return Err(PacketError::ErrAmrWbCorruptedPacket);
+        }
+
+        Ok(())
+    }
+
+    fn is_partition_head(&self, _packet: &[u8]) -> bool {
+        true
+    }
+
+    fn is_partition_tail(&self, _marker: bool, _packet: &[u8]) -> bool {
+        true
+    }
+}
+
+/// Builds one RFC 4867 RTP payload (CMR = "no request") from one validated
+/// 3GPP IF frame, allocating only the returned buffer.
+///
+/// The caller guarantees `if_frame` is well-formed.
+fn build_payload(if_frame: &[u8], octet_align: bool) -> Vec<u8> {
+    // Octet-aligned output is one payload header plus the complete IF frame.
+    // the bandwidth-efficient layout is never larger, so this never reallocates.
+    let mut writer = BitWriter::with_capacity(1 + if_frame.len());
+
+    // Payload header: CMR (4 bits) + 4 reserved zero bits when octet-aligned.
+    writer.put_bits(CMR_NO_REQUEST, 4);
+    if octet_align {
+        writer.put_bits(0, 4);
+    }
+
+    let header = if_frame[0];
+    let frame_type = (header >> 3) & 0x0f;
+    let good = (header >> 2) & 0x01 != 0;
+    let bits = FRAME_TYPE_BITS[frame_type as usize].map_or(0, usize::from);
+
+    writer.put_bits(0, 1); // F: this is the only frame.
+    writer.put_bits(u32::from(frame_type), 4);
+    writer.put_bits(u32::from(good), 1);
+    if octet_align {
+        writer.put_bits(0, 2);
+    }
+
+    writer.put_frame(&if_frame[1..], bits);
+    if octet_align {
+        writer.align_to_byte();
+    }
+
+    writer.into_bytes()
+}
+
+/// Most-significant-bit-first writer over a growing byte buffer.
+#[derive(Default)]
+struct BitWriter {
+    out: Vec<u8>,
+    acc: u64,
+    nbits: u32,
+}
+
+impl BitWriter {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            out: Vec::with_capacity(capacity),
+            acc: 0,
+            nbits: 0,
+        }
+    }
+
+    /// Appends the low `count` bits of `value` (`count` <= 8), MSB first.
+    fn put_bits(&mut self, value: u32, count: u32) {
+        let mask = (1u64 << count) - 1;
+        self.acc = (self.acc << count) | (u64::from(value) & mask);
+        self.nbits += count;
+        while self.nbits >= 8 {
+            self.nbits -= 8;
+            self.out.push((self.acc >> self.nbits) as u8);
+        }
+        self.acc &= (1u64 << self.nbits) - 1;
+    }
+
+    /// Appends `bits` speech bits read MSB-first from `data` (zero-padded short).
+    fn put_frame(&mut self, data: &[u8], bits: usize) {
+        let whole_bytes = bits / 8;
+        for offset in 0..whole_bytes {
+            self.put_bits(u32::from(data.get(offset).copied().unwrap_or(0)), 8);
+        }
+        let remainder = (bits % 8) as u32;
+        if remainder > 0 {
+            let byte = data.get(whole_bytes).copied().unwrap_or(0);
+            self.put_bits(u32::from(byte >> (8 - remainder)), remainder);
+        }
+    }
+
+    /// Pads the current byte with zero bits up to the next octet boundary.
+    fn align_to_byte(&mut self) {
+        if self.nbits != 0 {
+            self.put_bits(0, 8 - self.nbits);
+        }
+    }
+
+    /// Finishes writing, zero-padding any partial trailing byte.
+    fn into_bytes(mut self) -> Vec<u8> {
+        self.align_to_byte();
+        self.out
+    }
+}
+
+/// Most-significant-bit-first reader over a byte slice.
+struct BitReader<'a> {
+    data: &'a [u8],
+    bit_pos: usize,
+}
+
+impl<'a> BitReader<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, bit_pos: 0 }
+    }
+
+    fn remaining(&self) -> usize {
+        self.data.len() * 8 - self.bit_pos
+    }
+
+    /// Reads `count` bits (`count` <= 32), MSB first.
+    fn get_bits(&mut self, count: usize) -> Result<u32, PacketError> {
+        if self.remaining() < count {
+            return Err(PacketError::ErrShortPacket);
+        }
+        let mut value = 0u32;
+        for _ in 0..count {
+            let bit = (self.data[self.bit_pos / 8] >> (7 - (self.bit_pos % 8))) & 1;
+            value = (value << 1) | u32::from(bit);
+            self.bit_pos += 1;
+        }
+        Ok(value)
+    }
+
+    /// Reads `bits` speech bits MSB-first, appending `ceil(bits / 8)` octet-aligned
+    /// (zero-padded) bytes to `out`.
+    fn get_frame_into(&mut self, bits: usize, out: &mut Vec<u8>) -> Result<(), PacketError> {
+        if self.remaining() < bits {
+            return Err(PacketError::ErrShortPacket);
+        }
+        let start = out.len();
+        out.resize(start + bits.div_ceil(8), 0);
+        for index in 0..bits {
+            let bit = (self.data[self.bit_pos / 8] >> (7 - (self.bit_pos % 8))) & 1;
+            out[start + index / 8] |= bit << (7 - (index % 8));
+            self.bit_pos += 1;
+        }
+        Ok(())
+    }
+
+    /// Skips forward to the next octet boundary.
+    fn align_to_byte(&mut self) {
+        let into_byte = self.bit_pos % 8;
+        if into_byte != 0 {
+            self.bit_pos += 8 - into_byte;
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Builds an IF frame: header octet `(FT << 3) | (Q << 2)` then `fill` bytes,
+    /// with padding bits in the final byte zeroed so it round-trips byte-for-byte.
+    fn if_frame(frame_type: u8, good: bool, fill: u8) -> Vec<u8> {
+        let bits = FRAME_TYPE_BITS[frame_type as usize].unwrap() as usize;
+        let mut data = vec![fill; bits.div_ceil(8)];
+        let remainder = bits % 8;
+        if remainder != 0 {
+            if let Some(last) = data.last_mut() {
+                *last &= 0xffu8 << (8 - remainder);
+            }
+        }
+        let mut out = vec![(frame_type << 3) | (u8::from(good) << 2)];
+        out.extend_from_slice(&data);
+        out
+    }
+
+    fn round_trip(octet_align: bool, frames: &[Vec<u8>]) {
+        let input: Vec<u8> = frames.concat();
+        let mut pack = AmrWbPacketizer::default().with_octet_align(octet_align);
+        let mut depack = AmrWbDepacketizer::default().with_octet_align(octet_align);
+        let mut out = Vec::new();
+        let mut extra = CodecExtra::None;
+        for frame in frames {
+            let packets = pack.packetize(1500, frame).unwrap();
+            assert_eq!(packets.len(), 1, "expected one packet per IF frame");
+            depack
+                .depacketize(&packets[0], &mut out, &mut extra)
+                .unwrap();
+        }
+        assert_eq!(out, input, "IF frames must survive the round-trip");
+    }
+
+    #[test]
+    fn octet_aligned_round_trip() {
+        round_trip(true, &[if_frame(8, true, 0xa5), if_frame(2, true, 0x5a)]);
+    }
+
+    #[test]
+    fn bandwidth_efficient_round_trip() {
+        round_trip(false, &[if_frame(0, true, 0xff), if_frame(8, true, 0x33)]);
+    }
+
+    #[test]
+    fn octet_aligned_single_frame_layout_matches_rfc() {
+        // CMR 15 + single FT 8 frame: header 0xF0, ToC 0x44 (F=0 FT=1000 Q=1),
+        // then 60 octet-aligned speech bytes (477 bits rounded up).
+        let input = if_frame(8, true, 0x00);
+        let mut pack = AmrWbPacketizer::default().with_octet_align(true);
+        let packets = pack.packetize(1500, &input).unwrap();
+        assert_eq!(packets[0].len(), 1 + 1 + 60);
+        assert_eq!(packets[0][0], 0xf0);
+        assert_eq!(packets[0][1], 0x44);
+    }
+
+    #[test]
+    fn standalone_no_data_is_rejected() {
+        let input = if_frame(15, false, 0);
+        let mut pack = AmrWbPacketizer::default().with_octet_align(true);
+        assert_eq!(
+            pack.packetize(1500, &input),
+            Err(PacketError::ErrAmrWbCorruptedPacket)
+        );
+    }
+
+    #[test]
+    fn no_data_is_accepted_from_peer() {
+        // CMR=15 followed by FT=15, Q=1 and no speech data.
+        let payload = [0xf0, 0x7c];
+        let mut depack = AmrWbDepacketizer::default().with_octet_align(true);
+        let mut out = Vec::new();
+        let mut extra = CodecExtra::None;
+
+        depack.depacketize(&payload, &mut out, &mut extra).unwrap();
+
+        assert_eq!(out, vec![0x7c]);
+    }
+
+    #[test]
+    fn empty_payload_depacketizes_to_nothing() {
+        let mut depack = AmrWbDepacketizer::default().with_octet_align(true);
+        let mut out = Vec::new();
+        let mut extra = CodecExtra::None;
+        depack.depacketize(&[], &mut out, &mut extra).unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn empty_input_produces_no_packets() {
+        let mut pack = AmrWbPacketizer::default().with_octet_align(true);
+        assert!(pack.packetize(1500, &[]).unwrap().is_empty());
+        assert_eq!(
+            pack.packetize(0, &if_frame(8, true, 1)),
+            Err(PacketError::PacketSizeLargerThanMtu(62, 0))
+        );
+    }
+
+    #[test]
+    fn truncated_speech_data_is_rejected() {
+        // FT 8 needs 60 speech bytes; supply only the header and ToC.
+        let payload = [0xf0, 0x44];
+        let mut depack = AmrWbDepacketizer::default().with_octet_align(true);
+        let mut out = Vec::new();
+        let mut extra = CodecExtra::None;
+        assert_eq!(
+            depack.depacketize(&payload, &mut out, &mut extra),
+            Err(PacketError::ErrShortPacket)
+        );
+    }
+
+    #[test]
+    fn reserved_frame_type_is_rejected() {
+        // CMR 0, ToC F=0 FT=1011 (11, reserved) Q=0 + pad = 0x58.
+        let payload = [0x00, 0x58];
+        let mut depack = AmrWbDepacketizer::default().with_octet_align(true);
+        let mut out = Vec::new();
+        let mut extra = CodecExtra::None;
+        assert_eq!(
+            depack.depacketize(&payload, &mut out, &mut extra),
+            Err(PacketError::ErrAmrWbCorruptedPacket)
+        );
+    }
+
+    #[test]
+    fn packetizer_rejects_frame_larger_than_mtu() {
+        let input = if_frame(8, true, 0x11);
+        let mut pack = AmrWbPacketizer::default().with_octet_align(true);
+        assert_eq!(
+            pack.packetize(61, &input),
+            Err(PacketError::PacketSizeLargerThanMtu(62, 61))
+        );
+    }
+
+    #[test]
+    fn packetizer_rejects_concatenated_if_frames() {
+        let input: Vec<u8> = [
+            if_frame(2, true, 0x12),
+            if_frame(9, true, 0x34), // SID
+        ]
+        .concat();
+        let mut pack = AmrWbPacketizer::default().with_octet_align(true);
+        assert_eq!(
+            pack.packetize(1500, &input),
+            Err(PacketError::ErrAmrWbCorruptedPacket)
+        );
+    }
+
+    #[test]
+    fn packetizer_rejects_reserved_frame_type() {
+        // IF header with FT=10 (reserved): (10 << 3) = 0x50.
+        let input = [0x50];
+        let mut pack = AmrWbPacketizer::default().with_octet_align(true);
+        assert_eq!(
+            pack.packetize(1500, &input),
+            Err(PacketError::ErrAmrWbCorruptedPacket)
+        );
+    }
+
+    #[test]
+    fn packetizer_rejects_truncated_if_frame() {
+        // IF header for FT=8 (needs 60 speech bytes) with no speech bytes following.
+        let input = [(8 << 3) | (1 << 2)];
+        let mut pack = AmrWbPacketizer::default().with_octet_align(true);
+        assert_eq!(
+            pack.packetize(1500, &input),
+            Err(PacketError::ErrShortPacket)
+        );
+    }
+
+    #[test]
+    fn depacketizer_accepts_more_than_twelve_frames() {
+        // RFC 4867 has no fixed 240 ms maximum. Use thirteen zero-length
+        // SPEECH_LOST entries to exercise a compound payload beyond 12 frames.
+        let mut payload = vec![0xf0];
+        payload.extend(std::iter::repeat_n(0xf0, 12));
+        payload.push(0x70);
+        let mut depack = AmrWbDepacketizer::default().with_octet_align(true);
+        let mut out = Vec::new();
+        let mut extra = CodecExtra::None;
+        depack.depacketize(&payload, &mut out, &mut extra).unwrap();
+        assert_eq!(out, vec![0x70; 13]);
+    }
+
+    #[test]
+    fn depacketizer_rejects_trailing_octet() {
+        for octet_align in [false, true] {
+            let frame = if_frame(0, true, 0x55);
+            let mut payload = build_payload(&frame, octet_align);
+            payload.push(0);
+
+            let mut depack = AmrWbDepacketizer::default().with_octet_align(octet_align);
+            let mut out = Vec::new();
+            let mut extra = CodecExtra::None;
+            assert_eq!(
+                depack.depacketize(&payload, &mut out, &mut extra),
+                Err(PacketError::ErrAmrWbCorruptedPacket)
+            );
+        }
+    }
+
+    #[test]
+    fn depacketizer_rejects_nonzero_terminal_padding() {
+        let frame = if_frame(0, true, 0x55);
+        let mut payload = build_payload(&frame, false);
+        *payload.last_mut().unwrap() |= 1;
+
+        let mut depack = AmrWbDepacketizer::default().with_octet_align(false);
+        let mut out = Vec::new();
+        let mut extra = CodecExtra::None;
+        assert_eq!(
+            depack.depacketize(&payload, &mut out, &mut extra),
+            Err(PacketError::ErrAmrWbCorruptedPacket)
+        );
+    }
+}

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -141,6 +141,7 @@ impl DepacketizingBuffer {
             | CodecDepacketizer::Boxed(_)
             | CodecDepacketizer::Opus(_)
             | CodecDepacketizer::G711(_)
+            | CodecDepacketizer::AmrWb(_)
             | CodecDepacketizer::Null(_) => Contiguity::None,
         };
 

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -142,6 +142,7 @@ impl DepacketizingBuffer {
             | CodecDepacketizer::Opus(_)
             | CodecDepacketizer::ComfortNoise(_)
             | CodecDepacketizer::G711(_)
+            | CodecDepacketizer::AmrWb(_)
             | CodecDepacketizer::Null(_) => Contiguity::None,
         };
 

--- a/src/packet/error.rs
+++ b/src/packet/error.rs
@@ -18,6 +18,8 @@ pub enum PacketError {
     ErrVP8CorruptedPacket,
     ErrVP9CorruptedPacket,
     ErrAv1CorruptedPacket,
+    ErrAmrWbCorruptedPacket,
+    PacketSizeLargerThanMtu(usize, usize),
 }
 
 impl fmt::Display for PacketError {
@@ -43,6 +45,10 @@ impl fmt::Display for PacketError {
             PacketError::ErrVP8CorruptedPacket => write!(f, "VP8 corrupted packet"),
             PacketError::ErrVP9CorruptedPacket => write!(f, "VP9 corrupted packet"),
             PacketError::ErrAv1CorruptedPacket => write!(f, "AV1 corrupted packet"),
+            PacketError::ErrAmrWbCorruptedPacket => write!(f, "AMR-WB corrupted packet"),
+            PacketError::PacketSizeLargerThanMtu(size, mtu) => {
+                write!(f, "Packet size exceeds MTU: {size} > {mtu}")
+            }
         }
     }
 }

--- a/src/packet/error.rs
+++ b/src/packet/error.rs
@@ -20,6 +20,8 @@ pub enum PacketError {
     ErrVP9CorruptedPacket,
     ErrAv1CorruptedPacket,
     ErrRedCorruptedPacket,
+    ErrAmrWbCorruptedPacket,
+    PacketSizeLargerThanMtu(usize, usize),
 }
 
 impl fmt::Display for PacketError {
@@ -47,6 +49,10 @@ impl fmt::Display for PacketError {
             PacketError::ErrVP9CorruptedPacket => write!(f, "VP9 corrupted packet"),
             PacketError::ErrAv1CorruptedPacket => write!(f, "AV1 corrupted packet"),
             PacketError::ErrRedCorruptedPacket => write!(f, "RED corrupted packet"),
+            PacketError::ErrAmrWbCorruptedPacket => write!(f, "AMR-WB corrupted packet"),
+            PacketError::PacketSizeLargerThanMtu(size, mtu) => {
+                write!(f, "Packet size exceeds MTU: {size} > {mtu}")
+            }
         }
     }
 }

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -13,6 +13,9 @@ pub use av1::Av1CodecExtra;
 pub use av1::detect_av1_keyframe;
 use av1::{Av1Depacketizer, Av1Packetizer};
 
+mod amr_wb;
+use amr_wb::{AmrWbDepacketizer, AmrWbPacketizer};
+
 mod g7xx;
 use g7xx::{G711Depacketizer, G711Packetizer, G722Packetizer};
 
@@ -286,6 +289,7 @@ pub(crate) enum CodecPacketizer {
     Vp8(Vp8Packetizer),
     Vp9(Vp9Packetizer),
     Av1(Av1Packetizer),
+    AmrWb(AmrWbPacketizer),
     Null(NullPacketizer),
     #[allow(unused)]
     Boxed(Box<dyn Packetizer + Send + Sync + UnwindSafe>),
@@ -301,6 +305,7 @@ pub(crate) enum CodecDepacketizer {
     Vp8(Vp8Depacketizer),
     Vp9(Vp9Depacketizer),
     Av1(Av1Depacketizer),
+    AmrWb(AmrWbDepacketizer),
     Null(NullDepacketizer),
     #[allow(unused)]
     Boxed(Box<dyn Depacketizer + Send + Sync + UnwindSafe>),
@@ -313,6 +318,7 @@ impl CodecPacketizer {
             Codec::PCMU => CodecPacketizer::G711(G711Packetizer::default()),
             Codec::PCMA => CodecPacketizer::G711(G711Packetizer::default()),
             Codec::G722 => CodecPacketizer::G722(G722Packetizer::default()),
+            Codec::AmrWb => CodecPacketizer::AmrWb(AmrWbPacketizer::default()),
             Codec::H264 => CodecPacketizer::H264(H264Packetizer::default()),
             Codec::H265 => CodecPacketizer::H265(H265Packetizer::default()),
             Codec::H266 => CodecPacketizer::H266(H266Packetizer::default()),
@@ -339,6 +345,7 @@ impl From<Codec> for CodecDepacketizer {
             Codec::PCMU => CodecDepacketizer::G711(G711Depacketizer),
             Codec::PCMA => CodecDepacketizer::G711(G711Depacketizer),
             Codec::G722 => CodecDepacketizer::G711(G711Depacketizer),
+            Codec::AmrWb => CodecDepacketizer::AmrWb(AmrWbDepacketizer::default()),
             Codec::H264 => CodecDepacketizer::H264(H264Depacketizer::default()),
             Codec::H265 => CodecDepacketizer::H265(H265Depacketizer::default()),
             Codec::H266 => CodecDepacketizer::H266(H266Depacketizer::default()),
@@ -365,6 +372,7 @@ impl Packetizer for CodecPacketizer {
             Vp8(v) => v.packetize(mtu, b),
             Vp9(v) => v.packetize(mtu, b),
             Av1(v) => v.packetize(mtu, b),
+            AmrWb(v) => v.packetize(mtu, b),
             Null(v) => v.packetize(mtu, b),
             Boxed(v) => v.packetize(mtu, b),
         }
@@ -381,6 +389,7 @@ impl Packetizer for CodecPacketizer {
             CodecPacketizer::Vp8(v) => v.is_marker(data, previous, last),
             CodecPacketizer::Vp9(v) => v.is_marker(data, previous, last),
             CodecPacketizer::Av1(v) => v.is_marker(data, previous, last),
+            CodecPacketizer::AmrWb(v) => v.is_marker(data, previous, last),
             CodecPacketizer::Null(v) => v.is_marker(data, previous, last),
             CodecPacketizer::Boxed(v) => v.is_marker(data, previous, last),
         }
@@ -399,6 +408,7 @@ impl Depacketizer for CodecDepacketizer {
             Vp8(v) => v.out_size_hint(packets_size),
             Vp9(v) => v.out_size_hint(packets_size),
             Av1(v) => v.out_size_hint(packets_size),
+            AmrWb(v) => v.out_size_hint(packets_size),
             Null(v) => v.out_size_hint(packets_size),
             Boxed(v) => v.out_size_hint(packets_size),
         }
@@ -420,6 +430,7 @@ impl Depacketizer for CodecDepacketizer {
             Vp8(v) => v.depacketize(packet, out, extra),
             Vp9(v) => v.depacketize(packet, out, extra),
             Av1(v) => v.depacketize(packet, out, extra),
+            AmrWb(v) => v.depacketize(packet, out, extra),
             Null(v) => v.depacketize(packet, out, extra),
             Boxed(v) => v.depacketize(packet, out, extra),
         }
@@ -436,6 +447,7 @@ impl Depacketizer for CodecDepacketizer {
             Vp8(v) => v.is_partition_head(packet),
             Vp9(v) => v.is_partition_head(packet),
             Av1(v) => v.is_partition_head(packet),
+            AmrWb(v) => v.is_partition_head(packet),
             Null(v) => v.is_partition_head(packet),
             Boxed(v) => v.is_partition_head(packet),
         }
@@ -452,6 +464,7 @@ impl Depacketizer for CodecDepacketizer {
             Vp8(v) => v.is_partition_tail(marker, packet),
             Vp9(v) => v.is_partition_tail(marker, packet),
             Av1(v) => v.is_partition_tail(marker, packet),
+            AmrWb(v) => v.is_partition_tail(marker, packet),
             Null(v) => v.is_partition_tail(marker, packet),
             Boxed(v) => v.is_partition_tail(marker, packet),
         }

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -13,6 +13,9 @@ pub use av1::Av1CodecExtra;
 pub use av1::detect_av1_keyframe;
 use av1::{Av1Depacketizer, Av1Packetizer};
 
+mod amr_wb;
+use amr_wb::{AmrWbDepacketizer, AmrWbPacketizer};
+
 mod g7xx;
 use g7xx::{G711Depacketizer, G711Packetizer, G722Packetizer};
 
@@ -294,6 +297,7 @@ pub(crate) enum CodecPacketizer {
     Vp8(Vp8Packetizer),
     Vp9(Vp9Packetizer),
     Av1(Av1Packetizer),
+    AmrWb(AmrWbPacketizer),
     Null(NullPacketizer),
     #[allow(unused)]
     Boxed(Box<dyn Packetizer + Send + Sync + UnwindSafe>),
@@ -310,6 +314,7 @@ pub(crate) enum CodecDepacketizer {
     Vp8(Vp8Depacketizer),
     Vp9(Vp9Depacketizer),
     Av1(Av1Depacketizer),
+    AmrWb(AmrWbDepacketizer),
     Null(NullDepacketizer),
     #[allow(unused)]
     Boxed(Box<dyn Depacketizer + Send + Sync + UnwindSafe>),
@@ -323,6 +328,7 @@ impl CodecPacketizer {
             Codec::PCMA => CodecPacketizer::G711(G711Packetizer::default()),
             Codec::G722 => CodecPacketizer::G722(G722Packetizer::default()),
             Codec::CN => CodecPacketizer::ComfortNoise(ComfortNoisePacketizer),
+            Codec::AmrWb => CodecPacketizer::AmrWb(AmrWbPacketizer::default()),
             Codec::H264 => CodecPacketizer::H264(H264Packetizer::default()),
             Codec::H265 => CodecPacketizer::H265(H265Packetizer::default()),
             Codec::H266 => CodecPacketizer::H266(H266Packetizer::default()),
@@ -351,6 +357,7 @@ impl From<Codec> for CodecDepacketizer {
             Codec::PCMA => CodecDepacketizer::G711(G711Depacketizer),
             Codec::G722 => CodecDepacketizer::G711(G711Depacketizer),
             Codec::CN => CodecDepacketizer::ComfortNoise(ComfortNoiseDepacketizer),
+            Codec::AmrWb => CodecDepacketizer::AmrWb(AmrWbDepacketizer::default()),
             Codec::H264 => CodecDepacketizer::H264(H264Depacketizer::default()),
             Codec::H265 => CodecDepacketizer::H265(H265Depacketizer::default()),
             Codec::H266 => CodecDepacketizer::H266(H266Depacketizer::default()),
@@ -379,6 +386,7 @@ impl Packetizer for CodecPacketizer {
             Vp8(v) => v.packetize(mtu, b),
             Vp9(v) => v.packetize(mtu, b),
             Av1(v) => v.packetize(mtu, b),
+            AmrWb(v) => v.packetize(mtu, b),
             Null(v) => v.packetize(mtu, b),
             Boxed(v) => v.packetize(mtu, b),
         }
@@ -396,6 +404,7 @@ impl Packetizer for CodecPacketizer {
             CodecPacketizer::Vp8(v) => v.is_marker(data, previous, last),
             CodecPacketizer::Vp9(v) => v.is_marker(data, previous, last),
             CodecPacketizer::Av1(v) => v.is_marker(data, previous, last),
+            CodecPacketizer::AmrWb(v) => v.is_marker(data, previous, last),
             CodecPacketizer::Null(v) => v.is_marker(data, previous, last),
             CodecPacketizer::Boxed(v) => v.is_marker(data, previous, last),
         }
@@ -415,6 +424,7 @@ impl Depacketizer for CodecDepacketizer {
             Vp8(v) => v.out_size_hint(packets_size),
             Vp9(v) => v.out_size_hint(packets_size),
             Av1(v) => v.out_size_hint(packets_size),
+            AmrWb(v) => v.out_size_hint(packets_size),
             Null(v) => v.out_size_hint(packets_size),
             Boxed(v) => v.out_size_hint(packets_size),
         }
@@ -437,6 +447,7 @@ impl Depacketizer for CodecDepacketizer {
             Vp8(v) => v.depacketize(packet, out, extra),
             Vp9(v) => v.depacketize(packet, out, extra),
             Av1(v) => v.depacketize(packet, out, extra),
+            AmrWb(v) => v.depacketize(packet, out, extra),
             Null(v) => v.depacketize(packet, out, extra),
             Boxed(v) => v.depacketize(packet, out, extra),
         }
@@ -454,6 +465,7 @@ impl Depacketizer for CodecDepacketizer {
             Vp8(v) => v.is_partition_head(packet),
             Vp9(v) => v.is_partition_head(packet),
             Av1(v) => v.is_partition_head(packet),
+            AmrWb(v) => v.is_partition_head(packet),
             Null(v) => v.is_partition_head(packet),
             Boxed(v) => v.is_partition_head(packet),
         }
@@ -471,6 +483,7 @@ impl Depacketizer for CodecDepacketizer {
             Vp8(v) => v.is_partition_tail(marker, packet),
             Vp9(v) => v.is_partition_tail(marker, packet),
             Av1(v) => v.is_partition_tail(marker, packet),
+            AmrWb(v) => v.is_partition_tail(marker, packet),
             Null(v) => v.is_partition_tail(marker, packet),
             Boxed(v) => v.is_partition_tail(marker, packet),
         }

--- a/src/packet/payload.rs
+++ b/src/packet/payload.rs
@@ -32,6 +32,12 @@ impl Payloader {
             }
         }
 
+        // Select the AMR-WB layout from the octet-align fmtp param (RFC 4867);
+        // absent means bandwidth-efficient.
+        if let CodecPacketizer::AmrWb(ref mut amr) = pack {
+            *amr = amr.with_octet_align(spec.format.octet_align.unwrap_or(false));
+        }
+
         Payloader {
             pack,
             clock_rate: spec.rtp_clock_rate(),

--- a/src/packet/payload.rs
+++ b/src/packet/payload.rs
@@ -126,6 +126,12 @@ impl Payloader {
             }
         }
 
+        // Select the AMR-WB layout from the octet-align fmtp param (RFC 4867);
+        // absent means bandwidth-efficient.
+        if let CodecPacketizer::AmrWb(ref mut amr) = pack {
+            *amr = amr.with_octet_align(spec.format.octet_align.unwrap_or(false));
+        }
+
         Payloader {
             pack,
             clock_rate: spec.rtp_clock_rate(),

--- a/src/rtp/mtime.rs
+++ b/src/rtp/mtime.rs
@@ -48,10 +48,11 @@ impl Frequency {
     /// Cycles in a second of a 48 kHz signal.
     pub const FORTY_EIGHT_KHZ: Frequency = Self::make(48_000);
 
-    /// Cycles in a second of a 16000 Hz signal.
+    /// Cycles in a second of a 16 kHz signal.
     ///
-    /// This is the nominal clock rate for G722. G722 samples at 16 kHz but its RTP
-    /// clock rate is 8000 Hz (RFC 3551 §4.5.2). See
+    /// This is the nominal codec clock rate for G722 and the RTP clock rate for
+    /// AMR-WB. G722 samples at 16 kHz but its RTP clock rate is 8000 Hz
+    /// (RFC 3551 §4.5.2). See
     /// <https://en.wikipedia.org/wiki/RTP_payload_formats#cite_note-55>
     pub const SIXTEEN_KHZ: Frequency = Self::make(16_000);
 

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -974,11 +974,59 @@ pub enum FormatParam {
     /// out-of-order NAL unit decoding. Valid range: 0–32767.
     SpropMaxDonDiff(u16),
 
+    /// AMR-WB octet alignment (RFC 4867). `octet-align=1` selects the
+    /// octet-aligned layout; absence/`0` is bandwidth-efficient.
+    OctetAlign(bool),
+
+    /// AMR-WB active codec modes as a bitmask (RFC 4867).
+    ModeSet(u16),
+
+    /// AMR-WB required interval between codec mode changes (RFC 4867).
+    ModeChangePeriod(u8),
+
+    /// AMR-WB mode-change capability (RFC 4867). `mode-change-capability=2`
+    /// is the most common value.
+    ModeChangeCapability(u8),
+
+    /// AMR-WB preference for changes only between neighboring modes (RFC 4867).
+    ModeChangeNeighbor(bool),
+
+    /// AMR-WB maximum frame redundancy in milliseconds (RFC 4867). `max-red=0`
+    /// disables redundancy.
+    MaxRed(u16),
+
+    /// AMR-WB payload CRC (RFC 4867). `crc=1` enables per-frame CRC.
+    Crc(bool),
+
+    /// AMR-WB maximum interleaving-group size (RFC 4867). Unsupported.
+    Interleaving(u16),
+
+    /// AMR-WB robust sorting (RFC 4867). Unsupported when enabled.
+    RobustSorting(bool),
+
+    /// A recognized AMR-WB parameter with an invalid value.
+    InvalidAmrWb,
+
     /// RTX (resend) codecs, which PT it concerns.
     Apt(Pt),
 
     /// Unrecognized fmtp.
     Unknown,
+}
+
+fn parse_binary(value: &str) -> Option<bool> {
+    match value {
+        "0" => Some(false),
+        "1" => Some(true),
+        _ => None,
+    }
+}
+
+fn parse_amr_wb_mode_set(value: &str) -> Option<u16> {
+    value.split(',').try_fold(0u16, |mask, value| {
+        let mode: u8 = value.parse().ok()?;
+        (mode <= 8).then_some(mask | (1 << mode))
+    })
 }
 
 impl FormatParam {
@@ -1005,6 +1053,27 @@ impl FormatParam {
                 .ok()
                 .filter(|&v| v <= 32767)
                 .map(SpropMaxDonDiff),
+            "octet-align" => parse_binary(v).map(OctetAlign).or(Some(InvalidAmrWb)),
+            "mode-set" => parse_amr_wb_mode_set(v).map(ModeSet).or(Some(InvalidAmrWb)),
+            "mode-change-period" => v
+                .parse()
+                .ok()
+                .filter(|v| matches!(v, 1 | 2))
+                .map(ModeChangePeriod)
+                .or(Some(InvalidAmrWb)),
+            "mode-change-capability" => v
+                .parse()
+                .ok()
+                .filter(|v| matches!(v, 1 | 2))
+                .map(ModeChangeCapability)
+                .or(Some(InvalidAmrWb)),
+            "mode-change-neighbor" => parse_binary(v)
+                .map(ModeChangeNeighbor)
+                .or(Some(InvalidAmrWb)),
+            "max-red" => v.parse().map(MaxRed).ok().or(Some(InvalidAmrWb)),
+            "crc" => parse_binary(v).map(Crc).or(Some(InvalidAmrWb)),
+            "interleaving" => v.parse().map(Interleaving).ok().or(Some(InvalidAmrWb)),
+            "robust-sorting" => parse_binary(v).map(RobustSorting).or(Some(InvalidAmrWb)),
             "apt" => v.parse::<u8>().map(|v| Apt(Pt::from(v))).ok(),
             _ => None,
         }
@@ -1092,6 +1161,30 @@ impl fmt::Display for FormatParam {
                 )
             }
             SpropMaxDonDiff(v) => write!(f, "sprop-max-don-diff={}", *v),
+            OctetAlign(v) => write!(f, "octet-align={}", i32::from(*v)),
+            ModeSet(mask) => {
+                write!(f, "mode-set=")?;
+                let mut first = true;
+                for mode in 0..=8 {
+                    if mask & (1 << mode) == 0 {
+                        continue;
+                    }
+                    if !first {
+                        write!(f, ",")?;
+                    }
+                    write!(f, "{mode}")?;
+                    first = false;
+                }
+                Ok(())
+            }
+            ModeChangePeriod(v) => write!(f, "mode-change-period={}", *v),
+            ModeChangeCapability(v) => write!(f, "mode-change-capability={}", *v),
+            ModeChangeNeighbor(v) => write!(f, "mode-change-neighbor={}", i32::from(*v)),
+            MaxRed(v) => write!(f, "max-red={}", *v),
+            Crc(v) => write!(f, "crc={}", i32::from(*v)),
+            Interleaving(v) => write!(f, "interleaving={}", *v),
+            RobustSorting(v) => write!(f, "robust-sorting={}", i32::from(*v)),
+            InvalidAmrWb => Ok(()),
             Apt(v) => write!(f, "apt={v}"),
             Unknown => Ok(()),
         }

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -999,6 +999,39 @@ pub enum FormatParam {
     /// out-of-order NAL unit decoding. Valid range: 0–32767.
     SpropMaxDonDiff(u16),
 
+    /// AMR-WB octet alignment (RFC 4867). `octet-align=1` selects the
+    /// octet-aligned layout; absence/`0` is bandwidth-efficient.
+    OctetAlign(bool),
+
+    /// AMR-WB active codec modes as a bitmask (RFC 4867).
+    ModeSet(u16),
+
+    /// AMR-WB required interval between codec mode changes (RFC 4867).
+    ModeChangePeriod(u8),
+
+    /// AMR-WB mode-change capability (RFC 4867). `mode-change-capability=2`
+    /// is the most common value.
+    ModeChangeCapability(u8),
+
+    /// AMR-WB preference for changes only between neighboring modes (RFC 4867).
+    ModeChangeNeighbor(bool),
+
+    /// AMR-WB maximum frame redundancy in milliseconds (RFC 4867). `max-red=0`
+    /// disables redundancy.
+    MaxRed(u16),
+
+    /// AMR-WB payload CRC (RFC 4867). `crc=1` enables per-frame CRC.
+    Crc(bool),
+
+    /// AMR-WB maximum interleaving-group size (RFC 4867). Unsupported.
+    Interleaving(u16),
+
+    /// AMR-WB robust sorting (RFC 4867). Unsupported when enabled.
+    RobustSorting(bool),
+
+    /// A recognized AMR-WB parameter with an invalid value.
+    InvalidAmrWb,
+
     /// RTX (resend) codecs, which PT it concerns.
     Apt(Pt),
 
@@ -1010,10 +1043,25 @@ pub enum FormatParam {
     Unknown,
 }
 
+fn parse_binary(value: &str) -> Option<bool> {
+    match value {
+        "0" => Some(false),
+        "1" => Some(true),
+        _ => None,
+    }
+}
+
+fn parse_amr_wb_mode_set(value: &str) -> Option<u16> {
+    value.split(',').try_fold(0u16, |mask, value| {
+        let mode: u8 = value.parse().ok()?;
+        (mode <= 8).then_some(mask | (1 << mode))
+    })
+}
+
 impl FormatParam {
     pub fn parse(k: &str, v: &str) -> Self {
         use FormatParam::*;
-        match k {
+        match k.to_ascii_lowercase().as_str() {
             "minptime" => v.parse().map(MinPTime).ok(),
             "useinbandfec" => Some(UseInbandFec(v == "1")),
             "usedtx" => Some(UseDtx(v == "1")),
@@ -1034,6 +1082,27 @@ impl FormatParam {
                 .ok()
                 .filter(|&v| v <= 32767)
                 .map(SpropMaxDonDiff),
+            "octet-align" => parse_binary(v).map(OctetAlign).or(Some(InvalidAmrWb)),
+            "mode-set" => parse_amr_wb_mode_set(v).map(ModeSet).or(Some(InvalidAmrWb)),
+            "mode-change-period" => v
+                .parse()
+                .ok()
+                .filter(|v| matches!(v, 1 | 2))
+                .map(ModeChangePeriod)
+                .or(Some(InvalidAmrWb)),
+            "mode-change-capability" => v
+                .parse()
+                .ok()
+                .filter(|v| matches!(v, 1 | 2))
+                .map(ModeChangeCapability)
+                .or(Some(InvalidAmrWb)),
+            "mode-change-neighbor" => parse_binary(v)
+                .map(ModeChangeNeighbor)
+                .or(Some(InvalidAmrWb)),
+            "max-red" => v.parse().map(MaxRed).ok().or(Some(InvalidAmrWb)),
+            "crc" => parse_binary(v).map(Crc).or(Some(InvalidAmrWb)),
+            "interleaving" => v.parse().map(Interleaving).ok().or(Some(InvalidAmrWb)),
+            "robust-sorting" => parse_binary(v).map(RobustSorting).or(Some(InvalidAmrWb)),
             "apt" => v.parse::<u8>().map(|v| Apt(Pt::from(v))).ok(),
             _ => None,
         }
@@ -1121,6 +1190,30 @@ impl fmt::Display for FormatParam {
                 )
             }
             SpropMaxDonDiff(v) => write!(f, "sprop-max-don-diff={}", *v),
+            OctetAlign(v) => write!(f, "octet-align={}", i32::from(*v)),
+            ModeSet(mask) => {
+                write!(f, "mode-set=")?;
+                let mut first = true;
+                for mode in 0..=8 {
+                    if mask & (1 << mode) == 0 {
+                        continue;
+                    }
+                    if !first {
+                        write!(f, ",")?;
+                    }
+                    write!(f, "{mode}")?;
+                    first = false;
+                }
+                Ok(())
+            }
+            ModeChangePeriod(v) => write!(f, "mode-change-period={}", *v),
+            ModeChangeCapability(v) => write!(f, "mode-change-capability={}", *v),
+            ModeChangeNeighbor(v) => write!(f, "mode-change-neighbor={}", i32::from(*v)),
+            MaxRed(v) => write!(f, "max-red={}", *v),
+            Crc(v) => write!(f, "crc={}", i32::from(*v)),
+            Interleaving(v) => write!(f, "interleaving={}", *v),
+            RobustSorting(v) => write!(f, "robust-sorting={}", i32::from(*v)),
+            InvalidAmrWb => Ok(()),
             Apt(v) => write!(f, "apt={v}"),
             Red(v) => write!(f, "{v}/{v}"),
             Unknown => Ok(()),

--- a/tests/amr-wb.rs
+++ b/tests/amr-wb.rs
@@ -1,0 +1,368 @@
+//! AMR-WB (RFC 4867 / RFC 7875) negotiation and media round-trip tests.
+
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+use str0m::change::SdpOffer;
+use str0m::format::{Codec, FormatParams};
+use str0m::media::{Direction, Frequency, MediaKind, MediaTime, Mid};
+use str0m::{Event, RtcConfig, RtcError};
+
+mod common;
+use common::{Peer, TestRtc, init_crypto_default, init_log, progress};
+
+/// Speech bits carried by each AMR-WB frame type (RFC 4867 Table 1a). Reserved
+/// types (10..=13) and the empty frames (14 speech-lost, 15 no-data) are 0.
+const FT_BITS: [u16; 16] = [
+    132, 177, 253, 285, 317, 365, 397, 461, 477, 40, 0, 0, 0, 0, 0, 0,
+];
+
+/// Build a valid 3GPP IF frame for AMR-WB frame type `ft` (Q = 1, good frame):
+/// the header octet `(FT << 3) | (Q << 2)` followed by the speech bytes filled
+/// with `fill`. Padding bits in the final speech byte are zeroed so the frame
+/// round-trips byte-for-byte in both the octet-aligned and bandwidth-efficient
+/// layouts.
+fn if_frame(ft: u8, fill: u8) -> Vec<u8> {
+    let bits = FT_BITS[ft as usize] as usize;
+    let mut data = vec![fill; bits.div_ceil(8)];
+    let remainder = bits % 8;
+    if remainder != 0 {
+        if let Some(last) = data.last_mut() {
+            *last &= 0xffu8 << (8 - remainder);
+        }
+    }
+    let mut v = vec![(ft << 3) | (1 << 2)];
+    v.extend(data);
+    v
+}
+
+/// Assert a received IF frame is an intact round-trip: a 1-octet header with the
+/// good (Q) bit set, the correct length for its frame type, and — for frames that
+/// carry speech — byte-identical to `if_frame(ft, fill)`.
+fn assert_pristine_frame(data: &[u8]) {
+    assert!(!data.is_empty(), "empty AMR-WB frame");
+    let ft = (data[0] >> 3) & 0x0f;
+    assert_eq!((data[0] >> 2) & 1, 1, "Q bit should be 1 (good frame)");
+    let nbytes = (FT_BITS[ft as usize] as usize).div_ceil(8);
+    assert_eq!(data.len(), 1 + nbytes, "wrong length for FT {ft}");
+    if nbytes > 0 {
+        let expected = if_frame(ft, data[1]);
+        assert_eq!(data, expected.as_slice(), "FT {ft} corrupted in transit");
+    }
+}
+
+/// A config closure that enables a single AMR-WB payload type (PT 122) with the
+/// given `octet_align` setting. `None` and `Some(false)` are bandwidth-efficient
+/// (the RFC default); `Some(true)` is octet-aligned.
+fn amr_wb_config(octet_align: Option<bool>) -> impl FnOnce(RtcConfig) -> RtcConfig {
+    move |c| {
+        let mut c = c.clear_codecs();
+        c.codec_config().add_config(
+            122u8.into(),
+            None,
+            Codec::AmrWb,
+            Frequency::SIXTEEN_KHZ,
+            Some(1),
+            FormatParams {
+                octet_align,
+                mode_change_capability: Some(2),
+                max_red: Some(0),
+                ..Default::default()
+            },
+        );
+        c
+    }
+}
+
+/// Build two peers with a single AMR-WB PT using `octet_align`, negotiate, and
+/// drive them to connected. Returns the peers and the media mid.
+fn connect_amr_wb(octet_align: Option<bool>) -> (TestRtc, TestRtc, Mid) {
+    let mut l = TestRtc::new_with_config(Peer::Left, amr_wb_config(octet_align));
+    let mut r = TestRtc::new_with_config(Peer::Right, amr_wb_config(octet_align));
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    let mut change = l.sdp_api();
+    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+    let (offer, pending) = change.apply().unwrap();
+
+    let answer = r.rtc.sdp_api().accept_offer(offer).unwrap();
+    l.rtc.sdp_api().accept_answer(pending, answer).unwrap();
+
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r).unwrap();
+    }
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    (l, r, mid)
+}
+
+/// Negotiate AMR-WB with the given layout, then send one frame of every mode
+/// (the nine speech modes and SID) repeatedly and verify each is received
+/// intact at the 16 kHz media clock.
+fn round_trip_all_modes(octet_align: Option<bool>) {
+    init_log();
+    init_crypto_default();
+
+    let (mut l, mut r, mid) = connect_amr_wb(octet_align);
+
+    let pt = l
+        .rtc
+        .codec_config()
+        .find(|p| p.spec().codec == Codec::AmrWb)
+        .expect("AMR-WB to be negotiated")
+        .pt();
+
+    // Every transmittable AMR-WB mode: the nine speech modes and SID frame.
+    const MODES: [u8; 10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+    let mut samples: u64 = 0;
+    let mut idx: usize = 0;
+    loop {
+        let ft = MODES[idx % MODES.len()];
+        let frame = if_frame(ft, idx as u8);
+        let wallclock = l.start + l.duration();
+        let time = MediaTime::new(samples, Frequency::SIXTEEN_KHZ);
+        l.writer(mid)
+            .unwrap()
+            .write(pt, wallclock, time, frame)
+            .unwrap();
+        samples += 320;
+        idx += 1;
+
+        progress(&mut l, &mut r).unwrap();
+        if l.duration() > Duration::from_secs(1) {
+            break;
+        }
+    }
+
+    let media: Vec<_> = r
+        .events
+        .iter()
+        .filter_map(|(_, e)| match e {
+            Event::MediaData(d) => Some(d),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        !media.is_empty(),
+        "R received no AMR-WB MediaData (octet_align={octet_align:?})"
+    );
+
+    let (mut saw_speech, mut saw_sid) = (false, false);
+    for d in &media {
+        assert_eq!(d.params.spec().codec, Codec::AmrWb);
+        assert_eq!(d.time.frequency(), Frequency::SIXTEEN_KHZ);
+        assert_pristine_frame(&d.data);
+        match (d.data[0] >> 3) & 0x0f {
+            0..=8 => saw_speech = true,
+            9 => saw_sid = true,
+            _ => {}
+        }
+    }
+    assert!(
+        saw_speech && saw_sid,
+        "expected speech and SID frames to round-trip (octet_align={octet_align:?})"
+    );
+}
+
+/// Negotiate AMR-WB and verify both the negotiated parameters and that the
+/// generated offer carries the expected rtpmap/fmtp lines.
+#[test]
+pub fn amr_wb_negotiates_with_default_fmtp() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let mut l = TestRtc::new_with_config(Peer::Left, |c| c.clear_codecs().enable_amr_wb(true));
+    let mut r = TestRtc::new_with_config(Peer::Right, |c| c.clear_codecs().enable_amr_wb(true));
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    let mut change = l.sdp_api();
+    change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+    let (offer, pending) = change.apply().unwrap();
+
+    // The offer advertises AMR-WB the way production IMS/VoLTE endpoints expect.
+    let offer_sdp = offer.to_sdp_string();
+    assert!(
+        offer_sdp.contains("a=rtpmap:122 AMR-WB/16000/1"),
+        "offer missing AMR-WB rtpmap:\n{offer_sdp}"
+    );
+    assert!(
+        offer_sdp.contains("a=fmtp:122 octet-align=1;mode-change-capability=2;max-red=0"),
+        "offer missing AMR-WB fmtp:\n{offer_sdp}"
+    );
+
+    let answer = r.rtc.sdp_api().accept_offer(offer)?;
+    l.rtc.sdp_api().accept_answer(pending, answer)?;
+
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r)?;
+    }
+
+    for peer in [&l, &r] {
+        let params = peer
+            .rtc
+            .codec_config()
+            .find(|p| p.spec().codec == Codec::AmrWb)
+            .cloned()
+            .expect("AMR-WB to be negotiated");
+        let spec = params.spec();
+        assert_eq!(spec.clock_rate, Frequency::SIXTEEN_KHZ);
+        assert_eq!(spec.channels, Some(1));
+        assert_eq!(spec.format.octet_align, Some(true));
+        assert_eq!(spec.format.mode_change_capability, Some(2));
+        assert_eq!(spec.format.max_red, Some(0));
+    }
+
+    Ok(())
+}
+
+/// Octet-aligned (`octet-align=1`) end-to-end round-trip across every mode.
+#[test]
+pub fn amr_wb_octet_aligned_round_trip() {
+    round_trip_all_modes(Some(true));
+}
+
+/// Bandwidth-efficient (no `octet-align`, the RFC default) round-trip. This
+/// exercises the bit-packed packetizer/depacketizer path negotiated end-to-end.
+#[test]
+pub fn amr_wb_bandwidth_efficient_round_trip() {
+    round_trip_all_modes(None);
+}
+
+/// An explicit `octet-align=0` is also bandwidth-efficient; round-trip it too.
+#[test]
+pub fn amr_wb_octet_align_zero_round_trip() {
+    round_trip_all_modes(Some(false));
+}
+
+/// A bandwidth-efficient config advertises AMR-WB without `octet-align`, and the
+/// layout stays unset on both peers after negotiation.
+#[test]
+pub fn amr_wb_bandwidth_efficient_offer_omits_octet_align() {
+    init_log();
+    init_crypto_default();
+
+    let mut l = TestRtc::new_with_config(Peer::Left, amr_wb_config(None));
+    let mut r = TestRtc::new_with_config(Peer::Right, amr_wb_config(None));
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    let mut change = l.sdp_api();
+    change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+    let (offer, pending) = change.apply().unwrap();
+
+    let offer_sdp = offer.to_sdp_string();
+    assert!(
+        offer_sdp.contains("a=rtpmap:122 AMR-WB/16000/1"),
+        "offer missing AMR-WB rtpmap:\n{offer_sdp}"
+    );
+    assert!(
+        offer_sdp.contains("a=fmtp:122 mode-change-capability=2;max-red=0"),
+        "bandwidth-efficient offer should carry the hint fmtp:\n{offer_sdp}"
+    );
+    assert!(
+        !offer_sdp.contains("octet-align"),
+        "bandwidth-efficient offer must not advertise octet-align:\n{offer_sdp}"
+    );
+
+    let answer = r.rtc.sdp_api().accept_offer(offer).unwrap();
+    l.rtc.sdp_api().accept_answer(pending, answer).unwrap();
+
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r).unwrap();
+    }
+
+    for peer in [&l, &r] {
+        let spec = peer
+            .rtc
+            .codec_config()
+            .find(|p| p.spec().codec == Codec::AmrWb)
+            .expect("AMR-WB to be negotiated")
+            .spec();
+        assert_eq!(
+            spec.format.octet_align, None,
+            "bandwidth-efficient negotiation leaves octet-align unset"
+        );
+    }
+}
+
+#[test]
+fn amr_wb_answer_echoes_explicit_transport_shape() {
+    init_log();
+    init_crypto_default();
+
+    let mut l = TestRtc::new_with_config(Peer::Left, amr_wb_config(None));
+    let mut r = TestRtc::new_with_config(Peer::Right, amr_wb_config(None));
+
+    let mut change = l.sdp_api();
+    change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+    let (offer, _) = change.apply().unwrap();
+    let offer_sdp = offer
+        .to_sdp_string()
+        .replace("AMR-WB/16000/1", "AMR-WB/16000")
+        .replace(
+            "mode-change-capability=2;max-red=0",
+            "octet-align=0;mode-change-capability=2;max-red=0;crc=0;robust-sorting=0",
+        );
+    let offer = SdpOffer::from_sdp_string(&offer_sdp).unwrap();
+
+    let answer_sdp = r.rtc.sdp_api().accept_offer(offer).unwrap().to_sdp_string();
+
+    assert!(answer_sdp.contains("a=rtpmap:122 AMR-WB/16000\r\n"));
+    assert!(!answer_sdp.contains("AMR-WB/16000/1"));
+    assert!(answer_sdp.contains(
+        "a=fmtp:122 octet-align=0;mode-change-capability=2;max-red=0;crc=0;robust-sorting=0"
+    ));
+}
+
+#[test]
+fn amr_wb_unsupported_or_invalid_offers_are_declined() {
+    init_log();
+    init_crypto_default();
+
+    for parameter in [
+        "interleaving=30",
+        "mode-set=0,2,8",
+        "mode-change-period=2",
+        "mode-change-neighbor=1",
+        "crc=1",
+        "robust-sorting=1",
+        "max-red=65536",
+    ] {
+        let mut l = TestRtc::new_with_config(Peer::Left, |c| c.clear_codecs().enable_amr_wb(true));
+        let mut r = TestRtc::new_with_config(Peer::Right, |c| c.clear_codecs().enable_amr_wb(true));
+
+        let mut change = l.sdp_api();
+        change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+        let (offer, _) = change.apply().unwrap();
+        let offer_sdp = offer.to_sdp_string().replace(
+            "octet-align=1;mode-change-capability=2;max-red=0",
+            &format!("octet-align=1;mode-change-capability=2;max-red=0;{parameter}"),
+        );
+        let offer = SdpOffer::from_sdp_string(&offer_sdp).unwrap();
+
+        let answer_sdp = r.rtc.sdp_api().accept_offer(offer).unwrap().to_sdp_string();
+        assert!(
+            !answer_sdp.contains("a=rtpmap:122 AMR-WB"),
+            "unsupported `{parameter}` was accepted:\n{answer_sdp}"
+        );
+    }
+}

--- a/tests/amr-wb.rs
+++ b/tests/amr-wb.rs
@@ -1,0 +1,369 @@
+//! AMR-WB (RFC 4867 / RFC 7875) negotiation and media round-trip tests.
+
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+use str0m::change::SdpOffer;
+use str0m::format::{Codec, FormatParams};
+use str0m::media::{Direction, Frequency, MediaKind, MediaTime, Mid};
+use str0m::{Event, RtcConfig, RtcError};
+
+mod common;
+use common::{Peer, TestRtc, init_crypto_default, init_log, progress};
+
+/// Speech bits carried by each AMR-WB frame type (RFC 4867 Table 1a). Reserved
+/// types (10..=13) and the empty frames (14 speech-lost, 15 no-data) are 0.
+const FT_BITS: [u16; 16] = [
+    132, 177, 253, 285, 317, 365, 397, 461, 477, 40, 0, 0, 0, 0, 0, 0,
+];
+
+/// Build a valid 3GPP IF frame for AMR-WB frame type `ft` (Q = 1, good frame):
+/// the header octet `(FT << 3) | (Q << 2)` followed by the speech bytes filled
+/// with `fill`. Padding bits in the final speech byte are zeroed so the frame
+/// round-trips byte-for-byte in both the octet-aligned and bandwidth-efficient
+/// layouts.
+fn if_frame(ft: u8, fill: u8) -> Vec<u8> {
+    let bits = FT_BITS[ft as usize] as usize;
+    let mut data = vec![fill; bits.div_ceil(8)];
+    let remainder = bits % 8;
+    if remainder != 0 {
+        if let Some(last) = data.last_mut() {
+            *last &= 0xffu8 << (8 - remainder);
+        }
+    }
+    let mut v = vec![(ft << 3) | (1 << 2)];
+    v.extend(data);
+    v
+}
+
+/// Assert a received IF frame is an intact round-trip: a 1-octet header with the
+/// good (Q) bit set, the correct length for its frame type, and — for frames that
+/// carry speech — byte-identical to `if_frame(ft, fill)`.
+fn assert_pristine_frame(data: &[u8]) {
+    assert!(!data.is_empty(), "empty AMR-WB frame");
+    let ft = (data[0] >> 3) & 0x0f;
+    assert_eq!((data[0] >> 2) & 1, 1, "Q bit should be 1 (good frame)");
+    let nbytes = (FT_BITS[ft as usize] as usize).div_ceil(8);
+    assert_eq!(data.len(), 1 + nbytes, "wrong length for FT {ft}");
+    if nbytes > 0 {
+        let expected = if_frame(ft, data[1]);
+        assert_eq!(data, expected.as_slice(), "FT {ft} corrupted in transit");
+    }
+}
+
+/// A config closure that enables a single AMR-WB payload type (PT 122) with the
+/// given `octet_align` setting. `None` and `Some(false)` are bandwidth-efficient
+/// (the RFC default); `Some(true)` is octet-aligned.
+fn amr_wb_config(octet_align: Option<bool>) -> impl FnOnce(RtcConfig) -> RtcConfig {
+    move |c| {
+        let mut c = c.clear_codecs();
+        c.codec_config().add_config(
+            122u8.into(),
+            None,
+            Codec::AmrWb,
+            Frequency::SIXTEEN_KHZ,
+            Some(1),
+            FormatParams {
+                octet_align,
+                mode_change_capability: Some(2),
+                max_red: Some(0),
+                ..Default::default()
+            },
+        );
+        c
+    }
+}
+
+/// Build two peers with a single AMR-WB PT using `octet_align`, negotiate, and
+/// drive them to connected. Returns the peers and the media mid.
+fn connect_amr_wb(octet_align: Option<bool>) -> (TestRtc, TestRtc, Mid) {
+    let mut l = TestRtc::new_with_config(Peer::Left, amr_wb_config(octet_align));
+    let mut r = TestRtc::new_with_config(Peer::Right, amr_wb_config(octet_align));
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    let mut change = l.sdp_api();
+    let mid = change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+    let (offer, pending) = change.apply().unwrap();
+
+    let answer = r.rtc.sdp_api().accept_offer(offer).unwrap();
+    l.rtc.sdp_api().accept_answer(pending, answer).unwrap();
+
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r).unwrap();
+    }
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    (l, r, mid)
+}
+
+/// Negotiate AMR-WB with the given layout, then send one frame of every mode
+/// (the nine speech modes and SID) repeatedly and verify each is received
+/// intact at the 16 kHz media clock.
+fn round_trip_all_modes(octet_align: Option<bool>) {
+    init_log();
+    init_crypto_default();
+
+    let (mut l, mut r, mid) = connect_amr_wb(octet_align);
+
+    let pt = l
+        .rtc
+        .codec_config()
+        .find(|p| p.spec().codec == Codec::AmrWb)
+        .expect("AMR-WB to be negotiated")
+        .pt();
+
+    // Every transmittable AMR-WB mode: the nine speech modes and SID frame.
+    const MODES: [u8; 10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+    let mut samples: u64 = 0;
+    let mut idx: usize = 0;
+    loop {
+        let ft = MODES[idx % MODES.len()];
+        let frame = if_frame(ft, idx as u8);
+        let wallclock = l.start + l.duration();
+        let time = MediaTime::new(samples, Frequency::SIXTEEN_KHZ);
+        l.writer(mid)
+            .unwrap()
+            .write(pt, wallclock, time, frame)
+            .unwrap();
+        samples += 320;
+        idx += 1;
+
+        progress(&mut l, &mut r).unwrap();
+        if l.duration() > Duration::from_secs(1) {
+            break;
+        }
+    }
+
+    let media: Vec<_> = r
+        .events
+        .iter()
+        .filter_map(|(_, e)| match e {
+            Event::MediaData(d) => Some(d),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        !media.is_empty(),
+        "R received no AMR-WB MediaData (octet_align={octet_align:?})"
+    );
+
+    let (mut saw_speech, mut saw_sid) = (false, false);
+    for d in &media {
+        assert_eq!(d.params.spec().codec, Codec::AmrWb);
+        assert_eq!(d.time.frequency(), Frequency::SIXTEEN_KHZ);
+        assert_pristine_frame(&d.data);
+        match (d.data[0] >> 3) & 0x0f {
+            0..=8 => saw_speech = true,
+            9 => saw_sid = true,
+            _ => {}
+        }
+    }
+    assert!(
+        saw_speech && saw_sid,
+        "expected speech and SID frames to round-trip (octet_align={octet_align:?})"
+    );
+}
+
+/// Negotiate AMR-WB and verify both the negotiated parameters and that the
+/// generated offer carries the expected rtpmap/fmtp lines.
+#[test]
+pub fn amr_wb_negotiates_with_default_fmtp() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let mut l = TestRtc::new_with_config(Peer::Left, |c| c.clear_codecs().enable_amr_wb(true));
+    let mut r = TestRtc::new_with_config(Peer::Right, |c| c.clear_codecs().enable_amr_wb(true));
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    let mut change = l.sdp_api();
+    change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+    let (offer, pending) = change.apply().unwrap();
+
+    // The default advertises only the AMR-WB behavior str0m can enforce.
+    let offer_sdp = offer.to_sdp_string();
+    assert!(
+        offer_sdp.contains("a=rtpmap:122 AMR-WB/16000/1"),
+        "offer missing AMR-WB rtpmap:\n{offer_sdp}"
+    );
+    assert!(
+        offer_sdp.contains("a=fmtp:122 octet-align=1;max-red=0"),
+        "offer missing AMR-WB fmtp:\n{offer_sdp}"
+    );
+    assert!(!offer_sdp.contains("mode-change-capability"));
+
+    let answer = r.rtc.sdp_api().accept_offer(offer)?;
+    l.rtc.sdp_api().accept_answer(pending, answer)?;
+
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r)?;
+    }
+
+    for peer in [&l, &r] {
+        let params = peer
+            .rtc
+            .codec_config()
+            .find(|p| p.spec().codec == Codec::AmrWb)
+            .cloned()
+            .expect("AMR-WB to be negotiated");
+        let spec = params.spec();
+        assert_eq!(spec.clock_rate, Frequency::SIXTEEN_KHZ);
+        assert_eq!(spec.channels, Some(1));
+        assert_eq!(spec.format.octet_align, Some(true));
+        assert_eq!(spec.format.mode_change_capability, None);
+        assert_eq!(spec.format.max_red, Some(0));
+    }
+
+    Ok(())
+}
+
+/// Octet-aligned (`octet-align=1`) end-to-end round-trip across every mode.
+#[test]
+pub fn amr_wb_octet_aligned_round_trip() {
+    round_trip_all_modes(Some(true));
+}
+
+/// Bandwidth-efficient (no `octet-align`, the RFC default) round-trip. This
+/// exercises the bit-packed packetizer/depacketizer path negotiated end-to-end.
+#[test]
+pub fn amr_wb_bandwidth_efficient_round_trip() {
+    round_trip_all_modes(None);
+}
+
+/// An explicit `octet-align=0` is also bandwidth-efficient; round-trip it too.
+#[test]
+pub fn amr_wb_octet_align_zero_round_trip() {
+    round_trip_all_modes(Some(false));
+}
+
+/// A bandwidth-efficient config advertises AMR-WB without `octet-align`, and the
+/// layout stays unset on both peers after negotiation.
+#[test]
+pub fn amr_wb_bandwidth_efficient_offer_omits_octet_align() {
+    init_log();
+    init_crypto_default();
+
+    let mut l = TestRtc::new_with_config(Peer::Left, amr_wb_config(None));
+    let mut r = TestRtc::new_with_config(Peer::Right, amr_wb_config(None));
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    let mut change = l.sdp_api();
+    change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+    let (offer, pending) = change.apply().unwrap();
+
+    let offer_sdp = offer.to_sdp_string();
+    assert!(
+        offer_sdp.contains("a=rtpmap:122 AMR-WB/16000/1"),
+        "offer missing AMR-WB rtpmap:\n{offer_sdp}"
+    );
+    assert!(
+        offer_sdp.contains("a=fmtp:122 mode-change-capability=2;max-red=0"),
+        "bandwidth-efficient offer should carry the hint fmtp:\n{offer_sdp}"
+    );
+    assert!(
+        !offer_sdp.contains("octet-align"),
+        "bandwidth-efficient offer must not advertise octet-align:\n{offer_sdp}"
+    );
+
+    let answer = r.rtc.sdp_api().accept_offer(offer).unwrap();
+    l.rtc.sdp_api().accept_answer(pending, answer).unwrap();
+
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r).unwrap();
+    }
+
+    for peer in [&l, &r] {
+        let spec = peer
+            .rtc
+            .codec_config()
+            .find(|p| p.spec().codec == Codec::AmrWb)
+            .expect("AMR-WB to be negotiated")
+            .spec();
+        assert_eq!(
+            spec.format.octet_align, None,
+            "bandwidth-efficient negotiation leaves octet-align unset"
+        );
+    }
+}
+
+#[test]
+fn amr_wb_answer_echoes_mixed_case_transport_shape() {
+    init_log();
+    init_crypto_default();
+
+    let mut l = TestRtc::new_with_config(Peer::Left, amr_wb_config(None));
+    let mut r = TestRtc::new_with_config(Peer::Right, amr_wb_config(None));
+
+    let mut change = l.sdp_api();
+    change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+    let (offer, _) = change.apply().unwrap();
+    let offer_sdp = offer
+        .to_sdp_string()
+        .replace("AMR-WB/16000/1", "AMR-WB/16000")
+        .replace(
+            "mode-change-capability=2;max-red=0",
+            "Octet-Align=0;Mode-Change-Capability=2;Max-Red=0;CRC=0;Robust-Sorting=0",
+        );
+    let offer = SdpOffer::from_sdp_string(&offer_sdp).unwrap();
+
+    let answer_sdp = r.rtc.sdp_api().accept_offer(offer).unwrap().to_sdp_string();
+
+    assert!(answer_sdp.contains("a=rtpmap:122 AMR-WB/16000\r\n"));
+    assert!(!answer_sdp.contains("AMR-WB/16000/1"));
+    assert!(answer_sdp.contains(
+        "a=fmtp:122 octet-align=0;mode-change-capability=2;max-red=0;crc=0;robust-sorting=0"
+    ));
+}
+
+#[test]
+fn amr_wb_unsupported_or_invalid_offers_are_declined() {
+    init_log();
+    init_crypto_default();
+
+    for parameter in [
+        "interleaving=30",
+        "mode-set=0,2,8",
+        "mode-change-period=2",
+        "mode-change-neighbor=1",
+        "crc=1",
+        "robust-sorting=1",
+        "max-red=65536",
+    ] {
+        let mut l = TestRtc::new_with_config(Peer::Left, |c| c.clear_codecs().enable_amr_wb(true));
+        let mut r = TestRtc::new_with_config(Peer::Right, |c| c.clear_codecs().enable_amr_wb(true));
+
+        let mut change = l.sdp_api();
+        change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+        let (offer, _) = change.apply().unwrap();
+        let offer_sdp = offer.to_sdp_string().replace(
+            "octet-align=1;max-red=0",
+            &format!("octet-align=1;max-red=0;{parameter}"),
+        );
+        let offer = SdpOffer::from_sdp_string(&offer_sdp).unwrap();
+
+        let answer_sdp = r.rtc.sdp_api().accept_offer(offer).unwrap().to_sdp_string();
+        assert!(
+            !answer_sdp.contains("a=rtpmap:122 AMR-WB"),
+            "unsupported `{parameter}` was accepted:\n{answer_sdp}"
+        );
+    }
+}


### PR DESCRIPTION
Not ready, need more iterations

## Architecture / mental model

This change adds an **AMR-WB RTP payload adapter**, not an AMR-WB encoder or decoder. Applications provide and receive already encoded 3GPP IF frames; str0m negotiates the supported transport profile and converts between IF frames and RFC 4867 RTP payloads.

There are three representations to keep distinct:

1. **SDP representation:** `CodecSpec` and `FormatParams` describe the negotiated payload shape.
2. **Application representation:** 3GPP IF frames, consisting of a one-byte `FT/Q` header followed by encoded speech bytes.
3. **Network representation:** RFC 4867 RTP payloads containing CMR, ToC entries, and speech bits.

```mermaid
flowchart LR
    subgraph Control["Control plane: SDP negotiation"]
        Config["CodecConfig<br/>PT 122, 16 kHz, mono"]
        Params["FormatParam / FormatParams"]
        Gate["AMR-WB compatibility gate"]
        Spec["Negotiated CodecSpec"]

        Config --> Params --> Gate --> Spec
    end

    subgraph Send["Send path"]
        Writer["Writer::write<br/>one 3GPP IF frame + MediaTime"]
        Payloader["Payloader<br/>select negotiated layout"]
        Packetizer["AmrWbPacketizer<br/>IF frame -> RFC 4867 payload"]
        RTPOut["RTP / SRTP"]

        Writer --> Payloader --> Packetizer --> RTPOut
    end

    subgraph Receive["Receive path"]
        RTPIn["RTP / SRTP"]
        Buffer["DepacketizingBuffer"]
        Depacketizer["AmrWbDepacketizer<br/>RFC 4867 -> IF frames"]
        Event["Event::MediaData"]

        RTPIn --> Buffer --> Depacketizer --> Event
    end

    Spec -. configures .-> Payloader
    Spec -. configures .-> Depacketizer
```

### Control plane

`enable_amr_wb(true)` adds an opt-in mono codec configuration using dynamic PT 122, a 16 kHz RTP clock, and the common IMS/VoLTE format:

```text
octet-align=1;mode-change-capability=2;max-red=0
```

The SDP layer parses AMR-WB parameters into typed `FormatParams`. Compatibility matching then accepts only configurations the packet layer can actually process. Parameters that change the wire format must match and are echoed unchanged in the answer.

Unsupported or malformed configurations are declined rather than negotiated and misdecoded. This includes CRC, interleaving, robust sorting, multiple channels, restricted mode sets, and unsupported mode-change constraints.

### Send path

Each `Writer::write` call must contain **exactly one 3GPP IF frame** and one media timestamp. AMR-WB frames represent 20 ms, or 320 ticks at 16 kHz, so accepting concatenated frames would make timestamp ownership ambiguous.

The packetizer:

- validates the IF header, frame type, encoded length, and MTU;
- rejects reserved frame types, concatenated frames, and standalone `NO_DATA`;
- emits exactly one RFC 4867 RTP payload;
- uses either octet-aligned or bandwidth-efficient packing according to SDP;
- emits CMR 15, meaning no codec mode request.

The generic RTP layer supplies sequence numbers, the rebased 16 kHz timestamp, extensions, and the talkspurt marker.

### Receive path

Incoming RTP is mapped to the negotiated payload type, and the depacketizer is configured from the same `octet-align` setting as the sender.

Unlike the send API, the receiver accepts valid compound RFC 4867 payloads because remote peers may place multiple ToC entries in one RTP packet. These are returned as concatenated IF frames in `Event::MediaData`.

The receiver rejects reserved frame types, truncated speech data, unexpected trailing octets, and nonzero terminal padding.

### Code map

- SDP parsing and serialization: data.rs
- Typed codec parameters: format_params.rs
- Compatibility and answer shaping: payload_params.rs
- RFC 4867 conversion: amr_wb.rs
- Runtime packetizer dispatch: mod.rs
- Send configuration: payload.rs
- Receive configuration: mod.rs
- End-to-end coverage: amr-wb.rs

A useful review order is: **SDP compatibility rules → packet conversion → runtime wiring → integration and malformed-input tests**.