### PR TITLE
Expose StreamTx send queue information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
   * Replace timeout scans with a global scheduler while preserving the `Reason` API #1008
+  * Expose the latest send queue information on `StreamTx` #1005
   * Fix VP9 non-flexible SS advertising a bogus R=0 GOF for single-layer streams #999
   * Support G722 audio codec (16 kHz codec with 8 kHz RTP clock per RFC 3551) #992
   * Apply reliability parameters to a DCEP-receiving in-band channel #1004

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -790,7 +790,9 @@ pub mod rtp {
         Vp8Descriptor, Vp8DescriptorError, Vp8Patch, Vp8PatchBuilder, Vp8PatchError,
     };
     pub use crate::rtp_::{RtpHeader, SeqNo, Ssrc, VideoOrientation};
-    pub use crate::streams::{RtpPacket, RtpWrite, StreamPaused, StreamRx, StreamTx};
+    pub use crate::streams::{
+        RtpPacket, RtpWrite, StreamPaused, StreamRx, StreamTx, StreamTxQueueInfo,
+    };
 
     /// Debug output of the unencrypted RTP and RTCP packets.
     ///

--- a/src/pacer/leaky.rs
+++ b/src/pacer/leaky.rs
@@ -368,7 +368,7 @@ impl LeakyBucketPacer {
                     (
                         acc.0 + q.snapshot.total_queue_time(now),
                         acc.1 + q.snapshot.packet_count,
-                        acc.2 + DataSize::from(q.snapshot.size),
+                        acc.2 + DataSize::from(q.snapshot.byte_size),
                     )
                 });
         if queued_packets == 0 {
@@ -886,7 +886,7 @@ mod test {
             use_for_padding: true,
             snapshot: QueueSnapshot {
                 created_at: now,
-                size: 10_usize,
+                byte_size: 10_usize,
                 packet_count: 1332,
                 total_queue_time_origin: duration_ms(1_000),
                 last_emitted: Some(now + duration_ms(500)),
@@ -901,7 +901,7 @@ mod test {
             use_for_padding: false,
             snapshot: QueueSnapshot {
                 created_at: now,
-                size: 30_usize,
+                byte_size: 30_usize,
                 packet_count: 5,
                 total_queue_time_origin: duration_ms(337),
                 last_emitted: None,
@@ -913,7 +913,7 @@ mod test {
         state.snapshot.merge(&other.snapshot);
 
         assert_eq!(state.midrid.mid(), Mid::from("001"));
-        assert_eq!(state.snapshot.size, 40_usize);
+        assert_eq!(state.snapshot.byte_size, 40_usize);
         assert_eq!(state.snapshot.packet_count, 1337);
         assert_eq!(state.snapshot.total_queue_time_origin, duration_ms(1337));
 
@@ -1347,7 +1347,7 @@ mod test {
                     use_for_padding: !self.is_audio && self.last_emitted.is_some(),
                     snapshot: QueueSnapshot {
                         created_at: now,
-                        size: self.queue.iter().map(QueuedPacket::size).sum(),
+                        byte_size: self.queue.iter().map(QueuedPacket::size).sum(),
                         packet_count: self.packet_count,
                         total_queue_time_origin: self.total_time_spent_queued,
                         last_emitted: self.last_emitted,

--- a/src/pacer/queue.rs
+++ b/src/pacer/queue.rs
@@ -8,7 +8,7 @@ pub struct QueueSnapshot {
     /// Time this snapshot was made
     pub created_at: Instant,
     /// The total byte size of the snapshot.
-    pub size: usize,
+    pub byte_size: usize,
     /// The total number of packets in the queue.
     /// NB: This is not a [`usize`] because it will later be used to divide a [`Duration`], for which
     /// [`usize`] isn't implement. If the queues end up with 2^32 packets something has gone very wrong
@@ -56,7 +56,7 @@ impl Default for QueueSnapshot {
     fn default() -> Self {
         Self {
             created_at: not_happening(),
-            size: Default::default(),
+            byte_size: Default::default(),
             packet_count: Default::default(),
             total_queue_time_origin: Default::default(),
             last_emitted: Default::default(),
@@ -89,7 +89,7 @@ impl QueueSnapshot {
     /// Merge other into self.
     pub fn merge(&mut self, other: &Self) {
         self.created_at = self.created_at.min(other.created_at);
-        self.size += other.size;
+        self.byte_size += other.byte_size;
         self.packet_count += other.packet_count;
         self.total_queue_time_origin += other.total_queue_time_origin;
         self.last_emitted = self.last_emitted.max(other.last_emitted);

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -19,7 +19,7 @@ use crate::scheduler::Scheduler;
 use crate::util::already_happened;
 
 pub use self::receive::StreamRx;
-pub use self::send::{RtpWrite, StreamTx};
+pub use self::send::{RtpWrite, StreamTx, StreamTxQueueInfo};
 
 mod receive;
 pub(crate) mod register;

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -41,8 +41,13 @@ pub const DEFAULT_RTX_CACHE_DURATION: Duration = Duration::from_secs(3);
 pub const DEFAULT_RTX_RATIO_CAP: Option<f32> = Some(0.15f32);
 
 /// A recently sampled view of an outgoing stream's send queue.
+///
+/// str0m refreshes this information as part of its regular pacer and bandwidth-estimation
+/// processing. Reading it does not cause a new value to be computed.
 pub trait StreamTxQueueInfo {
     /// When this queue information was sampled.
+    ///
+    /// Compare this value between reads to determine whether str0m has computed a new sample.
     fn created_at(&self) -> Instant;
 
     /// Total number of bytes in the queue.
@@ -360,6 +365,8 @@ impl StreamTx {
     /// Information sampled during the latest pacer update for this stream's send queue.
     ///
     /// This is `None` until the pacer has observed the stream for the first time.
+    /// Calling this method does not refresh the information; use
+    /// [`StreamTxQueueInfo::created_at()`] to determine whether a new sample is available.
     pub fn queue_info(&self) -> Option<&dyn StreamTxQueueInfo> {
         self.queue_info
             .as_ref()

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -360,7 +360,6 @@ impl StreamTx {
     /// Information sampled during the latest pacer update for this stream's send queue.
     ///
     /// This is `None` until the pacer has observed the stream for the first time.
-    /// The returned information is only valid when bandwidth estimation (BWE) is enabled.
     pub fn queue_info(&self) -> Option<&dyn StreamTxQueueInfo> {
         self.queue_info
             .as_ref()

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -40,6 +40,39 @@ pub const DEFAULT_RTX_CACHE_DURATION: Duration = Duration::from_secs(3);
 
 pub const DEFAULT_RTX_RATIO_CAP: Option<f32> = Some(0.15f32);
 
+/// A recently sampled view of an outgoing stream's send queue.
+pub trait StreamTxQueueInfo {
+    /// When this queue information was sampled.
+    fn created_at(&self) -> Instant;
+
+    /// Total number of bytes in the queue.
+    fn byte_size(&self) -> usize;
+
+    /// Total number of packets in the queue.
+    fn packet_count(&self) -> usize;
+
+    /// When the first packet still in the queue was enqueued.
+    fn first_unsent(&self) -> Option<Instant>;
+}
+
+impl StreamTxQueueInfo for QueueSnapshot {
+    fn created_at(&self) -> Instant {
+        self.created_at
+    }
+
+    fn byte_size(&self) -> usize {
+        self.byte_size
+    }
+
+    fn packet_count(&self) -> usize {
+        self.packet_count as usize
+    }
+
+    fn first_unsent(&self) -> Option<Instant> {
+        self.first_unsent
+    }
+}
+
 /// Outgoing encoded stream.
 ///
 /// A stream is a primary SSRC + optional RTX SSRC.
@@ -86,6 +119,9 @@ pub struct StreamTx {
     /// The packets here do not have correct sequence numbers, header extension values etc.
     /// They must be updated when we are about to send.
     send_queue: SendQueue,
+
+    /// The queue information sampled during the latest pacer update.
+    queue_info: Option<QueueSnapshot>,
 
     /// Whether this sender is to be unpaced in BWE situations.
     ///
@@ -278,6 +314,7 @@ impl StreamTx {
             last_used: already_happened(),
             rtp_and_wallclock: None,
             send_queue: SendQueue::new(),
+            queue_info: None,
             unpaced: None,
             resends: VecDeque::new(),
             padding: 0,
@@ -318,6 +355,16 @@ impl StreamTx {
     /// This is used to separate streams with the same [`Mid`] when using simulcast.
     pub fn rid(&self) -> Option<Rid> {
         self.midrid.rid()
+    }
+
+    /// Information sampled during the latest pacer update for this stream's send queue.
+    ///
+    /// This is `None` until the pacer has observed the stream for the first time.
+    /// The returned information is only valid when bandwidth estimation (BWE) is enabled.
+    pub fn queue_info(&self) -> Option<&dyn StreamTxQueueInfo> {
+        self.queue_info
+            .as_ref()
+            .map(|info| info as &dyn StreamTxQueueInfo)
     }
 
     /// Configure the RTX (resend) cache.
@@ -1048,6 +1095,8 @@ impl StreamTx {
             snapshot.merge(&snapshot_padding);
         }
 
+        self.queue_info = Some(snapshot);
+
         QueueState {
             midrid: self.midrid,
             unpaced,
@@ -1067,7 +1116,7 @@ impl StreamTx {
             .iter()
             .fold(QueueSnapshot::default(), |mut snapshot, r| {
                 snapshot.total_queue_time_origin += now.duration_since(r.queued_at);
-                snapshot.size += r.payload_size;
+                snapshot.byte_size += r.payload_size;
                 snapshot.packet_count += 1;
                 snapshot.first_unsent = snapshot
                     .first_unsent
@@ -1097,7 +1146,7 @@ impl StreamTx {
 
         Some(QueueSnapshot {
             created_at: now,
-            size: self.padding,
+            byte_size: self.padding,
             packet_count: fake_packets as u32,
             total_queue_time_origin: fake_duration,
             priority: QueuePriority::Padding,
@@ -1160,6 +1209,7 @@ impl StreamTx {
 
     pub(crate) fn reset_buffers(&mut self) {
         self.send_queue.clear();
+        self.queue_info = None;
         self.rtx_cache.clear();
         self.resends.clear();
         self.padding = 0;
@@ -1222,4 +1272,34 @@ struct Resend {
     seq_no: SeqNo,
     queued_at: Instant,
     payload_size: usize,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn queue_info_is_cached_on_queue_state_update() {
+        let mut stream = StreamTx::new(42.into(), None, MidRid(Mid::from("0"), None), false, 1200);
+
+        assert!(stream.queue_info().is_none());
+
+        let now = Instant::now();
+        let first_unsent = now - Duration::from_millis(10);
+        stream.resends.push_back(Resend {
+            seq_no: 7.into(),
+            queued_at: first_unsent,
+            payload_size: 123,
+        });
+        stream.queue_state(now);
+
+        let info = stream.queue_info().expect("queue info after pacer update");
+        assert_eq!(info.created_at(), now);
+        assert_eq!(info.byte_size(), 123);
+        assert_eq!(info.packet_count(), 1);
+        assert_eq!(info.first_unsent(), Some(first_unsent));
+
+        stream.reset_buffers();
+        assert!(stream.queue_info().is_none());
+    }
 }

--- a/src/streams/send_queue.rs
+++ b/src/streams/send_queue.rs
@@ -91,7 +91,7 @@ impl SendQueue {
 
         QueueSnapshot {
             created_at: now,
-            size: self.total.unsent_size,
+            byte_size: self.total.unsent_size,
             packet_count: self.total.unsent_count as u32,
             total_queue_time_origin: self.total.queue_time,
             last_emitted: self.last_emitted,
@@ -233,7 +233,7 @@ mod test {
             QueueSnapshot {
                 created_at: snapshot_at,
                 packet_count: 0,
-                size: 0,
+                byte_size: 0,
                 total_queue_time_origin: Duration::ZERO,
                 first_unsent: None,
                 priority: QueuePriority::Empty,
@@ -270,7 +270,7 @@ mod test {
             QueueSnapshot {
                 created_at: snapshot_at,
                 packet_count: 1,
-                size: 2,
+                byte_size: 2,
                 total_queue_time_origin: Duration::from_secs(3),
                 first_unsent: Some(start),
                 priority: QueuePriority::Media,


### PR DESCRIPTION
## Summary

Expose the latest BWE send-queue snapshot through `StreamTx::queue_info()` and the public `StreamTxQueueInfo` trait. Keep the pacer snapshot cached per stream, preserve its native `Instant` fields, and rename the internal byte count to `byte_size`.

Closes #1001