### PR TITLE
Normalize RTC close draining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "dimpl"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a11091ebc139b18d6b5878d8769ca43ad5ea8a7e2f5ed1e1f25e172951ef0ce"
+checksum = "bb2b8390bf0021eae92cf96a0e3a54c531b6315c47edfe9220f5fc61bc9e1f63"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1715,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "sctp-proto"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5376eaf8a764118abd6bee29673c68eab91f0913b448fe2944e74488b63c37b5"
+checksum = "199c5c38008c2c151e27afd228230b1b69f849b1f7629f5df86662ee1f456187"
 dependencies = [
  "bytes",
  "crc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,12 @@ _str0m_test = { path = "crates/_str0m_test" }
 # Core dependencies
 tracing = "0.1.37"
 fastrand = "2.0.1"
-sctp-proto = "0.10.0"
+sctp-proto = "0.10.1"
 combine = "4.6.6"
 subtle = "2.0.0"
 arrayvec = "0.7.6"
 serde = { version = "1.0.152", features = ["derive"] }
-dimpl = { version = "0.7.0", default-features = false }
+dimpl = { version = "0.7.1", default-features = false }
 drv = { version = "0.4.3" }
 time = "0.3"
 base64ct = "1"

--- a/crates/proto/src/crypto/provider.rs
+++ b/crates/proto/src/crypto/provider.rs
@@ -193,6 +193,16 @@ pub trait DtlsInstance: CryptoSafe {
     /// Return the negotiated DTLS protocol version. May return `None` before handshake completion.
     fn protocol_version(&self) -> Option<ProtocolVersion>;
 
+    /// Return true after close has started and while close output may still need polling.
+    fn is_closing(&self) -> bool {
+        false
+    }
+
+    /// Return true once close output has drained and the instance is closed.
+    fn is_closed(&self) -> bool {
+        false
+    }
+
     /// Initiate graceful shutdown by sending a DTLS `close_notify` alert.
     fn close(&mut self) -> Result<(), DtlsImplError>;
 }

--- a/crypto/apple-crypto/src/dtls.rs
+++ b/crypto/apple-crypto/src/dtls.rs
@@ -170,6 +170,14 @@ impl DtlsInstance for AppleCryptoDtlsInstance {
         self.dtls.protocol_version()
     }
 
+    fn is_closing(&self) -> bool {
+        self.dtls.is_closing()
+    }
+
+    fn is_closed(&self) -> bool {
+        self.dtls.is_closed()
+    }
+
     fn close(&mut self) -> Result<(), DtlsImplError> {
         self.dtls.close()
     }

--- a/crypto/aws-lc-rs/src/dtls.rs
+++ b/crypto/aws-lc-rs/src/dtls.rs
@@ -112,6 +112,14 @@ impl DtlsInstance for AwsLcRsDtlsInstance {
         self.dtls.protocol_version()
     }
 
+    fn is_closing(&self) -> bool {
+        self.dtls.is_closing()
+    }
+
+    fn is_closed(&self) -> bool {
+        self.dtls.is_closed()
+    }
+
     fn close(&mut self) -> Result<(), DtlsImplError> {
         self.dtls.close()
     }

--- a/crypto/openssl/src/dtls_dimpl.rs
+++ b/crypto/openssl/src/dtls_dimpl.rs
@@ -113,6 +113,14 @@ impl DtlsInstance for DimplDtlsInstance {
         self.dtls.protocol_version()
     }
 
+    fn is_closing(&self) -> bool {
+        self.dtls.is_closing()
+    }
+
+    fn is_closed(&self) -> bool {
+        self.dtls.is_closed()
+    }
+
     fn close(&mut self) -> Result<(), DtlsImplError> {
         self.dtls.close()
     }

--- a/crypto/openssl/src/dtls_ossl.rs
+++ b/crypto/openssl/src/dtls_ossl.rs
@@ -658,12 +658,20 @@ impl DtlsInstance for OsslDtlsInstance {
         Some(ProtocolVersion::DTLS1_2)
     }
 
+    fn is_closing(&self) -> bool {
+        self.close_notify_sent || self.close_notify_received
+    }
+
+    fn is_closed(&self) -> bool {
+        self.close_notify_sent && self.pending_packets.is_empty()
+    }
+
     fn close(&mut self) -> Result<(), DtlsImplError> {
         if let State::Established(ref mut stream) = self.inner.tls.state {
             let _ = stream.shutdown();
-            self.close_notify_sent = true;
             self.collect_output();
         }
+        self.close_notify_sent = true;
         Ok(())
     }
 }

--- a/crypto/rust-crypto/src/dtls.rs
+++ b/crypto/rust-crypto/src/dtls.rs
@@ -112,6 +112,14 @@ impl DtlsInstance for RustCryptoDtlsInstance {
         self.dtls.protocol_version()
     }
 
+    fn is_closing(&self) -> bool {
+        self.dtls.is_closing()
+    }
+
+    fn is_closed(&self) -> bool {
+        self.dtls.is_closed()
+    }
+
     fn close(&mut self) -> Result<(), DtlsImplError> {
         self.dtls.close()
     }

--- a/crypto/wincrypto/src/dtls_dimpl.rs
+++ b/crypto/wincrypto/src/dtls_dimpl.rs
@@ -103,6 +103,14 @@ impl DtlsInstance for WinCryptoDtlsInstance {
         self.dtls.protocol_version()
     }
 
+    fn is_closing(&self) -> bool {
+        self.dtls.is_closing()
+    }
+
+    fn is_closed(&self) -> bool {
+        self.dtls.is_closed()
+    }
+
     fn close(&mut self) -> Result<(), DtlsImplError> {
         self.dtls.close()
     }

--- a/crypto/wincrypto/src/dtls_schannel.rs
+++ b/crypto/wincrypto/src/dtls_schannel.rs
@@ -85,6 +85,7 @@ impl DtlsProvider for WinCryptoDtlsProvider {
             pending_outputs: VecDeque::new(),
             queued_app_data: VecDeque::new(),
             last_timeout: None,
+            close_requested: false,
         }))
     }
 }
@@ -100,6 +101,8 @@ struct WinCryptoDtlsInstance {
     queued_app_data: VecDeque<Vec<u8>>,
     /// The last time we were given via handle_timeout, used for calculating next timeout.
     last_timeout: Option<Instant>,
+    /// Native SChannel DTLS currently has no close_notify support.
+    close_requested: bool,
 }
 
 #[derive(Debug)]
@@ -260,7 +263,16 @@ impl DtlsInstance for WinCryptoDtlsInstance {
         Some(ProtocolVersion::DTLS1_2)
     }
 
+    fn is_closing(&self) -> bool {
+        self.close_requested
+    }
+
+    fn is_closed(&self) -> bool {
+        self.close_requested && self.pending_outputs.is_empty()
+    }
+
     fn close(&mut self) -> Result<(), DtlsImplError> {
-        Err(dtls_crypto_error(DtlsCryptoOperation::Encrypt))
+        self.close_requested = true;
+        Ok(())
     }
 }

--- a/src/dtls.rs
+++ b/src/dtls.rs
@@ -118,6 +118,10 @@ impl Dtls {
         self.instance.protocol_version()
     }
 
+    pub fn is_closed(&self) -> bool {
+        self.pending_packets.is_empty() && self.instance.is_closed()
+    }
+
     /// Set the remote fingerprint (extracted from peer certificate).
     pub fn set_remote_fingerprint(&mut self, fingerprint: Fingerprint) {
         self.remote_fingerprint = Some(fingerprint);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -899,8 +899,7 @@ pub use error::RtcError;
 /// }
 /// ```
 pub struct Rtc {
-    alive: bool,
-    closing: bool,
+    state: RtcState,
     ice: IceAgent,
     dtls: Dtls,
     dtls_connected: bool,
@@ -921,6 +920,13 @@ pub struct Rtc {
     last_timeout_reason: Reason,
     crypto_provider: Arc<crate::crypto::CryptoProvider>,
     fingerprint_verification: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RtcState {
+    Alive,
+    Closing,
+    Closed,
 }
 
 struct SendAddr {
@@ -1245,8 +1251,7 @@ impl Rtc {
         }
 
         Ok(Rtc {
-            alive: true,
-            closing: false,
+            state: RtcState::Alive,
             ice,
             dtls: Dtls::new(
                 &dtls_cert,
@@ -1297,7 +1302,7 @@ impl Rtc {
     /// assert!(!rtc.is_alive());
     /// ```
     pub fn is_alive(&self) -> bool {
-        self.alive
+        self.state != RtcState::Closed
     }
 
     /// Force disconnects the instance making [`Rtc::is_alive()`] return `false`.
@@ -1314,10 +1319,7 @@ impl Rtc {
     /// assert!(!rtc.is_alive());
     /// ```
     pub fn disconnect(&mut self) {
-        if self.alive {
-            debug!("Set alive=false");
-            self.alive = false;
-        }
+        self.state = RtcState::Closed;
     }
 
     /// Add a local ICE candidate. Local candidates are socket addresses the `Rtc` instance
@@ -1446,7 +1448,7 @@ impl Rtc {
             panic!("In rtp_mode use direct_api().stream_tx().write_rtp()");
         }
 
-        if !self.alive {
+        if self.state == RtcState::Closed {
             return None;
         }
 
@@ -1560,37 +1562,8 @@ impl Rtc {
     }
 
     fn do_poll_output(&mut self) -> Result<Output, RtcError> {
-        if !self.alive {
-            self.last_timeout_reason = Reason::NotHappening;
-            return Ok(Output::Timeout(not_happening()));
-        }
-
-        if self.closing {
-            // Drain DTLS output to move packets into the poll_packet queue
-            loop {
-                if let DtlsOutput::Timeout(_) = self.dtls.poll_output(&mut self.dtls_buf) {
-                    break;
-                }
-            }
-
-            // Transmit pending DTLS packets one at a time (the close_notify record).
-            // The caller must keep calling poll_output() until we return Timeout.
-            if let Some(send) = &self.send_addr {
-                if let Some(contents) = self.dtls.poll_packet() {
-                    let t = net::Transmit {
-                        proto: send.proto,
-                        source: send.source,
-                        destination: send.destination,
-                        contents,
-                    };
-                    return Ok(Output::Transmit(t));
-                }
-            }
-
-            // All packets drained — mark as not alive
-            self.alive = false;
-            self.last_timeout_reason = Reason::NotHappening;
-            return Ok(Output::Timeout(not_happening()));
+        if self.state != RtcState::Alive {
+            return self.poll_inactive_output();
         }
 
         while let Some(e) = self.ice.poll_event() {
@@ -1833,6 +1806,36 @@ impl Rtc {
         Ok(Output::Timeout(next))
     }
 
+    #[cold]
+    #[inline(never)]
+    fn poll_inactive_output(&mut self) -> Result<Output, RtcError> {
+        if self.state == RtcState::Closed {
+            self.last_timeout_reason = Reason::NotHappening;
+            return Ok(Output::Timeout(not_happening()));
+        }
+
+        loop {
+            if let DtlsOutput::Timeout(_) = self.dtls.poll_output(&mut self.dtls_buf) {
+                break;
+            }
+        }
+
+        if let Some(send) = &self.send_addr {
+            if let Some(contents) = self.dtls.poll_packet() {
+                return Ok(Output::Transmit(net::Transmit {
+                    proto: send.proto,
+                    source: send.source,
+                    destination: send.destination,
+                    contents,
+                }));
+            }
+        }
+
+        self.state = RtcState::Closed;
+        self.last_timeout_reason = Reason::NotHappening;
+        Ok(Output::Timeout(not_happening()))
+    }
+
     /// The reason for the last [`Output::Timeout`]
     ///
     /// This is updated when calling [`Rtc::poll_output()`] and the next output
@@ -1937,7 +1940,7 @@ impl Rtc {
     /// }
     /// ```
     pub fn handle_input(&mut self, input: Input) -> Result<(), RtcError> {
-        if !self.alive {
+        if self.state == RtcState::Closed {
             return Ok(());
         }
 
@@ -1957,7 +1960,9 @@ impl Rtc {
     /// as a `Transmit`. Once the packet is drained, the `Rtc` instance becomes
     /// not alive.
     pub fn close(&mut self) -> Result<(), RtcError> {
-        self.closing = true;
+        if self.state != RtcState::Closed {
+            self.state = RtcState::Closing;
+        }
         Ok(self.dtls.close()?)
     }
 
@@ -2063,7 +2068,7 @@ impl Rtc {
     /// // TODO write data channel data.
     /// ```
     pub fn channel(&mut self, id: ChannelId) -> Option<Channel<'_>> {
-        if !self.alive {
+        if self.state == RtcState::Closed {
             return None;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1033,7 +1033,11 @@ pub enum Event {
     /// is opaque and application-defined (RFC 4585 Section 6.4).
     AppSpecificFeedback(AppSpecificFeedback),
 
-    /// We have received the DTLS close packet
+    /// The remote DTLS connection or SCTP association has closed.
+    ///
+    /// When this event is emitted, `Rtc` starts graceful local shutdown and
+    /// remains alive only while [`Rtc::poll_output()`] drains pending protocol
+    /// output such as the DTLS close_notify response.
     Closed,
 
     /// Debug output of incoming and outgoing RTCP/RTP packets.
@@ -1291,6 +1295,11 @@ impl Rtc {
     ///
     /// The instance can be manually disconnected using [`Rtc::disconnect()`].
     ///
+    /// During graceful shutdown, this remains `true` until [`Rtc::poll_output()`]
+    /// has drained pending protocol output. App-facing operations such as
+    /// [`Rtc::writer()`] and [`Rtc::channel()`] are unavailable during that
+    /// closing drain.
+    ///
     /// ```
     /// # use std::time::Instant;
     /// # use str0m::Rtc;
@@ -1448,7 +1457,7 @@ impl Rtc {
             panic!("In rtp_mode use direct_api().stream_tx().write_rtp()");
         }
 
-        if self.state == RtcState::Closed {
+        if self.state != RtcState::Alive {
             return None;
         }
 
@@ -1562,8 +1571,9 @@ impl Rtc {
     }
 
     fn do_poll_output(&mut self) -> Result<Output, RtcError> {
-        if self.state != RtcState::Alive {
-            return self.poll_inactive_output();
+        if self.state == RtcState::Closed {
+            self.last_timeout_reason = Reason::NotHappening;
+            return Ok(Output::Timeout(not_happening()));
         }
 
         while let Some(e) = self.ice.poll_event() {
@@ -1665,6 +1675,7 @@ impl Rtc {
                     break;
                 }
                 DtlsOutput::CloseNotify => {
+                    self.start_close()?;
                     return Ok(Output::Event(Event::Closed));
                 }
                 other => {
@@ -1718,6 +1729,7 @@ impl Rtc {
                     return Ok(Output::Event(Event::ChannelClose(id)));
                 }
                 SctpEvent::AssociationLost => {
+                    self.start_close()?;
                     return Ok(Output::Event(Event::Closed));
                 }
                 SctpEvent::Data { id, binary, data } => {
@@ -1801,39 +1813,14 @@ impl Rtc {
             time
         };
 
-        self.last_timeout_reason = reason;
-
-        Ok(Output::Timeout(next))
-    }
-
-    #[cold]
-    #[inline(never)]
-    fn poll_inactive_output(&mut self) -> Result<Output, RtcError> {
-        if self.state == RtcState::Closed {
+        if self.state == RtcState::Closing {
+            self.state = RtcState::Closed;
             self.last_timeout_reason = Reason::NotHappening;
             return Ok(Output::Timeout(not_happening()));
         }
 
-        loop {
-            if let DtlsOutput::Timeout(_) = self.dtls.poll_output(&mut self.dtls_buf) {
-                break;
-            }
-        }
-
-        if let Some(send) = &self.send_addr {
-            if let Some(contents) = self.dtls.poll_packet() {
-                return Ok(Output::Transmit(net::Transmit {
-                    proto: send.proto,
-                    source: send.source,
-                    destination: send.destination,
-                    contents,
-                }));
-            }
-        }
-
-        self.state = RtcState::Closed;
-        self.last_timeout_reason = Reason::NotHappening;
-        Ok(Output::Timeout(not_happening()))
+        self.last_timeout_reason = reason;
+        Ok(Output::Timeout(next))
     }
 
     /// The reason for the last [`Output::Timeout`]
@@ -1956,14 +1943,20 @@ impl Rtc {
 
     /// Sends the DTLS close_notify to the remote.
     ///
-    /// The close_notify packet will be emitted via the next `poll_output()` call
-    /// as a `Transmit`. Once the packet is drained, the `Rtc` instance becomes
-    /// not alive.
+    /// The `Rtc` instance enters a closing drain state where app-facing
+    /// operations stop, but [`Rtc::poll_output()`] continues polling the normal
+    /// protocol subsystems until pending shutdown output has drained. Once the
+    /// drain is complete, [`Rtc::is_alive()`] returns `false`.
     pub fn close(&mut self) -> Result<(), RtcError> {
-        if self.state != RtcState::Closed {
+        self.start_close()
+    }
+
+    fn start_close(&mut self) -> Result<(), RtcError> {
+        if self.state == RtcState::Alive {
+            self.dtls.close()?;
             self.state = RtcState::Closing;
         }
-        Ok(self.dtls.close()?)
+        Ok(())
     }
 
     fn init_time(&mut self, now: Instant) {
@@ -2068,7 +2061,7 @@ impl Rtc {
     /// // TODO write data channel data.
     /// ```
     pub fn channel(&mut self, id: ChannelId) -> Option<Channel<'_>> {
-        if self.state == RtcState::Closed {
+        if self.state != RtcState::Alive {
             return None;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -920,6 +920,7 @@ pub struct Rtc {
     last_timeout_reason: Reason,
     crypto_provider: Arc<crate::crypto::CryptoProvider>,
     fingerprint_verification: bool,
+    close_dtls_started: bool,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -1035,9 +1036,9 @@ pub enum Event {
 
     /// The remote DTLS connection or SCTP association has closed.
     ///
-    /// When this event is emitted, `Rtc` starts graceful local shutdown and
-    /// remains alive only while [`Rtc::poll_output()`] drains pending protocol
-    /// output such as the DTLS close_notify response.
+    /// When this event is emitted, `Rtc` starts local shutdown signals and
+    /// remains alive only while [`Rtc::poll_output()`] drains pending local
+    /// close output such as RTCP BYE and the DTLS close_notify response.
     Closed,
 
     /// Debug output of incoming and outgoing RTCP/RTP packets.
@@ -1284,6 +1285,7 @@ impl Rtc {
             last_timeout_reason: Reason::NotHappening,
             crypto_provider,
             fingerprint_verification: config.fingerprint_verification,
+            close_dtls_started: false,
         })
     }
 
@@ -1295,8 +1297,8 @@ impl Rtc {
     ///
     /// The instance can be manually disconnected using [`Rtc::disconnect()`].
     ///
-    /// During graceful shutdown, this remains `true` until [`Rtc::poll_output()`]
-    /// has drained pending protocol output. App-facing operations such as
+    /// During shutdown, this remains `true` until [`Rtc::poll_output()`]
+    /// has drained pending local close output. App-facing operations such as
     /// [`Rtc::writer()`] and [`Rtc::channel()`] are unavailable during that
     /// closing drain.
     ///
@@ -1698,6 +1700,15 @@ impl Rtc {
                             if is_would_block(&e) {
                                 self.sctp.push_back_transmit(packets);
                                 break;
+                            } else if self.state == RtcState::Closing {
+                                debug!(
+                                    "Dropping SCTP transmit while closing after DTLS error: {e}"
+                                );
+                                packets.pop_front();
+                                if !packets.is_empty() {
+                                    self.sctp.push_back_transmit(packets);
+                                }
+                                return self.do_poll_output();
                             } else {
                                 return Err(e.into());
                             }
@@ -1791,7 +1802,7 @@ impl Rtc {
             self.session.clear_feedback();
         }
 
-        let stats = self.stats.as_mut();
+        let stats_timeout = self.stats.as_mut().and_then(|s| s.poll_timeout());
 
         let time_and_reason = (None, Reason::NotHappening)
             .soonest((self.next_dtls_timeout, Reason::DTLS))
@@ -1799,7 +1810,7 @@ impl Rtc {
             .soonest(self.session.poll_timeout())
             .soonest((self.sctp.poll_timeout(), Reason::Sctp))
             .soonest((self.chan.poll_timeout(&self.sctp), Reason::Channel))
-            .soonest((stats.and_then(|s| s.poll_timeout()), Reason::Stats));
+            .soonest((stats_timeout, Reason::Stats));
 
         // trace!("poll_output timeout reason: {}", time_and_reason.1);
 
@@ -1813,7 +1824,7 @@ impl Rtc {
             time
         };
 
-        if self.state == RtcState::Closing {
+        if self.state == RtcState::Closing && self.close_drain_complete() {
             self.state = RtcState::Closed;
             self.last_timeout_reason = Reason::NotHappening;
             return Ok(Output::Timeout(not_happening()));
@@ -1941,22 +1952,42 @@ impl Rtc {
         Ok(())
     }
 
-    /// Sends the DTLS close_notify to the remote.
+    /// Starts local shutdown.
     ///
-    /// The `Rtc` instance enters a closing drain state where app-facing
-    /// operations stop, but [`Rtc::poll_output()`] continues polling the normal
-    /// protocol subsystems until pending shutdown output has drained. Once the
+    /// The `Rtc` instance schedules RTCP BYE, requests SCTP shutdown, and sends
+    /// DTLS close_notify without waiting for remote replies. It enters a closing
+    /// drain state where app-facing operations stop, but [`Rtc::poll_output()`]
+    /// continues polling until pending local close output has drained. Once the
     /// drain is complete, [`Rtc::is_alive()`] returns `false`.
     pub fn close(&mut self) -> Result<(), RtcError> {
         self.start_close()
     }
 
     fn start_close(&mut self) -> Result<(), RtcError> {
-        if self.state == RtcState::Alive {
-            self.dtls.close()?;
+        if self.state == RtcState::Closed {
+            return Ok(());
+        }
+
+        if self.state != RtcState::Closing {
+            self.session.close_rtp();
+            self.sctp.close()?;
             self.state = RtcState::Closing;
         }
+
+        self.start_dtls_close()
+    }
+
+    fn start_dtls_close(&mut self) -> Result<(), RtcError> {
+        if !self.close_dtls_started {
+            self.dtls.close()?;
+            self.close_dtls_started = true;
+        }
+
         Ok(())
+    }
+
+    fn close_drain_complete(&self) -> bool {
+        self.close_dtls_started && self.dtls.is_closed() && self.session.is_rtp_closed()
     }
 
     fn init_time(&mut self, now: Instant) {

--- a/src/sctp/mod.rs
+++ b/src/sctp/mod.rs
@@ -295,6 +295,14 @@ impl RtcSctp {
         self.state != RtcSctpState::Uninited
     }
 
+    pub fn is_closing(&self) -> bool {
+        self.assoc.as_ref().is_some_and(|a| a.is_closing())
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.assoc.as_ref().is_none_or(|a| a.is_closed())
+    }
+
     pub fn init(
         &mut self,
         client: bool,
@@ -519,6 +527,18 @@ impl RtcSctp {
         }
     }
 
+    pub fn close(&mut self) -> Result<(), SctpError> {
+        let Some(assoc) = &mut self.assoc else {
+            return Ok(());
+        };
+
+        if assoc.is_closing() || assoc.is_closed() {
+            return Ok(());
+        }
+
+        Ok(assoc.shutdown()?)
+    }
+
     pub fn is_open(&self, id: u16) -> bool {
         if self.state != RtcSctpState::Established {
             return false;
@@ -553,7 +573,7 @@ impl RtcSctp {
     }
 
     pub fn write(&mut self, id: u16, binary: bool, buf: &[u8]) -> Result<usize, SctpError> {
-        if self.state != RtcSctpState::Established {
+        if self.state != RtcSctpState::Established || self.is_closing() || self.is_closed() {
             return Err(SctpError::WriteBeforeEstablished);
         }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -25,7 +25,7 @@ use crate::rtp_::MidRid;
 use crate::rtp_::Pt;
 use crate::rtp_::SRTCP_OVERHEAD;
 use crate::rtp_::SeqNo;
-use crate::rtp_::{Bitrate, ExtensionMap, Mid, Rtcp, RtcpFb};
+use crate::rtp_::{Bitrate, ExtensionMap, Goodbye, Mid, ReportList, Rtcp, RtcpFb};
 use crate::rtp_::{RtpHeader, SessionId, TwccPacketId, extend_u16};
 use crate::rtp_::{SrtpContext, Ssrc};
 use crate::rtp_::{TwccRecvRegister, TwccSendRegister};
@@ -113,6 +113,7 @@ pub(crate) struct Session {
 
     feedback_tx: VecDeque<Rtcp>,
     feedback_rx: VecDeque<Rtcp>,
+    rtp_closing: bool,
 
     raw_packets: Option<VecDeque<Box<RawPacket>>>,
 
@@ -184,6 +185,7 @@ impl Session {
             vp9_packetizer_mode: config.vp9_packetizer_mode,
             feedback_tx: VecDeque::new(),
             feedback_rx: VecDeque::new(),
+            rtp_closing: false,
             raw_packets: if config.enable_raw_packets {
                 Some(VecDeque::new())
             } else {
@@ -243,6 +245,10 @@ impl Session {
     }
 
     pub fn handle_timeout(&mut self, now: Instant) -> Result<(), RtcError> {
+        if self.rtp_closing {
+            return Ok(());
+        }
+
         // Payload any waiting frames
         self.do_payload()?;
 
@@ -803,9 +809,12 @@ impl Session {
             return None;
         }
 
-        let x = None
-            .or_else(|| self.poll_feedback())
-            .or_else(|| self.poll_packet(now));
+        let x = if self.rtp_closing {
+            self.poll_feedback()
+        } else {
+            None.or_else(|| self.poll_feedback())
+                .or_else(|| self.poll_packet(now))
+        };
 
         if let Some(x) = &x {
             // In RTP mode we trust the API user feeds the RTP packet sizes they
@@ -824,6 +833,25 @@ impl Session {
     pub fn clear_feedback(&mut self) {
         self.feedback_rx.clear();
         self.feedback_tx.clear();
+    }
+
+    pub fn close_rtp(&mut self) {
+        if self.rtp_closing {
+            return;
+        }
+
+        self.rtp_closing = true;
+        self.clear_feedback();
+        self.streams.reset_send_buffers();
+
+        for reports in ReportList::lists_from_iter(self.streams.local_sender_ssrcs()) {
+            self.feedback_tx
+                .push_back(Rtcp::Goodbye(Goodbye { reports }));
+        }
+    }
+
+    pub fn is_rtp_closed(&self) -> bool {
+        self.rtp_closing && self.feedback_tx.is_empty()
     }
 
     fn poll_feedback(&mut self) -> Option<net::DatagramSend> {
@@ -940,6 +968,14 @@ impl Session {
     }
 
     pub fn poll_timeout(&mut self) -> (Option<Instant>, Reason) {
+        if self.rtp_closing {
+            return if self.feedback_tx.is_empty() {
+                (None, Reason::NotHappening)
+            } else {
+                (Some(already_happened()), Reason::Feedback)
+            };
+        }
+
         let feedback_at = self.regular_feedback_at();
         let nack_at = self.nack_at();
         let twcc_at = self.twcc_at();

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -351,6 +351,19 @@ impl Streams {
         self.streams_tx.remove(&ssrc).is_some()
     }
 
+    pub(crate) fn local_sender_ssrcs(&self) -> Vec<Ssrc> {
+        self.streams_tx
+            .values()
+            .flat_map(|s| std::iter::once(s.ssrc()).chain(s.rtx()))
+            .collect()
+    }
+
+    pub(crate) fn reset_send_buffers(&mut self) {
+        for stream in self.streams_tx.values_mut() {
+            stream.reset_buffers();
+        }
+    }
+
     pub fn stream_rx(&mut self, ssrc: &Ssrc) -> Option<&mut StreamRx> {
         self.streams_rx.get_mut(ssrc)
     }

--- a/tests/dtls-close.rs
+++ b/tests/dtls-close.rs
@@ -11,19 +11,26 @@
 use std::net::Ipv4Addr;
 use std::time::Instant;
 
-use str0m::{Candidate, Event, Input, Output, Rtc, RtcError};
+use str0m::media::MediaKind;
+use str0m::rtp::rtcp::Rtcp;
+use str0m::rtp::{RawPacket, Ssrc};
+use str0m::{Candidate, Event, Input, Output, Rtc, RtcConfig, RtcError};
 use tracing::info_span;
 
 mod common;
 use common::{TestRtc, init_crypto_default, init_log, progress};
 
 fn direct_pair() -> (TestRtc, TestRtc) {
+    direct_pair_with_config(|c| c)
+}
+
+fn direct_pair_with_config(configure: impl Fn(RtcConfig) -> RtcConfig) -> (TestRtc, TestRtc) {
     init_log();
     init_crypto_default();
 
     let now = Instant::now();
-    let mut l = TestRtc::new_with_rtc(info_span!("L"), Rtc::new(now));
-    let mut r = TestRtc::new_with_rtc(info_span!("R"), Rtc::new(now));
+    let mut l = TestRtc::new_with_rtc(info_span!("L"), configure(Rtc::builder()).build(now));
+    let mut r = TestRtc::new_with_rtc(info_span!("R"), configure(Rtc::builder()).build(now));
 
     let host_l = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp").unwrap();
     let host_r = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp").unwrap();
@@ -151,6 +158,29 @@ fn remote_dtls_close_auto_replies_before_rtc_closes() -> Result<(), RtcError> {
     });
 
     assert!(!r.rtc.is_alive());
+
+    Ok(())
+}
+
+#[test]
+fn close_sends_rtcp_bye_for_local_senders() -> Result<(), RtcError> {
+    let (mut l, mut r) = direct_pair_with_config(|c| c.enable_raw_packets(true));
+    let mid = "aud".into();
+    let ssrc: Ssrc = 42.into();
+
+    l.direct_api().declare_media(mid, MediaKind::Audio);
+    l.direct_api().declare_stream_tx(ssrc, None, mid, None);
+
+    l.rtc.close()?;
+
+    progress_until(&mut l, &mut r, "RTCP BYE", |l, _| {
+        l.events.iter().any(|(_, event)| {
+            matches!(
+                event.as_raw_packet(),
+                Some(RawPacket::RtcpTx(Rtcp::Goodbye(bye))) if bye.reports.iter().any(|s| *s == ssrc)
+            )
+        })
+    });
 
     Ok(())
 }

--- a/tests/dtls-close.rs
+++ b/tests/dtls-close.rs
@@ -1,5 +1,4 @@
-//! Test that calling `Rtc::close()` sends a DTLS close_notify alert
-//! and marks the Rtc instance as not alive.
+//! Tests for the Rtc shutdown states.
 #![cfg(any(
     feature = "aws-lc-rs",
     feature = "rust-crypto",
@@ -12,14 +11,13 @@
 use std::net::Ipv4Addr;
 use std::time::Instant;
 
-use str0m::{Candidate, Event, Rtc};
+use str0m::{Candidate, Event, Input, Output, Rtc, RtcError};
 use tracing::info_span;
 
 mod common;
 use common::{TestRtc, init_crypto_default, init_log, progress};
 
-#[test]
-fn close_notify_received_by_remote() {
+fn direct_pair() -> (TestRtc, TestRtc) {
     init_log();
     init_crypto_default();
 
@@ -52,51 +50,107 @@ fn close_notify_received_by_remote() {
     l.direct_api().start_sctp(true);
     r.direct_api().start_sctp(false);
 
-    // Drive both sides until connected.
-    let mut iterations = 0;
-    while !(l.is_connected() && r.is_connected()) {
-        progress(&mut l, &mut r).unwrap();
-        iterations += 1;
-        assert!(iterations < 500, "DTLS handshake did not complete");
+    progress_until(&mut l, &mut r, "DTLS handshake", |l, r| {
+        l.is_connected() && r.is_connected()
+    });
+
+    (l, r)
+}
+
+fn progress_until(
+    l: &mut TestRtc,
+    r: &mut TestRtc,
+    label: &str,
+    mut done: impl FnMut(&TestRtc, &TestRtc) -> bool,
+) {
+    for _ in 0..500 {
+        if done(l, r) {
+            return;
+        }
+        progress(l, r).unwrap();
     }
-    println!("Both peers connected after {iterations} iterations");
 
-    // L initiates close.
-    println!("L calling close()");
-    l.rtc.close().expect("L close");
+    panic!("{label} did not complete");
+}
 
-    // Drive the close_notify packet from L to R.
-    let mut r_got_closed = false;
-    for i in 0..100 {
-        progress(&mut l, &mut r).unwrap();
-        if r.events.iter().any(|(_, e)| matches!(e, Event::Closed)) {
-            println!("R received Event::Closed after {i} progress iterations");
-            r_got_closed = true;
-            break;
+fn next_transmit(rtc: &mut TestRtc) -> str0m::net::Transmit {
+    for _ in 0..100 {
+        match rtc.rtc.poll_output().unwrap() {
+            Output::Transmit(transmit) => return transmit,
+            Output::Event(event) => rtc.events.push((rtc.last, event)),
+            Output::Timeout(_) => {}
         }
     }
+
+    panic!("expected transmit");
+}
+
+fn deliver(transmit: &str0m::net::Transmit, rtc: &mut TestRtc) -> Result<(), RtcError> {
+    rtc.rtc
+        .handle_input(Input::Receive(rtc.last, transmit.try_into()?))
+}
+
+fn deliver_until_closed_event(
+    sender: &mut TestRtc,
+    receiver: &mut TestRtc,
+) -> Result<(), RtcError> {
+    for _ in 0..100 {
+        let transmit = next_transmit(sender);
+        deliver(&transmit, receiver)?;
+
+        for _ in 0..100 {
+            match receiver.rtc.poll_output()? {
+                Output::Event(Event::Closed) => return Ok(()),
+                Output::Event(event) => receiver.events.push((receiver.last, event)),
+                Output::Transmit(_) => {}
+                Output::Timeout(_) => break,
+            }
+        }
+    }
+
+    panic!("expected remote closed event");
+}
+
+#[test]
+fn local_dtls_close_drains_before_rtc_closes() -> Result<(), RtcError> {
+    let (mut l, mut r) = direct_pair();
+
+    l.rtc.close()?;
 
     assert!(
-        r_got_closed,
-        "R should receive Event::Closed after L sends close_notify"
+        l.rtc.is_alive(),
+        "local close_notify still needs to be emitted"
     );
 
-    // After close, L should no longer be alive
-    assert!(!l.rtc.is_alive(), "L should not be alive after close");
+    progress_until(&mut l, &mut r, "local DTLS close", |l, r| {
+        !l.rtc.is_alive()
+            && r.events
+                .iter()
+                .any(|(_, event)| matches!(event, Event::Closed))
+    });
 
-    // R also initiates close and drains.
-    println!("R calling close()");
-    r.rtc.close().expect("R close");
+    assert!(!l.rtc.is_alive());
 
-    // poll_output needs to be called on R to drain the close and set alive=false.
-    // We need enough progress() calls to let R catch up timewise with L
-    // since progress() uses a 5ms window per call.
-    for _ in 0..100 {
-        progress(&mut l, &mut r).unwrap();
-        if !r.rtc.is_alive() {
-            break;
-        }
-    }
+    Ok(())
+}
 
-    assert!(!r.rtc.is_alive(), "R should not be alive after close");
+#[test]
+fn remote_dtls_close_auto_replies_before_rtc_closes() -> Result<(), RtcError> {
+    let (mut l, mut r) = direct_pair();
+
+    l.rtc.close()?;
+    deliver_until_closed_event(&mut l, &mut r)?;
+
+    assert!(
+        r.rtc.is_alive(),
+        "remote close_notify should leave Rtc alive until the response close_notify drains"
+    );
+
+    progress_until(&mut l, &mut r, "remote DTLS close reply", |_, r| {
+        !r.rtc.is_alive()
+    });
+
+    assert!(!r.rtc.is_alive());
+
+    Ok(())
 }


### PR DESCRIPTION
Summary

Normalize RTC closing so `RtcState::Closing` means the connection is draining local close output rather than waiting for peer shutdown replies. Closing keeps the regular poll path active only until local close output has drained.

`Rtc::close()` now schedules RTCP BYE, requests SCTP shutdown, and starts DTLS close_notify together. DTLS close is no longer delayed on SCTP reaching a closed state; if SCTP shutdown output can no longer be carried because DTLS is already closing, it is dropped during the close drain.

Incoming DTLS close_notify and SCTP association loss enter the same closing path, so str0m responds with local close signals and lets `poll_output()` drain them before `is_alive()` becomes false.

Schedule RTCP BYE for local RTP senders on close, drop pending media and ordinary feedback, and stop scheduling new RTP/RTCP work while preserving close-related output.

Use the published close-state predicates from `sctp-proto` and `dimpl` so str0m delegates SCTP and DTLS closing/closed semantics to the owning subsystems.