### PR TITLE
Cache per-stream timeout state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Cache per-stream timeout state to skip idle timeout work #1006
   * Fix VP9 non-flexible SS advertising a bogus R=0 GOF for single-layer streams #999
   * Support G722 audio codec (16 kHz codec with 8 kHz RTP clock per RFC 3551) #992
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -1010,7 +1010,7 @@ impl Session {
         self.streams.regular_feedback_at()
     }
 
-    fn paused_at(&mut self) -> Option<Instant> {
+    fn paused_at(&self) -> Option<Instant> {
         self.streams.paused_at()
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -1006,11 +1006,11 @@ impl Session {
         self.medias.iter().any(|m| m.mid() == mid)
     }
 
-    fn regular_feedback_at(&self) -> Option<Instant> {
+    fn regular_feedback_at(&mut self) -> Option<Instant> {
         self.streams.regular_feedback_at()
     }
 
-    fn paused_at(&self) -> Option<Instant> {
+    fn paused_at(&mut self) -> Option<Instant> {
         self.streams.paused_at()
     }
 

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -406,17 +406,23 @@ impl Streams {
     }
 
     pub(crate) fn regular_feedback_at(&mut self) -> Option<Instant> {
-        let r = self.streams_rx.values_mut().map(|s| s.receiver_report_at());
-        let s = self.streams_tx.values_mut().map(|s| s.sender_report_at());
+        let r = self
+            .streams_rx
+            .values_mut()
+            .map(|s| s.poll_receiver_report_at());
+        let s = self
+            .streams_tx
+            .values_mut()
+            .map(|s| s.poll_sender_report_at());
         r.chain(s).min()
     }
 
-    pub(crate) fn paused_at(&mut self) -> Option<Instant> {
-        self.streams_rx.values_mut().find_map(|s| s.paused_at())
+    pub(crate) fn paused_at(&self) -> Option<Instant> {
+        self.streams_rx.values().find_map(|s| s.paused_at())
     }
 
-    pub(crate) fn send_stream(&mut self) -> Option<Instant> {
-        self.streams_tx.values_mut().find_map(|s| s.send_at())
+    pub(crate) fn send_stream(&self) -> Option<Instant> {
+        self.streams_tx.values().find_map(|s| s.send_at())
     }
 
     pub(crate) fn is_receiving(&self) -> bool {
@@ -433,7 +439,7 @@ impl Streams {
         feedback: &mut VecDeque<Rtcp>,
     ) {
         self.mids_to_report.clear(); // Clear for checking StreamRx.
-        for stream in self.streams_rx.values_mut() {
+        for stream in self.streams_rx.values() {
             if stream.need_rr(now) {
                 self.mids_to_report.push(stream.mid());
             }
@@ -461,7 +467,7 @@ impl Streams {
         }
 
         self.mids_to_report.clear(); // start over for StreamTx.
-        for stream in self.streams_tx.values_mut() {
+        for stream in self.streams_tx.values() {
             if stream.need_sr(now) {
                 self.mids_to_report.push(stream.mid());
             }

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -405,22 +405,18 @@ impl Streams {
         None
     }
 
-    pub(crate) fn regular_feedback_at(&self) -> Option<Instant> {
-        let r = self.streams_rx.values().map(|s| s.receiver_report_at());
-        let s = self.streams_tx.values().map(|s| s.sender_report_at());
+    pub(crate) fn regular_feedback_at(&mut self) -> Option<Instant> {
+        let r = self.streams_rx.values_mut().map(|s| s.receiver_report_at());
+        let s = self.streams_tx.values_mut().map(|s| s.sender_report_at());
         r.chain(s).min()
     }
 
-    pub(crate) fn paused_at(&self) -> Option<Instant> {
-        self.streams_rx.values().find_map(|s| s.paused_at())
+    pub(crate) fn paused_at(&mut self) -> Option<Instant> {
+        self.streams_rx.values_mut().find_map(|s| s.paused_at())
     }
 
-    pub(crate) fn send_stream(&self) -> Option<Instant> {
-        if self.streams_tx.values().any(|s| s.need_timeout()) {
-            Some(already_happened())
-        } else {
-            None
-        }
+    pub(crate) fn send_stream(&mut self) -> Option<Instant> {
+        self.streams_tx.values_mut().find_map(|s| s.send_at())
     }
 
     pub(crate) fn is_receiving(&self) -> bool {
@@ -437,18 +433,23 @@ impl Streams {
         feedback: &mut VecDeque<Rtcp>,
     ) {
         self.mids_to_report.clear(); // Clear for checking StreamRx.
-        for stream in self.streams_rx.values() {
+        for stream in self.streams_rx.values_mut() {
             if stream.need_rr(now) {
                 self.mids_to_report.push(stream.mid());
             }
         }
 
         for stream in self.streams_rx.values_mut() {
+            let report_due = self.mids_to_report.contains(&stream.mid());
+            if !stream.timeout_due(now, report_due, do_nack) {
+                continue;
+            }
+
             stream.maybe_create_keyframe_request(sender_ssrc, feedback);
             stream.maybe_create_remb_request(sender_ssrc, feedback);
 
             // All StreamRx belonging to the same Mid are reported together.
-            if self.mids_to_report.contains(&stream.mid()) {
+            if report_due {
                 stream.create_rr_and_update(now, sender_ssrc, feedback);
             }
 
@@ -460,7 +461,7 @@ impl Streams {
         }
 
         self.mids_to_report.clear(); // start over for StreamTx.
-        for stream in self.streams_tx.values() {
+        for stream in self.streams_tx.values_mut() {
             if stream.need_sr(now) {
                 self.mids_to_report.push(stream.mid());
             }
@@ -468,9 +469,13 @@ impl Streams {
 
         for stream in self.streams_tx.values_mut() {
             let mid = stream.mid();
+            let report_due = self.mids_to_report.contains(&mid);
+            if !stream.timeout_due(now, report_due) {
+                continue;
+            }
 
             // All StreamTx belonging to the same Mid are reported together.
-            if self.mids_to_report.contains(&mid) {
+            if report_due {
                 stream.create_sr_and_update(now, feedback);
             }
 

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -18,6 +18,13 @@ use super::StreamPaused;
 use super::register::ReceiverRegister;
 use super::{RtpPacket, rr_interval};
 
+#[derive(Debug, Clone, Copy)]
+struct TimeoutCache {
+    feedback_at: Instant,
+    paused_at: Option<Instant>,
+    has_pending_feedback: bool,
+}
+
 /// Incoming encoded stream.
 ///
 /// A stream is a primary SSRC + optional RTX SSRC.
@@ -107,6 +114,10 @@ pub struct StreamRx {
 
     /// The configured threshold before considering the lack of packets as going into paused.
     pause_threshold: Duration,
+
+    /// Timeout state calculated while polling output. Mutable entry points
+    /// invalidate this so the next time update visits the stream.
+    timeout_cache: Option<TimeoutCache>,
 }
 
 /// The last sender info we recieved.
@@ -168,6 +179,7 @@ impl StreamRx {
             paused: true,
             need_paused_event: false,
             pause_threshold: Duration::from_millis(1500),
+            timeout_cache: None,
         }
     }
 
@@ -206,6 +218,7 @@ impl StreamRx {
     ///
     /// This event is emitted when no packet have received for this duration.
     pub fn set_pause_threshold(&mut self, t: Duration) {
+        self.invalidate_timeout();
         self.pause_threshold = t;
     }
 
@@ -221,6 +234,7 @@ impl StreamRx {
     /// * SSRC the identifier of the remote encoded stream to request a keyframe for.
     /// * kind PLI or FIR.
     pub fn request_keyframe(&mut self, kind: KeyframeRequestKind) {
+        self.invalidate_timeout();
         self.pending_request_keyframe = Some(kind);
     }
 
@@ -228,6 +242,7 @@ impl StreamRx {
     ///
     /// * bitrate Bitrate.
     pub fn request_remb(&mut self, bitrate: Bitrate) {
+        self.invalidate_timeout();
         self.pending_request_remb = Some(bitrate);
     }
 
@@ -236,15 +251,59 @@ impl StreamRx {
     /// Normally NACK is disabled by not having an RTX SSRC set. In some situations it might be
     /// desirable to manually suppress NACK sending regardless of RTX setting.
     pub fn suppress_nack(&mut self, suppress: bool) {
+        self.invalidate_timeout();
         self.suppress_nack = suppress;
     }
 
-    pub(crate) fn receiver_report_at(&self) -> Instant {
+    fn calculate_receiver_report_at(&self) -> Instant {
         let is_audio = self.rtx.is_none(); // this is maybe not correct, but it's all we got.
         self.last_receiver_report + rr_interval(is_audio)
     }
 
+    #[inline(always)]
+    pub(crate) fn receiver_report_at(&mut self) -> Instant {
+        self.poll_timeout().feedback_at
+    }
+
+    #[inline(always)]
+    pub(crate) fn paused_at(&mut self) -> Option<Instant> {
+        self.poll_timeout().paused_at
+    }
+
+    #[inline(always)]
+    fn poll_timeout(&mut self) -> TimeoutCache {
+        if let Some(cache) = self.timeout_cache {
+            return cache;
+        }
+
+        let cache = TimeoutCache {
+            feedback_at: self.calculate_receiver_report_at(),
+            paused_at: self.check_paused_at,
+            has_pending_feedback: self.pending_request_keyframe.is_some()
+                || self.pending_request_remb.is_some(),
+        };
+        self.timeout_cache = Some(cache);
+        cache
+    }
+
+    #[inline(always)]
+    pub(crate) fn timeout_due(&self, now: Instant, report_due: bool, do_nack: bool) -> bool {
+        report_due
+            || (do_nack && self.nack_enabled())
+            || self.timeout_cache.is_none_or(|cache| {
+                cache.has_pending_feedback
+                    || cache.paused_at.is_some_and(|deadline| deadline <= now)
+            })
+    }
+
+    #[inline(always)]
+    fn invalidate_timeout(&mut self) {
+        self.timeout_cache = None;
+    }
+
     pub(crate) fn handle_rtcp(&mut self, now: Instant, fb: RtcpFb) {
+        self.invalidate_timeout();
+
         use RtcpFb::*;
         match fb {
             SenderInfo(v) => {
@@ -314,11 +373,9 @@ impl StreamRx {
         self.stats.rtt = rtt;
     }
 
-    pub(crate) fn paused_at(&self) -> Option<Instant> {
-        self.check_paused_at
-    }
-
     pub(crate) fn handle_timeout(&mut self, now: Instant) {
+        self.invalidate_timeout();
+
         // No scheduled paused check?
         if self.check_paused_at.is_none() {
             return;
@@ -343,6 +400,8 @@ impl StreamRx {
         is_repair: bool,
         max_seq_lookup: impl Fn(Ssrc) -> Option<SeqNo>,
     ) -> SeqNo {
+        self.invalidate_timeout();
+
         // Select reference to register to use depending on RTX or not. The RTX has a separate
         // sequence number series to the main register.
         let register_ref = if is_repair {
@@ -390,6 +449,8 @@ impl StreamRx {
         is_repair: bool,
         seq_no: SeqNo,
     ) -> RegisterUpdateReceipt {
+        self.invalidate_timeout();
+
         self.last_used = now;
 
         let was_paused = self.paused;
@@ -455,6 +516,8 @@ impl StreamRx {
         seq_no: SeqNo,
         time: MediaTime,
     ) -> RtpPacket {
+        self.invalidate_timeout();
+
         trace!("Handle RTP: {:?}", header);
 
         let need_clock_rate = self.last_clock_rate.map(|(pt, _)| pt) != Some(header.payload_type);
@@ -510,6 +573,8 @@ impl StreamRx {
         sender_ssrc: Ssrc,
         feedback: &mut VecDeque<Rtcp>,
     ) {
+        self.invalidate_timeout();
+
         let Some(kind) = self.pending_request_keyframe.take() else {
             return;
         };
@@ -540,6 +605,8 @@ impl StreamRx {
         sender_ssrc: Ssrc,
         feedback: &mut VecDeque<Rtcp>,
     ) {
+        self.invalidate_timeout();
+
         let Some(bitrate) = self.pending_request_remb.take() else {
             return;
         };
@@ -558,7 +625,7 @@ impl StreamRx {
         x
     }
 
-    pub(crate) fn need_rr(&self, now: Instant) -> bool {
+    pub(crate) fn need_rr(&mut self, now: Instant) -> bool {
         if self.ssrc.is_probe() {
             return false;
         }
@@ -572,6 +639,8 @@ impl StreamRx {
         sender_ssrc: Ssrc,
         feedback: &mut VecDeque<Rtcp>,
     ) {
+        self.invalidate_timeout();
+
         let mut rr = self.create_receiver_report(now);
         rr.sender_ssrc = sender_ssrc;
 
@@ -656,6 +725,8 @@ impl StreamRx {
         sender_ssrc: Ssrc,
         feedback: &mut VecDeque<Rtcp>,
     ) -> Option<()> {
+        self.invalidate_timeout();
+
         if !self.nack_enabled() {
             return None;
         }
@@ -684,6 +755,8 @@ impl StreamRx {
     }
 
     pub(crate) fn poll_paused(&mut self) -> Option<StreamPaused> {
+        self.invalidate_timeout();
+
         if self.ssrc.is_probe() {
             return None;
         }
@@ -711,6 +784,8 @@ impl StreamRx {
 
     /// Poll the most recent sender info and when it was received
     pub(crate) fn poll_sender_info(&mut self) -> Option<(SenderInfo, Instant)> {
+        self.invalidate_timeout();
+
         let i = self.sender_info.as_mut()?;
         if i.emitted {
             return None;
@@ -722,6 +797,8 @@ impl StreamRx {
     }
 
     pub(crate) fn reset_buffers(&mut self, max_seq_lookup: impl Fn(Ssrc) -> Option<SeqNo>) {
+        self.invalidate_timeout();
+
         if let Some(r) = &mut self.register {
             r.clear(max_seq_lookup(self.ssrc));
         }
@@ -734,6 +811,8 @@ impl StreamRx {
 
     #[must_use]
     pub(crate) fn change_ssrc(&mut self, ssrc: Ssrc) -> bool {
+        self.invalidate_timeout();
+
         // Avoid flapping
         if ssrc == self.ssrc || Some(ssrc) == self.previous_ssrc {
             return false;
@@ -767,6 +846,8 @@ impl StreamRx {
     }
 
     pub(crate) fn maybe_reset_rtx(&mut self, rtx: Ssrc) {
+        self.invalidate_timeout();
+
         if let Some(current) = self.rtx {
             if current == rtx {
                 return;
@@ -798,6 +879,8 @@ impl StreamRx {
     /// > initial value is provided by out of band signaling such as key
     /// > management).
     pub fn reset_roc(&mut self, roc: u64) {
+        self.invalidate_timeout();
+
         self.register = None;
         self.register_rtx = None;
         self.reset_roc = Some(roc);
@@ -863,6 +946,34 @@ pub(crate) struct RegisterUpdateReceipt {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cached_timeout_short_circuits_until_due_or_mutated() {
+        let now = Instant::now();
+        let mut stream = StreamRx::new(7.into(), MidRid("mid".into(), None), false);
+        stream.rtx = Some(8.into());
+        stream.last_receiver_report = now;
+
+        let report_at = now + rr_interval(false);
+        assert_eq!(stream.receiver_report_at(), report_at);
+        assert!(!stream.timeout_due(now, false, false));
+        assert!(stream.timeout_due(report_at, true, false));
+
+        stream.request_keyframe(KeyframeRequestKind::Pli);
+        assert!(stream.timeout_due(now, false, false));
+    }
+
+    #[test]
+    fn discovering_rtx_invalidates_audio_report_deadline() {
+        let now = Instant::now();
+        let mut stream = StreamRx::new(7.into(), MidRid("mid".into(), None), false);
+        stream.last_receiver_report = now;
+
+        assert_eq!(stream.receiver_report_at(), now + rr_interval(true));
+
+        stream.maybe_reset_rtx(8.into());
+        assert_eq!(stream.receiver_report_at(), now + rr_interval(false));
+    }
 
     #[test]
     fn paused_timestamp_repair_moves_time_forward() {

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -255,19 +255,14 @@ impl StreamRx {
         self.suppress_nack = suppress;
     }
 
-    fn calculate_receiver_report_at(&self) -> Instant {
+    pub(crate) fn receiver_report_at(&self) -> Instant {
         let is_audio = self.rtx.is_none(); // this is maybe not correct, but it's all we got.
         self.last_receiver_report + rr_interval(is_audio)
     }
 
     #[inline(always)]
-    pub(crate) fn receiver_report_at(&mut self) -> Instant {
+    pub(crate) fn poll_receiver_report_at(&mut self) -> Instant {
         self.poll_timeout().feedback_at
-    }
-
-    #[inline(always)]
-    pub(crate) fn paused_at(&mut self) -> Option<Instant> {
-        self.poll_timeout().paused_at
     }
 
     #[inline(always)]
@@ -277,7 +272,7 @@ impl StreamRx {
         }
 
         let cache = TimeoutCache {
-            feedback_at: self.calculate_receiver_report_at(),
+            feedback_at: self.receiver_report_at(),
             paused_at: self.check_paused_at,
             has_pending_feedback: self.pending_request_keyframe.is_some()
                 || self.pending_request_remb.is_some(),
@@ -371,6 +366,10 @@ impl StreamRx {
         let ntp_time = now.to_ntp_duration();
         let rtt = calculate_rtt(ntp_time, dlrr.last_rr_delay, dlrr.last_rr_time);
         self.stats.rtt = rtt;
+    }
+
+    pub(crate) fn paused_at(&self) -> Option<Instant> {
+        self.check_paused_at
     }
 
     pub(crate) fn handle_timeout(&mut self, now: Instant) {
@@ -625,7 +624,7 @@ impl StreamRx {
         x
     }
 
-    pub(crate) fn need_rr(&mut self, now: Instant) -> bool {
+    pub(crate) fn need_rr(&self, now: Instant) -> bool {
         if self.ssrc.is_probe() {
             return false;
         }
@@ -955,7 +954,7 @@ mod tests {
         stream.last_receiver_report = now;
 
         let report_at = now + rr_interval(false);
-        assert_eq!(stream.receiver_report_at(), report_at);
+        assert_eq!(stream.poll_receiver_report_at(), report_at);
         assert!(!stream.timeout_due(now, false, false));
         assert!(stream.timeout_due(report_at, true, false));
 
@@ -969,10 +968,10 @@ mod tests {
         let mut stream = StreamRx::new(7.into(), MidRid("mid".into(), None), false);
         stream.last_receiver_report = now;
 
-        assert_eq!(stream.receiver_report_at(), now + rr_interval(true));
+        assert_eq!(stream.poll_receiver_report_at(), now + rr_interval(true));
 
         stream.maybe_reset_rtx(8.into());
-        assert_eq!(stream.receiver_report_at(), now + rr_interval(false));
+        assert_eq!(stream.poll_receiver_report_at(), now + rr_interval(false));
     }
 
     #[test]

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -18,13 +18,6 @@ use super::StreamPaused;
 use super::register::ReceiverRegister;
 use super::{RtpPacket, rr_interval};
 
-#[derive(Debug, Clone, Copy)]
-struct TimeoutCache {
-    feedback_at: Instant,
-    paused_at: Option<Instant>,
-    has_pending_feedback: bool,
-}
-
 /// Incoming encoded stream.
 ///
 /// A stream is a primary SSRC + optional RTX SSRC.
@@ -118,6 +111,13 @@ pub struct StreamRx {
     /// Timeout state calculated while polling output. Mutable entry points
     /// invalidate this so the next time update visits the stream.
     timeout_cache: Option<TimeoutCache>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TimeoutCache {
+    feedback_at: Instant,
+    paused_at: Option<Instant>,
+    has_pending_feedback: bool,
 }
 
 /// The last sender info we recieved.

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -38,12 +38,6 @@ pub const DEFAULT_RTX_CACHE_DURATION: Duration = Duration::from_secs(3);
 
 pub const DEFAULT_RTX_RATIO_CAP: Option<f32> = Some(0.15f32);
 
-#[derive(Debug, Clone, Copy)]
-struct TimeoutCache {
-    feedback_at: Instant,
-    send_at: Option<Instant>,
-}
-
 /// Outgoing encoded stream.
 ///
 /// A stream is a primary SSRC + optional RTX SSRC.
@@ -147,6 +141,12 @@ pub struct StreamTx {
     /// Timeout state calculated while polling output. Mutable entry points
     /// invalidate this so the next time update visits the stream.
     timeout_cache: Option<TimeoutCache>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TimeoutCache {
+    feedback_at: Instant,
+    send_at: Option<Instant>,
 }
 
 /// RTP packet data to enqueue on a direct RTP send stream.

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -860,7 +860,7 @@ impl StreamTx {
         })
     }
 
-    fn calculate_sender_report_at(&self) -> Instant {
+    pub(crate) fn sender_report_at(&self) -> Instant {
         let Some(kind) = self.kind else {
             // First handle_timeout sets the kind. No sender report until then.
             return not_happening();
@@ -869,13 +869,14 @@ impl StreamTx {
     }
 
     #[inline(always)]
-    pub(crate) fn sender_report_at(&mut self) -> Instant {
+    pub(crate) fn poll_sender_report_at(&mut self) -> Instant {
         self.poll_timeout().feedback_at
     }
 
     #[inline(always)]
-    pub(crate) fn send_at(&mut self) -> Option<Instant> {
-        self.poll_timeout().send_at
+    pub(crate) fn send_at(&self) -> Option<Instant> {
+        self.timeout_cache
+            .map_or(Some(already_happened()), |cache| cache.send_at)
     }
 
     #[inline(always)]
@@ -885,7 +886,7 @@ impl StreamTx {
         }
 
         let cache = TimeoutCache {
-            feedback_at: self.calculate_sender_report_at(),
+            feedback_at: self.sender_report_at(),
             send_at: (self.kind.is_none() || self.need_timeout()).then_some(already_happened()),
         };
         self.timeout_cache = Some(cache);
@@ -984,7 +985,7 @@ impl StreamTx {
         Some(())
     }
 
-    pub(crate) fn need_sr(&mut self, now: Instant) -> bool {
+    pub(crate) fn need_sr(&self, now: Instant) -> bool {
         now >= self.sender_report_at()
     }
 
@@ -1299,7 +1300,7 @@ mod tests {
         stream.last_sender_report = now;
 
         let report_at = now + rr_interval(false);
-        assert_eq!(stream.sender_report_at(), report_at);
+        assert_eq!(stream.poll_sender_report_at(), report_at);
         assert!(!stream.timeout_due(now, false));
         assert!(stream.timeout_due(report_at, true));
 
@@ -1311,6 +1312,7 @@ mod tests {
     fn uninitialized_stream_requests_immediate_timeout() {
         let mut stream = StreamTx::new(7.into(), None, MidRid("mid".into(), None), false, 1200);
 
+        stream.poll_sender_report_at();
         assert_eq!(stream.send_at(), Some(already_happened()));
     }
 }

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -38,6 +38,12 @@ pub const DEFAULT_RTX_CACHE_DURATION: Duration = Duration::from_secs(3);
 
 pub const DEFAULT_RTX_RATIO_CAP: Option<f32> = Some(0.15f32);
 
+#[derive(Debug, Clone, Copy)]
+struct TimeoutCache {
+    feedback_at: Instant,
+    send_at: Option<Instant>,
+}
+
 /// Outgoing encoded stream.
 ///
 /// A stream is a primary SSRC + optional RTX SSRC.
@@ -137,6 +143,10 @@ pub struct StreamTx {
 
     /// MTU warn threshold; used to cap spurious-padding RTX cache lookups.
     mtu_warn: usize,
+
+    /// Timeout state calculated while polling output. Mutable entry points
+    /// invalidate this so the next time update visits the stream.
+    timeout_cache: Option<TimeoutCache>,
 }
 
 /// RTP packet data to enqueue on a direct RTP send stream.
@@ -291,6 +301,7 @@ impl StreamTx {
             remote_acked_ssrc: false,
             remote_acked_rtx_ssrc: false,
             mtu_warn,
+            timeout_cache: None,
         }
     }
 
@@ -333,6 +344,8 @@ impl StreamTx {
         max_age: Duration,
         rtx_ratio_cap: Option<f32>,
     ) {
+        self.invalidate_timeout();
+
         // Dump old cache to avoid having to deal with resizing logic inside the cache impl.
         self.rtx_cache = RtxCache::new(max_packets, max_age);
         if rtx_ratio_cap.is_some() {
@@ -356,6 +369,7 @@ impl StreamTx {
     ///
     /// This overrides the default behavior.
     pub fn set_unpaced(&mut self, unpaced: bool) {
+        self.invalidate_timeout();
         self.unpaced = Some(unpaced);
     }
 
@@ -363,6 +377,8 @@ impl StreamTx {
     ///
     /// The write command carries the RTP payload and optional RTP metadata.
     pub fn write_rtp(&mut self, rtp: RtpWrite) {
+        self.invalidate_timeout();
+
         let RtpWrite {
             pt,
             seq_no,
@@ -439,6 +455,8 @@ impl StreamTx {
         params: &[PayloadParams],
         buf: &mut Vec<u8>,
     ) -> Option<PacketReceipt> {
+        self.invalidate_timeout();
+
         let mid = self.midrid.mid();
         let rid = self.midrid.rid();
         let ssrc_rtx = self.rtx;
@@ -842,7 +860,7 @@ impl StreamTx {
         })
     }
 
-    pub(crate) fn sender_report_at(&self) -> Instant {
+    fn calculate_sender_report_at(&self) -> Instant {
         let Some(kind) = self.kind else {
             // First handle_timeout sets the kind. No sender report until then.
             return not_happening();
@@ -850,15 +868,56 @@ impl StreamTx {
         self.last_sender_report + rr_interval(kind.is_audio())
     }
 
+    #[inline(always)]
+    pub(crate) fn sender_report_at(&mut self) -> Instant {
+        self.poll_timeout().feedback_at
+    }
+
+    #[inline(always)]
+    pub(crate) fn send_at(&mut self) -> Option<Instant> {
+        self.poll_timeout().send_at
+    }
+
+    #[inline(always)]
+    fn poll_timeout(&mut self) -> TimeoutCache {
+        if let Some(cache) = self.timeout_cache {
+            return cache;
+        }
+
+        let cache = TimeoutCache {
+            feedback_at: self.calculate_sender_report_at(),
+            send_at: (self.kind.is_none() || self.need_timeout()).then_some(already_happened()),
+        };
+        self.timeout_cache = Some(cache);
+        cache
+    }
+
+    #[inline(always)]
+    pub(crate) fn timeout_due(&self, now: Instant, report_due: bool) -> bool {
+        report_due
+            || self
+                .timeout_cache
+                .is_none_or(|cache| cache.send_at.is_some_and(|deadline| deadline <= now))
+    }
+
+    #[inline(always)]
+    fn invalidate_timeout(&mut self) {
+        self.timeout_cache = None;
+    }
+
     pub(crate) fn poll_keyframe_request(&mut self) -> Option<KeyframeRequestKind> {
+        self.invalidate_timeout();
         self.pending_request_keyframe.take()
     }
 
     pub(crate) fn poll_remb_request(&mut self) -> Option<Bitrate> {
+        self.invalidate_timeout();
         self.pending_request_remb.take()
     }
 
     pub(crate) fn handle_rtcp(&mut self, now: Instant, fb: RtcpFb) {
+        self.invalidate_timeout();
+
         use RtcpFb::*;
         match fb {
             ReceptionReport(r) => {
@@ -900,6 +959,8 @@ impl StreamTx {
         entries: impl Iterator<Item = NackEntry>,
         now: Instant,
     ) -> Option<()> {
+        self.invalidate_timeout();
+
         // Turning NackEntry into SeqNo we need to know a SeqNo "close by" to lengthen the 16 bit
         // sequence number into the 64 bit we have in SeqNo.
         let seq_no = self.rtx_cache.last_cached_seq_no()?;
@@ -923,11 +984,13 @@ impl StreamTx {
         Some(())
     }
 
-    pub(crate) fn need_sr(&self, now: Instant) -> bool {
+    pub(crate) fn need_sr(&mut self, now: Instant) -> bool {
         now >= self.sender_report_at()
     }
 
     pub(crate) fn create_sr_and_update(&mut self, now: Instant, feedback: &mut VecDeque<Rtcp>) {
+        self.invalidate_timeout();
+
         let sr = self.create_sender_report(now);
 
         trace!("Created feedback SR: {:?}", sr);
@@ -1001,6 +1064,7 @@ impl StreamTx {
     }
 
     pub(crate) fn next_seq_no(&mut self) -> SeqNo {
+        self.invalidate_timeout();
         self.seq_no.inc()
     }
 
@@ -1013,10 +1077,13 @@ impl StreamTx {
     }
 
     pub(crate) fn visit_stats(&mut self, snapshot: &mut StatsSnapshot, now: Instant) {
+        self.invalidate_timeout();
         self.stats.fill(snapshot, self.midrid, now);
     }
 
     pub(crate) fn queue_state(&mut self, now: Instant) -> QueueState {
+        self.invalidate_timeout();
+
         // The unpaced flag is set to a default value on first handle_timeout. The
         // default is to not pace audio. We unwrap default to "true" here to not
         // apply any pacing until we know what kind of content we are sending.
@@ -1094,6 +1161,8 @@ impl StreamTx {
     }
 
     pub(crate) fn generate_padding(&mut self, padding: usize) {
+        self.invalidate_timeout();
+
         if !self.padding_enabled() {
             return;
         }
@@ -1109,6 +1178,8 @@ impl StreamTx {
         now: Instant,
         get_media: impl FnOnce() -> (&'a Media, &'a CodecConfig),
     ) {
+        self.invalidate_timeout();
+
         // If kind is None, this is the first time we ever get a handle_timeout.
         if self.kind.is_none() {
             let (media, config) = get_media();
@@ -1147,6 +1218,8 @@ impl StreamTx {
     }
 
     pub(crate) fn reset_buffers(&mut self) {
+        self.invalidate_timeout();
+
         self.send_queue.clear();
         self.rtx_cache.clear();
         self.resends.clear();
@@ -1157,6 +1230,8 @@ impl StreamTx {
     ///
     /// This updates the SSRCs and resets all relevant internal fields.
     pub(crate) fn reset_ssrc(&mut self, new_ssrc: Ssrc, new_rtx: Option<Ssrc>) {
+        self.invalidate_timeout();
+
         // Update the SSRC and RTX
         self.ssrc = new_ssrc;
         self.rtx = new_rtx;
@@ -1210,4 +1285,32 @@ struct Resend {
     seq_no: SeqNo,
     queued_at: Instant,
     payload_size: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cached_timeout_short_circuits_until_due() {
+        let now = Instant::now();
+        let mut stream = StreamTx::new(7.into(), None, MidRid("mid".into(), None), false, 1200);
+        stream.kind = Some(MediaKind::Video);
+        stream.last_sender_report = now;
+
+        let report_at = now + rr_interval(false);
+        assert_eq!(stream.sender_report_at(), report_at);
+        assert!(!stream.timeout_due(now, false));
+        assert!(stream.timeout_due(report_at, true));
+
+        stream.invalidate_timeout();
+        assert!(stream.timeout_due(now, false));
+    }
+
+    #[test]
+    fn uninitialized_stream_requests_immediate_timeout() {
+        let mut stream = StreamTx::new(7.into(), None, MidRid("mid".into(), None), false, 1200);
+
+        assert_eq!(stream.send_at(), Some(already_happened()));
+    }
 }


### PR DESCRIPTION
## Summary

Cache timeout state within `StreamTx` and `StreamRx`, invalidating it at mutable entry points. Keep the simple stream loops while using forced-inline deadline checks to skip child timeout work until a stream is dirty or due, preserving grouped RTCP reports and NACK processing.

Addresses the stream timeout traversal identified in #922.