### PR TITLE
perf: skip the per-stream and per-media walks in poll_event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
   * Replace `Reason` with precise `Timer` identities and a global timeout scheduler (breaking) #1008
+  * Skip the per-stream and per-media walks in `poll_event` when no event is queued #1009
   * Fix VP9 non-flexible SS advertising a bogus R=0 GOF for single-layer streams #999
   * Support G722 audio codec (16 kHz codec with 8 kHz RTP clock per RFC 3551) #992
   * Apply reliability parameters to a DCEP-receiving in-band channel #1004

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -946,6 +946,11 @@ fn as_sdp(session: &Session, params: AsSdpParams) -> Sdp {
 fn apply_offer(session: &mut Session, offer: SdpOffer) -> Result<(), RtcError> {
     offer.assert_consistency()?;
 
+    // Applying an SDP can queue MediaAdded and MediaChanged, via several paths.
+    // Mark once here rather than at each of them: negotiation is rare, and a
+    // spurious mark costs one extra walk, never a missed event.
+    session.mark_event_ready();
+
     update_session(session, &offer);
 
     let bundle_mids = offer.bundle_mids();
@@ -964,6 +969,9 @@ fn apply_answer(
     answer: SdpAnswer,
 ) -> Result<(), RtcError> {
     answer.assert_consistency()?;
+
+    // See apply_offer: the same events can be queued when applying an answer.
+    session.mark_event_ready();
 
     update_session(session, &answer);
 
@@ -1185,9 +1193,6 @@ fn add_new_lines(
                 .unwrap_or(false);
             let is_rejected = m.disabled && !is_in_bundle;
             media.need_open_event = is_offer && !is_rejected;
-            if media.need_open_event {
-                session.mark_event_ready();
-            }
 
             // Match/remap remote params.
             session

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -1185,6 +1185,9 @@ fn add_new_lines(
                 .unwrap_or(false);
             let is_rejected = m.disabled && !is_in_bundle;
             media.need_open_event = is_offer && !is_rejected;
+            if media.need_open_event {
+                session.mark_event_ready();
+            }
 
             // Match/remap remote params.
             session

--- a/src/session.rs
+++ b/src/session.rs
@@ -44,37 +44,6 @@ const NACK_MIN_INTERVAL: Duration = Duration::from_millis(33);
 /// Delay between reports of TWCC. This is deliberately very low.
 const TWCC_INTERVAL: Duration = Duration::from_millis(50);
 
-/// Coarse "something might be waiting" flag for the `poll_event` walks.
-///
-/// `poll_event()` answers "does any stream have a keyframe request, a fresh sender
-/// report, a pause transition?" and "does any media have a completed sample?" by
-/// walking every stream and every media. In a 1:1 call that is invisible. In a
-/// conference each `Rtc` holds roughly one m-line per remote participant, and an SFU
-/// calls `poll_output()` thousands of times a second per connection, so the walks are
-/// paid O(N) times per connection and O(N^2) per room. The overwhelming majority of
-/// them find nothing.
-///
-/// The paths that queue an event mark this. The walks only run while it is marked, and
-/// it is cleared once a full poll has come back empty. Correctness does not depend on
-/// the mark being tight: a spurious mark costs one extra walk, never a missed event.
-#[derive(Debug, Default)]
-pub(crate) struct Readiness(bool);
-
-impl Readiness {
-    /// An event has been queued somewhere: the walks must run again.
-    pub(crate) fn mark(&mut self) {
-        self.0 = true;
-    }
-
-    fn is_marked(&self) -> bool {
-        self.0
-    }
-
-    fn clear(&mut self) {
-        self.0 = false;
-    }
-}
-
 pub(crate) struct Session {
     id: SessionId,
 
@@ -1394,6 +1363,37 @@ fn update_max_seq(map: &mut HashMap<Ssrc, SeqNo>, ssrc: Ssrc, seq_no: SeqNo) {
     let current = map.entry(ssrc).or_insert(seq_no);
     if seq_no > *current {
         *current = seq_no;
+    }
+}
+
+/// Coarse "something might be waiting" flag for the `poll_event` walks.
+///
+/// `poll_event()` answers "does any stream have a keyframe request, a fresh sender
+/// report, a pause transition?" and "does any media have a completed sample?" by
+/// walking every stream and every media. In a 1:1 call that is invisible. In a
+/// conference each `Rtc` holds roughly one m-line per remote participant, and an SFU
+/// calls `poll_output()` thousands of times a second per connection, so the walks are
+/// paid O(N) times per connection and O(N^2) per room. The overwhelming majority of
+/// them find nothing.
+///
+/// The paths that queue an event mark this. The walks only run while it is marked, and
+/// it is cleared once a full poll has come back empty. Correctness does not depend on
+/// the mark being tight: a spurious mark costs one extra walk, never a missed event.
+#[derive(Debug, Default)]
+pub(crate) struct Readiness(bool);
+
+impl Readiness {
+    /// An event has been queued somewhere: the walks must run again.
+    pub(crate) fn mark(&mut self) {
+        self.0 = true;
+    }
+
+    fn is_marked(&self) -> bool {
+        self.0
+    }
+
+    fn clear(&mut self) {
+        self.0 = false;
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -44,6 +44,37 @@ const NACK_MIN_INTERVAL: Duration = Duration::from_millis(33);
 /// Delay between reports of TWCC. This is deliberately very low.
 const TWCC_INTERVAL: Duration = Duration::from_millis(50);
 
+/// Coarse "something might be waiting" flag for the `poll_event` walks.
+///
+/// `poll_event()` answers "does any stream have a keyframe request, a fresh sender
+/// report, a pause transition?" and "does any media have a completed sample?" by
+/// walking every stream and every media. In a 1:1 call that is invisible. In a
+/// conference each `Rtc` holds roughly one m-line per remote participant, and an SFU
+/// calls `poll_output()` thousands of times a second per connection, so the walks are
+/// paid O(N) times per connection and O(N^2) per room. The overwhelming majority of
+/// them find nothing.
+///
+/// The paths that queue an event mark this. The walks only run while it is marked, and
+/// it is cleared once a full poll has come back empty. Correctness does not depend on
+/// the mark being tight: a spurious mark costs one extra walk, never a missed event.
+#[derive(Debug, Default)]
+pub(crate) struct Readiness(bool);
+
+impl Readiness {
+    /// An event has been queued somewhere: the walks must run again.
+    pub(crate) fn mark(&mut self) {
+        self.0 = true;
+    }
+
+    fn is_marked(&self) -> bool {
+        self.0
+    }
+
+    fn clear(&mut self) {
+        self.0 = false;
+    }
+}
+
 pub(crate) struct Session {
     id: SessionId,
 
@@ -54,6 +85,9 @@ pub(crate) struct Session {
 
     // The actual RTP encoded streams.
     pub streams: Streams,
+
+    /// Whether any of the `poll_event` walks can currently find something.
+    event_ready: Readiness,
 
     /// The app m-line. Spliced into medias above.
     app: Option<(Mid, usize)>,
@@ -152,6 +186,7 @@ impl Session {
             id,
             medias: vec![],
             streams: Streams::new(enable_stats, *config.mtu.end()),
+            event_ready: Readiness::default(),
             app: None,
             reordering_size_audio: config.reordering_size_audio,
             reordering_size_video: config.reordering_size_video,
@@ -307,7 +342,7 @@ impl Session {
                     self.create_twcc_feedback(sender_ssrc, now);
                 }
             }
-            Timer::PauseCheck(ssrc) => self.streams.handle_pause(now, ssrc),
+            Timer::PauseCheck(ssrc) => self.streams.handle_pause(now, ssrc, &mut self.event_ready),
             Timer::SendStream(ssrc) => {
                 self.streams
                     .handle_send_stream(now, ssrc, &self.medias, &self.codec_config);
@@ -633,7 +668,14 @@ impl Session {
         update_max_seq(&mut self.max_rx_seq_lookup, header.ssrc, seq_no);
 
         // Register reception in nack registers.
-        let receipt_outer = stream.update_register(now, &header, clock_rate, is_repair, seq_no);
+        let receipt_outer = stream.update_register(
+            now,
+            &header,
+            clock_rate,
+            is_repair,
+            seq_no,
+            &mut self.event_ready,
+        );
 
         // RTX packets must be rewritten to be a normal packet. This only changes the
         // the seq_no, however MediaTime might be different when interpreted against the
@@ -660,7 +702,14 @@ impl Session {
             update_max_seq(&mut self.max_rx_seq_lookup, header.ssrc, seq_no);
 
             // Now update the "main" register with the repaired packet info.
-            let receipt = stream.update_register(now, &header, clock_rate, false, seq_no);
+            let receipt = stream.update_register(
+                now,
+                &header,
+                clock_rate,
+                false,
+                seq_no,
+                &mut self.event_ready,
+            );
             (receipt, data)
         } else {
             // This is not RTX, the outer seq and time is what we use. The first
@@ -699,6 +748,9 @@ impl Session {
                 self.reordering_size_video,
                 &self.codec_config,
             );
+            // The depayloader may have completed a sample, so poll_event_fallible()
+            // has something to find.
+            self.event_ready.mark();
         }
     }
 
@@ -747,14 +799,14 @@ impl Session {
                 let Some(stream) = self.streams.stream_rx(&ssrc) else {
                     continue;
                 };
-                stream.handle_rtcp(now, fb);
+                stream.handle_rtcp(now, fb, &mut self.event_ready);
                 s.invalidate(TimerScope::StreamRx(ssrc));
             } else {
                 let ssrc = fb.ssrc();
                 let Some(stream) = self.streams.stream_tx(&ssrc) else {
                     continue;
                 };
-                stream.handle_rtcp(now, fb);
+                stream.handle_rtcp(now, fb, &mut self.event_ready);
                 s.invalidate(TimerScope::StreamTx(ssrc));
             }
         }
@@ -799,21 +851,29 @@ impl Session {
 
         // This must be before pending_packet.take() since we need to emit the unpaused event
         // before the first packet causing the unpause.
-        if let Some(paused) = self.streams.poll_stream_paused() {
-            if paused.paused {
-                if let Some(media) = self.medias.iter_mut().find(|m| m.mid() == paused.mid) {
-                    // Drop held partial depacketizer state so pre-pause fragments can't
-                    // complete into stale MediaData after the stream resumes.
-                    media.reset_depayloaders_for_rid(paused.rid);
+        if self.event_ready.is_marked() {
+            if let Some(paused) = self.streams.poll_stream_paused() {
+                if paused.paused {
+                    if let Some(media) = self.medias.iter_mut().find(|m| m.mid() == paused.mid) {
+                        // Drop held partial depacketizer state so pre-pause fragments can't
+                        // complete into stale MediaData after the stream resumes.
+                        media.reset_depayloaders_for_rid(paused.rid);
+                    }
                 }
+                return Some(Event::StreamPaused(paused));
             }
-            return Some(Event::StreamPaused(paused));
         }
 
         if self.rtp_mode {
             if let Some(packet) = self.pending_packet.take() {
                 return Some(Event::RtpPacket(packet));
             }
+        }
+
+        // Everything below walks every stream or every media. Skip the lot unless a
+        // producing path has actually queued something.
+        if !self.event_ready.is_marked() {
+            return None;
         }
 
         if let Some(req) = self.streams.poll_keyframe_request() {
@@ -848,6 +908,11 @@ impl Session {
                 }));
             }
         }
+
+        // Every walk above came back empty, so the mark is spent. It is only reached
+        // once SRTP is ready, which matters: before that poll_event() bails out early
+        // and MediaAdded/MediaChanged are still queued from negotiation.
+        self.event_ready.clear();
 
         None
     }
@@ -1175,7 +1240,14 @@ impl Session {
         self.medias.len() + if self.app.is_some() { 1 } else { 0 }
     }
 
+    /// A path outside `Session` queued an event (see `Readiness`).
+    pub(crate) fn mark_event_ready(&mut self) {
+        self.event_ready.mark();
+    }
+
     pub fn add_media(&mut self, media: Media) {
+        // Media::new() sets need_open_event, so poll_event has a MediaAdded to surface.
+        self.event_ready.mark();
         self.medias.push(media);
     }
 
@@ -1249,6 +1321,8 @@ impl Session {
         }
 
         media.set_direction(direction);
+        // May have set need_changed_event, so poll_event has a MediaChanged to surface.
+        self.event_ready.mark();
 
         if old_dir.is_sending() && !direction.is_sending() {
             self.streams.reset_buffers_tx(mid);

--- a/src/session.rs
+++ b/src/session.rs
@@ -909,10 +909,12 @@ impl Session {
             }
         }
 
-        // Every walk above came back empty, so the mark is spent. It is only reached
-        // once SRTP is ready, which matters: before that poll_event() bails out early
-        // and MediaAdded/MediaChanged are still queued from negotiation.
-        self.event_ready.clear();
+        // Every walk above came back empty. In rtp_mode nothing else walks, so the mark
+        // is spent here. In media mode poll_event_fallible() still has the sample walk,
+        // and clears it when that also comes back empty.
+        if self.rtp_mode {
+            self.event_ready.clear();
+        }
 
         None
     }
@@ -923,10 +925,22 @@ impl Session {
             return Ok(None);
         }
 
+        if !self.event_ready.is_marked() {
+            return Ok(None);
+        }
+
         for media in &mut self.medias {
             if let Some(e) = media.poll_sample(&self.codec_config)? {
                 return Ok(Some(Event::MediaData(e)));
             }
+        }
+
+        // poll_event() runs its walks before this one, so both have now come back empty
+        // and the mark is spent. Only clear once those walks have actually had their
+        // chance though: until SRTP is ready poll_event() bails out early, and
+        // MediaAdded/MediaChanged are queued during negotiation, before that point.
+        if self.ready_for_srtp() {
+            self.event_ready.clear();
         }
 
         Ok(None)

--- a/src/session.rs
+++ b/src/session.rs
@@ -668,14 +668,9 @@ impl Session {
         update_max_seq(&mut self.max_rx_seq_lookup, header.ssrc, seq_no);
 
         // Register reception in nack registers.
-        let receipt_outer = stream.update_register(
-            now,
-            &header,
-            clock_rate,
-            is_repair,
-            seq_no,
-            &mut self.event_ready,
-        );
+        let ready = &mut self.event_ready;
+        let receipt_outer =
+            stream.update_register(now, &header, clock_rate, is_repair, seq_no, ready);
 
         // RTX packets must be rewritten to be a normal packet. This only changes the
         // the seq_no, however MediaTime might be different when interpreted against the
@@ -702,14 +697,8 @@ impl Session {
             update_max_seq(&mut self.max_rx_seq_lookup, header.ssrc, seq_no);
 
             // Now update the "main" register with the repaired packet info.
-            let receipt = stream.update_register(
-                now,
-                &header,
-                clock_rate,
-                false,
-                seq_no,
-                &mut self.event_ready,
-            );
+            let ready = &mut self.event_ready;
+            let receipt = stream.update_register(now, &header, clock_rate, false, seq_no, ready);
             (receipt, data)
         } else {
             // This is not RTX, the outer seq and time is what we use. The first
@@ -755,6 +744,7 @@ impl Session {
     }
 
     fn handle_rtcp(&mut self, now: Instant, buf: &[u8], s: &mut Scheduler) -> Option<()> {
+        let ready = &mut self.event_ready;
         let srtp: &mut SrtpContext = self.srtp_rx.as_mut()?;
         let unprotected = srtp.unprotect_rtcp(buf)?;
 
@@ -799,14 +789,14 @@ impl Session {
                 let Some(stream) = self.streams.stream_rx(&ssrc) else {
                     continue;
                 };
-                stream.handle_rtcp(now, fb, &mut self.event_ready);
+                stream.handle_rtcp(now, fb, ready);
                 s.invalidate(TimerScope::StreamRx(ssrc));
             } else {
                 let ssrc = fb.ssrc();
                 let Some(stream) = self.streams.stream_tx(&ssrc) else {
                     continue;
                 };
-                stream.handle_rtcp(now, fb, &mut self.event_ready);
+                stream.handle_rtcp(now, fb, ready);
                 s.invalidate(TimerScope::StreamTx(ssrc));
             }
         }
@@ -849,9 +839,11 @@ impl Session {
             return Some(Event::AppSpecificFeedback(feedback));
         }
 
+        let ready = self.event_ready.is_marked();
+
         // This must be before pending_packet.take() since we need to emit the unpaused event
         // before the first packet causing the unpause.
-        if self.event_ready.is_marked() {
+        if ready {
             if let Some(paused) = self.streams.poll_stream_paused() {
                 if paused.paused {
                     if let Some(media) = self.medias.iter_mut().find(|m| m.mid() == paused.mid) {
@@ -872,7 +864,7 @@ impl Session {
 
         // Everything below walks every stream or every media. Skip the lot unless a
         // producing path has actually queued something.
-        if !self.event_ready.is_marked() {
+        if !ready {
             return None;
         }
 

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -16,6 +16,7 @@ use crate::rtp_::{MediaTime, SenderInfo};
 use crate::rtp_::{Mid, Rid, SeqNo};
 use crate::rtp_::{Rtcp, RtpHeader};
 use crate::scheduler::Scheduler;
+use crate::session::Readiness;
 use crate::util::already_happened;
 
 pub use self::receive::StreamRx;
@@ -554,9 +555,9 @@ impl Streams {
         }
     }
 
-    pub(crate) fn handle_pause(&mut self, now: Instant, ssrc: Ssrc) {
+    pub(crate) fn handle_pause(&mut self, now: Instant, ssrc: Ssrc, ready: &mut Readiness) {
         if let Some(stream) = self.streams_rx.get_mut(&ssrc) {
-            stream.handle_timeout(now);
+            stream.handle_timeout(now, ready);
         }
     }
 

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -4,7 +4,6 @@ use std::time::{Duration, Instant};
 
 use crate::Timer;
 use crate::media::KeyframeRequestKind;
-use crate::session::Readiness;
 use crate::rtp_::MidRid;
 use crate::rtp_::{Bitrate, DlrrItem, ExtendedReport, extend_u32};
 use crate::rtp_::{Fir, FirEntry, Frequency, MediaTime, Remb};
@@ -13,6 +12,7 @@ use crate::rtp_::{ReportBlock, ReportList, Rid, Rrtr, Rtcp};
 use crate::rtp_::{RtcpFb, RtpHeader, SenderInfo, SeqNo};
 use crate::rtp_::{SdesType, Ssrc};
 use crate::scheduler::Scheduler;
+use crate::session::Readiness;
 use crate::stats::{MediaIngressStats, RemoteEgressStats, StatsSnapshot};
 use crate::util::{InstantExt, SystemTimeExt};
 use crate::util::{already_happened, calculate_rtt};

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, Instant};
 
 use crate::Timer;
 use crate::media::KeyframeRequestKind;
+use crate::session::Readiness;
 use crate::rtp_::MidRid;
 use crate::rtp_::{Bitrate, DlrrItem, ExtendedReport, extend_u32};
 use crate::rtp_::{Fir, FirEntry, Frequency, MediaTime, Remb};
@@ -262,11 +263,12 @@ impl StreamRx {
         }
     }
 
-    pub(crate) fn handle_rtcp(&mut self, now: Instant, fb: RtcpFb) {
+    pub(crate) fn handle_rtcp(&mut self, now: Instant, fb: RtcpFb, ready: &mut Readiness) {
         use RtcpFb::*;
         match fb {
             SenderInfo(v) => {
                 self.set_sender_info(now, v);
+                ready.mark();
             }
             SourceDescription(v) => {
                 for (sdes, st) in v.values {
@@ -332,7 +334,7 @@ impl StreamRx {
         self.stats.rtt = rtt;
     }
 
-    pub(crate) fn handle_timeout(&mut self, now: Instant) {
+    pub(crate) fn handle_timeout(&mut self, now: Instant, ready: &mut Readiness) {
         // No scheduled paused check?
         if self.check_paused_at.is_none() {
             return;
@@ -349,6 +351,7 @@ impl StreamRx {
 
         self.paused = true;
         self.need_paused_event = true;
+        ready.mark();
     }
 
     pub(crate) fn extend_seq(
@@ -403,6 +406,7 @@ impl StreamRx {
         clock_rate: Frequency,
         is_repair: bool,
         seq_no: SeqNo,
+        ready: &mut Readiness,
     ) -> RegisterUpdateReceipt {
         self.last_used = now;
 
@@ -410,6 +414,7 @@ impl StreamRx {
         if was_paused {
             self.paused = false;
             self.need_paused_event = true;
+            ready.mark();
         }
         self.check_paused_at = Some(now + self.pause_threshold);
 
@@ -895,7 +900,14 @@ mod tests {
         };
 
         let seq_no = stream.extend_seq(&header, false, |_| None);
-        let receipt = stream.update_register(now, &header, Frequency::NINETY_KHZ, false, seq_no);
+        let receipt = stream.update_register(
+            now,
+            &header,
+            Frequency::NINETY_KHZ,
+            false,
+            seq_no,
+            &mut Readiness::default(),
+        );
 
         assert!(
             receipt.time.numer() > previous_time,

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 use std::time::Instant;
 
 use crate::Timer;
-use crate::session::Readiness;
 use crate::format::CodecConfig;
 use crate::format::PayloadParams;
 use crate::io::DATAGRAM_MAX_PACKET_SIZE;
@@ -24,6 +23,7 @@ use crate::rtp_::{Pt, Rid, RtcpFb, SenderInfo, SenderReport, Ssrc};
 use crate::rtp_::{SRTP_BLOCK_SIZE, SeqNo};
 use crate::scheduler::Scheduler;
 use crate::session::PacketReceipt;
+use crate::session::Readiness;
 use crate::stats::StatsSnapshot;
 use crate::util::value_history::ValueHistory;
 use crate::util::{InstantExt, already_happened, not_happening};

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 use crate::Timer;
+use crate::session::Readiness;
 use crate::format::CodecConfig;
 use crate::format::PayloadParams;
 use crate::io::DATAGRAM_MAX_PACKET_SIZE;
@@ -870,7 +871,7 @@ impl StreamTx {
         self.pending_request_remb.take()
     }
 
-    pub(crate) fn handle_rtcp(&mut self, now: Instant, fb: RtcpFb) {
+    pub(crate) fn handle_rtcp(&mut self, now: Instant, fb: RtcpFb, ready: &mut Readiness) {
         use RtcpFb::*;
         match fb {
             ReceptionReport(r) => {
@@ -894,13 +895,16 @@ impl StreamTx {
             Pli(_) => {
                 self.stats.increase_plis();
                 self.pending_request_keyframe = Some(KeyframeRequestKind::Pli);
+                ready.mark();
             }
             Fir(_) => {
                 self.stats.increase_firs();
                 self.pending_request_keyframe = Some(KeyframeRequestKind::Fir);
+                ready.mark();
             }
             Remb(r) => {
                 self.pending_request_remb = Some(Bitrate::from(r.bitrate as f64));
+                ready.mark();
             }
             Twcc(_) => unreachable!("TWCC should be handled on session level"),
             _ => {}

--- a/tests/poll-scaling.rs
+++ b/tests/poll-scaling.rs
@@ -1,0 +1,160 @@
+//! How much does one `poll_output()` cost, as a function of the number of
+//! m-lines on the connection?
+//!
+//! This is the shape that matters for a server. A 1:1 call has 2 m-lines and the
+//! cost is invisible. An SFU client in an N-person room has ~N m-lines (one per
+//! other participant), and `poll_output` is called thousands of times per second
+//! per connection — so any per-call linear scan over medias/streams is paid
+//! O(N) times, O(N^2) per room.
+//!
+//! The number reported is the cost of a poll that finds NOTHING to do (returns
+//! `Output::Timeout`). In a real SFU that is the majority of calls: every drain
+//! ends with one, by construction.
+//!
+//! Ignored by default, since it is a measurement rather than an assertion and it
+//! takes a while. Run with:
+//!
+//!     cargo test --release --test poll-scaling -- --ignored --nocapture
+//!
+//! `--release` is essential; a debug build hides the effect entirely.
+//!
+//! Methodology note, because it cost us several wrong conclusions. Report the
+//! MINIMUM of N trials, never the mean: CPU benchmark noise is additive, so the
+//! fastest trial is the closest to the true cost. And never compare two numbers
+//! measured minutes apart, because the machine drifts (thermal throttling, power
+//! source). To compare two versions, prebuild both test binaries, run them back to
+//! back alternating the order, and pair the results.
+
+use std::net::Ipv4Addr;
+use std::time::{Duration, Instant};
+
+use str0m::media::{Direction, MediaKind, Mid};
+use str0m::{Output, RtcError};
+
+mod common;
+use common::{Peer, TestRtc, init_crypto_default, init_log, negotiate, progress};
+
+/// m-line counts to sweep. 2 = a 1:1 call. 30 = a mid-size conference.
+const MLINES: &[usize] = &[2, 5, 10, 20, 30, 50];
+
+/// Polls timed per trial.
+const ITERATIONS: usize = 50_000;
+
+/// Trials per data point. We report the MINIMUM: a CPU benchmark's noise is
+/// almost entirely additive (scheduling, interrupts, frequency dips), so the
+/// fastest trial is the closest to the true cost. Reporting the mean instead
+/// makes the numbers swing ~20% run to run and the comparison meaningless.
+const TRIALS: usize = 7;
+
+#[test]
+#[ignore = "measurement, not an assertion; run explicitly with --ignored"]
+fn poll_output_cost_by_mline_count() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    println!();
+    println!("cost of ONE poll_output() that returns Timeout (i.e. finds nothing to do)");
+    println!();
+    println!(
+        "{:>8}  {:>12}  {:>12}  {:>10}",
+        "m-lines", "ns/poll", "vs 2 m-lines", "ns/m-line"
+    );
+    println!("{:->8}  {:->12}  {:->12}  {:->10}", "", "", "", "");
+
+    let mut baseline: Option<f64> = None;
+
+    for &n in MLINES {
+        let ns = measure(n)?;
+
+        let base = *baseline.get_or_insert(ns);
+        println!(
+            "{:>8}  {:>12.0}  {:>11.1}x  {:>10.1}",
+            n,
+            ns,
+            ns / base,
+            ns / n as f64
+        );
+    }
+
+    println!();
+    println!("A flat 'vs 2 m-lines' column means poll_output is O(1) in the number of");
+    println!("m-lines. A column that tracks the m-line count means it is O(N), and an");
+    println!("SFU pays that N times per iteration.");
+    println!();
+
+    Ok(())
+}
+
+/// Build a connection with `n` send-only m-lines (the SFU-to-viewer direction),
+/// get media flowing on each so the StreamTx actually exist, then time a
+/// `poll_output()` that has nothing left to produce.
+fn measure(n: usize) -> Result<f64, RtcError> {
+    let mut l = TestRtc::new(Peer::Left); // the "SFU"
+    let mut r = TestRtc::new(Peer::Right); // the viewer
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    // One m-line per remote participant the viewer is subscribed to.
+    let mids: Vec<Mid> = negotiate(&mut l, &mut r, |change| {
+        (0..n)
+            .map(|_| change.add_media(MediaKind::Video, Direction::SendOnly, None, None, None))
+            .collect()
+    });
+
+    loop {
+        if l.is_connected() && r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r)?;
+    }
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    // Write one packet on every m-line, so each has a live StreamTx. Without this
+    // the streams do not exist and the scan has nothing to scan.
+    let params = l.params_vp8();
+    let pt = params.pt();
+    for (i, mid) in mids.iter().enumerate() {
+        let wallclock = l.start + l.duration();
+        let time = l.duration().into();
+        l.writer(*mid)
+            .unwrap()
+            .write(pt, wallclock, time, vec![1_u8, 2, 3, (i % 250) as u8])?;
+        progress(&mut l, &mut r)?;
+    }
+
+    // Drain everything so the next poll is a pure "nothing to do" poll.
+    loop {
+        match l.rtc.poll_output()? {
+            Output::Timeout(_) => break,
+            Output::Transmit(_) | Output::Event(_) => continue,
+        }
+    }
+
+    // Warm up: caches, branch predictors, CPU frequency.
+    for _ in 0..ITERATIONS {
+        std::hint::black_box(l.rtc.poll_output()?);
+    }
+
+    // Time the empty poll. It is idempotent — it keeps returning Timeout — so we
+    // can call it repeatedly without changing the connection's state.
+    let mut best = f64::MAX;
+    for _ in 0..TRIALS {
+        let t0 = Instant::now();
+        for _ in 0..ITERATIONS {
+            let out = l.rtc.poll_output()?;
+            debug_assert!(matches!(out, Output::Timeout(_)));
+            std::hint::black_box(&out);
+        }
+        let elapsed: Duration = t0.elapsed();
+        let ns = elapsed.as_nanos() as f64 / ITERATIONS as f64;
+        if ns < best {
+            best = ns;
+        }
+    }
+
+    Ok(best)
+}


### PR DESCRIPTION
## The problem

On every call to `poll_output()`, `poll_event` walks every stream and every media to ask whether anything is queued: four `values_mut().find_map(..)` walks (keyframe, sender feedback, REMB, paused), a loop over `medias` for `MediaAdded` and `MediaChanged`, and the sample walk in `poll_event_fallible`.

In a 1:1 call, with two m-lines, this is invisible. In a conference it is not: each `Rtc` holds roughly one m-line per remote participant, so the walks are O(N).

We run str0m server side in an SFU. In a 30 participant room, one connection makes about **53,000 `poll_output()` calls per second, and 86% of them return only a `Timeout`**. Each of those is a full walk that finds nothing. The cost is paid O(N) times per iteration, O(N^2) per room, and it does not depend on how much media is actually flowing.

This is the same thing @lherman-cs described in #922 ("str0m is burning quite a few CPU cycles just polling for notifications ... ideally we'd have an O(1) way to handle stream notifications"), and the idea below is his.

## The change

A single coarse readiness flag owned by `Session`:

```rust
#[derive(Debug, Default)]
pub(crate) struct Readiness(bool);
```

No shared mutable state, no atomic. The paths that queue an event take `&mut Readiness` and mark it where they already queue the thing: incoming PLI, FIR and REMB on `StreamTx`, a fresh sender report on `StreamRx`, pause and unpause transitions, the depayloader completing a sample, and the SDP paths that queue `MediaAdded` and `MediaChanged`.

The walks only run while the flag is marked, and it is cleared once an exhaustive poll has come back empty.

**Correctness does not depend on the mark being tight.** A spurious mark costs one extra walk, never a missed event. That is what makes it safe to keep the producer side conservative.

Two subtleties, since that is where the correctness lives:

* The mark is cleared at the end of the poll chain, not at the end of `poll_event()`. `lib.rs` calls `poll_event()` and then `poll_event_fallible()`, so the sample walk still has to run. In `rtp_mode` nothing walks the medias, so there the mark is spent in `poll_event()`.
* It has to survive the pre SRTP window. `poll_event()` bails out early until SRTP is ready, while `MediaAdded` and `MediaChanged` are queued during negotiation, so clearing then would lose them.

This targets `timeout-scheduler` (#1008), which already removes the timeout side of the problem. No public API change.

## Results

Our SFU, 100 participants in rooms of 10 on one thread, every camera on, one speaker at a time rotating with a 600 ms handover overlap, silent participants on Opus DTX. Same binary, only the str0m dependency changes. Paired runs, alternating order, 60 second windows.

CPU goes from **0.720 to 0.602 cores**. Mean saving 16.1 percent, median 17.4, 6 of 6 pairs positive, 95 percent confidence interval 10 to 22.

The profile agrees from the other side:

| symbol | #1008 alone | #1008 + this |
|---|---|---|
| `Session::poll_event_fallible` | 6.8 % | 1.5 % |
| `Rtc::do_poll_output` | 6.0 % | 2.1 % |
| `Streams::poll_remb_request` | 2.0 % | 0.6 % |
| `Scheduler::arm` | 1.3 % | 1.2 % |

846 tests pass, clippy is clean.

## Why one coarse bit is enough

I expected it to fail. We do not run in `rtp_mode`, so every incoming RTP packet depayloads and marks readiness, and I assumed the bit would end up permanently set and the guards useless.

It does not, because a mark only survives one exhaustive poll. At roughly 100 packets per second per client against thousands of `poll_output` calls, the vast majority of calls still skip the walks. Splitting readiness by event kind buys nothing measurable here, so this keeps the single bit.

---

*Note: this PR was written in French and translated to English with the help of an AI tool. Apologies for any awkward phrasing.*
