### PR TITLE
fix: streams reset handshake, make stream ids safely reusable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Reset SCTP streams when closing data channels and safely reuse stream IDs #1010
   * Fix small padding invisible to the pacer #1020
   * Fix H.264 negotiation: accept a negotiable (downgradable) level and recognize the Constrained High profile #1016
   * Expose the latest send queue information on `StreamTx` #1005

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,8 +1716,6 @@ dependencies = [
 [[package]]
 name = "sctp-proto"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199c5c38008c2c151e27afd228230b1b69f849b1f7629f5df86662ee1f456187"
 dependencies = [
  "bytes",
  "crc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1715,7 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "sctp-proto"
-version = "0.10.1"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801033d212d17c3ad6b523c3fb3a41de323707b10b75cb437d05d5eff3b15204"
 dependencies = [
  "bytes",
  "crc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1715,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "sctp-proto"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199c5c38008c2c151e27afd228230b1b69f849b1f7629f5df86662ee1f456187"
+checksum = "f895c3c33ae20283f9129bd09db2ca69138798b372ef2b98bd2946d23ea4819b"
 dependencies = [
  "bytes",
  "crc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,7 @@ _str0m_test = { path = "crates/_str0m_test" }
 # Core dependencies
 tracing = "0.1.37"
 fastrand = "2.0.1"
-# sctp-proto = "0.10.1"
-sctp-proto = { path = "../sctp-proto" }
+sctp-proto = "0.10.2"
 combine = "4.6.6"
 subtle = "2.0.0"
 arrayvec = "0.7.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,8 @@ _str0m_test = { path = "crates/_str0m_test" }
 # Core dependencies
 tracing = "0.1.37"
 fastrand = "2.0.1"
-sctp-proto = "0.10.1"
+# sctp-proto = "0.10.1"
+sctp-proto = { path = "../sctp-proto" }
 combine = "4.6.6"
 subtle = "2.0.0"
 arrayvec = "0.7.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ _str0m_test = { path = "crates/_str0m_test" }
 # Core dependencies
 tracing = "0.1.37"
 fastrand = "2.0.1"
-sctp-proto = "0.10.1"
+sctp-proto = "0.10.3"
 combine = "4.6.6"
 subtle = "2.0.0"
 arrayvec = "0.7.6"

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -173,9 +173,18 @@ impl fmt::Debug for ChannelData {
 pub(crate) struct ChannelHandler {
     allocations: Vec<ChannelAllocation>,
     next_channel_id: usize,
-    /// Stream IDs recently closed, with the time they were closed.
-    /// Excluded from allocation until the cooldown expires.
-    closed_stream_ids: Vec<(u16, Instant)>,
+    /// Stream IDs of closed channels, excluded from allocation until the
+    /// reset handshake completes or the max-hold expires.
+    closed_stream_ids: Vec<ClosedStreamId>,
+}
+
+/// A stream ID held back from reallocation after its channel closed.
+#[derive(Debug)]
+struct ClosedStreamId {
+    stream_id: u16,
+    /// When the hold started. Only used for the max-hold fallback,
+    /// normal release is the reset-completion signal from SCTP.
+    held_since: Instant,
 }
 
 #[derive(Debug)]
@@ -190,7 +199,12 @@ struct ChannelAllocation {
     config: Option<ChannelConfig>,
 }
 
-const STREAM_ID_COOLDOWN: Duration = Duration::from_secs(2);
+/// Upper bound on how long a stream ID is held when the reset handshake never
+/// completes. Prevents leaking IDs forever.
+///
+/// The normal release path is the completion signal itself, the SCTP layer
+/// retries transient open errors.
+const STREAM_ID_MAX_HOLD: Duration = Duration::from_secs(30);
 
 impl ChannelHandler {
     pub fn new_channel(&mut self, config: &ChannelConfig) -> ChannelId {
@@ -292,7 +306,7 @@ impl ChannelHandler {
             .allocations
             .iter()
             .filter_map(|a| a.sctp_stream_id)
-            .chain(self.closed_stream_ids.iter().map(|(id, _)| *id))
+            .chain(self.closed_stream_ids.iter().map(|c| c.stream_id))
             .collect();
 
         for a in &mut self.allocations {
@@ -365,10 +379,18 @@ impl ChannelHandler {
         }
     }
 
-    /// Remove stream IDs from the cooldown list that have expired.
+    /// Release held stream IDs whose max-hold fallback expired.
+    /// The normal release path is `stream_reset_complete`,
+    /// this only reclaims IDs whose reset handshake never completes (broken/dead peer).
     pub fn expire_closed_stream_ids(&mut self, now: Instant) {
         self.closed_stream_ids
-            .retain(|(_, closed_at)| now.duration_since(*closed_at) < STREAM_ID_COOLDOWN);
+            .retain(|c| now.duration_since(c.held_since) < STREAM_ID_MAX_HOLD);
+    }
+
+    /// The reset handshake for a held stream ID completed, release it for
+    /// reallocation immediately.
+    pub fn stream_reset_complete(&mut self, stream_id: u16) {
+        self.closed_stream_ids.retain(|c| c.stream_id != stream_id);
     }
 
     pub fn remove_channel(&mut self, id: ChannelId, now: Instant) {
@@ -378,7 +400,10 @@ impl ChannelHandler {
             .find(|a| a.id == id)
             .and_then(|a| a.sctp_stream_id)
         {
-            self.closed_stream_ids.push((stream_id, now));
+            self.closed_stream_ids.push(ClosedStreamId {
+                stream_id,
+                held_since: now,
+            });
         }
         self.allocations.retain(|a| a.id != id)
     }
@@ -407,7 +432,7 @@ mod tests {
     }
 
     #[test]
-    fn stream_id_not_reused_during_cooldown() {
+    fn stream_id_held_until_reset_complete() {
         let now = Instant::now();
         let mut handler = ChannelHandler::default();
 
@@ -419,39 +444,62 @@ mod tests {
         handler.allocations[0].sctp_stream_id = Some(0);
         handler.allocations[1].sctp_stream_id = Some(2);
 
-        // Close channel 0 (stream ID 0). It should enter cooldown.
+        // Close channel 0 (stream ID 0). It should be held.
         handler.remove_channel(id0, now);
         assert_eq!(handler.closed_stream_ids.len(), 1);
-        assert_eq!(handler.closed_stream_ids[0].0, 0);
+        assert_eq!(handler.closed_stream_ids[0].stream_id, 0);
 
-        // Allocate a new channel and manually assign a stream ID the way
-        // do_allocations would — stream 0 should be skipped (in cooldown).
+        // Build the taken list as do_allocations does — stream 0 is held.
         let _id2 = handler.new_channel(&Default::default());
-        // Build the taken list as do_allocations does.
         let taken: Vec<u16> = handler
             .allocations
             .iter()
             .filter_map(|a| a.sctp_stream_id)
-            .chain(handler.closed_stream_ids.iter().map(|(id, _)| *id))
+            .chain(handler.closed_stream_ids.iter().map(|c| c.stream_id))
             .collect();
-        // Stream 0 is in cooldown, stream 2 is active, so next available is 4.
-        assert!(taken.contains(&0), "stream 0 should be in cooldown");
+        assert!(taken.contains(&0), "stream 0 should be held");
         assert!(taken.contains(&2), "stream 2 should be active");
 
-        // After cooldown expires, stream 0 should be available again.
-        let after_cooldown = now + STREAM_ID_COOLDOWN;
-        handler.expire_closed_stream_ids(after_cooldown);
+        // Elapsed time alone does not release the ID (short of max-hold):
+        // the release condition is the reset handshake completing.
+        handler.expire_closed_stream_ids(now + Duration::from_secs(10));
+        assert_eq!(
+            handler.closed_stream_ids.len(),
+            1,
+            "stream 0 should stay held until reset completes"
+        );
+
+        // The completion signal releases it immediately.
+        handler.stream_reset_complete(0);
         assert!(handler.closed_stream_ids.is_empty());
 
         let taken_after: Vec<u16> = handler
             .allocations
             .iter()
             .filter_map(|a| a.sctp_stream_id)
-            .chain(handler.closed_stream_ids.iter().map(|(id, _)| *id))
+            .chain(handler.closed_stream_ids.iter().map(|c| c.stream_id))
             .collect();
         assert!(
             !taken_after.contains(&0),
-            "stream 0 should be available after cooldown"
+            "stream 0 should be available after reset completion"
         );
+    }
+
+    #[test]
+    fn stream_id_released_by_max_hold_fallback() {
+        let now = Instant::now();
+        let mut handler = ChannelHandler::default();
+
+        let id0 = handler.new_channel(&Default::default());
+        handler.allocations[0].sctp_stream_id = Some(0);
+        handler.remove_channel(id0, now);
+
+        // Reset never completes. Just before max-hold: still held.
+        handler.expire_closed_stream_ids(now + STREAM_ID_MAX_HOLD - Duration::from_millis(1));
+        assert_eq!(handler.closed_stream_ids.len(), 1);
+
+        // At max-hold: released even without reset completion.
+        handler.expire_closed_stream_ids(now + STREAM_ID_MAX_HOLD);
+        assert!(handler.closed_stream_ids.is_empty());
     }
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,6 +1,5 @@
 //! Data channel related types.
 
-use std::time::Duration;
 use std::{fmt, str, time::Instant};
 
 use crate::sctp::RtcSctp;
@@ -173,9 +172,9 @@ impl fmt::Debug for ChannelData {
 pub(crate) struct ChannelHandler {
     allocations: Vec<ChannelAllocation>,
     next_channel_id: usize,
-    /// Stream IDs recently closed, with the time they were closed.
-    /// Excluded from allocation until the cooldown expires.
-    closed_stream_ids: Vec<(u16, Instant)>,
+    /// Stream IDs of closed channels whose reset handshake is still
+    /// outstanding, excluded from allocation until it completes.
+    closed_stream_ids: Vec<u16>,
 }
 
 #[derive(Debug)]
@@ -183,26 +182,31 @@ struct ChannelAllocation {
     id: ChannelId,
 
     /// Stream id, when it is known. This might be delayed awaiting sctp initialization to
-    /// know if we are client or server.
+    /// know if we are client or server, or awaiting the reset handshake of a previous
+    /// incarnation of a negotiated id.
     sctp_stream_id: Option<u16>,
+
+    /// The out-of-band negotiated stream id the user asked for. Promoted to
+    /// `sctp_stream_id` once reset which was holding it completes.
+    negotiated_stream_id: Option<u16>,
 
     /// Holds the config until it is used in handle_timeout.
     config: Option<ChannelConfig>,
 }
 
-const STREAM_ID_COOLDOWN: Duration = Duration::from_secs(2);
-
 impl ChannelHandler {
     pub fn new_channel(&mut self, config: &ChannelConfig) -> ChannelId {
         let id = self.next_channel_id();
 
-        // For out-of-band negotiated, the id is already set.
-        let sctp_stream_id = config.negotiated;
-        if let Some(sctp_stream_id) = sctp_stream_id {
-            let exists = self
-                .allocations
-                .iter()
-                .any(|a| a.sctp_stream_id == Some(sctp_stream_id));
+        // Out-of-band negotiated means the user names the stream id
+        // instead of us allocating one. We record it as a request in
+        // and leave `sctp_stream_id` unset.
+        let negotiated_stream_id = config.negotiated;
+        if let Some(sctp_stream_id) = negotiated_stream_id {
+            let exists = self.allocations.iter().any(|a| {
+                a.sctp_stream_id == Some(sctp_stream_id)
+                    || a.negotiated_stream_id == Some(sctp_stream_id)
+            });
             assert!(
                 !exists,
                 "sctp_stream_id ({}) exists already",
@@ -212,7 +216,8 @@ impl ChannelHandler {
 
         let alloc = ChannelAllocation {
             id,
-            sctp_stream_id,
+            sctp_stream_id: None,
+            negotiated_stream_id,
             // The config is none until we confirm we definitely want this channel.
             config: None,
         };
@@ -268,12 +273,23 @@ impl ChannelHandler {
         ChannelId(id)
     }
 
+    /// Whether a stream id is held back awaiting a reset completion.
+    fn is_held(&self, sctp_stream_id: u16) -> bool {
+        self.closed_stream_ids.contains(&sctp_stream_id)
+    }
+
     fn need_allocation(&self) -> bool {
-        self.allocations.iter().any(|a| a.sctp_stream_id.is_none())
+        self.allocations.iter().any(|a| {
+            a.sctp_stream_id.is_none()
+                // A negotiated id that is still held cannot be allocated yet.
+                && a.negotiated_stream_id.is_none_or(|want| !self.is_held(want))
+        })
     }
 
     fn need_open(&self) -> bool {
-        self.allocations.iter().any(|a| a.config.is_some())
+        self.allocations
+            .iter()
+            .any(|a| a.config.is_some() && a.sctp_stream_id.is_some())
     }
 
     // Do automatic allocations of sctp stream id.
@@ -292,13 +308,28 @@ impl ChannelHandler {
             .allocations
             .iter()
             .filter_map(|a| a.sctp_stream_id)
-            .chain(self.closed_stream_ids.iter().map(|(id, _)| *id))
+            .chain(self.closed_stream_ids.iter().copied())
             .collect();
 
         for a in &mut self.allocations {
             if a.sctp_stream_id.is_some() {
                 continue;
             }
+
+            // Out-of-band negotiated. The user picked the id, all we do is wait until
+            // no closed generation of it is still awaiting its reset handshake.
+            if let Some(want) = a.negotiated_stream_id {
+                if taken.contains(&want) {
+                    debug!("Negotiated stream id {} still held, retry later", want);
+                    continue;
+                }
+
+                debug!("Associate negotiated stream id {:?} => {}", a.id, want);
+                a.sctp_stream_id = Some(want);
+                taken.push(want);
+                continue;
+            }
+
             // We need to allocate
             let mut proposed = base;
 
@@ -316,10 +347,14 @@ impl ChannelHandler {
     // Actually open channels.
     fn open_channels(&mut self, sctp: &mut RtcSctp) {
         for a in &mut self.allocations {
-            let Some(config) = a.config.take() else {
+            // The stream id must be known before the config is taken. A negotiated
+            // channel waiting out a previous incarnation's reset has no id yet, and
+            // consuming its config here would leave nothing to open it with once the
+            // id is released.
+            let Some(sctp_stream_id) = a.sctp_stream_id else {
                 continue;
             };
-            let Some(sctp_stream_id) = a.sctp_stream_id else {
+            let Some(config) = a.config.take() else {
                 continue;
             };
 
@@ -347,6 +382,7 @@ impl ChannelHandler {
             let alloc = ChannelAllocation {
                 id,
                 sctp_stream_id: Some(sctp_stream_id),
+                negotiated_stream_id: None,
                 config: None,
             };
             self.allocations.push(alloc);
@@ -365,21 +401,36 @@ impl ChannelHandler {
         }
     }
 
-    /// Remove stream IDs from the cooldown list that have expired.
-    pub fn expire_closed_stream_ids(&mut self, now: Instant) {
-        self.closed_stream_ids
-            .retain(|(_, closed_at)| now.duration_since(*closed_at) < STREAM_ID_COOLDOWN);
+    /// The reset handshake for a held stream ID completed, release it for
+    /// reallocation immediately.
+    ///
+    /// Completions are reported per stream generation, so the same id can be held
+    /// more than once when resets overlap. Release a single generation, the id only
+    /// becomes reusable once every one of them has completed.
+    pub fn stream_reset_complete(&mut self, stream_id: u16) {
+        if let Some(pos) = self.closed_stream_ids.iter().position(|c| *c == stream_id) {
+            self.closed_stream_ids.remove(pos);
+        }
     }
 
-    pub fn remove_channel(&mut self, id: ChannelId, now: Instant) {
-        if let Some(stream_id) = self
+    /// The association is gone, so no reset can ever complete on it.
+    /// The held IDs belong to an association nobody will send on again.
+    pub fn association_lost(&mut self) {
+        self.closed_stream_ids.clear();
+    }
+
+    /// Remove a closed channel.
+    pub fn remove_channel(&mut self, id: ChannelId, reset_pending: bool) {
+        let stream_id = self
             .allocations
             .iter()
             .find(|a| a.id == id)
-            .and_then(|a| a.sctp_stream_id)
-        {
-            self.closed_stream_ids.push((stream_id, now));
+            .and_then(|a| a.sctp_stream_id);
+
+        if let (true, Some(stream_id)) = (reset_pending, stream_id) {
+            self.closed_stream_ids.push(stream_id);
         }
+
         self.allocations.retain(|a| a.id != id)
     }
 }
@@ -390,7 +441,6 @@ mod tests {
 
     #[test]
     fn channel_id_allocation() {
-        let now = Instant::now();
         let mut handler = ChannelHandler::default();
 
         // allocate first channel, get unique id
@@ -401,14 +451,13 @@ mod tests {
 
         // free channel 0, allocate two more channels and verify that the
         // new channels have unique IDs.
-        handler.remove_channel(ChannelId(0), now);
+        handler.remove_channel(ChannelId(0), true);
         assert_eq!(handler.new_channel(&Default::default()), ChannelId(2));
         assert_eq!(handler.new_channel(&Default::default()), ChannelId(3));
     }
 
     #[test]
-    fn stream_id_not_reused_during_cooldown() {
-        let now = Instant::now();
+    fn stream_id_held_until_reset_complete() {
         let mut handler = ChannelHandler::default();
 
         // Simulate two channels with known stream IDs (as if do_allocations ran
@@ -419,39 +468,197 @@ mod tests {
         handler.allocations[0].sctp_stream_id = Some(0);
         handler.allocations[1].sctp_stream_id = Some(2);
 
-        // Close channel 0 (stream ID 0). It should enter cooldown.
-        handler.remove_channel(id0, now);
-        assert_eq!(handler.closed_stream_ids.len(), 1);
-        assert_eq!(handler.closed_stream_ids[0].0, 0);
+        // Close channel 0 (stream ID 0) with its reset outstanding. It should be held.
+        handler.remove_channel(id0, true);
+        assert_eq!(handler.closed_stream_ids, vec![0]);
 
-        // Allocate a new channel and manually assign a stream ID the way
-        // do_allocations would — stream 0 should be skipped (in cooldown).
+        // Build the taken list as do_allocations does — stream 0 is held.
         let _id2 = handler.new_channel(&Default::default());
-        // Build the taken list as do_allocations does.
         let taken: Vec<u16> = handler
             .allocations
             .iter()
             .filter_map(|a| a.sctp_stream_id)
-            .chain(handler.closed_stream_ids.iter().map(|(id, _)| *id))
+            .chain(handler.closed_stream_ids.iter().copied())
             .collect();
-        // Stream 0 is in cooldown, stream 2 is active, so next available is 4.
-        assert!(taken.contains(&0), "stream 0 should be in cooldown");
+        assert!(taken.contains(&0), "stream 0 should be held");
         assert!(taken.contains(&2), "stream 2 should be active");
 
-        // After cooldown expires, stream 0 should be available again.
-        let after_cooldown = now + STREAM_ID_COOLDOWN;
-        handler.expire_closed_stream_ids(after_cooldown);
+        // The completion signal is the only thing that releases it.
+        handler.stream_reset_complete(0);
         assert!(handler.closed_stream_ids.is_empty());
 
         let taken_after: Vec<u16> = handler
             .allocations
             .iter()
             .filter_map(|a| a.sctp_stream_id)
-            .chain(handler.closed_stream_ids.iter().map(|(id, _)| *id))
+            .chain(handler.closed_stream_ids.iter().copied())
             .collect();
         assert!(
             !taken_after.contains(&0),
-            "stream 0 should be available after cooldown"
+            "stream 0 should be available after reset completion"
         );
+    }
+
+    #[test]
+    fn negotiated_stream_id_cannot_overlap_held_generation() {
+        let sctp = RtcSctp::new(1200);
+        let mut handler = ChannelHandler::default();
+        let config = ChannelConfig {
+            negotiated: Some(4),
+            ..Default::default()
+        };
+
+        // The old generation was granted the id it asked for.
+        let old = handler.new_channel(&config);
+        handler.do_allocations(&sctp);
+        assert_eq!(handler.stream_id_by_channel_id(old), Some(4));
+
+        handler.remove_channel(old, true);
+        assert_eq!(handler.closed_stream_ids, vec![4]);
+
+        // A replacement asking for the same id may be declared, but must stall
+        // without the id until the old reset completes.
+        let _replacement = handler.new_channel(&config);
+        handler.do_allocations(&sctp);
+
+        let overlaps_held_generation = handler.allocations.iter().any(|allocation| {
+            handler
+                .closed_stream_ids
+                .iter()
+                .any(|closed| allocation.sctp_stream_id == Some(*closed))
+        });
+
+        assert!(
+            !overlaps_held_generation,
+            "a negotiated ID must remain unavailable until its old reset completes"
+        );
+    }
+
+    #[test]
+    fn negotiated_stream_keeps_config_while_waiting_for_reset() {
+        let mut sctp = RtcSctp::new(1200);
+        let mut handler = ChannelHandler::default();
+        let config = ChannelConfig {
+            label: "replacement".into(),
+            negotiated: Some(4),
+            ..Default::default()
+        };
+
+        handler.closed_stream_ids.push(4);
+        let replacement = handler.new_channel(&config);
+        handler.confirm(replacement, config);
+
+        handler.do_allocations(&sctp);
+        handler.open_channels(&mut sctp);
+
+        let allocation = handler
+            .allocations
+            .iter()
+            .find(|allocation| allocation.id == replacement)
+            .unwrap();
+        assert!(
+            allocation.config.is_some(),
+            "a negotiated channel must retain its config while its stream id is held"
+        );
+
+        handler.stream_reset_complete(4);
+        handler.do_allocations(&sctp);
+        handler.open_channels(&mut sctp);
+
+        assert_eq!(
+            sctp.config(4).map(|config| config.label.as_str()),
+            Some("replacement"),
+            "the negotiated channel must open once the old reset completes"
+        );
+    }
+
+    #[test]
+    fn negotiated_stream_waiting_for_reset_does_not_spin_timeout() {
+        let now = Instant::now();
+        let mut sctp = RtcSctp::new(1200);
+        sctp.init(true, now, None, None).unwrap();
+
+        let mut handler = ChannelHandler::default();
+        let config = ChannelConfig {
+            negotiated: Some(4),
+            ..Default::default()
+        };
+
+        handler.closed_stream_ids.push(4);
+        let replacement = handler.new_channel(&config);
+        handler.confirm(replacement, config);
+        handler.handle_timeout(now, &mut sctp);
+
+        assert_eq!(
+            handler.poll_timeout(&sctp),
+            None,
+            "a channel that cannot open until network input arrives must not request an immediate timeout"
+        );
+    }
+
+    #[test]
+    fn one_reset_completion_releases_only_one_stream_generation() {
+        let mut handler = ChannelHandler::default();
+
+        // sctp-proto 0.10.3 reports reset completion per stream generation.
+        // Two outstanding generations of the same stream id therefore need two
+        // completion events before the id is reusable.
+        handler.closed_stream_ids.extend([4, 4]);
+
+        handler.stream_reset_complete(4);
+
+        assert_eq!(
+            handler.closed_stream_ids,
+            vec![4],
+            "the first completion must not release a newer pending generation"
+        );
+    }
+
+    #[test]
+    fn stream_id_remains_held_without_reset_completion() {
+        let sctp = RtcSctp::new(1200);
+        let mut handler = ChannelHandler::default();
+
+        let id = handler.new_channel(&Default::default());
+        handler.allocations[0].sctp_stream_id = Some(0);
+        handler.remove_channel(id, true);
+
+        // There is no timer that can release the id.
+        for _ in 0..100 {
+            handler.do_allocations(&sctp);
+        }
+
+        assert_eq!(
+            handler.closed_stream_ids,
+            vec![0],
+            "elapsed time alone cannot make an SCTP stream ID safe to reuse"
+        );
+    }
+
+    #[test]
+    fn stream_id_not_held_when_no_reset_is_pending() {
+        let mut handler = ChannelHandler::default();
+
+        let id0 = handler.new_channel(&Default::default());
+        handler.allocations[0].sctp_stream_id = Some(0);
+
+        // The stream never made it into the association, so no reset was started and
+        // no completion will ever arrive. Holding the id would leak it forever.
+        handler.remove_channel(id0, false);
+        assert!(handler.closed_stream_ids.is_empty());
+    }
+
+    #[test]
+    fn association_lost_releases_held_stream_ids() {
+        let mut handler = ChannelHandler::default();
+
+        let id0 = handler.new_channel(&Default::default());
+        handler.allocations[0].sctp_stream_id = Some(0);
+        handler.remove_channel(id0, true);
+        assert_eq!(handler.closed_stream_ids, vec![0]);
+
+        // No reset can complete on a dead association, nothing holds the id back.
+        handler.association_lost();
+        assert!(handler.closed_stream_ids.is_empty());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1731,13 +1731,25 @@ impl Rtc {
                     let id = self.chan.channel_id_by_stream_id(id).unwrap();
                     return Ok(Output::Event(Event::ChannelOpen(id, label)));
                 }
-                SctpEvent::Close { id } => {
-                    let Some(id) = self.chan.channel_id_by_stream_id(id) else {
-                        warn!("Drop ChannelClose event for id: {:?}", id);
+                SctpEvent::Close { id: stream_id, reset_complete, } => {
+                    let Some(channel_id) = self.chan.channel_id_by_stream_id(stream_id) else {
+                        warn!("Drop ChannelClose event for id: {:?}", stream_id);
                         continue;
                     };
-                    self.chan.remove_channel(id, self.last_now);
-                    return Ok(Output::Event(Event::ChannelClose(id)));
+                    // remove_channel pushes the hold entry, for remote-initiated
+                    // closes the reset handshake is already complete, so release
+                    // the stream id right away.
+                    self.chan.remove_channel(channel_id, self.last_now);
+                    if reset_complete {
+                        self.chan.stream_reset_complete(stream_id);
+                    }
+                    return Ok(Output::Event(Event::ChannelClose(channel_id)));
+                }
+                SctpEvent::StreamResetComplete { id } => {
+                    // Completion of a reset we initiated: the stream id can be
+                    // recycled. Internal bookkeeping only.
+                    self.chan.stream_reset_complete(id);
+                    continue;
                 }
                 SctpEvent::AssociationLost => {
                     self.start_close()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1731,23 +1731,18 @@ impl Rtc {
                     let id = self.chan.channel_id_by_stream_id(id).unwrap();
                     return Ok(Output::Event(Event::ChannelOpen(id, label)));
                 }
-                SctpEvent::Close { id: stream_id, reset_complete, } => {
+                SctpEvent::Close { id: stream_id } => {
                     let Some(channel_id) = self.chan.channel_id_by_stream_id(stream_id) else {
                         warn!("Drop ChannelClose event for id: {:?}", stream_id);
                         continue;
                     };
-                    // remove_channel pushes the hold entry, for remote-initiated
-                    // closes the reset handshake is already complete, so release
-                    // the stream id right away.
+                    // remove_channel holds the stream id from reallocation until
+                    // the reset handshake completes.
                     self.chan.remove_channel(channel_id, self.last_now);
-                    if reset_complete {
-                        self.chan.stream_reset_complete(stream_id);
-                    }
                     return Ok(Output::Event(Event::ChannelClose(channel_id)));
                 }
                 SctpEvent::StreamResetComplete { id } => {
-                    // Completion of a reset we initiated: the stream id can be
-                    // recycled. Internal bookkeeping only.
+                    // The reset handshake completed, the stream id can be used again.
                     self.chan.stream_reset_complete(id);
                     continue;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1739,15 +1739,26 @@ impl Rtc {
                     let id = self.chan.channel_id_by_stream_id(id).unwrap();
                     return Ok(Output::Event(Event::ChannelOpen(id, label)));
                 }
-                SctpEvent::Close { id } => {
-                    let Some(id) = self.chan.channel_id_by_stream_id(id) else {
-                        warn!("Drop ChannelClose event for id: {:?}", id);
+                SctpEvent::Close {
+                    id: stream_id,
+                    reset_pending,
+                } => {
+                    let Some(channel_id) = self.chan.channel_id_by_stream_id(stream_id) else {
+                        warn!("Drop ChannelClose event for id: {:?}", stream_id);
                         continue;
                     };
-                    self.chan.remove_channel(id, self.last_now);
-                    return Ok(Output::Event(Event::ChannelClose(id)));
+                    // When a reset is outstanding, remove_channel holds the stream id
+                    // back from reallocation until the handshake completes.
+                    self.chan.remove_channel(channel_id, reset_pending);
+                    return Ok(Output::Event(Event::ChannelClose(channel_id)));
+                }
+                SctpEvent::StreamResetComplete { id } => {
+                    // The reset handshake completed, the stream id can be used again.
+                    self.chan.stream_reset_complete(id);
+                    continue;
                 }
                 SctpEvent::AssociationLost => {
+                    self.chan.association_lost();
                     self.start_close()?;
                     return Ok(Output::Event(Event::Closed));
                 }
@@ -2022,7 +2033,6 @@ impl Rtc {
         self.last_now = now;
         self.ice.handle_timeout(now);
         self.sctp.handle_timeout(now);
-        self.chan.expire_closed_stream_ids(now);
         self.chan.handle_timeout(now, &mut self.sctp);
         self.session.handle_timeout(now)?;
 

--- a/src/sctp/mod.rs
+++ b/src/sctp/mod.rs
@@ -873,7 +873,7 @@ impl RtcSctp {
                         if in_band || matches!(e, ProtoError::ErrStreamResetPending) {
                             // RFC 6525 reset handshake for a previous
                             // incarnation of this stream id hasn't finished yet
-                            // 
+                            //
                             // - AlreadyExist clears when the remote's reciprocal reset arrives
                             // - ResetPending when the RECONFIG-RESPONSE arrives (silently)
                             //

--- a/src/sctp/mod.rs
+++ b/src/sctp/mod.rs
@@ -730,6 +730,11 @@ impl RtcSctp {
             return None;
         }
 
+        // Remove closed entries. handle_timeout() also does this, but the
+        // remote can reuse a stream id (its reset handshake completed) before
+        // our next timeout.
+        self.entries.retain(|e| e.state != StreamEntryState::Closed);
+
         if let Some(t) = self.pushed_back_transmit.take() {
             return Some(SctpEvent::Transmit { packets: t });
         }
@@ -882,7 +887,7 @@ impl RtcSctp {
                                 continue;
                             }
 
-                            warn!("Opening stream {} failed after retries: {:?}", entry.id, e);
+                            debug!("Opening stream {} failed after retries: {:?}", entry.id, e);
                             entry.do_close = true;
                             entry.set_state(StreamEntryState::Closed);
                             let stream_id = entry.id;

--- a/src/sctp/mod.rs
+++ b/src/sctp/mod.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::net::SocketAddr;
 use std::panic::UnwindSafe;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use sctp_proto::{Association, AssociationHandle, DatagramEvent};
 use sctp_proto::{Endpoint, EndpointConfig, Stream, StreamEvent, Transmit};
@@ -84,6 +84,11 @@ struct StreamEntry {
     id: u16,
     /// If we are to close this entry.
     do_close: bool,
+    /// Whether the reset handshake for this stream has completed.
+    /// Set when the remote initiates the close
+    reset_complete: bool,
+    /// Deadline for retrying `open_stream` when it fails.
+    open_deadline: Option<Instant>,
     /// If the queued outgoing data drops below this threshold, Rtc is to emit an
     /// event to the user.
     buffered_threshold: BufferedThresholdConfig,
@@ -127,6 +132,14 @@ pub(crate) enum SctpEvent {
         label: String,
     },
     Close {
+        id: u16,
+        /// Whether the reset handshake already completed for this stream.
+        reset_complete: bool,
+    },
+    /// The reset handshake for a locally initiated close completed, the remote's
+    /// reciprocal reset arrived and sctp-proto unregistered the stream. The
+    /// stream id is now safe to recycle.
+    StreamResetComplete {
         id: u16,
     },
     Data {
@@ -246,6 +259,17 @@ impl StreamEntry {
 /// SCTP framing per outgoing datagram: 12-byte common header + ~16-byte DATA
 /// chunk header + some extra.
 const SCTP_OVERHEAD: usize = 40;
+
+/// How long `open_stream` keeps retrying when blocked by a transient error
+/// which could happen during reset handshake (RFC 6525).
+/// Past this the peer is considered broken and the open gives up.
+const STREAM_OPEN_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Backstop poll interval while an open is retrying. Retries are normally
+/// driven by the network input that unblocks them,
+/// either the reciprocal reset or RECONFIG-RESPONSE arriving.
+/// This interval guarantees progress in case of absence of the latter messages.
+const STREAM_OPEN_RETRY_INTERVAL: Duration = Duration::from_millis(500);
 
 /// Empirical: SCTP `max_payload_size` of 1200 has produced 1277-byte DTLS-wrapped
 /// datagrams (77 bytes combined SCTP + DTLS overhead).
@@ -524,6 +548,11 @@ impl RtcSctp {
     pub fn close_stream(&mut self, id: u16) {
         if let Some(entry) = self.entries.iter_mut().find(|v| v.id == id) {
             entry.do_close = true;
+
+            // Close esplicitally sctp stream to allow re-use of the same id.
+            if let Some(Ok(mut stream)) = self.assoc.as_mut().map(|assoc| assoc.stream(id)) {
+                let _ = stream.close();
+            }
         }
     }
 
@@ -750,14 +779,30 @@ impl RtcSctp {
                         );
                     }
                     StreamEvent::Finished { id } | StreamEvent::Stopped { id, .. } => {
-                        let entry = stream_entry(
-                            &mut self.entries,
-                            id,
-                            StreamEntryState::AwaitConfig,
-                            "closed",
-                        );
-                        debug!("Stream {} closed", id);
-                        entry.do_close = true;
+                        match self.entries.iter_mut().find(|e| e.id == id) {
+                            // If the event arrives on a live stream, it's a remote-initiated close.
+                            // sctp-proto has already unregistered the stream and auto-queued the
+                            // reciprocal reset.
+                            Some(entry)
+                                if entry.state != StreamEntryState::Closed
+                                    && entry.state != StreamEntryState::AwaitOpen =>
+                            {
+                                debug!("Stream {} closed by remote", id);
+                                entry.do_close = true;
+                                entry.reset_complete = true;
+                            }
+                            // No entry, or entry in Closed or AwaitOpen: this Finished completes
+                            // a reset WE initiated earlier, the remote's reciprocal reset has
+                            // arrived. Signal the allocator that the id is reusable.
+                            // 
+                            // AwaitOpen is included because a new incarnation may already be
+                            // waiting on the same id: this completion must unblock
+                            // its retry, not close it.
+                            _ => {
+                                debug!("Stream {} reset complete", id);
+                                return Some(SctpEvent::StreamResetComplete { id });
+                            }
+                        }
                     }
                     StreamEvent::BufferedAmountLow { id } => {
                         return Some(SctpEvent::BufferedAmountLow { id });
@@ -779,9 +824,17 @@ impl RtcSctp {
                 debug!("Open stream {}", entry.id);
                 match assoc.open_stream(entry.id, PayloadProtocolIdentifier::Unknown) {
                     Ok(mut s) => {
+                        entry.open_deadline = None;
+
                         if !entry.configure_reliability(&mut s) {
                             entry.set_state(StreamEntryState::Closed);
-                            return Some(SctpEvent::Close { id: entry.id });
+                            let stream_id = entry.id;
+                            let reset_complete = entry.reset_complete;
+                            self.sctp_propagate_close(stream_id);
+                            return Some(SctpEvent::Close {
+                                id: stream_id,
+                                reset_complete,
+                            });
                         }
 
                         let config = entry.config.as_ref().expect("config if AwaitOpen");
@@ -809,25 +862,52 @@ impl RtcSctp {
                                     );
                                     entry.do_close = true;
                                     entry.set_state(StreamEntryState::Closed);
-                                    return Some(SctpEvent::Close { id: entry.id });
+                                    let stream_id = entry.id;
+                                    let reset_complete = entry.reset_complete;
+                                    self.sctp_propagate_close(stream_id);
+                                    return Some(SctpEvent::Close {
+                                        id: stream_id,
+                                        reset_complete,
+                                    });
                                 }
                             }
                         }
 
                         // Continuing means we are opening the stream out-of-band.
                     }
-                    Err(ProtoError::ErrStreamAlreadyExist) => {
+                    Err(
+                        e @ (ProtoError::ErrStreamAlreadyExist | ProtoError::ErrStreamResetPending),
+                    ) => {
                         let config = entry.config.as_ref().expect("config if AwaitOpen");
                         let in_band = config.negotiated.is_none();
 
-                        if in_band {
-                            warn!(
-                                "Opening stream {} failed: ErrStreamAlreadyExists with in-band",
-                                entry.id
-                            );
+                        if in_band || matches!(e, ProtoError::ErrStreamResetPending) {
+                            // RFC 6525 reset handshake for a previous
+                            // incarnation of this stream id hasn't finished yet
+                            // 
+                            // - AlreadyExist clears when the remote's reciprocal reset arrives
+                            // - ResetPending when the RECONFIG-RESPONSE arrives (silently)
+                            //
+                            // In both cases,  stay in AwaitOpen and retry until past the deadline.
+                            let deadline = *entry
+                                .open_deadline
+                                .get_or_insert(self.last_now + STREAM_OPEN_TIMEOUT);
+
+                            if self.last_now < deadline {
+                                debug!("Stream {} open blocked ({:?}), will retry", entry.id, e);
+                                continue;
+                            }
+
+                            warn!("Opening stream {} failed after retries: {:?}", entry.id, e);
                             entry.do_close = true;
                             entry.set_state(StreamEntryState::Closed);
-                            return Some(SctpEvent::Close { id: entry.id });
+                            let stream_id = entry.id;
+                            let reset_complete = entry.reset_complete;
+                            self.sctp_propagate_close(stream_id);
+                            return Some(SctpEvent::Close {
+                                id: stream_id,
+                                reset_complete,
+                            });
                         }
 
                         // Continuing means we are opening the stream out-of-band. The error can happen
@@ -837,7 +917,13 @@ impl RtcSctp {
                         warn!("Opening stream {} failed: {:?}", entry.id, e);
                         entry.do_close = true;
                         entry.set_state(StreamEntryState::Closed);
-                        return Some(SctpEvent::Close { id: entry.id });
+                        let stream_id = entry.id;
+                        let reset_complete = entry.reset_complete;
+                        self.sctp_propagate_close(stream_id);
+                        return Some(SctpEvent::Close {
+                            id: stream_id,
+                            reset_complete,
+                        });
                     }
                 }
 
@@ -857,7 +943,13 @@ impl RtcSctp {
 
             if entry.do_close && entry.state != StreamEntryState::Closed {
                 entry.set_state(StreamEntryState::Closed);
-                return Some(SctpEvent::Close { id: entry.id });
+                let stream_id = entry.id;
+                let reset_complete = entry.reset_complete;
+                self.sctp_propagate_close(stream_id);
+                return Some(SctpEvent::Close {
+                    id: stream_id,
+                    reset_complete,
+                });
             }
 
             let mut stream = match assoc.stream(entry.id) {
@@ -947,7 +1039,13 @@ impl RtcSctp {
                                     );
                                     entry.do_close = true;
                                     entry.set_state(StreamEntryState::Closed);
-                                    return Some(SctpEvent::Close { id: entry.id });
+                                    let stream_id = entry.id;
+                                    let reset_complete = entry.reset_complete;
+                                    self.sctp_propagate_close(stream_id);
+                                    return Some(SctpEvent::Close {
+                                        id: stream_id,
+                                        reset_complete,
+                                    });
                                 }
                             }
                         }
@@ -987,7 +1085,26 @@ impl RtcSctp {
     }
 
     pub fn poll_timeout(&mut self) -> Option<Instant> {
-        self.assoc.as_mut().and_then(|a| a.poll_timeout())
+        let assoc_timeout = self.assoc.as_mut().and_then(|a| a.poll_timeout());
+
+        // Wakeup backstop for entries whose open_stream() is being retried.
+        //
+        // Normally no wakeup is needed: a blocked open re-attempts on the
+        // next do_poll(), and the packet that unblocks it (the peer's
+        // RECONFIG-RESPONSE or reset) itself triggers handle_input() and that poll.
+        //
+        // Returning a wakeup while any entry retries guarantees the open
+        // either resolves or fails within STREAM_OPEN_TIMEOUT.
+        let retry_timeout = self
+            .entries
+            .iter()
+            .any(|e| e.state == StreamEntryState::AwaitOpen && e.open_deadline.is_some())
+            .then(|| self.last_now + STREAM_OPEN_RETRY_INTERVAL);
+
+        match (assoc_timeout, retry_timeout) {
+            (Some(a), Some(r)) => Some(a.min(r)),
+            (a, r) => a.or(r),
+        }
     }
 
     pub fn push_back_transmit(&mut self, data: VecDeque<Vec<u8>>) {
@@ -1013,6 +1130,13 @@ impl RtcSctp {
             .iter()
             .find(|s| s.id == sctp_stream_id)
             .and_then(|s| s.config.as_ref())
+    }
+
+    fn sctp_propagate_close(&mut self, stream_id: u16) {
+        // Close esplicitally sctp stream to allow re-use of the same id.
+        if let Some(Ok(mut stream)) = self.assoc.as_mut().map(|assoc| assoc.stream(stream_id)) {
+            let _ = stream.close();
+        }
     }
 
     #[cfg(test)]
@@ -1052,6 +1176,8 @@ fn stream_entry<'a>(
             state: initial_state,
             id,
             do_close: false,
+            reset_complete: false,
+            open_deadline: None,
             buffered_threshold: BufferedThresholdConfig::Unconfigured,
         };
         entries.push(e);
@@ -1108,7 +1234,15 @@ impl fmt::Debug for SctpEvent {
                 .field("id", id)
                 .field("label", label)
                 .finish(),
-            Self::Close { id } => f.debug_struct("Close").field("id", id).finish(),
+            Self::Close { id, reset_complete } => f
+                .debug_struct("Close")
+                .field("id", id)
+                .field("reset_complete", reset_complete)
+                .finish(),
+            Self::StreamResetComplete { id } => f
+                .debug_struct("StreamResetComplete")
+                .field("id", id)
+                .finish(),
             Self::Data { id, binary, data } => f
                 .debug_struct("Data")
                 .field("id", id)
@@ -1266,9 +1400,10 @@ mod tests {
     }
 
     /// Regression test: when `assoc.open_stream()` returns `ErrStreamAlreadyExist`
-    /// for an in-band (DCEP) data channel, the entry must transition to Closed and
-    /// emit `SctpEvent::Close`. Before the fix, it stayed in `AwaitOpen` and retried
-    /// on every `do_poll()`, causing an infinite loop.
+    /// for an in-band (DCEP) data channel, the entry must eventually transition to
+    /// Closed and emit `SctpEvent::Close`. The error is transient (a reset
+    /// handshake could clear it), so the entry retries first — but bounded by
+    /// `STREAM_OPEN_TIMEOUT`, not the infinite loop this once was.
     #[test]
     fn err_stream_already_exist_in_band_returns_close() {
         let (mut client, _server) = connect_client_server();
@@ -1296,16 +1431,25 @@ mod tests {
             state: StreamEntryState::AwaitOpen,
             id: stream_id,
             do_close: false,
+            reset_complete: false,
+            open_deadline: None,
             buffered_threshold: BufferedThresholdConfig::Unconfigured,
         });
 
-        // Before the fix: do_poll() would return None (continue skipped close handling)
-        // and the entry would remain in AwaitOpen, retrying forever.
-        // After the fix: do_poll() should return SctpEvent::Close.
+        // The first poll retries instead of failing (arms the deadline).
+        let event = client.do_poll();
+        assert!(
+            event.is_none(),
+            "expected retry (no event) for stream {stream_id}, got {event:?}"
+        );
+
+        // Past the deadline the open gives up and closes.
+        let later = Instant::now() + STREAM_OPEN_TIMEOUT + Duration::from_secs(1);
+        client.handle_timeout(later);
         let event = client.do_poll();
 
         assert!(
-            matches!(&event, Some(SctpEvent::Close { id }) if *id == stream_id),
+            matches!(&event, Some(SctpEvent::Close { id, .. }) if *id == stream_id),
             "expected SctpEvent::Close for stream {stream_id}, got {event:?}"
         );
 

--- a/src/sctp/mod.rs
+++ b/src/sctp/mod.rs
@@ -84,9 +84,6 @@ struct StreamEntry {
     id: u16,
     /// If we are to close this entry.
     do_close: bool,
-    /// Whether the reset handshake for this stream has completed.
-    /// Set when the remote initiates the close
-    reset_complete: bool,
     /// Deadline for retrying `open_stream` when it fails.
     open_deadline: Option<Instant>,
     /// If the queued outgoing data drops below this threshold, Rtc is to emit an
@@ -133,12 +130,9 @@ pub(crate) enum SctpEvent {
     },
     Close {
         id: u16,
-        /// Whether the reset handshake already completed for this stream.
-        reset_complete: bool,
     },
-    /// The reset handshake for a locally initiated close completed, the remote's
-    /// reciprocal reset arrived and sctp-proto unregistered the stream. The
-    /// stream id is now safe to recycle.
+    /// The reset handshake for a closed stream completed and sctp-proto emitted
+    /// StreamEvent::ResetComplete. The stream id is now safe to be used again.
     StreamResetComplete {
         id: u16,
     },
@@ -549,7 +543,7 @@ impl RtcSctp {
         if let Some(entry) = self.entries.iter_mut().find(|v| v.id == id) {
             entry.do_close = true;
 
-            // Close esplicitally sctp stream to allow re-use of the same id.
+            // Explicitly close the sctp stream to allow re-use of the same id.
             if let Some(Ok(mut stream)) = self.assoc.as_mut().map(|assoc| assoc.stream(id)) {
                 let _ = stream.close();
             }
@@ -779,30 +773,28 @@ impl RtcSctp {
                         );
                     }
                     StreamEvent::Finished { id } | StreamEvent::Stopped { id, .. } => {
-                        match self.entries.iter_mut().find(|e| e.id == id) {
-                            // If the event arrives on a live stream, it's a remote-initiated close.
-                            // sctp-proto has already unregistered the stream and auto-queued the
-                            // reciprocal reset.
-                            Some(entry)
-                                if entry.state != StreamEntryState::Closed
-                                    && entry.state != StreamEntryState::AwaitOpen =>
+                        // sctp-proto unregistered it when a reset  arrived.
+                        // Id reuse is signalled separately by StreamEvent::ResetComplete.
+                        //
+                        // Only a live entry has anything to drop. Closed entries and
+                        // missing ones already went through Close, and an AwaitOpen
+                        // entry is a new incarnation waiting on the same id, it must
+                        // not be killed by the old pending teardown.
+                        if let Some(entry) = self.entries.iter_mut().find(|e| e.id == id) {
+                            if entry.state != StreamEntryState::Closed
+                                && entry.state != StreamEntryState::AwaitOpen
                             {
-                                debug!("Stream {} closed by remote", id);
+                                debug!("Stream {} finished", id);
                                 entry.do_close = true;
-                                entry.reset_complete = true;
-                            }
-                            // No entry, or entry in Closed or AwaitOpen: this Finished completes
-                            // a reset WE initiated earlier, the remote's reciprocal reset has
-                            // arrived. Signal the allocator that the id is reusable.
-                            // 
-                            // AwaitOpen is included because a new incarnation may already be
-                            // waiting on the same id: this completion must unblock
-                            // its retry, not close it.
-                            _ => {
-                                debug!("Stream {} reset complete", id);
-                                return Some(SctpEvent::StreamResetComplete { id });
                             }
                         }
+                    }
+                    StreamEvent::ResetComplete { id } => {
+                        // The reset handshake for this id has fully completed,
+                        // open_stream() stops failing for it. Signal the allocator
+                        // that the id is reusable.
+                        debug!("Stream {} reset complete", id);
+                        return Some(SctpEvent::StreamResetComplete { id });
                     }
                     StreamEvent::BufferedAmountLow { id } => {
                         return Some(SctpEvent::BufferedAmountLow { id });
@@ -829,12 +821,8 @@ impl RtcSctp {
                         if !entry.configure_reliability(&mut s) {
                             entry.set_state(StreamEntryState::Closed);
                             let stream_id = entry.id;
-                            let reset_complete = entry.reset_complete;
                             self.sctp_propagate_close(stream_id);
-                            return Some(SctpEvent::Close {
-                                id: stream_id,
-                                reset_complete,
-                            });
+                            return Some(SctpEvent::Close { id: stream_id });
                         }
 
                         let config = entry.config.as_ref().expect("config if AwaitOpen");
@@ -863,12 +851,8 @@ impl RtcSctp {
                                     entry.do_close = true;
                                     entry.set_state(StreamEntryState::Closed);
                                     let stream_id = entry.id;
-                                    let reset_complete = entry.reset_complete;
                                     self.sctp_propagate_close(stream_id);
-                                    return Some(SctpEvent::Close {
-                                        id: stream_id,
-                                        reset_complete,
-                                    });
+                                    return Some(SctpEvent::Close { id: stream_id });
                                 }
                             }
                         }
@@ -902,12 +886,8 @@ impl RtcSctp {
                             entry.do_close = true;
                             entry.set_state(StreamEntryState::Closed);
                             let stream_id = entry.id;
-                            let reset_complete = entry.reset_complete;
                             self.sctp_propagate_close(stream_id);
-                            return Some(SctpEvent::Close {
-                                id: stream_id,
-                                reset_complete,
-                            });
+                            return Some(SctpEvent::Close { id: stream_id });
                         }
 
                         // Continuing means we are opening the stream out-of-band. The error can happen
@@ -918,12 +898,8 @@ impl RtcSctp {
                         entry.do_close = true;
                         entry.set_state(StreamEntryState::Closed);
                         let stream_id = entry.id;
-                        let reset_complete = entry.reset_complete;
                         self.sctp_propagate_close(stream_id);
-                        return Some(SctpEvent::Close {
-                            id: stream_id,
-                            reset_complete,
-                        });
+                        return Some(SctpEvent::Close { id: stream_id });
                     }
                 }
 
@@ -944,12 +920,8 @@ impl RtcSctp {
             if entry.do_close && entry.state != StreamEntryState::Closed {
                 entry.set_state(StreamEntryState::Closed);
                 let stream_id = entry.id;
-                let reset_complete = entry.reset_complete;
                 self.sctp_propagate_close(stream_id);
-                return Some(SctpEvent::Close {
-                    id: stream_id,
-                    reset_complete,
-                });
+                return Some(SctpEvent::Close { id: stream_id });
             }
 
             let mut stream = match assoc.stream(entry.id) {
@@ -1040,12 +1012,8 @@ impl RtcSctp {
                                     entry.do_close = true;
                                     entry.set_state(StreamEntryState::Closed);
                                     let stream_id = entry.id;
-                                    let reset_complete = entry.reset_complete;
                                     self.sctp_propagate_close(stream_id);
-                                    return Some(SctpEvent::Close {
-                                        id: stream_id,
-                                        reset_complete,
-                                    });
+                                    return Some(SctpEvent::Close { id: stream_id });
                                 }
                             }
                         }
@@ -1133,7 +1101,7 @@ impl RtcSctp {
     }
 
     fn sctp_propagate_close(&mut self, stream_id: u16) {
-        // Close esplicitally sctp stream to allow re-use of the same id.
+        // Explicitly close the sctp stream to allow re-use of the same id.
         if let Some(Ok(mut stream)) = self.assoc.as_mut().map(|assoc| assoc.stream(stream_id)) {
             let _ = stream.close();
         }
@@ -1176,7 +1144,6 @@ fn stream_entry<'a>(
             state: initial_state,
             id,
             do_close: false,
-            reset_complete: false,
             open_deadline: None,
             buffered_threshold: BufferedThresholdConfig::Unconfigured,
         };
@@ -1234,11 +1201,7 @@ impl fmt::Debug for SctpEvent {
                 .field("id", id)
                 .field("label", label)
                 .finish(),
-            Self::Close { id, reset_complete } => f
-                .debug_struct("Close")
-                .field("id", id)
-                .field("reset_complete", reset_complete)
-                .finish(),
+            Self::Close { id } => f.debug_struct("Close").field("id", id).finish(),
             Self::StreamResetComplete { id } => f
                 .debug_struct("StreamResetComplete")
                 .field("id", id)
@@ -1431,7 +1394,6 @@ mod tests {
             state: StreamEntryState::AwaitOpen,
             id: stream_id,
             do_close: false,
-            reset_complete: false,
             open_deadline: None,
             buffered_threshold: BufferedThresholdConfig::Unconfigured,
         });
@@ -1449,7 +1411,7 @@ mod tests {
         let event = client.do_poll();
 
         assert!(
-            matches!(&event, Some(SctpEvent::Close { id, .. }) if *id == stream_id),
+            matches!(&event, Some(SctpEvent::Close { id }) if *id == stream_id),
             "expected SctpEvent::Close for stream {stream_id}, got {event:?}"
         );
 

--- a/src/sctp/mod.rs
+++ b/src/sctp/mod.rs
@@ -1,11 +1,11 @@
 #![allow(clippy::new_without_default)]
 
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::fmt;
 use std::net::SocketAddr;
 use std::panic::UnwindSafe;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use sctp_proto::{Association, AssociationHandle, DatagramEvent};
 use sctp_proto::{Endpoint, EndpointConfig, Stream, StreamEvent, Transmit};
@@ -42,6 +42,13 @@ pub(crate) struct RtcSctp {
     handle: AssociationHandle,
     assoc: Option<Association>,
     entries: Vec<StreamEntry>,
+    // Stream ids that still owe a `StreamEvent::ResetComplete`,
+    // thos ids needs to be held back from reuse.
+    reset_pending: HashSet<u16>,
+    // Completed resets awaiting delivery to the caller.
+    // Used to guarantee emission ordering, ResetComplete must
+    // be sent after Close.
+    reset_complete: VecDeque<u16>,
     pushed_back_transmit: Option<VecDeque<Vec<u8>>>,
     last_now: Instant,
     client: bool,
@@ -84,6 +91,8 @@ struct StreamEntry {
     id: u16,
     /// If we are to close this entry.
     do_close: bool,
+    /// Deadline for retrying `open_stream` when it fails.
+    open_deadline: Option<Instant>,
     /// If the queued outgoing data drops below this threshold, Rtc is to emit an
     /// event to the user.
     buffered_threshold: BufferedThresholdConfig,
@@ -127,6 +136,15 @@ pub(crate) enum SctpEvent {
         label: String,
     },
     Close {
+        id: u16,
+        /// Whether a reset handshake is outstanding for this stream id.
+        reset_pending: bool,
+    },
+    /// The reset handshake for a closed stream completed and sctp-proto emitted
+    /// StreamEvent::ResetComplete. The stream id is now safe to be used again.
+    ///
+    /// Always reported after the `Close` for the same id.
+    StreamResetComplete {
         id: u16,
     },
     Data {
@@ -247,6 +265,17 @@ impl StreamEntry {
 /// chunk header + some extra.
 const SCTP_OVERHEAD: usize = 40;
 
+/// How long `open_stream` keeps retrying when blocked by a transient error
+/// which could happen during reset handshake (RFC 6525).
+/// Past this the peer is considered broken and the open gives up.
+const STREAM_OPEN_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Backstop poll interval while an open is retrying. Retries are normally
+/// driven by the network input that unblocks them,
+/// either the reciprocal reset or RECONFIG-RESPONSE arriving.
+/// This interval guarantees progress in case of absence of the latter messages.
+const STREAM_OPEN_RETRY_INTERVAL: Duration = Duration::from_millis(500);
+
 /// Empirical: SCTP `max_payload_size` of 1200 has produced 1277-byte DTLS-wrapped
 /// datagrams (77 bytes combined SCTP + DTLS overhead).
 const _: () = assert!(
@@ -275,6 +304,8 @@ impl RtcSctp {
             handle: AssociationHandle(0), // temporary
             assoc: None,
             entries: vec![],
+            reset_pending: HashSet::new(),
+            reset_complete: VecDeque::new(),
             pushed_back_transmit: None,
             last_now: Instant::now(), // placeholder until init()
             client: false,
@@ -522,9 +553,13 @@ impl RtcSctp {
 
     /// Close stream.
     pub fn close_stream(&mut self, id: u16) {
-        if let Some(entry) = self.entries.iter_mut().find(|v| v.id == id) {
-            entry.do_close = true;
-        }
+        let Some(entry) = self.entries.iter_mut().find(|v| v.id == id) else {
+            return;
+        };
+        entry.do_close = true;
+
+        // Explicitly close the sctp stream to allow re-use of the same id.
+        let _ = self.sctp_propagate_close(id);
     }
 
     pub fn close(&mut self) -> Result<(), SctpError> {
@@ -707,6 +742,11 @@ impl RtcSctp {
             return None;
         }
 
+        // Remove closed entries. handle_timeout() also does this, but the
+        // remote can reuse a stream id (its reset handshake completed) before
+        // our next timeout.
+        self.entries.retain(|e| e.state != StreamEntryState::Closed);
+
         if let Some(t) = self.pushed_back_transmit.take() {
             return Some(SctpEvent::Transmit { packets: t });
         }
@@ -736,6 +776,9 @@ impl RtcSctp {
 
             if let Event::AssociationLost { ref reason } = e {
                 debug!("Association lost, reason: {}", reason);
+                // No reset can complete on a dead association.
+                self.reset_pending.clear();
+                self.reset_complete.clear();
                 return Some(SctpEvent::AssociationLost);
             }
 
@@ -750,14 +793,31 @@ impl RtcSctp {
                         );
                     }
                     StreamEvent::Finished { id } | StreamEvent::Stopped { id, .. } => {
-                        let entry = stream_entry(
-                            &mut self.entries,
-                            id,
-                            StreamEntryState::AwaitConfig,
-                            "closed",
-                        );
-                        debug!("Stream {} closed", id);
-                        entry.do_close = true;
+                        // sctp-proto unregistered it when a reset arrived.
+                        // Id reuse is signalled separately by StreamEvent::ResetComplete.
+                        //
+                        // sctp-proto arms that completion here, so from now on a reset
+                        // is outstanding for the id even if we never closed it locally.
+                        self.reset_pending.insert(id);
+
+                        // Only a live entry has anything to drop. Closed entries and
+                        // missing ones already went through Close, and an AwaitOpen
+                        // entry is a new incarnation waiting on the same id, it must
+                        // not be killed by the old pending teardown.
+                        if let Some(entry) = self.entries.iter_mut().find(|e| e.id == id) {
+                            if entry.state != StreamEntryState::Closed
+                                && entry.state != StreamEntryState::AwaitOpen
+                            {
+                                debug!("Stream {} finished", id);
+                                entry.do_close = true;
+                            }
+                        }
+                    }
+                    StreamEvent::ResetComplete { id } => {
+                        // The reset handshake for this id has fully completed.
+                        debug!("Stream {} reset complete", id);
+                        self.reset_pending.remove(&id);
+                        self.reset_complete.push_back(id);
                     }
                     StreamEvent::BufferedAmountLow { id } => {
                         return Some(SctpEvent::BufferedAmountLow { id });
@@ -779,9 +839,16 @@ impl RtcSctp {
                 debug!("Open stream {}", entry.id);
                 match assoc.open_stream(entry.id, PayloadProtocolIdentifier::Unknown) {
                     Ok(mut s) => {
+                        entry.open_deadline = None;
+
                         if !entry.configure_reliability(&mut s) {
                             entry.set_state(StreamEntryState::Closed);
-                            return Some(SctpEvent::Close { id: entry.id });
+                            let stream_id = entry.id;
+                            let reset_pending = self.sctp_propagate_close(stream_id);
+                            return Some(SctpEvent::Close {
+                                id: stream_id,
+                                reset_pending,
+                            });
                         }
 
                         let config = entry.config.as_ref().expect("config if AwaitOpen");
@@ -809,35 +876,89 @@ impl RtcSctp {
                                     );
                                     entry.do_close = true;
                                     entry.set_state(StreamEntryState::Closed);
-                                    return Some(SctpEvent::Close { id: entry.id });
+                                    let stream_id = entry.id;
+                                    let reset_pending = self.sctp_propagate_close(stream_id);
+                                    return Some(SctpEvent::Close {
+                                        id: stream_id,
+                                        reset_pending,
+                                    });
                                 }
                             }
                         }
 
                         // Continuing means we are opening the stream out-of-band.
                     }
-                    Err(ProtoError::ErrStreamAlreadyExist) => {
+                    Err(
+                        e @ (ProtoError::ErrStreamAlreadyExist | ProtoError::ErrStreamResetPending),
+                    ) => {
                         let config = entry.config.as_ref().expect("config if AwaitOpen");
                         let in_band = config.negotiated.is_none();
 
-                        if in_band {
-                            warn!(
-                                "Opening stream {} failed: ErrStreamAlreadyExists with in-band",
-                                entry.id
-                            );
+                        // ErrStreamAlreadyExist has two causes:
+                        // - the remote created it by sending on it first
+                        // - a previous incarnation of the id is still registered,
+                        //   reset handshake hasn't finished
+                        let stale_incarnation = matches!(e, ProtoError::ErrStreamAlreadyExist)
+                            && assoc
+                                .stream(entry.id)
+                                .map(|s| !s.is_readable() && !s.is_writable())
+                                .unwrap_or(false);
+
+                        if in_band
+                            || stale_incarnation
+                            || matches!(e, ProtoError::ErrStreamResetPending)
+                        {
+                            // RFC 6525 reset handshake for a previous
+                            // incarnation of this stream id hasn't finished yet
+                            //
+                            // - AlreadyExist clears when the remote's reciprocal reset arrives
+                            // - ResetPending when the RECONFIG-RESPONSE arrives (silently)
+                            //
+                            // In both cases,  stay in AwaitOpen and retry until past the deadline.
+                            let deadline = *entry
+                                .open_deadline
+                                .get_or_insert(self.last_now + STREAM_OPEN_TIMEOUT);
+
+                            if self.last_now < deadline {
+                                debug!("Stream {} open blocked ({:?}), will retry", entry.id, e);
+                                continue;
+                            }
+
+                            debug!("Opening stream {} failed after retries: {:?}", entry.id, e);
                             entry.do_close = true;
                             entry.set_state(StreamEntryState::Closed);
-                            return Some(SctpEvent::Close { id: entry.id });
+                            let stream_id = entry.id;
+                            let reset_pending = self.sctp_propagate_close(stream_id);
+                            return Some(SctpEvent::Close {
+                                id: stream_id,
+                                reset_pending,
+                            });
                         }
 
-                        // Continuing means we are opening the stream out-of-band. The error can happen
-                        // if both streams are declared and one side starts sending to the other
+                        // Continuing means we are adopting the live out-of-band stream the
+                        // remote created. It skipped the Ok branch above, so reliability
+                        // params haven't been applied to it yet.
+                        let mut stream = assoc.stream(entry.id).expect("stream that exists");
+                        if !entry.configure_reliability(&mut stream) {
+                            entry.set_state(StreamEntryState::Closed);
+                            let stream_id = entry.id;
+                            let reset_pending = self.sctp_propagate_close(stream_id);
+                            return Some(SctpEvent::Close {
+                                id: stream_id,
+                                reset_pending,
+                            });
+                        }
                     }
                     Err(e) => {
                         warn!("Opening stream {} failed: {:?}", entry.id, e);
                         entry.do_close = true;
                         entry.set_state(StreamEntryState::Closed);
-                        return Some(SctpEvent::Close { id: entry.id });
+                        let stream_id = entry.id;
+                        let reset_pending = self.sctp_propagate_close(stream_id);
+                        return Some(SctpEvent::Close {
+                            id: stream_id,
+                            reset_pending,
+                        });
                     }
                 }
 
@@ -857,7 +978,12 @@ impl RtcSctp {
 
             if entry.do_close && entry.state != StreamEntryState::Closed {
                 entry.set_state(StreamEntryState::Closed);
-                return Some(SctpEvent::Close { id: entry.id });
+                let stream_id = entry.id;
+                let reset_pending = self.sctp_propagate_close(stream_id);
+                return Some(SctpEvent::Close {
+                    id: stream_id,
+                    reset_pending,
+                });
             }
 
             let mut stream = match assoc.stream(entry.id) {
@@ -947,7 +1073,12 @@ impl RtcSctp {
                                     );
                                     entry.do_close = true;
                                     entry.set_state(StreamEntryState::Closed);
-                                    return Some(SctpEvent::Close { id: entry.id });
+                                    let stream_id = entry.id;
+                                    let reset_pending = self.sctp_propagate_close(stream_id);
+                                    return Some(SctpEvent::Close {
+                                        id: stream_id,
+                                        reset_pending,
+                                    });
                                 }
                             }
                         }
@@ -983,11 +1114,36 @@ impl RtcSctp {
             }
         }
 
+        // Reset completions are reported last. Reaching here means the entry loop had
+        // no `Close` left to emit, so the close for a released id has been delivered.
+        if let Some(id) = self.reset_complete.pop_front() {
+            return Some(SctpEvent::StreamResetComplete { id });
+        }
+
         None
     }
 
     pub fn poll_timeout(&mut self) -> Option<Instant> {
-        self.assoc.as_mut().and_then(|a| a.poll_timeout())
+        let assoc_timeout = self.assoc.as_mut().and_then(|a| a.poll_timeout());
+
+        // Wakeup backstop for entries whose open_stream() is being retried.
+        //
+        // Normally no wakeup is needed: a blocked open re-attempts on the
+        // next do_poll(), and the packet that unblocks it (the peer's
+        // RECONFIG-RESPONSE or reset) itself triggers handle_input() and that poll.
+        //
+        // Returning a wakeup while any entry retries guarantees the open
+        // either resolves or fails within STREAM_OPEN_TIMEOUT.
+        let retry_timeout = self
+            .entries
+            .iter()
+            .any(|e| e.state == StreamEntryState::AwaitOpen && e.open_deadline.is_some())
+            .then(|| self.last_now + STREAM_OPEN_RETRY_INTERVAL);
+
+        match (assoc_timeout, retry_timeout) {
+            (Some(a), Some(r)) => Some(a.min(r)),
+            (a, r) => a.or(r),
+        }
     }
 
     pub fn push_back_transmit(&mut self, data: VecDeque<Vec<u8>>) {
@@ -1013,6 +1169,26 @@ impl RtcSctp {
             .iter()
             .find(|s| s.id == sctp_stream_id)
             .and_then(|s| s.config.as_ref())
+    }
+
+    /// Close the sctp stream to allow re-use of the same id.
+    ///
+    /// Returns whether a reset handshake is outstanding for `stream_id`.
+    fn sctp_propagate_close(&mut self, stream_id: u16) -> bool {
+        let did_reset = match self.assoc.as_mut().map(|assoc| assoc.stream(stream_id)) {
+            // `close()` only fails on the reset, which needs an established
+            // association. Closing a channel while the association is shutting down
+            // therefore queues nothing and no completion will ever arrive.
+            Some(Ok(mut stream)) => stream.close().is_ok(),
+            // No stream to reset.
+            _ => false,
+        };
+
+        if did_reset {
+            self.reset_pending.insert(stream_id);
+        }
+
+        self.reset_pending.contains(&stream_id)
     }
 
     #[cfg(test)]
@@ -1052,6 +1228,7 @@ fn stream_entry<'a>(
             state: initial_state,
             id,
             do_close: false,
+            open_deadline: None,
             buffered_threshold: BufferedThresholdConfig::Unconfigured,
         };
         entries.push(e);
@@ -1108,7 +1285,15 @@ impl fmt::Debug for SctpEvent {
                 .field("id", id)
                 .field("label", label)
                 .finish(),
-            Self::Close { id } => f.debug_struct("Close").field("id", id).finish(),
+            Self::Close { id, reset_pending } => f
+                .debug_struct("Close")
+                .field("id", id)
+                .field("reset_pending", reset_pending)
+                .finish(),
+            Self::StreamResetComplete { id } => f
+                .debug_struct("StreamResetComplete")
+                .field("id", id)
+                .finish(),
             Self::Data { id, binary, data } => f
                 .debug_struct("Data")
                 .field("id", id)
@@ -1266,9 +1451,10 @@ mod tests {
     }
 
     /// Regression test: when `assoc.open_stream()` returns `ErrStreamAlreadyExist`
-    /// for an in-band (DCEP) data channel, the entry must transition to Closed and
-    /// emit `SctpEvent::Close`. Before the fix, it stayed in `AwaitOpen` and retried
-    /// on every `do_poll()`, causing an infinite loop.
+    /// for an in-band (DCEP) data channel, the entry must eventually transition to
+    /// Closed and emit `SctpEvent::Close`. The error is transient (a reset
+    /// handshake could clear it), so the entry retries first — but bounded by
+    /// `STREAM_OPEN_TIMEOUT`, not the infinite loop this once was.
     #[test]
     fn err_stream_already_exist_in_band_returns_close() {
         let (mut client, _server) = connect_client_server();
@@ -1296,22 +1482,121 @@ mod tests {
             state: StreamEntryState::AwaitOpen,
             id: stream_id,
             do_close: false,
+            open_deadline: None,
             buffered_threshold: BufferedThresholdConfig::Unconfigured,
         });
 
-        // Before the fix: do_poll() would return None (continue skipped close handling)
-        // and the entry would remain in AwaitOpen, retrying forever.
-        // After the fix: do_poll() should return SctpEvent::Close.
+        // The first poll retries instead of failing (arms the deadline).
+        let event = client.do_poll();
+        assert!(
+            event.is_none(),
+            "expected retry (no event) for stream {stream_id}, got {event:?}"
+        );
+
+        // Past the deadline the open gives up and closes.
+        let later = Instant::now() + STREAM_OPEN_TIMEOUT + Duration::from_secs(1);
+        client.handle_timeout(later);
         let event = client.do_poll();
 
         assert!(
-            matches!(&event, Some(SctpEvent::Close { id }) if *id == stream_id),
+            matches!(&event, Some(SctpEvent::Close { id, .. }) if *id == stream_id),
             "expected SctpEvent::Close for stream {stream_id}, got {event:?}"
         );
 
         // Verify entry transitioned to Closed.
         let entry = client.entries.iter().find(|e| e.id == stream_id).unwrap();
         assert_eq!(entry.state, StreamEntryState::Closed);
+    }
+
+    #[test]
+    fn negotiated_reuse_does_not_report_open_for_old_closed_stream() {
+        let (mut client, _server) = connect_client_server();
+        let stream_id = 0;
+
+        let assoc = client.assoc.as_mut().unwrap();
+        let mut old = assoc
+            .open_stream(stream_id, PayloadProtocolIdentifier::Unknown)
+            .expect("old stream should open");
+        old.close().expect("old stream should start closing");
+
+        client.entries.push(StreamEntry {
+            config: Some(ChannelConfig {
+                label: "replacement".to_string(),
+                ordered: true,
+                reliability: Reliability::Reliable,
+                negotiated: Some(stream_id),
+                protocol: String::new(),
+            }),
+            state: StreamEntryState::AwaitOpen,
+            id: stream_id,
+            do_close: false,
+            open_deadline: None,
+            buffered_threshold: BufferedThresholdConfig::Unconfigured,
+        });
+
+        for _ in 0..10 {
+            match client.do_poll() {
+                Some(SctpEvent::Open { id, .. }) if id == stream_id => {
+                    panic!("replacement was reported open while the old stream still exists")
+                }
+                Some(_) => {}
+                None => break,
+            }
+        }
+    }
+
+    #[test]
+    fn close_is_reported_before_reset_complete_when_events_are_batched() {
+        let now = Instant::now();
+        let (mut client, mut server) = connect_client_server();
+        let stream_id = 0;
+        let config = ChannelConfig {
+            label: "batched-close".to_string(),
+            negotiated: Some(stream_id),
+            ..Default::default()
+        };
+
+        client.open_stream(stream_id, config.clone());
+        server.open_stream(stream_id, config);
+        assert!(matches!(
+            client.do_poll(),
+            Some(SctpEvent::Open { id, .. }) if id == stream_id
+        ));
+        assert!(matches!(
+            server.do_poll(),
+            Some(SctpEvent::Open { id, .. }) if id == stream_id
+        ));
+
+        client.close_stream(stream_id);
+
+        // Move all reset packets in both directions without polling client
+        // application events. This batches Finished and ResetComplete in the
+        // association event queue, which is valid for a sans-I/O caller.
+        for _ in 0..4 {
+            while let Some(transmit) = client.poll_transmit() {
+                for packet in transmit_to_vec(transmit).unwrap() {
+                    server.handle_input(now, &packet);
+                }
+            }
+            while let Some(transmit) = server.poll_transmit() {
+                for packet in transmit_to_vec(transmit).unwrap() {
+                    client.handle_input(now, &packet);
+                }
+            }
+        }
+
+        for _ in 0..10 {
+            match client.do_poll() {
+                Some(SctpEvent::Close { id, .. }) if id == stream_id => return,
+                Some(SctpEvent::StreamResetComplete { id }) if id == stream_id => {
+                    panic!("ResetComplete was reported before Close")
+                }
+                Some(_) => {}
+                None => break,
+            }
+        }
+
+        panic!("stream close was not reported");
     }
 
     /// Regression test: the DCEP-receiving side of an in-band channel must apply

--- a/tests/data-channel.rs
+++ b/tests/data-channel.rs
@@ -155,10 +155,9 @@ pub fn data_channel_close_reopen() -> Result<(), RtcError> {
     loop {
         progress(&mut l, &mut r)?;
 
-        let l_open = l
-            .events
-            .iter()
-            .any(|(_, e)| matches!(e, Event::ChannelOpen(id, label) if *id == cid2 && label == "churn2"));
+        let l_open = l.events.iter().any(
+            |(_, e)| matches!(e, Event::ChannelOpen(id, label) if *id == cid2 && label == "churn2"),
+        );
         let r_open = r
             .events
             .iter()
@@ -189,10 +188,9 @@ pub fn data_channel_close_reopen() -> Result<(), RtcError> {
 
         progress(&mut l, &mut r)?;
 
-        let got_data = r
-            .events
-            .iter()
-            .any(|(_, e)| matches!(e, Event::ChannelData(d) if d.data.as_slice() == b"hello again"));
+        let got_data = r.events.iter().any(
+            |(_, e)| matches!(e, Event::ChannelData(d) if d.data.as_slice() == b"hello again"),
+        );
         if got_data {
             break;
         }

--- a/tests/data-channel.rs
+++ b/tests/data-channel.rs
@@ -56,6 +56,155 @@ pub fn data_channel() -> Result<(), RtcError> {
     Ok(())
 }
 
+/// Closing a data channel must propagate to the remote peer (via the SCTP
+/// stream reset handshake), and once the handshake completes the freed stream
+/// id must be reusable by a new in-band channel.
+#[test]
+pub fn data_channel_close_reopen() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let mut l = TestRtc::new(Peer::Left);
+    let mut r = TestRtc::new(Peer::Right);
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    let mut change = l.sdp_api();
+    let cid = change.add_channel("churn".into());
+    let (offer, pending) = change.apply().unwrap();
+
+    let answer = r.rtc.sdp_api().accept_offer(offer)?;
+    l.rtc.sdp_api().accept_answer(pending, answer)?;
+
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r)?;
+    }
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    // Wait until both sides see the channel open.
+    loop {
+        progress(&mut l, &mut r)?;
+
+        let l_open = l
+            .events
+            .iter()
+            .any(|(_, e)| matches!(e, Event::ChannelOpen(id, _) if *id == cid));
+        let r_open = r
+            .events
+            .iter()
+            .any(|(_, e)| matches!(e, Event::ChannelOpen(_, _)));
+
+        if l_open && r_open {
+            break;
+        }
+        assert!(
+            l.duration() < Duration::from_secs(10),
+            "first channel should open on both sides"
+        );
+    }
+
+    let stream_id = l
+        .direct_api()
+        .sctp_stream_id_by_channel_id(cid)
+        .expect("stream id for open channel");
+
+    // Close locally. The reset handshake must inform the remote, which
+    // previously never received ChannelClose.
+    l.direct_api().close_data_channel(cid);
+
+    loop {
+        progress(&mut l, &mut r)?;
+
+        let l_closed = l
+            .events
+            .iter()
+            .any(|(_, e)| matches!(e, Event::ChannelClose(id) if *id == cid));
+        let r_closed = r
+            .events
+            .iter()
+            .any(|(_, e)| matches!(e, Event::ChannelClose(_)));
+
+        if l_closed && r_closed {
+            break;
+        }
+        assert!(
+            l.duration() < Duration::from_secs(20),
+            "both sides should see ChannelClose"
+        );
+    }
+
+    // The reset handshake finishes with round-trips (reciprocal reset and
+    // RECONFIG-RESPONSEs) that carry no public events, so there is nothing to
+    // wait on here. Creating the next channel immediately is fine: its stream
+    // id allocation happens on a later timeout, by which time the handshake
+    // rounds have been ferried through. The stream id assertion below fails
+    // loudly if the allocator did not release the id in time.
+    let cid2 = l.direct_api().create_data_channel(ChannelConfig {
+        label: "churn2".into(),
+        ..Default::default()
+    });
+    assert_ne!(cid, cid2);
+
+    loop {
+        progress(&mut l, &mut r)?;
+
+        let l_open = l
+            .events
+            .iter()
+            .any(|(_, e)| matches!(e, Event::ChannelOpen(id, label) if *id == cid2 && label == "churn2"));
+        let r_open = r
+            .events
+            .iter()
+            .any(|(_, e)| matches!(e, Event::ChannelOpen(_, label) if label == "churn2"));
+
+        if l_open && r_open {
+            break;
+        }
+        assert!(
+            l.duration() < Duration::from_secs(30),
+            "reopened channel should open on both sides"
+        );
+    }
+
+    // The freed stream id must have been reused, proving the allocator
+    // released it when the reset handshake completed.
+    assert_eq!(
+        l.direct_api().sctp_stream_id_by_channel_id(cid2),
+        Some(stream_id),
+        "reopened channel should reuse the freed stream id"
+    );
+
+    // Data flows on the reopened channel.
+    loop {
+        if let Some(mut chan) = l.channel(cid2) {
+            chan.write(false, b"hello again").expect("write to succeed");
+        }
+
+        progress(&mut l, &mut r)?;
+
+        let got_data = r
+            .events
+            .iter()
+            .any(|(_, e)| matches!(e, Event::ChannelData(d) if d.data.as_slice() == b"hello again"));
+        if got_data {
+            break;
+        }
+        assert!(
+            l.duration() < Duration::from_secs(40),
+            "data should flow on the reopened channel"
+        );
+    }
+
+    Ok(())
+}
+
 #[test]
 pub fn data_channel_flood() -> Result<(), RtcError> {
     init_log();

--- a/tests/data-channel.rs
+++ b/tests/data-channel.rs
@@ -1,12 +1,33 @@
 use std::net::Ipv4Addr;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use netem::NetemConfig;
 use str0m::channel::ChannelConfig;
-use str0m::{Event, RtcError};
+use str0m::{Event, Input, Output, RtcError};
 
 mod common;
-use common::{Peer, TestRtc, init_crypto_default, init_log, progress};
+use common::{Peer, TestRtc, connect_l_r, init_crypto_default, init_log, progress};
+
+/// Poll one peer while deliberately withholding all of its network output.
+///
+/// This models an application that keeps driving its local RTC while packets
+/// to the peer are delayed. Public events are returned to the test; transmits
+/// are dropped instead of being handed to the remote `TestRtc`.
+fn poll_without_delivering_network(
+    rtc: &mut TestRtc,
+    now: Instant,
+) -> Result<Vec<Event>, RtcError> {
+    rtc.rtc.handle_input(Input::Timeout(now))?;
+
+    let mut events = vec![];
+    loop {
+        match rtc.rtc.poll_output()? {
+            Output::Event(event) => events.push(event),
+            Output::Transmit(_) => {}
+            Output::Timeout(_) => return Ok(events),
+        }
+    }
+}
 
 #[test]
 pub fn data_channel() -> Result<(), RtcError> {
@@ -52,6 +73,277 @@ pub fn data_channel() -> Result<(), RtcError> {
     }
 
     assert!(r.events.len() > 120);
+
+    Ok(())
+}
+
+/// Closing a data channel must propagate to the remote peer (via the SCTP
+/// stream reset handshake), and once the handshake completes the freed stream
+/// id must be reusable by a new in-band channel.
+#[test]
+pub fn data_channel_close_reopen() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let mut l = TestRtc::new(Peer::Left);
+    let mut r = TestRtc::new(Peer::Right);
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    let mut change = l.sdp_api();
+    let cid = change.add_channel("churn".into());
+    let (offer, pending) = change.apply().unwrap();
+
+    let answer = r.rtc.sdp_api().accept_offer(offer)?;
+    l.rtc.sdp_api().accept_answer(pending, answer)?;
+
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r)?;
+    }
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    // Wait until both sides see the channel open.
+    loop {
+        progress(&mut l, &mut r)?;
+
+        let l_open = l
+            .events
+            .iter()
+            .any(|(_, e)| matches!(e, Event::ChannelOpen(id, _) if *id == cid));
+        let r_open = r
+            .events
+            .iter()
+            .any(|(_, e)| matches!(e, Event::ChannelOpen(_, _)));
+
+        if l_open && r_open {
+            break;
+        }
+        assert!(
+            l.duration() < Duration::from_secs(10),
+            "first channel should open on both sides"
+        );
+    }
+
+    let stream_id = l
+        .direct_api()
+        .sctp_stream_id_by_channel_id(cid)
+        .expect("stream id for open channel");
+
+    // Close locally. The reset handshake must inform the remote, which
+    // previously never received ChannelClose.
+    l.direct_api().close_data_channel(cid);
+
+    loop {
+        progress(&mut l, &mut r)?;
+
+        let l_closed = l
+            .events
+            .iter()
+            .any(|(_, e)| matches!(e, Event::ChannelClose(id) if *id == cid));
+        let r_closed = r
+            .events
+            .iter()
+            .any(|(_, e)| matches!(e, Event::ChannelClose(_)));
+
+        if l_closed && r_closed {
+            break;
+        }
+        assert!(
+            l.duration() < Duration::from_secs(20),
+            "both sides should see ChannelClose"
+        );
+    }
+
+    // The reset handshake finishes with round-trips (reciprocal reset and
+    // RECONFIG-RESPONSEs) that carry no public events, so there is nothing to
+    // wait on here. Creating the next channel immediately is fine: its stream
+    // id allocation happens on a later timeout, by which time the handshake
+    // rounds have been ferried through. The stream id assertion below fails
+    // loudly if the allocator did not release the id in time.
+    let cid2 = l.direct_api().create_data_channel(ChannelConfig {
+        label: "churn2".into(),
+        ..Default::default()
+    });
+    assert_ne!(cid, cid2);
+
+    loop {
+        progress(&mut l, &mut r)?;
+
+        let l_open = l.events.iter().any(
+            |(_, e)| matches!(e, Event::ChannelOpen(id, label) if *id == cid2 && label == "churn2"),
+        );
+        let r_open = r
+            .events
+            .iter()
+            .any(|(_, e)| matches!(e, Event::ChannelOpen(_, label) if label == "churn2"));
+
+        if l_open && r_open {
+            break;
+        }
+        assert!(
+            l.duration() < Duration::from_secs(30),
+            "reopened channel should open on both sides"
+        );
+    }
+
+    // The freed stream id must have been reused, proving the allocator
+    // released it when the reset handshake completed.
+    assert_eq!(
+        l.direct_api().sctp_stream_id_by_channel_id(cid2),
+        Some(stream_id),
+        "reopened channel should reuse the freed stream id"
+    );
+
+    // Data flows on the reopened channel.
+    loop {
+        if let Some(mut chan) = l.channel(cid2) {
+            chan.write(false, b"hello again").expect("write to succeed");
+        }
+
+        progress(&mut l, &mut r)?;
+
+        let got_data = r.events.iter().any(
+            |(_, e)| matches!(e, Event::ChannelData(d) if d.data.as_slice() == b"hello again"),
+        );
+        if got_data {
+            break;
+        }
+        assert!(
+            l.duration() < Duration::from_secs(40),
+            "data should flow on the reopened channel"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+pub fn negotiated_reuse_waits_for_reset_before_channel_open() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let (mut l, mut r) = connect_l_r();
+    let stream_id = 10;
+    let config = ChannelConfig {
+        label: "old-generation".into(),
+        negotiated: Some(stream_id),
+        ..Default::default()
+    };
+    let old_l = l.direct_api().create_data_channel(config.clone());
+    let _old_r = r.direct_api().create_data_channel(config);
+
+    loop {
+        progress(&mut l, &mut r)?;
+        let left_open = l
+            .events
+            .iter()
+            .any(|(_, event)| matches!(event, Event::ChannelOpen(id, _) if *id == old_l));
+        let right_open = r
+            .events
+            .iter()
+            .any(|(_, event)| matches!(event, Event::ChannelOpen(_, _)));
+        if left_open && right_open {
+            break;
+        }
+        assert!(
+            l.duration() < Duration::from_secs(10),
+            "negotiated channel should open on both peers"
+        );
+    }
+
+    l.events.clear();
+    l.direct_api().close_data_channel(old_l);
+
+    // Process the local close, but withhold its RE-CONFIG packets. The old
+    // SCTP stream therefore still exists and its reset cannot be complete.
+    let close_at = l.last;
+    let close_events = poll_without_delivering_network(&mut l, close_at)?;
+    assert!(
+        close_events
+            .iter()
+            .any(|event| matches!(event, Event::ChannelClose(id) if *id == old_l)),
+        "the old local channel should close"
+    );
+
+    let replacement = l.direct_api().create_data_channel(ChannelConfig {
+        label: "replacement".into(),
+        negotiated: Some(stream_id),
+        ..Default::default()
+    });
+    let replacement_events =
+        poll_without_delivering_network(&mut l, close_at + Duration::from_millis(1))?;
+
+    assert!(
+        !replacement_events
+            .iter()
+            .any(|event| matches!(event, Event::ChannelOpen(id, _) if *id == replacement)),
+        "a negotiated replacement must not open before the old reset completes"
+    );
+
+    Ok(())
+}
+
+#[test]
+pub fn unconfirmed_reset_keeps_stream_id_reserved() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let (mut l, mut r) = connect_l_r();
+    let old = l.direct_api().create_data_channel(ChannelConfig::default());
+
+    loop {
+        progress(&mut l, &mut r)?;
+        if l.events
+            .iter()
+            .any(|(_, event)| matches!(event, Event::ChannelOpen(id, _) if *id == old))
+        {
+            break;
+        }
+        assert!(
+            l.duration() < Duration::from_secs(10),
+            "first channel should open"
+        );
+    }
+
+    let old_stream_id = l
+        .direct_api()
+        .sctp_stream_id_by_channel_id(old)
+        .expect("old channel should have a stream ID");
+    l.direct_api().close_data_channel(old);
+
+    // Drop all local reset traffic and advance well past the close. No peer response
+    // has made the old ID safe during this interval, so it stays reserved.
+    let close_at = l.last;
+    let close_events = poll_without_delivering_network(&mut l, close_at)?;
+    assert!(
+        close_events
+            .iter()
+            .any(|event| matches!(event, Event::ChannelClose(id) if *id == old)),
+        "the old local channel should close"
+    );
+    poll_without_delivering_network(&mut l, close_at + Duration::from_secs(31))?;
+
+    let replacement = l.direct_api().create_data_channel(ChannelConfig::default());
+    poll_without_delivering_network(
+        &mut l,
+        close_at + Duration::from_secs(31) + Duration::from_millis(1),
+    )?;
+
+    let replacement_stream_id = l
+        .direct_api()
+        .sctp_stream_id_by_channel_id(replacement)
+        .expect("replacement should have a stream ID");
+    assert_ne!(
+        replacement_stream_id, old_stream_id,
+        "elapsed time cannot make an unconfirmed reset safe; another free ID should be used"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Closing a data channel was local-only, the remote never got `ChannelClose`, and the id stayed occupied on the wire, reusing it hit sctp-proto's `ErrStreamAlreadyExist` / `ErrStreamResetPending`, treated as fatal, so the new channel died instantly (seen in litep2p under churn).

fix:
- `close_stream()` closes the underlying stream, sending the reset, so both sides close and free the id.
- `StreamEvent::Finished` classification:
   - if live stream then the remote-initiated reset
   - otherwise completion of our own reset, which implies the internal emission of `SctpEvent::StreamResetComplete`.
- The allocator holds a closed id until reset complete or a 30s max-hold timer exceeds.
- Transient open errors retry for up to 10s instead of failing, driven by the packet that resolves them or a poll_timeout backstop 

The cooldown approach is being discarded because a stream ID can be re-used once the reset handshake has been completed.
