### PR TITLE
Add jitter to MediaIngressStats

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -197,6 +197,9 @@ pub struct MediaIngressStats {
     pub plis: u64,
     /// Number of nacks sent.
     pub nacks: u64,
+    /// Interarrival jitter, in RTP timestamp units, as reported in the last RTCP
+    /// receiver report we sent for this stream.
+    pub jitter: u32,
     /// Round-trip-time extracted from the last RTCP XR DLRR report block.
     pub rtt: Option<Duration>,
     /// Fraction of packets lost extracted from the last RTCP receiver report.
@@ -220,10 +223,10 @@ impl MediaIngressStats {
             self.rid == other.rid,
             "Cannot merge MediaIngressStats for different rids"
         );
-        let (rtt, loss) = if self.timestamp > other.timestamp {
-            (self.rtt, self.loss)
+        let (jitter, rtt, loss) = if self.timestamp > other.timestamp {
+            (self.jitter, self.rtt, self.loss)
         } else {
-            (other.rtt, other.loss)
+            (other.jitter, other.rtt, other.loss)
         };
 
         *self = Self {
@@ -234,6 +237,7 @@ impl MediaIngressStats {
             firs: self.firs + other.firs,
             plis: self.plis + other.plis,
             nacks: self.nacks + other.nacks,
+            jitter,
             rtt,
             loss,
             timestamp: self.timestamp.max(other.timestamp),

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -133,6 +133,8 @@ pub(crate) struct StreamRxStats {
     plis: u64,
     /// count of NACKs sent
     nacks: u64,
+    /// interarrival jitter (RTP timestamp units) from the last RR we sent
+    jitter: u32,
     /// round trip time from the last DLRR, if any
     rtt: Option<Duration>,
     /// fraction of packets lost from the last RR, if any
@@ -574,8 +576,9 @@ impl StreamRx {
         rr.sender_ssrc = sender_ssrc;
 
         if !rr.reports.is_empty() {
-            let l = rr.reports[rr.reports.len() - 1].fraction_lost;
-            self.stats.update_loss(l);
+            let report = &rr.reports[rr.reports.len() - 1];
+            self.stats.update_loss(report.fraction_lost);
+            self.stats.jitter = report.jitter;
         }
 
         let xr = self.create_extended_receiver_report(now);
@@ -829,6 +832,7 @@ impl StreamRxStats {
             firs: self.firs,
             plis: self.plis,
             nacks: self.nacks,
+            jitter: self.jitter,
             rtt: self.rtt,
             loss: self.loss,
             timestamp: now,


### PR DESCRIPTION
## Summary

Exposes the interarrival jitter we compute for a received stream on `MediaIngressStats`, mirroring the remote-reported jitter already available via `MediaEgressStats.remote.jitter`.

- `MediaIngressStats.jitter: u32` — the jitter, in RTP timestamp units, that we last reported in an RTCP receiver report for the stream. Same type as `RemoteIngressStats.jitter`.
- Populated from the RR at creation time (alongside the existing `loss` update), and merged most-recent-by-timestamp across SSRCs backing the same `(mid, rid)`, consistent with `rtt`/`loss`.

This closes the asymmetry where the locally-computed receive jitter was put on the wire in our RRs but never surfaced to the application, and brings parity with the browser `RTCInboundRtpStreamStats.jitter` field.