### PR TITLE
Add readiness gate to make idle poll_output O(1)

### DIFF
--- a/src/bwe/api.rs
+++ b/src/bwe/api.rs
@@ -1,5 +1,6 @@
 //! Bandwidth estimation.
 
+use crate::poll::RtcMut;
 use crate::{Rtc, rtp_::Mid};
 
 pub use crate::rtp_::Bitrate;
@@ -15,9 +16,16 @@ pub enum BweKind {
 }
 
 /// Access to the Bandwidth Estimate subsystem.
-pub struct Bwe<'a>(pub(crate) &'a mut Rtc);
+///
+/// The inner `RtcMut` arms the readiness on mutable deref only; see
+/// [`crate::poll`].
+pub struct Bwe<'a>(pub(crate) RtcMut<'a>);
 
 impl<'a> Bwe<'a> {
+    pub(crate) fn new(rtc: &'a mut Rtc) -> Self {
+        Bwe(RtcMut::new(rtc))
+    }
+
     /// Configure the desired bitrate.
     ///
     /// Configure the bandwidth estimation system with the desired bitrate.
@@ -37,11 +45,11 @@ impl<'a> Bwe<'a> {
     /// link can sustain 4.5Mbit/s there will eventually be an
     /// [`Event::EgressBitrateEstimate`][crate::Event::EgressBitrateEstimate] with this estimate.
     pub fn set_desired_bitrate(&mut self, desired_bitrate: Bitrate) {
-        self.0.session.set_bwe_desired_bitrate(desired_bitrate);
-        // Local decision: this only reconfigures the estimator and pacer timers.
-        // Any probing padding is produced later from the timeout path, so no
-        // event is queued now.
-        self.0.readiness.wake().no_events();
+        let mut m = self.0.mutate();
+        m.session.set_bwe_desired_bitrate(desired_bitrate);
+        // Reconfiguring BWE only re-arms the estimator/pacer timers; any probing
+        // padding is produced later from the timeout path, so no event is queued.
+        m.no_events();
     }
 
     /// Reset the BWE with a new init_bitrate
@@ -56,8 +64,9 @@ impl<'a> Bwe<'a> {
     /// provided init_bitrate.
     ///
     pub fn reset(&mut self, init_bitrate: Bitrate) {
-        self.0.session.reset_bwe(init_bitrate);
-        // Local decision: resetting the estimator moves no output, only timers.
-        self.0.readiness.wake().no_events();
+        let mut m = self.0.mutate();
+        m.session.reset_bwe(init_bitrate);
+        // Resetting the estimator moves no output, only timers.
+        m.no_events();
     }
 }

--- a/src/bwe/api.rs
+++ b/src/bwe/api.rs
@@ -38,6 +38,10 @@ impl<'a> Bwe<'a> {
     /// [`Event::EgressBitrateEstimate`][crate::Event::EgressBitrateEstimate] with this estimate.
     pub fn set_desired_bitrate(&mut self, desired_bitrate: Bitrate) {
         self.0.session.set_bwe_desired_bitrate(desired_bitrate);
+        // Local decision: this only reconfigures the estimator and pacer timers.
+        // Any probing padding is produced later from the timeout path, so no
+        // event is queued now.
+        self.0.readiness.wake().no_events();
     }
 
     /// Reset the BWE with a new init_bitrate
@@ -53,5 +57,7 @@ impl<'a> Bwe<'a> {
     ///
     pub fn reset(&mut self, init_bitrate: Bitrate) {
         self.0.session.reset_bwe(init_bitrate);
+        // Local decision: resetting the estimator moves no output, only timers.
+        self.0.readiness.wake().no_events();
     }
 }

--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -8,6 +8,7 @@ use crate::channel::ChannelId;
 use crate::crypto::Fingerprint;
 use crate::crypto::dtls::ProtocolVersion;
 use crate::media::{Media, MediaKind};
+use crate::poll::RtcMut;
 use crate::rtp_::MidRid;
 use crate::rtp_::{Mid, Rid, Ssrc};
 use crate::sctp::{ChannelConfig, SctpInitData};
@@ -35,7 +36,10 @@ use crate::streams::{DEFAULT_RTX_CACHE_DURATION, DEFAULT_RTX_RATIO_CAP, StreamRx
 ///  result in panics.
 /// </div>
 pub struct DirectApi<'a> {
-    rtc: &'a mut Rtc,
+    // `RtcMut` arms the readiness on mutable deref only, so the `&mut self`
+    // methods below re-poll the tree while the `&self` readers do not — with no
+    // per-method call to forget. See [`crate::poll`].
+    rtc: RtcMut<'a>,
 }
 
 impl<'a> DirectApi<'a> {
@@ -44,7 +48,9 @@ impl<'a> DirectApi<'a> {
     /// The `DirectApi` struct provides a high-level API for interacting with a WebRTC peer connection,
     /// and the `Rtc` instance provides low-level access to the underlying WebRTC functionality.
     pub fn new(rtc: &'a mut Rtc) -> Self {
-        DirectApi { rtc }
+        DirectApi {
+            rtc: RtcMut::new(rtc),
+        }
     }
 
     /// Sets the ICE controlling flag for this peer connection.
@@ -56,7 +62,6 @@ impl<'a> DirectApi<'a> {
     /// If `controlling` is `false`, this peer connection is set as the ICE controlled agent,
     /// meaning it will respond to connectivity checks sent by the controlling agent.
     pub fn set_ice_controlling(&mut self, controlling: bool) {
-        self.rtc.readiness.wake();
         self.rtc.ice.set_controlling(controlling);
     }
 
@@ -70,13 +75,11 @@ impl<'a> DirectApi<'a> {
 
     /// Sets the local ICE credentials.
     pub fn set_local_ice_credentials(&mut self, local_ice_credentials: IceCreds) {
-        self.rtc.readiness.wake();
         self.rtc.ice.set_local_credentials(local_ice_credentials);
     }
 
     /// Sets the remote ICE credentials.
     pub fn set_remote_ice_credentials(&mut self, remote_ice_credentials: IceCreds) {
-        self.rtc.readiness.wake();
         self.rtc.ice.set_remote_credentials(remote_ice_credentials);
     }
 
@@ -90,7 +93,6 @@ impl<'a> DirectApi<'a> {
     ///
     /// Returns `true` if the candidate was found and invalidated.
     pub fn invalidate_candidate(&mut self, c: &Candidate) -> bool {
-        self.rtc.readiness.wake();
         self.rtc.ice.invalidate_candidate(c)
     }
 
@@ -118,13 +120,11 @@ impl<'a> DirectApi<'a> {
 
     /// Sets the remote DTLS fingerprint.
     pub fn set_remote_fingerprint(&mut self, dtls_fingerprint: Fingerprint) {
-        self.rtc.readiness.wake();
         self.rtc.remote_fingerprint = Some(dtls_fingerprint);
     }
 
     /// Start the DTLS subsystem.
     pub fn start_dtls(&mut self, active: bool) -> Result<(), RtcError> {
-        self.rtc.readiness.wake();
         self.rtc.init_dtls(active)
     }
 
@@ -133,7 +133,6 @@ impl<'a> DirectApi<'a> {
     /// When `client` is `true`, this side initiates the SCTP association as the
     /// connecting party.
     pub fn start_sctp(&mut self, client: bool) {
-        self.rtc.readiness.wake();
         self.rtc
             .try_init_sctp(client, None, None)
             .expect("starting SCTP should be infallible")
@@ -171,13 +170,11 @@ impl<'a> DirectApi<'a> {
         client: bool,
         sctp_init_data: SctpInitData,
     ) -> Result<(), RtcError> {
-        self.rtc.readiness.wake();
         self.rtc.try_init_sctp(client, Some(sctp_init_data), None)
     }
 
     /// Create a new data channel.
     pub fn create_data_channel(&mut self, config: ChannelConfig) -> ChannelId {
-        self.rtc.readiness.wake();
         let id = self.rtc.chan.new_channel(&config);
         self.rtc.chan.confirm(id, config);
         id
@@ -185,19 +182,18 @@ impl<'a> DirectApi<'a> {
 
     /// Close a data channel.
     pub fn close_data_channel(&mut self, channel_id: ChannelId) {
-        self.rtc.readiness.wake();
-        self.rtc.chan.close_channel(channel_id, &mut self.rtc.sctp);
+        // One arming deref, then split-borrow the real `&mut Rtc`.
+        let rtc = &mut *self.rtc;
+        rtc.chan.close_channel(channel_id, &mut rtc.sctp);
     }
 
     /// Set whether to enable ice-lite.
     pub fn set_ice_lite(&mut self, ice_lite: bool) {
-        self.rtc.readiness.wake();
         self.rtc.ice.set_ice_lite(ice_lite);
     }
 
     /// Enable twcc feedback.
     pub fn enable_twcc_feedback(&mut self) {
-        self.rtc.readiness.wake();
         self.rtc.session.enable_twcc_feedback()
     }
 
@@ -227,7 +223,6 @@ impl<'a> DirectApi<'a> {
     /// All streams belong to a media identified by a `mid`. This creates the media without
     /// doing any SDP dance.
     pub fn declare_media(&mut self, mid: Mid, kind: MediaKind) -> &mut Media {
-        self.rtc.readiness.wake();
         let max_index = self.rtc.session.medias.iter().map(|m| m.index()).max();
 
         let next_index = if let Some(max_index) = max_index {
@@ -247,7 +242,6 @@ impl<'a> DirectApi<'a> {
     ///
     /// Removes media and all streams belong to a media identified by a `mid`.
     pub fn remove_media(&mut self, mid: Mid) {
-        self.rtc.readiness.wake();
         self.rtc.session.remove_media(mid);
     }
 
@@ -261,8 +255,6 @@ impl<'a> DirectApi<'a> {
         mid: Mid,
         rid: Option<Rid>,
     ) -> &mut StreamRx {
-        self.rtc.readiness.wake();
-
         let Some(_media) = self.rtc.session.media_by_mid(mid) else {
             panic!("No media declared for mid: {}", mid);
         };
@@ -282,7 +274,6 @@ impl<'a> DirectApi<'a> {
     ///
     /// Returns true if stream existed and was removed.
     pub fn remove_stream_rx(&mut self, ssrc: Ssrc) -> bool {
-        self.rtc.readiness.wake();
         self.rtc.session.streams.remove_stream_rx(ssrc)
     }
 
@@ -292,14 +283,11 @@ impl<'a> DirectApi<'a> {
     ///
     /// The stream must first be declared using [`DirectApi::expect_stream_rx`].
     pub fn stream_rx(&mut self, ssrc: &Ssrc) -> Option<&mut StreamRx> {
-        // Hands out a mutable stream; arm conservatively for what the caller does.
-        self.rtc.readiness.wake();
         self.rtc.session.streams.stream_rx(ssrc)
     }
 
     /// Obtain a recv stream by looking it up via mid/rid.
     pub fn stream_rx_by_mid(&mut self, mid: Mid, rid: Option<Rid>) -> Option<&mut StreamRx> {
-        self.rtc.readiness.wake();
         let midrid = MidRid(mid, rid);
         self.rtc.session.streams.stream_rx_by_midrid(midrid, true)
     }
@@ -318,9 +306,10 @@ impl<'a> DirectApi<'a> {
         mid: Mid,
         rid: Option<Rid>,
     ) -> &mut StreamTx {
-        self.rtc.readiness.wake();
+        // One arming deref, then split-borrow the real `&mut Rtc`.
+        let rtc = &mut *self.rtc;
 
-        let Some(media) = self.rtc.session.media_by_mid_mut(mid) else {
+        let Some(media) = rtc.session.media_by_mid_mut(mid) else {
             panic!("No media declared for mid: {}", mid);
         };
 
@@ -333,16 +322,12 @@ impl<'a> DirectApi<'a> {
             media.add_to_rid_tx(rid);
         }
 
-        let stream = self
-            .rtc
-            .session
-            .streams
-            .declare_stream_tx(ssrc, rtx, midrid);
+        let stream = rtc.session.streams.declare_stream_tx(ssrc, rtx, midrid);
 
         let size = if is_audio {
-            self.rtc.session.send_buffer_audio
+            rtc.session.send_buffer_audio
         } else {
-            self.rtc.session.send_buffer_video
+            rtc.session.send_buffer_video
         };
 
         stream.set_rtx_cache(size, DEFAULT_RTX_CACHE_DURATION, DEFAULT_RTX_RATIO_CAP);
@@ -354,7 +339,6 @@ impl<'a> DirectApi<'a> {
     ///
     /// Returns true if stream existed and was removed.
     pub fn remove_stream_tx(&mut self, ssrc: Ssrc) -> bool {
-        self.rtc.readiness.wake();
         self.rtc.session.streams.remove_stream_tx(ssrc)
     }
 
@@ -362,14 +346,11 @@ impl<'a> DirectApi<'a> {
     ///
     /// The stream must first be declared using [`DirectApi::declare_stream_tx`].
     pub fn stream_tx(&mut self, ssrc: &Ssrc) -> Option<&mut StreamTx> {
-        // Hands out a mutable stream (RTP writes); arm conservatively.
-        self.rtc.readiness.wake();
         self.rtc.session.streams.stream_tx(ssrc)
     }
 
     /// Obtain a send stream by looking it up via mid/rid.
     pub fn stream_tx_by_mid(&mut self, mid: Mid, rid: Option<Rid>) -> Option<&mut StreamTx> {
-        self.rtc.readiness.wake();
         let midrid = MidRid(mid, rid);
         self.rtc.session.streams.stream_tx_by_midrid(midrid)
     }
@@ -393,8 +374,6 @@ impl<'a> DirectApi<'a> {
         new_ssrc: Ssrc,
         new_rtx: Option<Ssrc>,
     ) -> Option<&mut StreamTx> {
-        self.rtc.readiness.wake();
-
         let midrid = MidRid(mid, rid);
 
         // Find the stream by mid/rid
@@ -432,11 +411,10 @@ impl<'a> DirectApi<'a> {
         media_ssrc: Ssrc,
         payload: impl Into<Arc<[u8]>>,
     ) {
-        self.rtc
-            .session
+        let mut m = self.rtc.mutate();
+        m.session
             .send_app_specific_feedback(sender_ssrc, media_ssrc, payload);
-        // Local decision: this only queues RTCP feedback, drained from the
-        // transmit path; it moves no timer.
-        self.rtc.readiness.wake().no_timeout();
+        // Only queues RTCP feedback, drained from the transmit path; no timer.
+        m.no_timeout();
     }
 }

--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -56,6 +56,7 @@ impl<'a> DirectApi<'a> {
     /// If `controlling` is `false`, this peer connection is set as the ICE controlled agent,
     /// meaning it will respond to connectivity checks sent by the controlling agent.
     pub fn set_ice_controlling(&mut self, controlling: bool) {
+        self.rtc.readiness.wake();
         self.rtc.ice.set_controlling(controlling);
     }
 
@@ -69,11 +70,13 @@ impl<'a> DirectApi<'a> {
 
     /// Sets the local ICE credentials.
     pub fn set_local_ice_credentials(&mut self, local_ice_credentials: IceCreds) {
+        self.rtc.readiness.wake();
         self.rtc.ice.set_local_credentials(local_ice_credentials);
     }
 
     /// Sets the remote ICE credentials.
     pub fn set_remote_ice_credentials(&mut self, remote_ice_credentials: IceCreds) {
+        self.rtc.readiness.wake();
         self.rtc.ice.set_remote_credentials(remote_ice_credentials);
     }
 
@@ -87,6 +90,7 @@ impl<'a> DirectApi<'a> {
     ///
     /// Returns `true` if the candidate was found and invalidated.
     pub fn invalidate_candidate(&mut self, c: &Candidate) -> bool {
+        self.rtc.readiness.wake();
         self.rtc.ice.invalidate_candidate(c)
     }
 
@@ -114,11 +118,13 @@ impl<'a> DirectApi<'a> {
 
     /// Sets the remote DTLS fingerprint.
     pub fn set_remote_fingerprint(&mut self, dtls_fingerprint: Fingerprint) {
+        self.rtc.readiness.wake();
         self.rtc.remote_fingerprint = Some(dtls_fingerprint);
     }
 
     /// Start the DTLS subsystem.
     pub fn start_dtls(&mut self, active: bool) -> Result<(), RtcError> {
+        self.rtc.readiness.wake();
         self.rtc.init_dtls(active)
     }
 
@@ -127,6 +133,7 @@ impl<'a> DirectApi<'a> {
     /// When `client` is `true`, this side initiates the SCTP association as the
     /// connecting party.
     pub fn start_sctp(&mut self, client: bool) {
+        self.rtc.readiness.wake();
         self.rtc
             .try_init_sctp(client, None, None)
             .expect("starting SCTP should be infallible")
@@ -164,11 +171,13 @@ impl<'a> DirectApi<'a> {
         client: bool,
         sctp_init_data: SctpInitData,
     ) -> Result<(), RtcError> {
+        self.rtc.readiness.wake();
         self.rtc.try_init_sctp(client, Some(sctp_init_data), None)
     }
 
     /// Create a new data channel.
     pub fn create_data_channel(&mut self, config: ChannelConfig) -> ChannelId {
+        self.rtc.readiness.wake();
         let id = self.rtc.chan.new_channel(&config);
         self.rtc.chan.confirm(id, config);
         id
@@ -176,16 +185,19 @@ impl<'a> DirectApi<'a> {
 
     /// Close a data channel.
     pub fn close_data_channel(&mut self, channel_id: ChannelId) {
+        self.rtc.readiness.wake();
         self.rtc.chan.close_channel(channel_id, &mut self.rtc.sctp);
     }
 
     /// Set whether to enable ice-lite.
     pub fn set_ice_lite(&mut self, ice_lite: bool) {
+        self.rtc.readiness.wake();
         self.rtc.ice.set_ice_lite(ice_lite);
     }
 
     /// Enable twcc feedback.
     pub fn enable_twcc_feedback(&mut self) {
+        self.rtc.readiness.wake();
         self.rtc.session.enable_twcc_feedback()
     }
 
@@ -215,6 +227,7 @@ impl<'a> DirectApi<'a> {
     /// All streams belong to a media identified by a `mid`. This creates the media without
     /// doing any SDP dance.
     pub fn declare_media(&mut self, mid: Mid, kind: MediaKind) -> &mut Media {
+        self.rtc.readiness.wake();
         let max_index = self.rtc.session.medias.iter().map(|m| m.index()).max();
 
         let next_index = if let Some(max_index) = max_index {
@@ -234,6 +247,7 @@ impl<'a> DirectApi<'a> {
     ///
     /// Removes media and all streams belong to a media identified by a `mid`.
     pub fn remove_media(&mut self, mid: Mid) {
+        self.rtc.readiness.wake();
         self.rtc.session.remove_media(mid);
     }
 
@@ -247,6 +261,8 @@ impl<'a> DirectApi<'a> {
         mid: Mid,
         rid: Option<Rid>,
     ) -> &mut StreamRx {
+        self.rtc.readiness.wake();
+
         let Some(_media) = self.rtc.session.media_by_mid(mid) else {
             panic!("No media declared for mid: {}", mid);
         };
@@ -266,6 +282,7 @@ impl<'a> DirectApi<'a> {
     ///
     /// Returns true if stream existed and was removed.
     pub fn remove_stream_rx(&mut self, ssrc: Ssrc) -> bool {
+        self.rtc.readiness.wake();
         self.rtc.session.streams.remove_stream_rx(ssrc)
     }
 
@@ -275,11 +292,14 @@ impl<'a> DirectApi<'a> {
     ///
     /// The stream must first be declared using [`DirectApi::expect_stream_rx`].
     pub fn stream_rx(&mut self, ssrc: &Ssrc) -> Option<&mut StreamRx> {
+        // Hands out a mutable stream; arm conservatively for what the caller does.
+        self.rtc.readiness.wake();
         self.rtc.session.streams.stream_rx(ssrc)
     }
 
     /// Obtain a recv stream by looking it up via mid/rid.
     pub fn stream_rx_by_mid(&mut self, mid: Mid, rid: Option<Rid>) -> Option<&mut StreamRx> {
+        self.rtc.readiness.wake();
         let midrid = MidRid(mid, rid);
         self.rtc.session.streams.stream_rx_by_midrid(midrid, true)
     }
@@ -298,6 +318,8 @@ impl<'a> DirectApi<'a> {
         mid: Mid,
         rid: Option<Rid>,
     ) -> &mut StreamTx {
+        self.rtc.readiness.wake();
+
         let Some(media) = self.rtc.session.media_by_mid_mut(mid) else {
             panic!("No media declared for mid: {}", mid);
         };
@@ -332,6 +354,7 @@ impl<'a> DirectApi<'a> {
     ///
     /// Returns true if stream existed and was removed.
     pub fn remove_stream_tx(&mut self, ssrc: Ssrc) -> bool {
+        self.rtc.readiness.wake();
         self.rtc.session.streams.remove_stream_tx(ssrc)
     }
 
@@ -339,11 +362,14 @@ impl<'a> DirectApi<'a> {
     ///
     /// The stream must first be declared using [`DirectApi::declare_stream_tx`].
     pub fn stream_tx(&mut self, ssrc: &Ssrc) -> Option<&mut StreamTx> {
+        // Hands out a mutable stream (RTP writes); arm conservatively.
+        self.rtc.readiness.wake();
         self.rtc.session.streams.stream_tx(ssrc)
     }
 
     /// Obtain a send stream by looking it up via mid/rid.
     pub fn stream_tx_by_mid(&mut self, mid: Mid, rid: Option<Rid>) -> Option<&mut StreamTx> {
+        self.rtc.readiness.wake();
         let midrid = MidRid(mid, rid);
         self.rtc.session.streams.stream_tx_by_midrid(midrid)
     }
@@ -367,6 +393,8 @@ impl<'a> DirectApi<'a> {
         new_ssrc: Ssrc,
         new_rtx: Option<Ssrc>,
     ) -> Option<&mut StreamTx> {
+        self.rtc.readiness.wake();
+
         let midrid = MidRid(mid, rid);
 
         // Find the stream by mid/rid
@@ -407,5 +435,8 @@ impl<'a> DirectApi<'a> {
         self.rtc
             .session
             .send_app_specific_feedback(sender_ssrc, media_ssrc, payload);
+        // Local decision: this only queues RTCP feedback, drained from the
+        // transmit path; it moves no timer.
+        self.rtc.readiness.wake().no_timeout();
     }
 }

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -68,6 +68,9 @@ impl<'a> SdpApi<'a> {
     pub fn accept_offer(self, offer: SdpOffer) -> Result<SdpAnswer, RtcError> {
         debug!("Accept offer");
 
+        // Applying an offer reshapes media, streams, ICE, DTLS and SCTP.
+        self.rtc.readiness.wake();
+
         // Invalidate any outstanding PendingOffer.
         self.rtc.next_change_id();
 
@@ -161,6 +164,9 @@ impl<'a> SdpApi<'a> {
         answer: SdpAnswer,
     ) -> Result<(), RtcError> {
         debug!("Accept answer");
+
+        // Applying an answer reshapes media, streams, ICE, DTLS and SCTP.
+        self.rtc.readiness.wake();
 
         // Ensure we don't use the wrong changes below. We must use that of pending.
         drop(self.changes);
@@ -355,6 +361,7 @@ impl<'a> SdpApi<'a> {
     /// If the direction is set for media that doesn't exist, or if the direction is
     /// the same that's already set [`SdpApi::apply()`] not require a negotiation.
     pub fn set_direction(&mut self, mid: Mid, dir: Direction) {
+        self.rtc.readiness.wake();
         let changed = self.rtc.session.set_direction(mid, dir);
 
         if changed {
@@ -377,6 +384,7 @@ impl<'a> SdpApi<'a> {
     ///
     /// [RFC 8843]: https://datatracker.ietf.org/doc/html/rfc8843#section-7.5.3
     pub fn stop_media(&mut self, mid: Mid) {
+        self.rtc.readiness.wake();
         let changed = self.rtc.session.stop_media(mid);
 
         if changed {
@@ -439,6 +447,7 @@ impl<'a> SdpApi<'a> {
     /// # }
     /// ```
     pub fn add_channel_with_config(&mut self, config: ChannelConfig) -> ChannelId {
+        self.rtc.readiness.wake();
         let has_media = self.rtc.session.app().is_some();
         let changes_contains_add_app = self.changes.contains_add_app();
 
@@ -503,6 +512,10 @@ impl<'a> SdpApi<'a> {
         if self.changes.is_empty() {
             return None;
         }
+
+        // Either enacts changes directly (no-negotiation channels) or bumps the
+        // change id for the pending offer; re-poll the tree either way.
+        self.rtc.readiness.wake();
 
         let change_id = self.rtc.next_change_id();
 

--- a/src/change/sdp.rs
+++ b/src/change/sdp.rs
@@ -12,6 +12,7 @@ use crate::format::CodecConfig;
 use crate::format::PayloadParams;
 use crate::media::{Media, Rids, Simulcast};
 use crate::packet::MediaKind;
+use crate::poll::RtcMut;
 use crate::rtp_::MidRid;
 use crate::rtp_::Rid;
 use crate::rtp_::{Direction, Extension, ExtensionMap, Mid, Pt, Ssrc};
@@ -28,14 +29,15 @@ use crate::streams::{DEFAULT_RTX_CACHE_DURATION, DEFAULT_RTX_RATIO_CAP, Streams}
 
 /// Changes to the Rtc via SDP Offer/Answer dance.
 pub struct SdpApi<'a> {
-    rtc: &'a mut Rtc,
+    // `RtcMut` arms the readiness on mutable deref only; see [`crate::poll`].
+    rtc: RtcMut<'a>,
     changes: Changes,
 }
 
 impl<'a> SdpApi<'a> {
     pub(crate) fn new(rtc: &'a mut Rtc) -> Self {
         SdpApi {
-            rtc,
+            rtc: RtcMut::new(rtc),
             changes: Changes::default(),
         }
     }
@@ -65,11 +67,8 @@ impl<'a> SdpApi<'a> {
     /// // send json_answer to remote peer.
     /// let json_answer = serde_json::to_vec(&answer).unwrap();
     /// ```
-    pub fn accept_offer(self, offer: SdpOffer) -> Result<SdpAnswer, RtcError> {
+    pub fn accept_offer(mut self, offer: SdpOffer) -> Result<SdpAnswer, RtcError> {
         debug!("Accept offer");
-
-        // Applying an offer reshapes media, streams, ICE, DTLS and SCTP.
-        self.rtc.readiness.wake();
 
         // Invalidate any outstanding PendingOffer.
         self.rtc.next_change_id();
@@ -84,7 +83,7 @@ impl<'a> SdpApi<'a> {
             ));
         }
 
-        add_ice_details(self.rtc, &offer, None)?;
+        add_ice_details(&mut *self.rtc, &offer, None)?;
 
         if self.rtc.remote_fingerprint.is_none() {
             if let Some(f) = offer.fingerprint() {
@@ -102,7 +101,7 @@ impl<'a> SdpApi<'a> {
         }
 
         // Ensure setup=active/passive is corresponding remote and init dtls.
-        init_dtls(self.rtc, &offer)?;
+        init_dtls(&mut *self.rtc, &offer)?;
 
         let remote_max_message_size = extract_max_message_size(offer.media_lines.iter());
 
@@ -129,7 +128,7 @@ impl<'a> SdpApi<'a> {
                 .try_init_sctp(client, init_data, remote_max_message_size)?;
         }
 
-        let params = AsSdpParams::new(self.rtc, None);
+        let params = AsSdpParams::new(&*self.rtc, None);
         let sdp = as_sdp(&self.rtc.session, params);
 
         debug!("Create answer");
@@ -159,14 +158,11 @@ impl<'a> SdpApi<'a> {
     /// rtc.sdp_api().accept_answer(pending, answer).unwrap();
     /// ```
     pub fn accept_answer(
-        self,
+        mut self,
         mut pending: SdpPendingOffer,
         answer: SdpAnswer,
     ) -> Result<(), RtcError> {
         debug!("Accept answer");
-
-        // Applying an answer reshapes media, streams, ICE, DTLS and SCTP.
-        self.rtc.readiness.wake();
 
         // Ensure we don't use the wrong changes below. We must use that of pending.
         drop(self.changes);
@@ -181,10 +177,10 @@ impl<'a> SdpApi<'a> {
             ));
         }
 
-        add_ice_details(self.rtc, &answer, Some(&pending))?;
+        add_ice_details(&mut *self.rtc, &answer, Some(&pending))?;
 
         // Ensure setup=active/passive is corresponding remote and init dtls.
-        init_dtls(self.rtc, &answer)?;
+        init_dtls(&mut *self.rtc, &answer)?;
 
         if self.rtc.remote_fingerprint.is_none() {
             if let Some(f) = answer.fingerprint() {
@@ -361,7 +357,6 @@ impl<'a> SdpApi<'a> {
     /// If the direction is set for media that doesn't exist, or if the direction is
     /// the same that's already set [`SdpApi::apply()`] not require a negotiation.
     pub fn set_direction(&mut self, mid: Mid, dir: Direction) {
-        self.rtc.readiness.wake();
         let changed = self.rtc.session.set_direction(mid, dir);
 
         if changed {
@@ -384,7 +379,6 @@ impl<'a> SdpApi<'a> {
     ///
     /// [RFC 8843]: https://datatracker.ietf.org/doc/html/rfc8843#section-7.5.3
     pub fn stop_media(&mut self, mid: Mid) {
-        self.rtc.readiness.wake();
         let changed = self.rtc.session.stop_media(mid);
 
         if changed {
@@ -447,7 +441,6 @@ impl<'a> SdpApi<'a> {
     /// # }
     /// ```
     pub fn add_channel_with_config(&mut self, config: ChannelConfig) -> ChannelId {
-        self.rtc.readiness.wake();
         let has_media = self.rtc.session.app().is_some();
         let changes_contains_add_app = self.changes.contains_add_app();
 
@@ -508,21 +501,17 @@ impl<'a> SdpApi<'a> {
     /// assert!(changes.apply().is_none());
     /// # }
     /// ```
-    pub fn apply(self) -> Option<(SdpOffer, SdpPendingOffer)> {
+    pub fn apply(mut self) -> Option<(SdpOffer, SdpPendingOffer)> {
         if self.changes.is_empty() {
             return None;
         }
-
-        // Either enacts changes directly (no-negotiation channels) or bumps the
-        // change id for the pending offer; re-poll the tree either way.
-        self.rtc.readiness.wake();
 
         let change_id = self.rtc.next_change_id();
 
         let requires_negotiation = self.changes.0.iter().any(requires_negotiation);
 
         if requires_negotiation {
-            let offer = create_offer(self.rtc, &self.changes);
+            let offer = create_offer(&mut *self.rtc, &self.changes);
             let pending = SdpPendingOffer {
                 change_id,
                 changes: self.changes,
@@ -531,7 +520,7 @@ impl<'a> SdpApi<'a> {
             Some((offer, pending))
         } else {
             debug!("Apply direct changes");
-            apply_direct_changes(self.rtc, self.changes);
+            apply_direct_changes(&mut *self.rtc, self.changes);
             None
         }
     }
@@ -562,7 +551,7 @@ impl<'a> SdpApi<'a> {
     /// let (_offer, pending) = changes.apply().unwrap();
     /// ```
     pub fn merge(&mut self, mut pending_offer: SdpPendingOffer) {
-        pending_offer.retain_relevant(self.rtc);
+        pending_offer.retain_relevant(&*self.rtc);
 
         // Prepend the original pending changes before the current SdpApi's own changes.
         //

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 use std::{fmt, str, time::Instant};
 
-use crate::poll::Wake;
+use crate::poll::{RtcMut, Wake};
 use crate::sctp::RtcSctp;
 use crate::util::already_happened;
 use crate::{Rtc, RtcError};
@@ -42,13 +42,14 @@ pub struct ChannelData {
 /// Get this handle from [`Rtc::channel()`][crate::Rtc::channel()].
 pub struct Channel<'a> {
     sctp_stream_id: u16,
-    rtc: &'a mut Rtc,
+    // `RtcMut` arms the readiness on mutable deref only; see [`crate::poll`].
+    rtc: RtcMut<'a>,
 }
 
 impl<'a> Channel<'a> {
     pub(crate) fn new(sctp_stream_id: u16, rtc: &'a mut Rtc) -> Self {
         Channel {
-            rtc,
+            rtc: RtcMut::new(rtc),
             sctp_stream_id,
         }
     }
@@ -74,10 +75,6 @@ impl<'a> Channel<'a> {
             "Data channel write() less than entire buffer"
         );
 
-        // Local decision: a write drives SCTP, which both transmits and re-arms
-        // its timers.
-        drop(self.rtc.readiness.wake());
-
         Ok(true)
     }
 
@@ -102,9 +99,6 @@ impl<'a> Channel<'a> {
         self.rtc
             .sctp
             .set_buffered_amount_low_threshold(self.sctp_stream_id, threshold);
-        // Local decision: lowering the threshold can make SCTP emit a
-        // ChannelBufferedAmountLow event; it moves no timer.
-        self.rtc.readiness.wake().no_timeout();
     }
 
     /// Get the channel config.

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 use std::{fmt, str, time::Instant};
 
+use crate::poll::Wake;
 use crate::sctp::RtcSctp;
 use crate::util::already_happened;
 use crate::{Rtc, RtcError};
@@ -73,6 +74,10 @@ impl<'a> Channel<'a> {
             "Data channel write() less than entire buffer"
         );
 
+        // Local decision: a write drives SCTP, which both transmits and re-arms
+        // its timers.
+        drop(self.rtc.readiness.wake());
+
         Ok(true)
     }
 
@@ -97,6 +102,9 @@ impl<'a> Channel<'a> {
         self.rtc
             .sctp
             .set_buffered_amount_low_threshold(self.sctp_stream_id, threshold);
+        // Local decision: lowering the threshold can make SCTP emit a
+        // ChannelBufferedAmountLow event; it moves no timer.
+        self.rtc.readiness.wake().no_timeout();
     }
 
     /// Get the channel config.
@@ -248,7 +256,7 @@ impl ChannelHandler {
             .and_then(|a| a.sctp_stream_id)
     }
 
-    pub(crate) fn handle_timeout(&mut self, _now: Instant, sctp: &mut RtcSctp) {
+    pub(crate) fn handle_timeout(&mut self, _now: Instant, sctp: &mut RtcSctp, _wake: &mut Wake) {
         if !sctp.is_inited() {
             return;
         }
@@ -258,6 +266,9 @@ impl ChannelHandler {
 
         // After do_allocations so we get a channel for any confirmed.
         self.open_channels(sctp);
+
+        // Opening channels drives SCTP, which can both emit events and re-arm
+        // its timers, so `_wake` is left armed.
     }
 
     /// Allocate next available `ChannelId`.
@@ -366,9 +377,13 @@ impl ChannelHandler {
     }
 
     /// Remove stream IDs from the cooldown list that have expired.
-    pub fn expire_closed_stream_ids(&mut self, now: Instant) {
+    pub fn expire_closed_stream_ids(&mut self, now: Instant, wake: &mut Wake) {
         self.closed_stream_ids
             .retain(|(_, closed_at)| now.duration_since(*closed_at) < STREAM_ID_COOLDOWN);
+
+        // Local decision: dropping expired stream-id reservations only moves the
+        // cleanup timer; it queues no event.
+        wake.no_events();
     }
 
     pub fn remove_channel(&mut self, id: ChannelId, now: Instant) {
@@ -440,7 +455,8 @@ mod tests {
 
         // After cooldown expires, stream 0 should be available again.
         let after_cooldown = now + STREAM_ID_COOLDOWN;
-        handler.expire_closed_stream_ids(after_cooldown);
+        let mut readiness = crate::poll::Readiness::armed();
+        handler.expire_closed_stream_ids(after_cooldown, &mut readiness.wake());
         assert!(handler.closed_stream_ids.is_empty());
 
         let taken_after: Vec<u16> = handler

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1432,10 +1432,6 @@ impl Rtc {
     /// rtc.sdp_api().accept_answer(pending, answer).unwrap();
     /// ```
     pub fn sdp_api(&mut self) -> SdpApi {
-        // SDP negotiation can change media, streams, ICE and channels at once.
-        // Still armed at the accessor pending threading `Wake` through the
-        // individual SdpApi mutations.
-        self.wake_all();
         SdpApi::new(self)
     }
 
@@ -1443,9 +1439,6 @@ impl Rtc {
     ///
     /// This is a low level API. For "normal" use via SDP, see [`Rtc::sdp_api()`].
     pub fn direct_api(&mut self) -> DirectApi {
-        // Low-level API touching media/streams/ICE/channels. Still armed at the
-        // accessor pending threading `Wake` through the individual mutations.
-        self.wake_all();
         DirectApi::new(self)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2200,7 +2200,7 @@ impl Rtc {
     ///
     /// Only relevant if BWE was enabled in the [`RtcConfig::enable_bwe()`]
     pub fn bwe(&mut self) -> Bwe {
-        Bwe(self)
+        Bwe::new(self)
     }
 
     fn is_correct_change_id(&self, change_id: usize) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -839,6 +839,9 @@ pub mod change;
 mod util;
 use util::{Soonest, not_happening};
 
+mod poll;
+use crate::poll::Readiness;
+
 mod session;
 use session::Session;
 
@@ -921,6 +924,13 @@ pub struct Rtc {
     crypto_provider: Arc<crate::crypto::CryptoProvider>,
     fingerprint_verification: bool,
     close_dtls_started: bool,
+    // Signals which halves of the tree may need re-polling. Written locally by
+    // the components that mutate, via the `Wake` guard handed down the tree;
+    // read (and cleared) by `poll_output`. See the `poll` module.
+    readiness: Readiness,
+    // Last timeout returned by `poll_output`, reused while the readiness says
+    // the timeout is still valid.
+    cached_timeout: Instant,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -1286,6 +1296,8 @@ impl Rtc {
             crypto_provider,
             fingerprint_verification: config.fingerprint_verification,
             close_dtls_started: false,
+            readiness: Readiness::armed(),
+            cached_timeout: start,
         })
     }
 
@@ -1359,6 +1371,9 @@ impl Rtc {
     ///
     /// [1]: https://www.rfc-editor.org/rfc/rfc8838.txt
     pub fn add_local_candidate(&mut self, c: Candidate) -> Option<&Candidate> {
+        // ICE is an external crate and can't take a `Wake`; adding a candidate
+        // can start connectivity checks (transmits) and arm timers.
+        self.wake_all();
         self.ice.add_local_candidate(c)
     }
 
@@ -1383,6 +1398,8 @@ impl Rtc {
     ///
     /// [1]: https://www.rfc-editor.org/rfc/rfc8838.txt
     pub fn add_remote_candidate(&mut self, c: Candidate) {
+        // ICE is an external crate and can't take a `Wake`; see above.
+        self.wake_all();
         self.ice.add_remote_candidate(c);
     }
 
@@ -1415,6 +1432,10 @@ impl Rtc {
     /// rtc.sdp_api().accept_answer(pending, answer).unwrap();
     /// ```
     pub fn sdp_api(&mut self) -> SdpApi {
+        // SDP negotiation can change media, streams, ICE and channels at once.
+        // Still armed at the accessor pending threading `Wake` through the
+        // individual SdpApi mutations.
+        self.wake_all();
         SdpApi::new(self)
     }
 
@@ -1422,6 +1443,9 @@ impl Rtc {
     ///
     /// This is a low level API. For "normal" use via SDP, see [`Rtc::sdp_api()`].
     pub fn direct_api(&mut self) -> DirectApi {
+        // Low-level API touching media/streams/ICE/channels. Still armed at the
+        // accessor pending threading `Wake` through the individual mutations.
+        self.wake_all();
         DirectApi::new(self)
     }
 
@@ -1463,11 +1487,17 @@ impl Rtc {
             return None;
         }
 
+        // Disjoint borrows: the writer mutates `session`, and carries an armed
+        // `Wake` into which its methods narrow their own re-poll decision.
+        let Rtc {
+            session, readiness, ..
+        } = self;
+
         // This does not catch potential RIDs required to send simulcast, but
         // it's a good start. An error might arise later on RID mismatch.
-        self.session.media_by_mid_mut(mid)?;
+        session.media_by_mid_mut(mid)?;
 
-        Some(Writer::new(&mut self.session, mid))
+        Some(Writer::new(session, readiness.wake(), mid))
     }
 
     /// Currently configured media.
@@ -1572,19 +1602,72 @@ impl Rtc {
         Ok(o)
     }
 
+    /// Conservatively re-poll the whole tree.
+    ///
+    /// The degenerate, un-narrowed case of a [`Wake`][poll::Wake] guard: it
+    /// folds into the same readiness a threaded component would, but makes no
+    /// local decision. Used by mutation paths not yet threaded with their own
+    /// guard; each such call is an opportunity to push the decision down.
+    fn wake_all(&mut self) {
+        drop(self.readiness.wake());
+    }
+
     fn do_poll_output(&mut self) -> Result<Output, RtcError> {
         if self.state == RtcState::Closed {
             self.last_timeout_reason = Reason::NotHappening;
             return Ok(Output::Timeout(not_happening()));
         }
 
+        if self.readiness.wants_events() {
+            if let Some(output) = self.poll_pipeline()? {
+                return Ok(output);
+            }
+            // A full pass drained no output; the pipeline stays quiescent until
+            // a component's `Wake` guard re-arms it.
+            self.readiness.clear_events();
+        }
+
+        if self.readiness.wants_timeout() {
+            let stats = self.stats.as_mut();
+
+            let time_and_reason = (None, Reason::NotHappening)
+                .soonest((self.next_dtls_timeout, Reason::DTLS))
+                .soonest((self.ice.poll_timeout(), Reason::Ice))
+                .soonest(self.session.poll_timeout())
+                .soonest((self.sctp.poll_timeout(), Reason::Sctp))
+                .soonest((self.chan.poll_timeout(&self.sctp), Reason::Channel))
+                .soonest((stats.and_then(|s| s.poll_timeout()), Reason::Stats));
+
+            let time = time_and_reason.0.unwrap_or_else(not_happening);
+
+            // We want to guarantee time doesn't go backwards.
+            self.cached_timeout = time.max(self.last_now);
+            self.last_timeout_reason = time_and_reason.1;
+            self.readiness.clear_timeout();
+        }
+
+        if self.state == RtcState::Closing && self.close_drain_complete() {
+            self.state = RtcState::Closed;
+            self.last_timeout_reason = Reason::NotHappening;
+            return Ok(Output::Timeout(not_happening()));
+        }
+
+        Ok(Output::Timeout(self.cached_timeout))
+    }
+
+    /// Drain the next event or transmit from the component tree, walking it
+    /// top-down and returning the first output produced.
+    ///
+    /// Returns `None` once a full pass produces nothing: the tree is quiescent
+    /// and `do_poll_output` can fall through to the timeout.
+    fn poll_pipeline(&mut self) -> Result<Option<Output>, RtcError> {
         while let Some(e) = self.ice.poll_event() {
             match e {
                 IceAgentEvent::IceRestart(_) => {
                     //
                 }
                 IceAgentEvent::IceConnectionStateChange(v) => {
-                    return Ok(Output::Event(Event::IceConnectionStateChange(v)));
+                    return Ok(Some(Output::Event(Event::IceConnectionStateChange(v))));
                 }
                 IceAgentEvent::DiscoveredRecv { proto, source } => {
                     debug!("ICE remote address: {:?}/{:?}", Pii(source), proto);
@@ -1678,7 +1761,7 @@ impl Rtc {
                 }
                 DtlsOutput::CloseNotify => {
                     self.start_close()?;
-                    return Ok(Output::Event(Event::Closed));
+                    return Ok(Some(Output::Event(Event::Closed)));
                 }
                 other => {
                     return Err(RtcError::Dtls(DtlsError::Io(std::io::Error::other(
@@ -1689,7 +1772,7 @@ impl Rtc {
         }
 
         if just_connected {
-            return Ok(Output::Event(Event::Connected));
+            return Ok(Some(Output::Event(Event::Connected)));
         }
 
         while let Some(e) = self.sctp.poll() {
@@ -1708,7 +1791,7 @@ impl Rtc {
                                 if !packets.is_empty() {
                                     self.sctp.push_back_transmit(packets);
                                 }
-                                return self.do_poll_output();
+                                return self.do_poll_output().map(Some);
                             } else {
                                 return Err(e.into());
                             }
@@ -1723,13 +1806,13 @@ impl Rtc {
 
                         // Run again since this would feed the DTLS subsystem
                         // to produce a packet now.
-                        return self.do_poll_output();
+                        return self.do_poll_output().map(Some);
                     }
                 }
                 SctpEvent::Open { id, label } => {
                     self.chan.ensure_channel_id_for(id);
                     let id = self.chan.channel_id_by_stream_id(id).unwrap();
-                    return Ok(Output::Event(Event::ChannelOpen(id, label)));
+                    return Ok(Some(Output::Event(Event::ChannelOpen(id, label))));
                 }
                 SctpEvent::Close { id } => {
                     let Some(id) = self.chan.channel_id_by_stream_id(id) else {
@@ -1737,11 +1820,11 @@ impl Rtc {
                         continue;
                     };
                     self.chan.remove_channel(id, self.last_now);
-                    return Ok(Output::Event(Event::ChannelClose(id)));
+                    return Ok(Some(Output::Event(Event::ChannelClose(id))));
                 }
                 SctpEvent::AssociationLost => {
                     self.start_close()?;
-                    return Ok(Output::Event(Event::Closed));
+                    return Ok(Some(Output::Event(Event::Closed)));
                 }
                 SctpEvent::Data { id, binary, data } => {
                     let Some(id) = self.chan.channel_id_by_stream_id(id) else {
@@ -1749,37 +1832,37 @@ impl Rtc {
                         continue;
                     };
                     let cd = ChannelData { id, binary, data };
-                    return Ok(Output::Event(Event::ChannelData(cd)));
+                    return Ok(Some(Output::Event(Event::ChannelData(cd))));
                 }
                 SctpEvent::BufferedAmountLow { id } => {
                     let Some(id) = self.chan.channel_id_by_stream_id(id) else {
                         warn!("Drop BufferedAmountLow for id: {:?}", id);
                         continue;
                     };
-                    return Ok(Output::Event(Event::ChannelBufferedAmountLow(id)));
+                    return Ok(Some(Output::Event(Event::ChannelBufferedAmountLow(id))));
                 }
             }
         }
 
         if let Some(ev) = self.session.poll_event() {
-            return Ok(Output::Event(ev));
+            return Ok(Some(Output::Event(ev)));
         }
 
         // Some polling needs to bubble up errors.
         if let Some(ev) = self.session.poll_event_fallible()? {
-            return Ok(Output::Event(ev));
+            return Ok(Some(Output::Event(ev)));
         }
 
         if let Some(e) = self.stats.as_mut().and_then(|s| s.poll_output()) {
-            return Ok(match e {
+            return Ok(Some(match e {
                 StatsEvent::Peer(s) => Output::Event(Event::PeerStats(s)),
                 StatsEvent::MediaIngress(s) => Output::Event(Event::MediaIngressStats(s)),
                 StatsEvent::MediaEgress(s) => Output::Event(Event::MediaEgressStats(s)),
-            });
+            }));
         }
 
         if let Some(v) = self.ice.poll_transmit() {
-            return Ok(Output::Transmit(v));
+            return Ok(Some(Output::Transmit(v)));
         }
 
         if let Some(send) = &self.send_addr {
@@ -1795,43 +1878,14 @@ impl Rtc {
                     destination: send.destination,
                     contents,
                 };
-                return Ok(Output::Transmit(t));
+                return Ok(Some(Output::Transmit(t)));
             }
         } else {
             // Don't allow accumulated feedback to build up indefinitely
             self.session.clear_feedback();
         }
 
-        let stats_timeout = self.stats.as_mut().and_then(|s| s.poll_timeout());
-
-        let time_and_reason = (None, Reason::NotHappening)
-            .soonest((self.next_dtls_timeout, Reason::DTLS))
-            .soonest((self.ice.poll_timeout(), Reason::Ice))
-            .soonest(self.session.poll_timeout())
-            .soonest((self.sctp.poll_timeout(), Reason::Sctp))
-            .soonest((self.chan.poll_timeout(&self.sctp), Reason::Channel))
-            .soonest((stats_timeout, Reason::Stats));
-
-        // trace!("poll_output timeout reason: {}", time_and_reason.1);
-
-        let time = time_and_reason.0.unwrap_or_else(not_happening);
-        let reason = time_and_reason.1;
-
-        // We want to guarantee time doesn't go backwards.
-        let next = if time < self.last_now {
-            self.last_now
-        } else {
-            time
-        };
-
-        if self.state == RtcState::Closing && self.close_drain_complete() {
-            self.state = RtcState::Closed;
-            self.last_timeout_reason = Reason::NotHappening;
-            return Ok(Output::Timeout(not_happening()));
-        }
-
-        self.last_timeout_reason = reason;
-        Ok(Output::Timeout(next))
+        Ok(None)
     }
 
     /// The reason for the last [`Output::Timeout`]
@@ -1942,6 +1996,7 @@ impl Rtc {
             return Ok(());
         }
 
+        // The handlers below each arm their own `Wake`; nothing to do here.
         match input {
             Input::Timeout(now) => self.do_handle_timeout(now)?,
             Input::Receive(recv_time, r) => {
@@ -1967,6 +2022,10 @@ impl Rtc {
         if self.state == RtcState::Closed {
             return Ok(());
         }
+
+        // Closing queues RTCP BYE and a DTLS close_notify that must be drained
+        // from the pipeline, so re-poll the whole tree.
+        self.wake_all();
 
         if self.state != RtcState::Closing {
             self.session.close_rtp();
@@ -2012,32 +2071,56 @@ impl Rtc {
         }
 
         self.last_now = now;
-        self.ice.handle_timeout(now);
-        self.sctp.handle_timeout(now);
-        self.chan.expire_closed_stream_ids(now);
-        self.chan.handle_timeout(now, &mut self.sctp);
-        self.session.handle_timeout(now)?;
 
-        if let Some(stats) = &mut self.stats {
+        // Disjoint borrows so each subsystem gets its own armed `Wake` and
+        // makes its own re-poll decision; the guards fold into `readiness`
+        // independently as each statement ends.
+        let Rtc {
+            ice,
+            sctp,
+            chan,
+            session,
+            stats,
+            send_addr,
+            peer_bytes_rx,
+            peer_bytes_tx,
+            readiness,
+            ..
+        } = self;
+
+        // ICE is an external crate and can't be handed a `Wake`. Driving it can
+        // transmit and re-arm timers, so arm both on its behalf at the boundary.
+        ice.handle_timeout(now);
+        drop(readiness.wake());
+
+        sctp.handle_timeout(now, &mut readiness.wake());
+        chan.expire_closed_stream_ids(now, &mut readiness.wake());
+        chan.handle_timeout(now, sctp, &mut readiness.wake());
+        session.handle_timeout(now, &mut readiness.wake())?;
+
+        if let Some(stats) = stats {
             if stats.wants_timeout(now) {
                 let mut snapshot = StatsSnapshot::new(now);
-                snapshot.peer_rx = self.peer_bytes_rx;
-                snapshot.peer_tx = self.peer_bytes_tx;
-                let current_round_trip_time = self.ice.nominated_pair_rtt();
-                let total_round_trip_time = self.ice.nominated_pair_total_rtt().unwrap_or_default();
-                let responses_received = self.ice.nominated_pair_responses_received().unwrap_or(0);
-                snapshot.selected_candidate_pair =
-                    self.send_addr.as_ref().map(|s| CandidatePairStats {
-                        protocol: s.proto,
-                        local: CandidateStats { addr: s.source },
-                        remote: CandidateStats {
-                            addr: s.destination,
-                        },
-                        current_round_trip_time,
-                        total_round_trip_time,
-                        responses_received,
-                    });
-                self.session.visit_stats(now, &mut snapshot);
+                snapshot.peer_rx = *peer_bytes_rx;
+                snapshot.peer_tx = *peer_bytes_tx;
+                let current_round_trip_time = ice.nominated_pair_rtt();
+                let total_round_trip_time = ice.nominated_pair_total_rtt().unwrap_or_default();
+                let responses_received = ice.nominated_pair_responses_received().unwrap_or(0);
+                snapshot.selected_candidate_pair = send_addr.as_ref().map(|s| CandidatePairStats {
+                    protocol: s.proto,
+                    local: CandidateStats { addr: s.source },
+                    remote: CandidateStats {
+                        addr: s.destination,
+                    },
+                    current_round_trip_time,
+                    total_round_trip_time,
+                    responses_received,
+                });
+                session.visit_stats(now, &mut snapshot);
+
+                // A stats snapshot surfaces as an event and re-arms the stats
+                // timer.
+                drop(readiness.wake());
                 stats.do_handle_timeout(&mut snapshot);
             }
         }
@@ -2057,6 +2140,15 @@ impl Rtc {
 
         self.peer_bytes_rx += bytes_rx as u64;
 
+        // Disjoint borrows so each subsystem gets its own armed `Wake`.
+        let Rtc {
+            ice,
+            dtls,
+            session,
+            readiness,
+            ..
+        } = self;
+
         match r.contents.inner {
             Stun(stun) => {
                 let packet = is::stun::StunPacket {
@@ -2065,11 +2157,17 @@ impl Rtc {
                     destination: r.destination,
                     message: stun,
                 };
-                self.ice.handle_packet(recv_time, packet);
+                // ICE is an external crate; arm both on its behalf.
+                ice.handle_packet(recv_time, packet);
+                drop(readiness.wake());
             }
-            Dtls(dtls) => self.dtls.handle_receive(dtls)?,
-            Rtp(rtp) => self.session.handle_rtp_receive(recv_time, rtp),
-            Rtcp(rtcp) => self.session.handle_rtcp_receive(recv_time, rtcp),
+            Dtls(dtls_packet) => {
+                dtls.handle_receive(dtls_packet)?;
+                // DTLS is an external crate; arm both on its behalf.
+                drop(readiness.wake());
+            }
+            Rtp(rtp) => session.handle_rtp_receive(recv_time, rtp, &mut readiness.wake()),
+            Rtcp(rtcp) => session.handle_rtcp_receive(recv_time, rtcp, &mut readiness.wake()),
         }
 
         Ok(())

--- a/src/media/writer.rs
+++ b/src/media/writer.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 
 use crate::RtcError;
 use crate::format::PayloadParams;
+use crate::poll::Wake;
 use crate::rtp_::AbsCaptureTime;
 use crate::rtp_::MidRid;
 use crate::rtp_::VideoOrientation;
@@ -18,6 +19,7 @@ use super::{ExtensionValues, KeyframeRequestKind, Media, MediaTime, Mid, Pt, Rid
 /// [`DirectApi::stream_tx`][crate::change::DirectApi::stream_tx].
 pub struct Writer<'a> {
     session: &'a mut Session,
+    wake: Wake<'a>,
     mid: Mid,
     rid: Option<Rid>,
     start_of_talkspurt: Option<bool>,
@@ -28,9 +30,13 @@ impl<'a> Writer<'a> {
     /// Create a new writer object.
     ///
     /// The `mid` parameter is required to have a corresponding media in `self.session`.
-    pub(crate) fn new(session: &'a mut Session, mid: Mid) -> Self {
+    ///
+    /// `wake` is armed: unless a method below narrows it, dropping this writer
+    /// re-polls the whole tree.
+    pub(crate) fn new(session: &'a mut Session, wake: Wake<'a>, mid: Mid) -> Self {
         Writer {
             session,
+            wake,
             mid,
             rid: None,
             start_of_talkspurt: None,
@@ -236,6 +242,11 @@ impl<'a> Writer<'a> {
             .ok_or(RtcError::NoReceiverSource(rid))?;
 
         stream.request_keyframe(kind);
+
+        // Local decision: a keyframe request only queues RTCP feedback, drained
+        // from the transmit path on the next poll. It moves no timer, so the
+        // timeout need not be recomputed on its behalf.
+        self.wake.no_timeout();
 
         Ok(())
     }

--- a/src/pacer/leaky.rs
+++ b/src/pacer/leaky.rs
@@ -196,6 +196,7 @@ impl LeakyBucketPacer {
     pub(crate) fn start_probe(&mut self, config: ProbeClusterConfig) {
         trace!(?config, "Probe start");
         self.probe_queue.push_back(ProbeClusterState::new(config));
+        self.request_immediate_timeout();
     }
 
     /// Get the cluster ID of the active probe, if any.
@@ -317,18 +318,23 @@ impl LeakyBucketPacer {
         }
 
         let any_queue_for_padding = self.queue_states.iter().any(|q| q.use_for_padding);
-        let padding_possible = self.padding_bitrate > Bitrate::ZERO && any_queue_for_padding;
 
-        if !padding_possible {
-            return None;
-        }
-
-        // If we're actively probing, use probe timing for padding
-        if let Some(probe) = self.probe_queue.front() {
+        // Probe padding bypasses the regular padding bitrate in
+        // maybe_create_padding_request(), so it needs its own timeout too —
+        // otherwise (when there is no regular padding rate) an active probe is
+        // never scheduled through the pacer, never completes, and keeps
+        // generating padding.
+        if let Some(probe) = self.probe_queue.front().filter(|_| any_queue_for_padding) {
             let next_probe_time = probe.next_probe_time();
             // We explicitly don't return a queue to poll here. We need another call to
             // handle_timeout to request the padding before we can poll the selected queue.
             return Some(((next_probe_time, PacerReason::Probe2), None));
+        }
+
+        let padding_possible = self.padding_bitrate > Bitrate::ZERO && any_queue_for_padding;
+
+        if !padding_possible {
+            return None;
         }
 
         // If all queues are empty and we have a padding rate, wait until we have drained

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -16,6 +16,131 @@
 //! mutation. A forgotten or over-broad narrow costs at most one redundant
 //! poll; it can never drop output. No component names another's scope, and
 //! `Rtc` holds no knowledge of which mutation affects what.
+//!
+//! The app-facing API wrappers ([`DirectApi`][crate::change::DirectApi],
+//! [`SdpApi`][crate::change::SdpApi], [`Channel`][crate::channel::Channel],
+//! [`Bwe`][crate::bwe::Bwe]) hold an [`RtcMut`] instead of `&mut Rtc`. It arms
+//! the readiness on *mutable* deref only, so a `&mut self` method that mutates
+//! re-polls the tree while a `&self` reader never does — and neither has to
+//! remember to call anything.
+
+use std::ops::{Deref, DerefMut};
+
+use crate::Rtc;
+
+/// A `&mut Rtc` handle that re-polls the tree when it is used mutably.
+///
+/// Change detection, à la a dirty-flag on mutable access: `deref` is a plain
+/// read and never arms; `deref_mut` arms both halves (the safe default).
+/// Because a `&self` method can only reach `deref` and a mutating `&mut self`
+/// method reaches `deref_mut`, "mutation re-polls, reads don't" is enforced by
+/// the borrow checker — a new method can't forget, and a read-only method
+/// can't accidentally arm.
+///
+/// Deliberately has no `Drop`: the API wrappers are held in `let` bindings
+/// across other `Rtc` use, and a destructor would extend their borrow to the
+/// end of scope. Arming therefore happens eagerly on the mutable access.
+///
+/// When a mutation only affects one half of the re-poll — and especially when
+/// that isn't known until the mutation is underway — take it through
+/// [`RtcMut::mutate`] and narrow the returned [`Mutation`] guard.
+pub(crate) struct RtcMut<'a> {
+    rtc: &'a mut Rtc,
+}
+
+impl<'a> RtcMut<'a> {
+    pub(crate) fn new(rtc: &'a mut Rtc) -> Self {
+        RtcMut { rtc }
+    }
+
+    /// Begin a mutation whose re-poll can be narrowed *after the fact*.
+    ///
+    /// The returned [`Mutation`] derefs to `Rtc`, so mutate through it, then
+    /// (optionally, conditionally) call [`Mutation::no_events`] /
+    /// [`Mutation::no_timeout`]. It folds its own — per-operation, never shared
+    /// — signal into the readiness when it drops.
+    ///
+    /// Plain `&mut *` (via [`DerefMut`]) is the shorthand for "arm both": it's
+    /// what methods that don't narrow, or that return a `&mut` borrowed from
+    /// the tree (which can't outlive a guard), use instead.
+    pub(crate) fn mutate(&mut self) -> Mutation<'_> {
+        Mutation {
+            rtc: self.rtc,
+            events: true,
+            timeout: true,
+        }
+    }
+}
+
+impl Deref for RtcMut<'_> {
+    type Target = Rtc;
+
+    fn deref(&self) -> &Rtc {
+        self.rtc
+    }
+}
+
+impl DerefMut for RtcMut<'_> {
+    fn deref_mut(&mut self) -> &mut Rtc {
+        self.rtc.readiness.wake();
+        self.rtc
+    }
+}
+
+/// A single mutation in progress, obtained from [`RtcMut::mutate`].
+///
+/// Derefs to `Rtc` for the actual change. Armed for both halves by default;
+/// narrow with [`Mutation::no_events`] / [`Mutation::no_timeout`] at any point
+/// before it drops — including conditionally, once the mutation has revealed
+/// which half it touched. Folds the (possibly narrowed) signal into the
+/// readiness on drop.
+///
+/// The signal is private to this one guard, so narrowing here can never
+/// interfere with another method call's decision regardless of call order —
+/// the property a long-lived shared guard could not offer.
+pub(crate) struct Mutation<'a> {
+    rtc: &'a mut Rtc,
+    events: bool,
+    timeout: bool,
+}
+
+impl Mutation<'_> {
+    /// Assert this mutation queued no event or transmit.
+    pub(crate) fn no_events(&mut self) {
+        self.events = false;
+    }
+
+    /// Assert this mutation moved no timer.
+    pub(crate) fn no_timeout(&mut self) {
+        self.timeout = false;
+    }
+}
+
+impl Deref for Mutation<'_> {
+    type Target = Rtc;
+
+    fn deref(&self) -> &Rtc {
+        self.rtc
+    }
+}
+
+impl DerefMut for Mutation<'_> {
+    fn deref_mut(&mut self) -> &mut Rtc {
+        self.rtc
+    }
+}
+
+impl Drop for Mutation<'_> {
+    fn drop(&mut self) {
+        let mut wake = self.rtc.readiness.wake();
+        if !self.events {
+            wake.no_events();
+        }
+        if !self.timeout {
+            wake.no_timeout();
+        }
+    }
+}
 
 /// The accumulated re-poll signal owned by [`Rtc`][crate::Rtc].
 ///

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,0 +1,97 @@
+//! Readiness signalling threaded through the component tree.
+//!
+//! Everything below [`Rtc`][crate::Rtc] forms a tree, and both events and new
+//! timeouts bubble up from the leaves. To avoid re-walking a quiescent tree on
+//! every `poll_output`, each path that takes `&mut` access to a sub-component
+//! is handed an armed [`Wake`] guard, threaded down like `&mut` state.
+//!
+//! A [`Wake`] defaults to re-polling *everything*: left untouched it signals
+//! both a pending event drain and a timeout recompute. A component narrows it
+//! locally — [`Wake::no_events`] / [`Wake::no_timeout`] — when it knows less
+//! changed. The guard folds its (possibly narrowed) signal into the owning
+//! [`Readiness`] on drop.
+//!
+//! The direction is deliberate: the safe default is to re-poll, and narrowing
+//! is an opt-in optimization owned by the component that performed the
+//! mutation. A forgotten or over-broad narrow costs at most one redundant
+//! poll; it can never drop output. No component names another's scope, and
+//! `Rtc` holds no knowledge of which mutation affects what.
+
+/// The accumulated re-poll signal owned by [`Rtc`][crate::Rtc].
+///
+/// `poll_output` reads it to decide whether to walk the event pipeline and
+/// whether to recompute the next timeout, clearing each half once it has
+/// proven that part of the tree quiescent.
+#[derive(Debug)]
+pub(crate) struct Readiness {
+    events: bool,
+    timeout: bool,
+}
+
+impl Readiness {
+    /// A fresh instance must poll the whole tree once.
+    pub(crate) fn armed() -> Self {
+        Readiness {
+            events: true,
+            timeout: true,
+        }
+    }
+
+    pub(crate) fn wants_events(&self) -> bool {
+        self.events
+    }
+
+    pub(crate) fn wants_timeout(&self) -> bool {
+        self.timeout
+    }
+
+    pub(crate) fn clear_events(&mut self) {
+        self.events = false;
+    }
+
+    pub(crate) fn clear_timeout(&mut self) {
+        self.timeout = false;
+    }
+
+    /// Hand out an armed guard for a mutable descent into the tree.
+    pub(crate) fn wake(&mut self) -> Wake<'_> {
+        Wake {
+            readiness: self,
+            events: true,
+            timeout: true,
+        }
+    }
+}
+
+/// An armed guard threaded into a component's mutating methods.
+///
+/// Narrowed locally by the component and folded into [`Readiness`] on drop.
+/// See the [module docs][self].
+#[must_use = "a Wake only re-polls the tree when it is dropped or narrowed; \
+              dropping it immediately is the conservative (re-poll all) default"]
+pub(crate) struct Wake<'a> {
+    readiness: &'a mut Readiness,
+    events: bool,
+    timeout: bool,
+}
+
+impl Wake<'_> {
+    /// Assert this path queued no event or transmit, so the event pipeline
+    /// need not be walked on its behalf.
+    pub(crate) fn no_events(&mut self) {
+        self.events = false;
+    }
+
+    /// Assert this path did not move any timer, so the next timeout need not
+    /// be recomputed on its behalf.
+    pub(crate) fn no_timeout(&mut self) {
+        self.timeout = false;
+    }
+}
+
+impl Drop for Wake<'_> {
+    fn drop(&mut self) {
+        self.readiness.events |= self.events;
+        self.readiness.timeout |= self.timeout;
+    }
+}

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -67,8 +67,9 @@ impl Readiness {
 ///
 /// Narrowed locally by the component and folded into [`Readiness`] on drop.
 /// See the [module docs][self].
-#[must_use = "a Wake only re-polls the tree when it is dropped or narrowed; \
-              dropping it immediately is the conservative (re-poll all) default"]
+///
+/// Dropping it immediately (e.g. `self.rtc.readiness.wake();`) is the
+/// conservative default: it re-polls everything. Narrow first to do less.
 pub(crate) struct Wake<'a> {
     readiness: &'a mut Readiness,
     events: bool,

--- a/src/sctp/mod.rs
+++ b/src/sctp/mod.rs
@@ -13,6 +13,8 @@ use sctp_proto::{Event, Payload, PayloadProtocolIdentifier, ServerConfig, Transp
 
 use snap::{b64_encode, webrtc_transport_config};
 
+use crate::poll::Wake;
+
 pub use sctp_proto::Error as ProtoError;
 use sctp_proto::ReliabilityType;
 
@@ -666,7 +668,9 @@ impl RtcSctp {
         }
     }
 
-    pub fn handle_timeout(&mut self, now: Instant) {
+    // `_wake` arms both: driving the association can produce transmits and
+    // channel events while also re-arming SCTP's own timers.
+    pub fn handle_timeout(&mut self, now: Instant, _wake: &mut Wake) {
         if self.state == RtcSctpState::Uninited {
             // Need to call `init()` before any timeouts are accepted.
             return;

--- a/src/session.rs
+++ b/src/session.rs
@@ -19,6 +19,7 @@ use crate::media::{KeyframeRequestKind, MID_PROBE};
 use crate::media::{MediaAdded, MediaChanged};
 use crate::pacer::PacerControl;
 use crate::pacer::{Pacer, PacerImpl};
+use crate::poll::Wake;
 use crate::rtp::{Extension, RawPacket};
 use crate::rtp_::Direction;
 use crate::rtp_::MidRid;
@@ -244,7 +245,10 @@ impl Session {
         self.srtp_tx = Some(SrtpContext::new(crypto, srtp_profile, &mat, left));
     }
 
-    pub fn handle_timeout(&mut self, now: Instant) -> Result<(), RtcError> {
+    // `_wake` arms both signals: driving the session both emits events (media,
+    // feedback, RTP) and re-arms its timers. Threaded here as the point where
+    // future per-stream narrowing would live.
+    pub fn handle_timeout(&mut self, now: Instant, _wake: &mut Wake) -> Result<(), RtcError> {
         if self.rtp_closing {
             return Ok(());
         }
@@ -355,7 +359,9 @@ impl Session {
             .push_back(Rtcp::AppSpecificFeedback(feedback));
     }
 
-    pub fn handle_rtp_receive(&mut self, now: Instant, message: &[u8]) {
+    // `_wake` arms both: incoming RTP can surface as a media/RTP event and
+    // re-arms receive-side timers (NACK, receiver reports).
+    pub fn handle_rtp_receive(&mut self, now: Instant, message: &[u8], _wake: &mut Wake) {
         let Some(header) = RtpHeader::parse(message, &self.exts) else {
             trace!("Failed to parse RTP header");
             return;
@@ -364,7 +370,9 @@ impl Session {
         self.handle_rtp(now, header, message);
     }
 
-    pub fn handle_rtcp_receive(&mut self, now: Instant, message: &[u8]) {
+    // `_wake` arms both: incoming RTCP can surface remote keyframe requests or
+    // sender feedback as events and updates report timers.
+    pub fn handle_rtcp_receive(&mut self, now: Instant, message: &[u8], _wake: &mut Wake) {
         // According to spec, the outer enclosing SRTCP packet should always be a SR or RR,
         // even if it's irrelevant and empty.
         // In practice I'm not sure that is happening, because libWebRTC hates empty packets.

--- a/tests/poll-scaling.rs
+++ b/tests/poll-scaling.rs
@@ -1,0 +1,160 @@
+//! How much does one `poll_output()` cost, as a function of the number of
+//! m-lines on the connection?
+//!
+//! This is the shape that matters for a server. A 1:1 call has 2 m-lines and the
+//! cost is invisible. An SFU client in an N-person room has ~N m-lines (one per
+//! other participant), and `poll_output` is called thousands of times per second
+//! per connection — so any per-call linear scan over medias/streams is paid
+//! O(N) times, O(N^2) per room.
+//!
+//! The number reported is the cost of a poll that finds NOTHING to do (returns
+//! `Output::Timeout`). In a real SFU that is the majority of calls: every drain
+//! ends with one, by construction.
+//!
+//! Ignored by default, since it is a measurement rather than an assertion and it
+//! takes a while. Run with:
+//!
+//!     cargo test --release --test poll-scaling -- --ignored --nocapture
+//!
+//! `--release` is essential; a debug build hides the effect entirely.
+//!
+//! Methodology note, because it cost us several wrong conclusions. Report the
+//! MINIMUM of N trials, never the mean: CPU benchmark noise is additive, so the
+//! fastest trial is the closest to the true cost. And never compare two numbers
+//! measured minutes apart, because the machine drifts (thermal throttling, power
+//! source). To compare two versions, prebuild both test binaries, run them back to
+//! back alternating the order, and pair the results.
+
+use std::net::Ipv4Addr;
+use std::time::{Duration, Instant};
+
+use str0m::media::{Direction, MediaKind, Mid};
+use str0m::{Output, RtcError};
+
+mod common;
+use common::{Peer, TestRtc, init_crypto_default, init_log, negotiate, progress};
+
+/// m-line counts to sweep. 2 = a 1:1 call. 30 = a mid-size conference.
+const MLINES: &[usize] = &[2, 5, 10, 20, 30, 50];
+
+/// Polls timed per trial.
+const ITERATIONS: usize = 50_000;
+
+/// Trials per data point. We report the MINIMUM: a CPU benchmark's noise is
+/// almost entirely additive (scheduling, interrupts, frequency dips), so the
+/// fastest trial is the closest to the true cost. Reporting the mean instead
+/// makes the numbers swing ~20% run to run and the comparison meaningless.
+const TRIALS: usize = 7;
+
+#[test]
+#[ignore = "measurement, not an assertion; run explicitly with --ignored"]
+fn poll_output_cost_by_mline_count() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    println!();
+    println!("cost of ONE poll_output() that returns Timeout (i.e. finds nothing to do)");
+    println!();
+    println!(
+        "{:>8}  {:>12}  {:>12}  {:>10}",
+        "m-lines", "ns/poll", "vs 2 m-lines", "ns/m-line"
+    );
+    println!("{:->8}  {:->12}  {:->12}  {:->10}", "", "", "", "");
+
+    let mut baseline: Option<f64> = None;
+
+    for &n in MLINES {
+        let ns = measure(n)?;
+
+        let base = *baseline.get_or_insert(ns);
+        println!(
+            "{:>8}  {:>12.0}  {:>11.1}x  {:>10.1}",
+            n,
+            ns,
+            ns / base,
+            ns / n as f64
+        );
+    }
+
+    println!();
+    println!("A flat 'vs 2 m-lines' column means poll_output is O(1) in the number of");
+    println!("m-lines. A column that tracks the m-line count means it is O(N), and an");
+    println!("SFU pays that N times per iteration.");
+    println!();
+
+    Ok(())
+}
+
+/// Build a connection with `n` send-only m-lines (the SFU-to-viewer direction),
+/// get media flowing on each so the StreamTx actually exist, then time a
+/// `poll_output()` that has nothing left to produce.
+fn measure(n: usize) -> Result<f64, RtcError> {
+    let mut l = TestRtc::new(Peer::Left); // the "SFU"
+    let mut r = TestRtc::new(Peer::Right); // the viewer
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    // One m-line per remote participant the viewer is subscribed to.
+    let mids: Vec<Mid> = negotiate(&mut l, &mut r, |change| {
+        (0..n)
+            .map(|_| change.add_media(MediaKind::Video, Direction::SendOnly, None, None, None))
+            .collect()
+    });
+
+    loop {
+        if l.is_connected() && r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r)?;
+    }
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    // Write one packet on every m-line, so each has a live StreamTx. Without this
+    // the streams do not exist and the scan has nothing to scan.
+    let params = l.params_vp8();
+    let pt = params.pt();
+    for (i, mid) in mids.iter().enumerate() {
+        let wallclock = l.start + l.duration();
+        let time = l.duration().into();
+        l.writer(*mid)
+            .unwrap()
+            .write(pt, wallclock, time, vec![1_u8, 2, 3, (i % 250) as u8])?;
+        progress(&mut l, &mut r)?;
+    }
+
+    // Drain everything so the next poll is a pure "nothing to do" poll.
+    loop {
+        match l.rtc.poll_output()? {
+            Output::Timeout(_) => break,
+            Output::Transmit(_) | Output::Event(_) => continue,
+        }
+    }
+
+    // Warm up: caches, branch predictors, CPU frequency.
+    for _ in 0..ITERATIONS {
+        std::hint::black_box(l.rtc.poll_output()?);
+    }
+
+    // Time the empty poll. It is idempotent — it keeps returning Timeout — so we
+    // can call it repeatedly without changing the connection's state.
+    let mut best = f64::MAX;
+    for _ in 0..TRIALS {
+        let t0 = Instant::now();
+        for _ in 0..ITERATIONS {
+            let out = l.rtc.poll_output()?;
+            debug_assert!(matches!(out, Output::Timeout(_)));
+            std::hint::black_box(&out);
+        }
+        let elapsed: Duration = t0.elapsed();
+        let ns = elapsed.as_nanos() as f64 / ITERATIONS as f64;
+        if ns < best {
+            best = ns;
+        }
+    }
+
+    Ok(best)
+}


### PR DESCRIPTION
Everything below Rtc forms a tree; events and timeouts bubble up. On main every poll_output re-walks the whole tree (the .soonest() timeout fold plus poll_event over all medias/streams), so an idle poll that only returns Output::Timeout is O(number of m-lines). An SFU calls poll_output thousands of times per second per connection, paying that scan O(N) times.

Introduce a Wake guard threaded down the tree (src/poll.rs). It defaults to re-polling everything and is narrowed locally by the component that mutated (no_events / no_timeout), folding into an Rtc-owned Readiness on drop. poll_output gates on it: skip the event pipeline unless something queued output, skip the timeout recompute unless a timer moved, otherwise return the cached timeout. Forgetting or over-arming costs a redundant poll, never dropped output.

The mutation and handle_input paths pass their own guard to each subsystem so the invalidation decision stays local (session, chan, sctp, Writer, Bwe, Channel). External crates (ice, sctp-proto) can't take a Wake, so those boundaries arm conservatively; SdpApi/DirectApi still arm at the accessor pending threading.

tests/poll-scaling.rs measures it: idle poll_output is flat ~27ns from 2 to 50 m-lines here, versus 135ns->1038ns (7.7x) on main.