### PR TITLE
Fix AV1 depacketizer overflow on unsized OBU aggregation

### DIFF
--- a/src/packet/av1.rs
+++ b/src/packet/av1.rs
@@ -369,8 +369,7 @@ impl Depacketizer for Av1Depacketizer {
         let mut obu_idx: usize = 0;
         while reader.remaining_bits() > 0 {
             let is_first_obu = obu_idx == 0;
-            let mut is_last_obu =
-                self.obu_count != 0 && obu_idx == (self.obu_count as usize - 1);
+            let mut is_last_obu = self.obu_count != 0 && obu_idx == (self.obu_count as usize - 1);
 
             // Read the length of obu
             let fragment_obu_length = if self.obu_count == 0 || !is_last_obu {

--- a/src/packet/av1.rs
+++ b/src/packet/av1.rs
@@ -366,10 +366,11 @@ impl Depacketizer for Av1Depacketizer {
         }
         *codec_extra = CodecExtra::Av1(Av1CodecExtra { is_keyframe });
 
-        let mut obu_idx = 0;
+        let mut obu_idx: usize = 0;
         while reader.remaining_bits() > 0 {
             let is_first_obu = obu_idx == 0;
-            let mut is_last_obu = self.obu_count != 0 && obu_idx == (self.obu_count - 1);
+            let mut is_last_obu =
+                self.obu_count != 0 && obu_idx == (self.obu_count as usize - 1);
 
             // Read the length of obu
             let fragment_obu_length = if self.obu_count == 0 || !is_last_obu {


### PR DESCRIPTION
obu_idx was inferred as u8 because it was compared against obu_count (u8). When the aggregation header signals no OBU count (obu_count == 0), the depacketize loop reads OBU fragments until the packet is exhausted, incrementing obu_idx each iteration. A packet with more than 255 OBU fragments overflowed the u8 at 'obu_idx += 1', panicking with 'attempt to add with overflow'.

Make obu_idx a usize and cast obu_count in the comparison (guarded by the obu_count != 0 check, so no underflow). Found by the depack_direct fuzz target.