### PR TITLE
Fix Rust 1.97 lint failures

### DIFF
--- a/crypto/openssl/src/dtls_ossl.rs
+++ b/crypto/openssl/src/dtls_ossl.rs
@@ -59,7 +59,7 @@ impl io::Read for IoBuffer {
         buf[..max].copy_from_slice(&self.incoming[..max]);
 
         if max == self.incoming.len() {
-            self.incoming.truncate(0);
+            self.incoming.clear();
         } else {
             self.incoming.drain(..max);
         }

--- a/src/rtp/rtcp/remb.rs
+++ b/src/rtp/rtcp/remb.rs
@@ -7,7 +7,7 @@ const BITRATE_MAX: f32 = 2.417_842_4e24; //0x3FFFFp+63;
 const MANTISSA_MAX: u32 = 0x7FFFFF;
 const REMB_OFFSET: usize = 16;
 
-const UNIQUE_IDENTIFIER: [u8; 4] = [b'R', b'E', b'M', b'B'];
+const UNIQUE_IDENTIFIER: [u8; 4] = *b"REMB";
 
 /*
     0                   1                   2                   3

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -449,10 +449,9 @@ impl StreamTx {
             (next, false)
         } else if let Some(next) = self.poll_packet_regular(now) {
             (next, false)
-        } else if let Some(next) = self.poll_packet_padding(now) {
-            (next, true)
         } else {
-            return None;
+            let next = self.poll_packet_padding(now)?;
+            (next, true)
         };
 
         let pop_send_queue = next.kind == NextPacketKind::Regular;


### PR DESCRIPTION
## Summary

Update three lint-triggering idioms for Rust 1.97: use byte-string syntax for the REMB identifier, simplify the final optional packet branch with `?`, and clear the OpenSSL DTLS input buffer directly.