### PR TITLE
Add support for Comfort Noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
   * Expose the latest send queue information on `StreamTx` #1005
   * Fix VP9 non-flexible SS advertising a bogus R=0 GOF for single-layer streams #999
   * Support G722 audio codec (16 kHz codec with 8 kHz RTP clock per RFC 3551) #992
-  * Support RFC 3389 Comfort Noise payloads #993
+  * Support RFC 3389 Comfort Noise payloads #1013
   * Apply reliability parameters to a DCEP-receiving in-band channel #1004
 
 # 0.21.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * Expose the latest send queue information on `StreamTx` #1005
   * Fix VP9 non-flexible SS advertising a bogus R=0 GOF for single-layer streams #999
   * Support G722 audio codec (16 kHz codec with 8 kHz RTP clock per RFC 3551) #992
+  * Support RFC 3389 Comfort Noise payloads #993
   * Apply reliability parameters to a DCEP-receiving in-band channel #1004
 
 # 0.21.0

--- a/src/_internal_test_exports/fuzz.rs
+++ b/src/_internal_test_exports/fuzz.rs
@@ -79,7 +79,7 @@ pub fn sdp_answer(data: &[u8]) -> Option<()> {
 pub fn depack(data: &[u8]) -> Option<()> {
     let mut rng = Rng::new(data);
 
-    let codec = match rng.u8(9)? {
+    let codec = match rng.u8(10)? {
         0 => Codec::Opus,
         1 => Codec::Vp8,
         2 => Codec::Vp9,
@@ -90,6 +90,7 @@ pub fn depack(data: &[u8]) -> Option<()> {
         7 => Codec::PCMU,
         8 => Codec::PCMA,
         9 => Codec::G722,
+        10 => Codec::ComfortNoise,
         _ => unreachable!(),
     };
 
@@ -209,7 +210,7 @@ pub fn rtcp(data: &[u8]) -> Option<()> {
 pub fn depack_direct(data: &[u8]) -> Option<()> {
     let mut rng = Rng::new(data);
 
-    let codec = match rng.u8(9)? {
+    let codec = match rng.u8(10)? {
         0 => Codec::Opus,
         1 => Codec::Vp8,
         2 => Codec::Vp9,
@@ -220,6 +221,7 @@ pub fn depack_direct(data: &[u8]) -> Option<()> {
         7 => Codec::PCMU,
         8 => Codec::PCMA,
         9 => Codec::G722,
+        10 => Codec::ComfortNoise,
         _ => unreachable!(),
     };
 

--- a/src/_internal_test_exports/fuzz.rs
+++ b/src/_internal_test_exports/fuzz.rs
@@ -90,7 +90,7 @@ pub fn depack(data: &[u8]) -> Option<()> {
         7 => Codec::PCMU,
         8 => Codec::PCMA,
         9 => Codec::G722,
-        10 => Codec::ComfortNoise,
+        10 => Codec::CN,
         _ => unreachable!(),
     };
 
@@ -221,7 +221,7 @@ pub fn depack_direct(data: &[u8]) -> Option<()> {
         7 => Codec::PCMU,
         8 => Codec::PCMA,
         9 => Codec::G722,
-        10 => Codec::ComfortNoise,
+        10 => Codec::CN,
         _ => unreachable!(),
     };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -257,6 +257,15 @@ impl RtcConfig {
         self
     }
 
+    /// Enable the RFC 3389 Comfort Noise payload at 8000 Hz.
+    ///
+    /// Disabled by default. Higher clock rates require a dynamic payload type
+    /// and can be added through [`RtcConfig::codec_config`].
+    pub fn enable_comfort_noise(mut self, enabled: bool) -> Self {
+        self.codec_config.enable_comfort_noise(enabled);
+        self
+    }
+
     /// Enable VP8 video codec.
     ///
     /// Enabled by default.
@@ -721,6 +730,18 @@ impl Default for RtcConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn enable_comfort_noise_updates_codec_config() {
+        let mut cfg = RtcConfig::default().enable_comfort_noise(true);
+
+        assert!(
+            cfg.codec_config()
+                .params()
+                .iter()
+                .any(|p| p.spec().codec == crate::format::Codec::ComfortNoise)
+        );
+    }
 
     #[test]
     fn default_mtu_is_datagram_mtu_target() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -739,7 +739,7 @@ mod tests {
             cfg.codec_config()
                 .params()
                 .iter()
-                .any(|p| p.spec().codec == crate::format::Codec::ComfortNoise)
+                .any(|p| p.spec().codec == crate::format::Codec::CN)
         );
     }
 

--- a/src/format/codec.rs
+++ b/src/format/codec.rs
@@ -53,6 +53,8 @@ pub enum Codec {
     PCMU,
     PCMA,
     G722,
+    /// Comfort Noise payload, per RFC 3389.
+    ComfortNoise,
     H264,
     // TODO show this when we support h265.
     #[doc(hidden)]
@@ -82,7 +84,7 @@ impl Codec {
     /// Tells if codec is audio.
     pub fn is_audio(&self) -> bool {
         use Codec::*;
-        matches!(self, Opus | PCMU | PCMA | G722)
+        matches!(self, Opus | PCMU | PCMA | G722 | ComfortNoise)
     }
 
     /// Tells if codec is video.
@@ -109,6 +111,7 @@ impl<'a> From<&'a str> for Codec {
             "pcmu" => Codec::PCMU,
             "pcma" => Codec::PCMA,
             "g722" => Codec::G722,
+            "cn" => Codec::ComfortNoise,
             "h264" => Codec::H264,
             "h265" => Codec::H265,
             "h266" => Codec::H266,
@@ -128,6 +131,7 @@ impl fmt::Display for Codec {
             Codec::PCMU => write!(f, "PCMU"),
             Codec::PCMA => write!(f, "PCMA"),
             Codec::G722 => write!(f, "G722"),
+            Codec::ComfortNoise => write!(f, "CN"),
             Codec::H264 => write!(f, "H264"),
             Codec::H265 => write!(f, "H265"),
             Codec::H266 => write!(f, "H266"),
@@ -163,6 +167,15 @@ mod test {
         assert_eq!(Codec::from("G722"), Codec::G722);
         assert_eq!(Codec::from("g722"), Codec::G722);
         assert_eq!(Codec::G722.to_string(), "G722");
+    }
+
+    #[test]
+    fn comfort_noise_is_audio_and_parses() {
+        assert!(Codec::ComfortNoise.is_audio());
+        assert!(!Codec::ComfortNoise.is_video());
+        assert_eq!(Codec::from("CN"), Codec::ComfortNoise);
+        assert_eq!(Codec::from("cn"), Codec::ComfortNoise);
+        assert_eq!(Codec::ComfortNoise.to_string(), "CN");
     }
 
     #[test]

--- a/src/format/codec.rs
+++ b/src/format/codec.rs
@@ -54,7 +54,7 @@ pub enum Codec {
     PCMA,
     G722,
     /// Comfort Noise payload, per RFC 3389.
-    ComfortNoise,
+    CN,
     H264,
     // TODO show this when we support h265.
     #[doc(hidden)]
@@ -84,7 +84,7 @@ impl Codec {
     /// Tells if codec is audio.
     pub fn is_audio(&self) -> bool {
         use Codec::*;
-        matches!(self, Opus | PCMU | PCMA | G722 | ComfortNoise)
+        matches!(self, Opus | PCMU | PCMA | G722 | CN)
     }
 
     /// Tells if codec is video.
@@ -111,7 +111,7 @@ impl<'a> From<&'a str> for Codec {
             "pcmu" => Codec::PCMU,
             "pcma" => Codec::PCMA,
             "g722" => Codec::G722,
-            "cn" => Codec::ComfortNoise,
+            "cn" => Codec::CN,
             "h264" => Codec::H264,
             "h265" => Codec::H265,
             "h266" => Codec::H266,
@@ -131,7 +131,7 @@ impl fmt::Display for Codec {
             Codec::PCMU => write!(f, "PCMU"),
             Codec::PCMA => write!(f, "PCMA"),
             Codec::G722 => write!(f, "G722"),
-            Codec::ComfortNoise => write!(f, "CN"),
+            Codec::CN => write!(f, "CN"),
             Codec::H264 => write!(f, "H264"),
             Codec::H265 => write!(f, "H265"),
             Codec::H266 => write!(f, "H266"),
@@ -171,11 +171,11 @@ mod test {
 
     #[test]
     fn comfort_noise_is_audio_and_parses() {
-        assert!(Codec::ComfortNoise.is_audio());
-        assert!(!Codec::ComfortNoise.is_video());
-        assert_eq!(Codec::from("CN"), Codec::ComfortNoise);
-        assert_eq!(Codec::from("cn"), Codec::ComfortNoise);
-        assert_eq!(Codec::ComfortNoise.to_string(), "CN");
+        assert!(Codec::CN.is_audio());
+        assert!(!Codec::CN.is_video());
+        assert_eq!(Codec::from("CN"), Codec::CN);
+        assert_eq!(Codec::from("cn"), Codec::CN);
+        assert_eq!(Codec::CN.to_string(), "CN");
     }
 
     #[test]

--- a/src/format/codec_config.rs
+++ b/src/format/codec_config.rs
@@ -19,6 +19,9 @@ pub(crate) const PT_PCMA: Pt = Pt::new_with_value(8);
 /// Default payload type for G722.
 pub(crate) const PT_G722: Pt = Pt::new_with_value(9);
 
+/// Static payload type for Comfort Noise at 8000 Hz (RFC 3389).
+pub(crate) const PT_COMFORT_NOISE: Pt = Pt::new_with_value(13);
+
 /// Default payload type for VP8.
 pub(crate) const PT_VP8: Pt = Pt::new_with_value(96);
 
@@ -231,6 +234,25 @@ impl CodecConfig {
             None,
             Codec::G722,
             Frequency::SIXTEEN_KHZ,
+            None,
+            Default::default(),
+        );
+    }
+
+    /// Add the static Comfort Noise payload type at 8000 Hz.
+    ///
+    /// Higher clock rates require dynamic payload types and can be configured
+    /// with [`CodecConfig::add_config`].
+    pub fn enable_comfort_noise(&mut self, enabled: bool) {
+        self.params.retain(|c| c.spec.codec != Codec::ComfortNoise);
+        if !enabled {
+            return;
+        }
+        self.add_config(
+            PT_COMFORT_NOISE,
+            None,
+            Codec::ComfortNoise,
+            Frequency::EIGHT_KHZ,
             None,
             Default::default(),
         );
@@ -561,6 +583,7 @@ impl Codec {
             Opus => Some(PT_OPUS),
             PCMU => Some(PT_PCMU),
             PCMA => Some(PT_PCMA),
+            ComfortNoise => Some(PT_COMFORT_NOISE),
             Vp8 => Some(PT_VP8),
             Vp9 => Some(PT_VP9),
             H265 => Some(PT_H265),
@@ -577,6 +600,34 @@ mod test {
 
     use super::*;
     use crate::format::{CodecSpec, FormatParams};
+
+    #[test]
+    fn enable_comfort_noise_uses_static_8khz_payload_type() {
+        let mut config = CodecConfig::empty();
+
+        config.enable_comfort_noise(true);
+
+        let params = config
+            .params()
+            .iter()
+            .find(|p| p.spec().codec == Codec::ComfortNoise)
+            .expect("Comfort Noise should be enabled");
+        assert_eq!(params.pt(), Pt::new_with_value(13));
+        assert_eq!(params.spec().clock_rate, Frequency::EIGHT_KHZ);
+        assert_eq!(params.spec().channels, None);
+        assert_eq!(
+            Codec::ComfortNoise.default_pt(),
+            Some(Pt::new_with_value(13))
+        );
+
+        config.enable_comfort_noise(false);
+        assert!(
+            config
+                .params()
+                .iter()
+                .all(|p| p.spec().codec != Codec::ComfortNoise)
+        );
+    }
 
     #[test]
     fn test_pt_conflict_different_directions() {

--- a/src/format/codec_config.rs
+++ b/src/format/codec_config.rs
@@ -630,6 +630,32 @@ mod test {
     }
 
     #[test]
+    fn comfort_noise_supports_dynamic_payload_types_at_higher_clock_rates() {
+        let mut config = CodecConfig::empty();
+
+        for (pt, clock_rate) in [(96, 16_000), (97, 24_000), (98, 32_000), (99, 48_000)] {
+            config.add_config(
+                pt.into(),
+                None,
+                Codec::ComfortNoise,
+                Frequency::new(clock_rate).unwrap(),
+                None,
+                FormatParams::default(),
+            );
+        }
+
+        let configured: Vec<_> = config
+            .params()
+            .iter()
+            .map(|p| (*p.pt(), p.spec().clock_rate.get()))
+            .collect();
+        assert_eq!(
+            configured,
+            vec![(96, 16_000), (97, 24_000), (98, 32_000), (99, 48_000)]
+        );
+    }
+
+    #[test]
     fn test_pt_conflict_different_directions() {
         // Simulates:
         // 1. str0m OFFER sendonly H264 PT 108, RTX PT 109

--- a/src/format/codec_config.rs
+++ b/src/format/codec_config.rs
@@ -602,6 +602,51 @@ mod test {
     use crate::format::{CodecSpec, FormatParams};
 
     #[test]
+    fn dynamic_comfort_noise_collision_does_not_use_static_pt_13() {
+        let mut claimed = PayloadParams::new(
+            96.into(),
+            None,
+            CodecSpec {
+                codec: Codec::Opus,
+                clock_rate: Frequency::FORTY_EIGHT_KHZ,
+                channels: Some(2),
+                format: FormatParams::default(),
+            },
+        );
+        claimed.locked = true;
+
+        let local_cn = PayloadParams::new(
+            97.into(),
+            None,
+            CodecSpec {
+                codec: Codec::ComfortNoise,
+                clock_rate: Frequency::SIXTEEN_KHZ,
+                channels: None,
+                format: FormatParams::default(),
+            },
+        );
+        let remote_cn = PayloadParams::new(
+            96.into(),
+            None,
+            CodecSpec {
+                codec: Codec::ComfortNoise,
+                clock_rate: Frequency::SIXTEEN_KHZ,
+                channels: None,
+                format: FormatParams::default(),
+            },
+        );
+
+        let mut config = CodecConfig::new_from_payload_params(vec![claimed, local_cn]);
+        config.update_params(&[remote_cn], Direction::SendOnly);
+
+        let cn = config
+            .iter()
+            .find(|p| p.spec().codec == Codec::ComfortNoise)
+            .expect("configured CN payload");
+        assert_ne!(*cn.pt(), 13, "PT 13 is reserved for CN at 8 kHz");
+    }
+
+    #[test]
     fn enable_comfort_noise_uses_static_8khz_payload_type() {
         let mut config = CodecConfig::empty();
 

--- a/src/format/codec_config.rs
+++ b/src/format/codec_config.rs
@@ -592,6 +592,14 @@ impl Codec {
     }
 }
 
+impl CodecSpec {
+    pub(crate) fn default_pt(&self) -> Option<Pt> {
+        self.codec.default_pt().filter(|_| {
+            self.codec != Codec::ComfortNoise || self.clock_rate == Frequency::EIGHT_KHZ
+        })
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::packet::MediaKind;

--- a/src/format/codec_config.rs
+++ b/src/format/codec_config.rs
@@ -638,7 +638,7 @@ mod test {
     }
 
     #[test]
-    fn dynamic_comfort_noise_collision_does_not_use_static_pt_13() {
+    fn dynamic_comfort_noise_collision_preserves_configured_pt() {
         let mut claimed = PayloadParams::new(
             96.into(),
             None,
@@ -679,7 +679,44 @@ mod test {
             .iter()
             .find(|p| p.spec().codec == Codec::ComfortNoise)
             .expect("configured CN payload");
-        assert_ne!(*cn.pt(), 13, "PT 13 is reserved for CN at 8 kHz");
+        assert_eq!(
+            *cn.pt(),
+            97,
+            "dynamic CN must retain its configured payload type"
+        );
+    }
+
+    #[test]
+    fn collision_preserves_configured_primary_and_rtx_pts() {
+        let mut claimed = PayloadParams::new(
+            96.into(),
+            Some(97.into()),
+            CodecSpec {
+                codec: Codec::H264,
+                clock_rate: Frequency::NINETY_KHZ,
+                channels: None,
+                format: FormatParams::default(),
+            },
+        );
+        claimed.locked = true;
+
+        let vp8 = CodecSpec {
+            codec: Codec::Vp8,
+            clock_rate: Frequency::NINETY_KHZ,
+            channels: None,
+            format: FormatParams::default(),
+        };
+        let local_vp8 = PayloadParams::new(110.into(), Some(111.into()), vp8);
+        let remote_vp8 = PayloadParams::new(96.into(), Some(97.into()), vp8);
+
+        let mut config = CodecConfig::new_from_payload_params(vec![claimed, local_vp8]);
+        config.update_params(&[remote_vp8], Direction::SendOnly);
+
+        let vp8 = config
+            .iter()
+            .find(|p| p.spec().codec == Codec::Vp8)
+            .expect("configured VP8 payload");
+        assert_eq!((*vp8.pt(), vp8.resend().map(|pt| *pt)), (110, Some(111)));
     }
 
     #[test]

--- a/src/format/codec_config.rs
+++ b/src/format/codec_config.rs
@@ -136,6 +136,18 @@ impl CodecConfig {
         self.params.push(p);
     }
 
+    fn add_static_config(&mut self, pt: Pt) {
+        let spec = CodecSpec::from_static_pt(pt).expect("known static payload type");
+        self.add_config(
+            pt,
+            None,
+            spec.codec,
+            spec.clock_rate,
+            spec.channels,
+            spec.format,
+        );
+    }
+
     /// Convenience for adding a h264 payload type.
     pub fn add_h264(
         &mut self,
@@ -192,14 +204,7 @@ impl CodecConfig {
         if !enabled {
             return;
         }
-        self.add_config(
-            PT_PCMU,
-            None,
-            Codec::PCMU,
-            Frequency::EIGHT_KHZ,
-            None,
-            Default::default(),
-        );
+        self.add_static_config(PT_PCMU);
     }
 
     /// Convenience for adding a PCM a-law payload type.
@@ -208,14 +213,7 @@ impl CodecConfig {
         if !enabled {
             return;
         }
-        self.add_config(
-            PT_PCMA,
-            None,
-            Codec::PCMA,
-            Frequency::EIGHT_KHZ,
-            None,
-            Default::default(),
-        );
+        self.add_static_config(PT_PCMA);
     }
 
     /// Convenience for adding a G722 payload type.
@@ -229,14 +227,7 @@ impl CodecConfig {
         if !enabled {
             return;
         }
-        self.add_config(
-            PT_G722,
-            None,
-            Codec::G722,
-            Frequency::SIXTEEN_KHZ,
-            None,
-            Default::default(),
-        );
+        self.add_static_config(PT_G722);
     }
 
     /// Add the static Comfort Noise payload type at 8000 Hz.
@@ -248,14 +239,7 @@ impl CodecConfig {
         if !enabled {
             return;
         }
-        self.add_config(
-            PT_COMFORT_NOISE,
-            None,
-            Codec::ComfortNoise,
-            Frequency::EIGHT_KHZ,
-            None,
-            Default::default(),
-        );
+        self.add_static_config(PT_COMFORT_NOISE);
     }
 
     /// Add a default OPUS payload type.
@@ -593,6 +577,30 @@ impl Codec {
 }
 
 impl CodecSpec {
+    /// Get the standardized codec definition for a static RTP payload type.
+    pub(crate) fn from_static_pt(pt: Pt) -> Option<Self> {
+        let (codec, clock_rate) = if pt == PT_PCMU {
+            (Codec::PCMU, Frequency::EIGHT_KHZ)
+        } else if pt == PT_PCMA {
+            (Codec::PCMA, Frequency::EIGHT_KHZ)
+        } else if pt == PT_G722 {
+            // G722 is represented as 16 kHz internally. CodecSpec::rtp_clock_rate()
+            // maps it to the standardized 8 kHz RTP clock rate on the wire.
+            (Codec::G722, Frequency::SIXTEEN_KHZ)
+        } else if pt == PT_COMFORT_NOISE {
+            (Codec::ComfortNoise, Frequency::EIGHT_KHZ)
+        } else {
+            return None;
+        };
+
+        Some(CodecSpec {
+            codec,
+            clock_rate,
+            channels: None,
+            format: FormatParams::default(),
+        })
+    }
+
     pub(crate) fn default_pt(&self) -> Option<Pt> {
         self.codec.default_pt().filter(|_| {
             self.codec != Codec::ComfortNoise || self.clock_rate == Frequency::EIGHT_KHZ
@@ -608,6 +616,26 @@ mod test {
 
     use super::*;
     use crate::format::{CodecSpec, FormatParams};
+
+    #[test]
+    fn static_payload_types_have_canonical_codec_definitions() {
+        let definitions = [
+            (PT_PCMU, Codec::PCMU, Frequency::EIGHT_KHZ),
+            (PT_PCMA, Codec::PCMA, Frequency::EIGHT_KHZ),
+            (PT_G722, Codec::G722, Frequency::SIXTEEN_KHZ),
+            (PT_COMFORT_NOISE, Codec::ComfortNoise, Frequency::EIGHT_KHZ),
+        ];
+
+        for (pt, codec, clock_rate) in definitions {
+            let spec = CodecSpec::from_static_pt(pt).expect("static payload definition");
+            assert_eq!(spec.codec, codec);
+            assert_eq!(spec.clock_rate, clock_rate);
+            assert_eq!(spec.channels, None);
+            assert_eq!(spec.format, FormatParams::default());
+        }
+
+        assert!(CodecSpec::from_static_pt(PT_OPUS).is_none());
+    }
 
     #[test]
     fn dynamic_comfort_noise_collision_does_not_use_static_pt_13() {

--- a/src/format/codec_config.rs
+++ b/src/format/codec_config.rs
@@ -559,23 +559,6 @@ impl DerefMut for CodecConfig {
     }
 }
 
-impl Codec {
-    /// Get the default PT for this codec, if one exists.
-    pub(crate) fn default_pt(&self) -> Option<Pt> {
-        use Codec::*;
-        match self {
-            Opus => Some(PT_OPUS),
-            PCMU => Some(PT_PCMU),
-            PCMA => Some(PT_PCMA),
-            ComfortNoise => Some(PT_COMFORT_NOISE),
-            Vp8 => Some(PT_VP8),
-            Vp9 => Some(PT_VP9),
-            H265 => Some(PT_H265),
-            _ => None,
-        }
-    }
-}
-
 impl CodecSpec {
     /// Get the standardized codec definition for a static RTP payload type.
     pub(crate) fn from_static_pt(pt: Pt) -> Option<Self> {
@@ -598,12 +581,6 @@ impl CodecSpec {
             clock_rate,
             channels: None,
             format: FormatParams::default(),
-        })
-    }
-
-    pub(crate) fn default_pt(&self) -> Option<Pt> {
-        self.codec.default_pt().filter(|_| {
-            self.codec != Codec::ComfortNoise || self.clock_rate == Frequency::EIGHT_KHZ
         })
     }
 }
@@ -733,10 +710,6 @@ mod test {
         assert_eq!(params.pt(), Pt::new_with_value(13));
         assert_eq!(params.spec().clock_rate, Frequency::EIGHT_KHZ);
         assert_eq!(params.spec().channels, None);
-        assert_eq!(
-            Codec::ComfortNoise.default_pt(),
-            Some(Pt::new_with_value(13))
-        );
 
         config.enable_comfort_noise(false);
         assert!(

--- a/src/format/codec_config.rs
+++ b/src/format/codec_config.rs
@@ -235,7 +235,7 @@ impl CodecConfig {
     /// Higher clock rates require dynamic payload types and can be configured
     /// with [`CodecConfig::add_config`].
     pub fn enable_comfort_noise(&mut self, enabled: bool) {
-        self.params.retain(|c| c.spec.codec != Codec::ComfortNoise);
+        self.params.retain(|c| c.spec.codec != Codec::CN);
         if !enabled {
             return;
         }
@@ -571,7 +571,7 @@ impl CodecSpec {
             // maps it to the standardized 8 kHz RTP clock rate on the wire.
             (Codec::G722, Frequency::SIXTEEN_KHZ)
         } else if pt == PT_COMFORT_NOISE {
-            (Codec::ComfortNoise, Frequency::EIGHT_KHZ)
+            (Codec::CN, Frequency::EIGHT_KHZ)
         } else {
             return None;
         };
@@ -600,7 +600,7 @@ mod test {
             (PT_PCMU, Codec::PCMU, Frequency::EIGHT_KHZ),
             (PT_PCMA, Codec::PCMA, Frequency::EIGHT_KHZ),
             (PT_G722, Codec::G722, Frequency::SIXTEEN_KHZ),
-            (PT_COMFORT_NOISE, Codec::ComfortNoise, Frequency::EIGHT_KHZ),
+            (PT_COMFORT_NOISE, Codec::CN, Frequency::EIGHT_KHZ),
         ];
 
         for (pt, codec, clock_rate) in definitions {
@@ -632,7 +632,7 @@ mod test {
             97.into(),
             None,
             CodecSpec {
-                codec: Codec::ComfortNoise,
+                codec: Codec::CN,
                 clock_rate: Frequency::SIXTEEN_KHZ,
                 channels: None,
                 format: FormatParams::default(),
@@ -642,7 +642,7 @@ mod test {
             96.into(),
             None,
             CodecSpec {
-                codec: Codec::ComfortNoise,
+                codec: Codec::CN,
                 clock_rate: Frequency::SIXTEEN_KHZ,
                 channels: None,
                 format: FormatParams::default(),
@@ -654,7 +654,7 @@ mod test {
 
         let cn = config
             .iter()
-            .find(|p| p.spec().codec == Codec::ComfortNoise)
+            .find(|p| p.spec().codec == Codec::CN)
             .expect("configured CN payload");
         assert_eq!(
             *cn.pt(),
@@ -705,19 +705,14 @@ mod test {
         let params = config
             .params()
             .iter()
-            .find(|p| p.spec().codec == Codec::ComfortNoise)
+            .find(|p| p.spec().codec == Codec::CN)
             .expect("Comfort Noise should be enabled");
         assert_eq!(params.pt(), Pt::new_with_value(13));
         assert_eq!(params.spec().clock_rate, Frequency::EIGHT_KHZ);
         assert_eq!(params.spec().channels, None);
 
         config.enable_comfort_noise(false);
-        assert!(
-            config
-                .params()
-                .iter()
-                .all(|p| p.spec().codec != Codec::ComfortNoise)
-        );
+        assert!(config.params().iter().all(|p| p.spec().codec != Codec::CN));
     }
 
     #[test]
@@ -728,7 +723,7 @@ mod test {
             config.add_config(
                 pt.into(),
                 None,
-                Codec::ComfortNoise,
+                Codec::CN,
                 Frequency::new(clock_rate).unwrap(),
                 None,
                 FormatParams::default(),

--- a/src/format/payload_params.rs
+++ b/src/format/payload_params.rs
@@ -696,7 +696,6 @@ impl PayloadParams {
                 // Try to use the codec's default PT first, fall back to any free PT
                 let new_pt = self
                     .spec
-                    .codec
                     .default_pt()
                     .filter(|pt| !claimed.is_claimed(*pt))
                     .or_else(|| claimed.find_unclaimed(PREFERED_RANGES, unlocked));

--- a/src/format/payload_params.rs
+++ b/src/format/payload_params.rs
@@ -693,11 +693,9 @@ impl PayloadParams {
             // If we're receiving, we control what PTs to use,
             // so we can remap the conflicting PT.
             if local_is_controlling && claimed.is_claimed(remote_pt) {
-                // Try to use the codec's default PT first, fall back to any free PT
-                let new_pt = self
-                    .spec
-                    .default_pt()
-                    .filter(|pt| !claimed.is_claimed(*pt))
+                // Prefer our configured PT, then fall back to any free PT.
+                let new_pt = (!claimed.is_claimed(self.pt))
+                    .then_some(self.pt)
                     .or_else(|| claimed.find_unclaimed(PREFERED_RANGES, unlocked));
 
                 if let Some(new_pt) = new_pt {
@@ -720,7 +718,12 @@ impl PayloadParams {
             if local_is_controlling {
                 if let Some(rtx) = remote_rtx {
                     if claimed.is_claimed(rtx) {
-                        if let Some(new_rtx) = claimed.find_unclaimed(PREFERED_RANGES, unlocked) {
+                        let new_rtx = self
+                            .resend
+                            .filter(|pt| !claimed.is_claimed(*pt))
+                            .or_else(|| claimed.find_unclaimed(PREFERED_RANGES, unlocked));
+
+                        if let Some(new_rtx) = new_rtx {
                             debug!("Remapped conflicting RTX PT {:?} => {}", rtx, new_rtx);
                             remote_rtx = Some(new_rtx);
                             unlocked.remove(&new_rtx);

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -409,9 +409,6 @@ impl Media {
             self.depayloaders.insert((pt, rid), buffer);
         }
 
-        // The entry will be there by now.
-        let buffer = self.depayloaders.get_mut(&key).unwrap();
-
         let meta = RtpMeta {
             received: packet.timestamp,
             time: packet.time,
@@ -419,6 +416,15 @@ impl Media {
             header: packet.header.clone(),
             last_sender_info: packet.last_sender_info,
         };
+
+        for ((other_pt, other_rid), buffer) in &mut self.depayloaders {
+            if *other_pt != pt && *other_rid == rid {
+                buffer.push_padding(meta.clone());
+            }
+        }
+
+        // The entry will be there by now.
+        let buffer = self.depayloaders.get_mut(&key).unwrap();
 
         buffer.push(meta, packet.payload);
     }

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -217,13 +217,18 @@ impl DepacketizingBuffer {
     pub fn pop(&mut self) -> Option<Result<Depacketized, PacketError>> {
         self.update_segments();
 
+        if self.segments.is_empty() {
+            self.discard_old_padding();
+            return None;
+        }
+
         // println!(
         //     "{:?} {:?}",
         //     self.queue.iter().map(|e| e.meta.seq_no).collect::<Vec<_>>(),
         //     self.segments
         // );
 
-        let (start, stop) = *self.segments.first()?;
+        let (start, stop) = *self.segments.first().expect("segment exists");
 
         let seq = {
             let last = self.queue.get(stop).expect("entry for stop index");
@@ -277,6 +282,31 @@ impl DepacketizingBuffer {
         self.last_emitted = Some((last, dep.codec_extra));
 
         Some(Ok(dep))
+    }
+
+    fn discard_old_padding(&mut self) {
+        let Some((mut last, extra)) = self.last_emitted else {
+            return;
+        };
+        let original_len = self.queue.len();
+
+        while self.queue.len() > self.hold_back {
+            let entry = self.queue.front().expect("queue exceeds hold back");
+            let is_padding = entry.data.is_empty() && !entry.head && !entry.tail;
+            if !is_padding {
+                break;
+            }
+
+            if last.is_next(entry.meta.seq_no) {
+                last = entry.meta.seq_no;
+            }
+            self.queue.pop_front();
+        }
+
+        if self.queue.len() != original_len {
+            self.depack_cache = None;
+        }
+        self.last_emitted = Some((last, extra));
     }
 
     fn depacketize(
@@ -648,6 +678,48 @@ mod test {
             "padding-only queue retained {} entries after a 1,000-packet run",
             buf.queue.len()
         );
+
+        // Returning to this PT after compaction must still be contiguous with the last packet.
+        buf.push(meta(1_002), vec![1, 9]);
+        let dep = buf.pop().expect("packet emitted").expect("valid packet");
+        assert!(dep.contiguous);
+    }
+
+    #[test]
+    fn padding_only_run_with_loss_stays_bounded_and_reports_discontinuity() {
+        let depack = CodecDepacketizer::Boxed(Box::new(TestDepack));
+        let mut buf = DepacketizingBuffer::new(depack, 3);
+        let meta = |seq: u64| RtpMeta {
+            received: Instant::now(),
+            seq_no: seq.into(),
+            time: MediaTime::from_90khz(seq),
+            last_sender_info: None,
+            header: RtpHeader {
+                sequence_number: seq as u16,
+                timestamp: seq as u32,
+                ..Default::default()
+            },
+        };
+
+        buf.push(meta(1), vec![1, 9]);
+        assert!(buf.pop().is_some());
+
+        // Sequence 2 is lost while another PT remains active.
+        for seq in 3..=1_002 {
+            buf.push_padding(meta(seq));
+            assert!(buf.pop().is_none());
+        }
+
+        assert!(buf.queue.len() <= buf.hold_back);
+
+        // A discontinuity waits for the normal hold-back before it is emitted.
+        buf.push(meta(1_003), vec![1, 9]);
+        assert!(buf.pop().is_none());
+        buf.push(meta(1_004), vec![1, 9]);
+        assert!(buf.pop().is_none());
+        buf.push(meta(1_005), vec![1, 9]);
+        let dep = buf.pop().expect("packet emitted").expect("valid packet");
+        assert!(!dep.contiguous);
     }
 
     fn test(

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -140,6 +140,7 @@ impl DepacketizingBuffer {
             | CodecDepacketizer::Av1(_)
             | CodecDepacketizer::Boxed(_)
             | CodecDepacketizer::Opus(_)
+            | CodecDepacketizer::ComfortNoise(_)
             | CodecDepacketizer::G711(_)
             | CodecDepacketizer::Null(_) => Contiguity::None,
         };

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -158,6 +158,14 @@ impl DepacketizingBuffer {
     }
 
     pub fn push(&mut self, meta: RtpMeta, data: impl Into<Arc<[u8]>>) {
+        self.push_entry(meta, data.into(), None);
+    }
+
+    pub(crate) fn push_padding(&mut self, meta: RtpMeta) {
+        self.push_entry(meta, Arc::from([]), Some((false, false)));
+    }
+
+    fn push_entry(&mut self, meta: RtpMeta, data: Arc<[u8]>, partition: Option<(bool, bool)>) {
         // We're not emitting frames in the wrong order. If we receive
         // packets that are before the last emitted, we drop.
         //
@@ -186,11 +194,13 @@ impl DepacketizingBuffer {
                 trace!("Drop exactly same packet: {}", meta.seq_no);
             }
             Err(i) => {
-                let data = data.into();
-                let head = self.depack.is_partition_head(data.as_ref());
-                let tail = self
-                    .depack
-                    .is_partition_tail(meta.header.marker, data.as_ref());
+                let (head, tail) = partition.unwrap_or_else(|| {
+                    (
+                        self.depack.is_partition_head(data.as_ref()),
+                        self.depack
+                            .is_partition_tail(meta.header.marker, data.as_ref()),
+                    )
+                });
 
                 // i is insertion point to maintain order
                 let entry = Entry {

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -618,6 +618,38 @@ mod test {
         ])
     }
 
+    #[test]
+    fn padding_only_run_does_not_grow_the_queue_without_bound() {
+        let depack = CodecDepacketizer::Boxed(Box::new(TestDepack));
+        let mut buf = DepacketizingBuffer::new(depack, 3);
+        let meta = |seq: u64| RtpMeta {
+            received: Instant::now(),
+            seq_no: seq.into(),
+            time: MediaTime::from_90khz(seq),
+            last_sender_info: None,
+            header: RtpHeader {
+                sequence_number: seq as u16,
+                timestamp: seq as u32,
+                ..Default::default()
+            },
+        };
+
+        // Emit one packet for this PT, then model a long run on another PT.
+        buf.push(meta(1), vec![1, 9]);
+        assert!(buf.pop().is_some());
+
+        for seq in 2..=1_001 {
+            buf.push_padding(meta(seq));
+            assert!(buf.pop().is_none());
+        }
+
+        assert!(
+            buf.queue.len() <= buf.hold_back,
+            "padding-only queue retained {} entries after a 1,000-packet run",
+            buf.queue.len()
+        );
+    }
+
     fn test(
         v: &[(
             u64,   // seq

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -215,10 +215,10 @@ impl DepacketizingBuffer {
     }
 
     pub fn pop(&mut self) -> Option<Result<Depacketized, PacketError>> {
+        self.discard_old_padding();
         self.update_segments();
 
         if self.segments.is_empty() {
-            self.discard_old_padding();
             return None;
         }
 
@@ -285,22 +285,23 @@ impl DepacketizingBuffer {
     }
 
     fn discard_old_padding(&mut self) {
-        let Some((mut last, extra)) = self.last_emitted else {
-            return;
-        };
         let original_len = self.queue.len();
         let is_padding = |entry: &Entry| entry.data.is_empty() && !entry.head && !entry.tail;
 
-        while self.queue.len() > self.hold_back {
-            let entry = self.queue.front().expect("queue exceeds hold back");
-            if !is_padding(entry) {
-                break;
+        if let Some((mut last, extra)) = self.last_emitted {
+            while self.queue.len() > self.hold_back {
+                let entry = self.queue.front().expect("queue exceeds hold back");
+                if !is_padding(entry) {
+                    break;
+                }
+
+                if last.is_next(entry.meta.seq_no) {
+                    last = entry.meta.seq_no;
+                }
+                self.queue.pop_front();
             }
 
-            if last.is_next(entry.meta.seq_no) {
-                last = entry.meta.seq_no;
-            }
-            self.queue.pop_front();
+            self.last_emitted = Some((last, extra));
         }
 
         // An incomplete frame can remain at the front while another payload type
@@ -325,7 +326,6 @@ impl DepacketizingBuffer {
         if self.queue.len() != original_len {
             self.depack_cache = None;
         }
-        self.last_emitted = Some((last, extra));
     }
 
     fn depacketize(

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -215,10 +215,10 @@ impl DepacketizingBuffer {
     }
 
     pub fn pop(&mut self) -> Option<Result<Depacketized, PacketError>> {
-        self.discard_old_padding();
         self.update_segments();
 
         if self.segments.is_empty() {
+            self.discard_old_padding();
             return None;
         }
 
@@ -258,6 +258,7 @@ impl DepacketizingBuffer {
         if wait_for_contiguity {
             // if we are not sending, cache the depacked
             self.depack_cache = Some((start..stop, dep));
+            self.discard_old_padding();
             return None;
         }
 

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -722,6 +722,44 @@ mod test {
         assert!(!dep.contiguous);
     }
 
+    #[test]
+    fn padding_after_incomplete_vp8_frame_does_not_grow_without_bound() {
+        let depack = CodecDepacketizer::Vp8(Default::default());
+        let mut buf = DepacketizingBuffer::new(depack, 3);
+        let meta = |seq: u64, marker: bool| RtpMeta {
+            received: Instant::now(),
+            seq_no: seq.into(),
+            time: MediaTime::from_90khz(seq),
+            last_sender_info: None,
+            header: RtpHeader {
+                marker,
+                sequence_number: seq as u16,
+                timestamp: seq as u32,
+                ..Default::default()
+            },
+        };
+
+        // Emit one complete VP8 frame for this PT.
+        buf.push(meta(1, true), [0x10, 0x00]);
+        assert!(buf.pop().is_some());
+
+        // The next frame's head is lost, leaving an S=0 fragment at the front.
+        buf.push(meta(2, false), [0x00]);
+        assert!(buf.pop().is_none());
+
+        // The sender switches PT. Every packet becomes synthetic padding here.
+        for seq in 3..=1_002 {
+            buf.push_padding(meta(seq, false));
+            assert!(buf.pop().is_none());
+        }
+
+        assert!(
+            buf.queue.len() <= buf.hold_back + 1,
+            "incomplete VP8 frame retained {} entries after a 1,000-packet PT switch",
+            buf.queue.len()
+        );
+    }
+
     fn test(
         v: &[(
             u64,   // seq

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -779,6 +779,84 @@ mod test {
         );
     }
 
+    #[test]
+    fn padding_after_waiting_vp8_frame_does_not_grow_without_bound() {
+        let depack = CodecDepacketizer::Vp8(Default::default());
+        let mut buf = DepacketizingBuffer::new(depack, 3);
+        let meta = |seq: u64, marker: bool| RtpMeta {
+            received: Instant::now(),
+            seq_no: seq.into(),
+            time: MediaTime::from_90khz(seq),
+            last_sender_info: None,
+            header: RtpHeader {
+                marker,
+                sequence_number: seq as u16,
+                timestamp: seq as u32,
+                ..Default::default()
+            },
+        };
+
+        buf.push(meta(1, true), [0x10, 0x00]);
+        assert!(buf.pop().is_some());
+
+        // Lose a frame head, then switch away long enough to compact its padding.
+        buf.push(meta(2, false), [0x00]);
+        assert!(buf.pop().is_none());
+        for seq in 3..=1_002 {
+            buf.push_padding(meta(seq, false));
+            assert!(buf.pop().is_none());
+        }
+
+        // One complete frame returns, but waits behind the orphan for hold-back.
+        buf.push(meta(1_003, true), [0x10, 0x00]);
+        assert!(buf.pop().is_none());
+
+        // Switching away again must remain bounded while that frame waits.
+        for seq in 1_004..=2_003 {
+            buf.push_padding(meta(seq, false));
+            assert!(buf.pop().is_none());
+        }
+
+        assert!(
+            buf.queue.len() <= buf.hold_back + 2,
+            "waiting VP8 frame retained {} entries after a second 1,000-packet PT switch",
+            buf.queue.len()
+        );
+    }
+
+    #[test]
+    fn padding_after_initial_incomplete_vp8_frame_does_not_grow_without_bound() {
+        let depack = CodecDepacketizer::Vp8(Default::default());
+        let mut buf = DepacketizingBuffer::new(depack, 3);
+        let meta = |seq: u64| RtpMeta {
+            received: Instant::now(),
+            seq_no: seq.into(),
+            time: MediaTime::from_90khz(seq),
+            last_sender_info: None,
+            header: RtpHeader {
+                sequence_number: seq as u16,
+                timestamp: seq as u32,
+                ..Default::default()
+            },
+        };
+
+        // Start observing this PT after the head of a VP8 frame was lost.
+        buf.push(meta(1), [0x00]);
+        assert!(buf.pop().is_none());
+
+        // The sender switches PT before this depayloader has emitted anything.
+        for seq in 2..=1_001 {
+            buf.push_padding(meta(seq));
+            assert!(buf.pop().is_none());
+        }
+
+        assert!(
+            buf.queue.len() <= buf.hold_back + 1,
+            "initial incomplete VP8 frame retained {} entries after a 1,000-packet PT switch",
+            buf.queue.len()
+        );
+    }
+
     fn test(
         v: &[(
             u64,   // seq

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -289,11 +289,11 @@ impl DepacketizingBuffer {
             return;
         };
         let original_len = self.queue.len();
+        let is_padding = |entry: &Entry| entry.data.is_empty() && !entry.head && !entry.tail;
 
         while self.queue.len() > self.hold_back {
             let entry = self.queue.front().expect("queue exceeds hold back");
-            let is_padding = entry.data.is_empty() && !entry.head && !entry.tail;
-            if !is_padding {
+            if !is_padding(entry) {
                 break;
             }
 
@@ -302,6 +302,25 @@ impl DepacketizingBuffer {
             }
             self.queue.pop_front();
         }
+
+        // An incomplete frame can remain at the front while another payload type
+        // contributes synthetic padding indefinitely. Keep the frame, but retain
+        // only the newest padding needed for the reordering window. Padding removed
+        // from behind media cannot advance last_emitted across that media.
+        let mut excess_padding = self
+            .queue
+            .iter()
+            .filter(|entry| is_padding(entry))
+            .count()
+            .saturating_sub(self.hold_back);
+        self.queue.retain(|entry| {
+            if excess_padding > 0 && is_padding(entry) {
+                excess_padding -= 1;
+                false
+            } else {
+                true
+            }
+        });
 
         if self.queue.len() != original_len {
             self.depack_cache = None;

--- a/src/packet/comfort_noise.rs
+++ b/src/packet/comfort_noise.rs
@@ -39,3 +39,39 @@ impl Depacketizer for ComfortNoiseDepacketizer {
         true
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn packetizer_rejects_payload_larger_than_mtu() {
+        let mut packetizer = ComfortNoisePacketizer;
+
+        let result = packetizer.packetize(8, &[0; 9]);
+
+        assert!(
+            result.is_err(),
+            "a CN payload cannot be fragmented and must not exceed the MTU"
+        );
+    }
+
+    #[test]
+    fn packetizer_does_not_emit_empty_cn_payload() {
+        let mut packetizer = ComfortNoisePacketizer;
+
+        let packets = packetizer.packetize(1200, &[]).unwrap();
+
+        assert!(packets.is_empty(), "an empty input is not a CN payload");
+    }
+
+    #[test]
+    fn depacketizer_rejects_empty_cn_payload() {
+        let mut depacketizer = ComfortNoiseDepacketizer;
+        let mut output = Vec::new();
+
+        let result = depacketizer.depacketize(&[], &mut output, &mut CodecExtra::None);
+
+        assert_eq!(result, Err(PacketError::ErrShortPacket));
+    }
+}

--- a/src/packet/comfort_noise.rs
+++ b/src/packet/comfort_noise.rs
@@ -1,0 +1,41 @@
+use super::{CodecExtra, Depacketizer, PacketError, Packetizer};
+
+#[derive(Debug)]
+pub struct ComfortNoisePacketizer;
+
+#[derive(Debug)]
+pub struct ComfortNoiseDepacketizer;
+
+impl Packetizer for ComfortNoisePacketizer {
+    fn packetize(&mut self, _mtu: usize, payload: &[u8]) -> Result<Vec<Vec<u8>>, PacketError> {
+        Ok(vec![payload.to_vec()])
+    }
+
+    fn is_marker(&mut self, _data: &[u8], _previous: Option<&[u8]>, _last: bool) -> bool {
+        false
+    }
+}
+
+impl Depacketizer for ComfortNoiseDepacketizer {
+    fn out_size_hint(&self, packets_size: usize) -> Option<usize> {
+        Some(packets_size)
+    }
+
+    fn depacketize(
+        &mut self,
+        packet: &[u8],
+        out: &mut Vec<u8>,
+        _codec_extra: &mut CodecExtra,
+    ) -> Result<(), PacketError> {
+        out.extend_from_slice(packet);
+        Ok(())
+    }
+
+    fn is_partition_head(&self, _packet: &[u8]) -> bool {
+        true
+    }
+
+    fn is_partition_tail(&self, _marker: bool, _packet: &[u8]) -> bool {
+        true
+    }
+}

--- a/src/packet/comfort_noise.rs
+++ b/src/packet/comfort_noise.rs
@@ -7,7 +7,15 @@ pub struct ComfortNoisePacketizer;
 pub struct ComfortNoiseDepacketizer;
 
 impl Packetizer for ComfortNoisePacketizer {
-    fn packetize(&mut self, _mtu: usize, payload: &[u8]) -> Result<Vec<Vec<u8>>, PacketError> {
+    fn packetize(&mut self, mtu: usize, payload: &[u8]) -> Result<Vec<Vec<u8>>, PacketError> {
+        if payload.is_empty() {
+            return Ok(vec![]);
+        }
+
+        if payload.len() > mtu {
+            return Err(PacketError::ErrPayloadTooLarge);
+        }
+
         Ok(vec![payload.to_vec()])
     }
 
@@ -27,6 +35,10 @@ impl Depacketizer for ComfortNoiseDepacketizer {
         out: &mut Vec<u8>,
         _codec_extra: &mut CodecExtra,
     ) -> Result<(), PacketError> {
+        if packet.is_empty() {
+            return Err(PacketError::ErrShortPacket);
+        }
+
         out.extend_from_slice(packet);
         Ok(())
     }

--- a/src/packet/error.rs
+++ b/src/packet/error.rs
@@ -7,6 +7,7 @@ use std::fmt;
 #[allow(missing_docs)]
 pub enum PacketError {
     ErrShortPacket,
+    ErrPayloadTooLarge,
     ErrTooManySpatialLayers,
     ErrTooManyPDiff,
     ErrH265CorruptedPacket,
@@ -24,6 +25,7 @@ impl fmt::Display for PacketError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             PacketError::ErrShortPacket => write!(f, "Packet is too short"),
+            PacketError::ErrPayloadTooLarge => write!(f, "Payload exceeds the MTU"),
             PacketError::ErrTooManySpatialLayers => write!(f, "Too many spatial layers"),
             PacketError::ErrTooManyPDiff => write!(f, "Too many P-Diff"),
             PacketError::ErrH265CorruptedPacket => write!(f, "H265 corrupted packet"),

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -64,6 +64,9 @@ use vp9::{Vp9Depacketizer, Vp9Packetizer};
 mod null;
 use null::{NullDepacketizer, NullPacketizer};
 
+mod comfort_noise;
+use comfort_noise::{ComfortNoiseDepacketizer, ComfortNoisePacketizer};
+
 mod buffer_rx;
 pub(crate) use buffer_rx::{DepacketizingBuffer, RtpMeta};
 
@@ -283,6 +286,7 @@ pub(crate) enum CodecPacketizer {
     H265(H265Packetizer),
     H266(H266Packetizer),
     Opus(OpusPacketizer),
+    ComfortNoise(ComfortNoisePacketizer),
     Vp8(Vp8Packetizer),
     Vp9(Vp9Packetizer),
     Av1(Av1Packetizer),
@@ -298,6 +302,7 @@ pub(crate) enum CodecDepacketizer {
     H265(H265Depacketizer),
     H266(H266Depacketizer),
     Opus(OpusDepacketizer),
+    ComfortNoise(ComfortNoiseDepacketizer),
     Vp8(Vp8Depacketizer),
     Vp9(Vp9Depacketizer),
     Av1(Av1Depacketizer),
@@ -313,6 +318,7 @@ impl CodecPacketizer {
             Codec::PCMU => CodecPacketizer::G711(G711Packetizer::default()),
             Codec::PCMA => CodecPacketizer::G711(G711Packetizer::default()),
             Codec::G722 => CodecPacketizer::G722(G722Packetizer::default()),
+            Codec::ComfortNoise => CodecPacketizer::ComfortNoise(ComfortNoisePacketizer),
             Codec::H264 => CodecPacketizer::H264(H264Packetizer::default()),
             Codec::H265 => CodecPacketizer::H265(H265Packetizer::default()),
             Codec::H266 => CodecPacketizer::H266(H266Packetizer::default()),
@@ -339,6 +345,7 @@ impl From<Codec> for CodecDepacketizer {
             Codec::PCMU => CodecDepacketizer::G711(G711Depacketizer),
             Codec::PCMA => CodecDepacketizer::G711(G711Depacketizer),
             Codec::G722 => CodecDepacketizer::G711(G711Depacketizer),
+            Codec::ComfortNoise => CodecDepacketizer::ComfortNoise(ComfortNoiseDepacketizer),
             Codec::H264 => CodecDepacketizer::H264(H264Depacketizer::default()),
             Codec::H265 => CodecDepacketizer::H265(H265Depacketizer::default()),
             Codec::H266 => CodecDepacketizer::H266(H266Depacketizer::default()),
@@ -362,6 +369,7 @@ impl Packetizer for CodecPacketizer {
             H265(v) => v.packetize(mtu, b),
             H266(v) => v.packetize(mtu, b),
             Opus(v) => v.packetize(mtu, b),
+            ComfortNoise(v) => v.packetize(mtu, b),
             Vp8(v) => v.packetize(mtu, b),
             Vp9(v) => v.packetize(mtu, b),
             Av1(v) => v.packetize(mtu, b),
@@ -375,6 +383,7 @@ impl Packetizer for CodecPacketizer {
             CodecPacketizer::G711(v) => v.is_marker(data, previous, last),
             CodecPacketizer::G722(v) => v.is_marker(data, previous, last),
             CodecPacketizer::Opus(v) => v.is_marker(data, previous, last),
+            CodecPacketizer::ComfortNoise(v) => v.is_marker(data, previous, last),
             CodecPacketizer::H264(v) => v.is_marker(data, previous, last),
             CodecPacketizer::H265(v) => v.is_marker(data, previous, last),
             CodecPacketizer::H266(v) => v.is_marker(data, previous, last),
@@ -395,6 +404,7 @@ impl Depacketizer for CodecDepacketizer {
             H265(v) => v.out_size_hint(packets_size),
             H266(v) => v.out_size_hint(packets_size),
             Opus(v) => v.out_size_hint(packets_size),
+            ComfortNoise(v) => v.out_size_hint(packets_size),
             G711(v) => v.out_size_hint(packets_size),
             Vp8(v) => v.out_size_hint(packets_size),
             Vp9(v) => v.out_size_hint(packets_size),
@@ -416,6 +426,7 @@ impl Depacketizer for CodecDepacketizer {
             H265(v) => v.depacketize(packet, out, extra),
             H266(v) => v.depacketize(packet, out, extra),
             Opus(v) => v.depacketize(packet, out, extra),
+            ComfortNoise(v) => v.depacketize(packet, out, extra),
             G711(v) => v.depacketize(packet, out, extra),
             Vp8(v) => v.depacketize(packet, out, extra),
             Vp9(v) => v.depacketize(packet, out, extra),
@@ -432,6 +443,7 @@ impl Depacketizer for CodecDepacketizer {
             H265(v) => v.is_partition_head(packet),
             H266(v) => v.is_partition_head(packet),
             Opus(v) => v.is_partition_head(packet),
+            ComfortNoise(v) => v.is_partition_head(packet),
             G711(v) => v.is_partition_head(packet),
             Vp8(v) => v.is_partition_head(packet),
             Vp9(v) => v.is_partition_head(packet),
@@ -448,6 +460,7 @@ impl Depacketizer for CodecDepacketizer {
             H265(v) => v.is_partition_tail(marker, packet),
             H266(v) => v.is_partition_tail(marker, packet),
             Opus(v) => v.is_partition_tail(marker, packet),
+            ComfortNoise(v) => v.is_partition_tail(marker, packet),
             G711(v) => v.is_partition_tail(marker, packet),
             Vp8(v) => v.is_partition_tail(marker, packet),
             Vp9(v) => v.is_partition_tail(marker, packet),
@@ -474,5 +487,31 @@ impl fmt::Display for MediaKind {
             MediaKind::Audio => write!(f, "audio"),
             MediaKind::Video => write!(f, "video"),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn comfort_noise_packetizer_preserves_payload_and_clears_marker() {
+        let payload = [42, 128, 64];
+        let mut packetizer = CodecPacketizer::from(Codec::ComfortNoise);
+
+        assert_eq!(
+            packetizer.packetize(1200, &payload).unwrap(),
+            vec![payload.to_vec()]
+        );
+        assert!(!packetizer.is_marker(&payload, None, true));
+
+        let mut depacketizer = CodecDepacketizer::from(Codec::ComfortNoise);
+        let mut output = Vec::new();
+        depacketizer
+            .depacketize(&payload, &mut output, &mut CodecExtra::None)
+            .unwrap();
+        assert_eq!(output, payload);
+        assert!(depacketizer.is_partition_head(&payload));
+        assert!(depacketizer.is_partition_tail(false, &payload));
     }
 }

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -318,7 +318,7 @@ impl CodecPacketizer {
             Codec::PCMU => CodecPacketizer::G711(G711Packetizer::default()),
             Codec::PCMA => CodecPacketizer::G711(G711Packetizer::default()),
             Codec::G722 => CodecPacketizer::G722(G722Packetizer::default()),
-            Codec::ComfortNoise => CodecPacketizer::ComfortNoise(ComfortNoisePacketizer),
+            Codec::CN => CodecPacketizer::ComfortNoise(ComfortNoisePacketizer),
             Codec::H264 => CodecPacketizer::H264(H264Packetizer::default()),
             Codec::H265 => CodecPacketizer::H265(H265Packetizer::default()),
             Codec::H266 => CodecPacketizer::H266(H266Packetizer::default()),
@@ -345,7 +345,7 @@ impl From<Codec> for CodecDepacketizer {
             Codec::PCMU => CodecDepacketizer::G711(G711Depacketizer),
             Codec::PCMA => CodecDepacketizer::G711(G711Depacketizer),
             Codec::G722 => CodecDepacketizer::G711(G711Depacketizer),
-            Codec::ComfortNoise => CodecDepacketizer::ComfortNoise(ComfortNoiseDepacketizer),
+            Codec::CN => CodecDepacketizer::ComfortNoise(ComfortNoiseDepacketizer),
             Codec::H264 => CodecDepacketizer::H264(H264Depacketizer::default()),
             Codec::H265 => CodecDepacketizer::H265(H265Depacketizer::default()),
             Codec::H266 => CodecDepacketizer::H266(H266Depacketizer::default()),
@@ -497,7 +497,7 @@ mod test {
     #[test]
     fn comfort_noise_packetizer_preserves_payload_and_clears_marker() {
         let payload = [42, 128, 64];
-        let mut packetizer = CodecPacketizer::from(Codec::ComfortNoise);
+        let mut packetizer = CodecPacketizer::from(Codec::CN);
 
         assert_eq!(
             packetizer.packetize(1200, &payload).unwrap(),
@@ -505,7 +505,7 @@ mod test {
         );
         assert!(!packetizer.is_marker(&payload, None, true));
 
-        let mut depacketizer = CodecDepacketizer::from(Codec::ComfortNoise);
+        let mut depacketizer = CodecDepacketizer::from(Codec::CN);
         let mut output = Vec::new();
         depacketizer
             .depacketize(&payload, &mut output, &mut CodecExtra::None)

--- a/src/packet/payload.rs
+++ b/src/packet/payload.rs
@@ -1,5 +1,5 @@
-use crate::format::CodecSpec;
 use crate::format::Vp9PacketizerMode;
+use crate::format::{Codec, CodecSpec};
 use crate::media::ToPayload;
 use crate::rtp::vla::VideoLayersAllocation;
 use crate::rtp_::Frequency;
@@ -12,6 +12,7 @@ use super::{CodecPacketizer, Packetizer};
 pub struct Payloader {
     pack: CodecPacketizer,
     clock_rate: Frequency,
+    allow_talkspurt_marker: bool,
 }
 
 impl Payloader {
@@ -35,6 +36,7 @@ impl Payloader {
         Payloader {
             pack,
             clock_rate: spec.rtp_clock_rate(),
+            allow_talkspurt_marker: spec.codec != Codec::ComfortNoise,
         }
     }
 
@@ -64,7 +66,7 @@ impl Payloader {
 
             let previous_data = stream.last_packet();
             let marker = self.pack.is_marker(data.as_slice(), previous_data, last)
-                || (is_audio && start_of_talk_spurt);
+                || (is_audio && self.allow_talkspurt_marker && start_of_talk_spurt);
 
             let seq_no = stream.next_seq_no();
 

--- a/src/packet/payload.rs
+++ b/src/packet/payload.rs
@@ -36,7 +36,7 @@ impl Payloader {
         Payloader {
             pack,
             clock_rate: spec.rtp_clock_rate(),
-            allow_talkspurt_marker: spec.codec != Codec::ComfortNoise,
+            allow_talkspurt_marker: spec.codec != Codec::CN,
         }
     }
 

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -315,7 +315,7 @@ impl MediaLine {
     }
 
     pub fn rtp_params(&self) -> Vec<PayloadParams> {
-        let rtp_maps: Vec<_> = self
+        let mut rtp_maps: Vec<_> = self
             .attrs
             .iter()
             .filter_map(|a| {
@@ -326,6 +326,14 @@ impl MediaLine {
                 }
             })
             .collect();
+
+        for pt in &self.pts {
+            if !rtp_maps.iter().any(|(mapped, _)| mapped == pt) {
+                if let Some(value) = static_rtp_map(*pt) {
+                    rtp_maps.push((*pt, value));
+                }
+            }
+        }
 
         let fmtps: Vec<_> = self
             .attrs
@@ -465,7 +473,7 @@ impl MediaLine {
                     }
                 })
                 .count();
-            if rtp_count == 0 {
+            if rtp_count == 0 && static_rtp_map(*m).is_none() {
                 return Some(format!("Missing a=rtp_map:{} for mid: {}", m, self.mid()));
             }
             if rtp_count > 1 {
@@ -673,6 +681,18 @@ impl MediaLine {
             }
         })
     }
+}
+
+fn static_rtp_map(pt: Pt) -> Option<RtpMap> {
+    if *pt != 13 {
+        return None;
+    }
+
+    Some(RtpMap {
+        codec: Codec::ComfortNoise,
+        clock_rate: Frequency::EIGHT_KHZ,
+        channels: None,
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -329,8 +329,8 @@ impl MediaLine {
 
         for pt in &self.pts {
             if !rtp_maps.iter().any(|(mapped, _)| mapped == pt) {
-                if let Some(value) = static_rtp_map(*pt) {
-                    rtp_maps.push((*pt, value));
+                if let Some(spec) = CodecSpec::from_static_pt(*pt) {
+                    rtp_maps.push((*pt, spec.into()));
                 }
             }
         }
@@ -473,7 +473,7 @@ impl MediaLine {
                     }
                 })
                 .count();
-            if rtp_count == 0 && static_rtp_map(*m).is_none() {
+            if rtp_count == 0 && CodecSpec::from_static_pt(*m).is_none() {
                 return Some(format!("Missing a=rtp_map:{} for mid: {}", m, self.mid()));
             }
             if rtp_count > 1 {
@@ -681,18 +681,6 @@ impl MediaLine {
             }
         })
     }
-}
-
-fn static_rtp_map(pt: Pt) -> Option<RtpMap> {
-    if *pt != 13 {
-        return None;
-    }
-
-    Some(RtpMap {
-        codec: Codec::ComfortNoise,
-        clock_rate: Frequency::EIGHT_KHZ,
-        channels: None,
-    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/sdp/parser.rs
+++ b/src/sdp/parser.rs
@@ -871,6 +871,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::format::Codec;
     use crate::io::Protocol;
 
     #[test]
@@ -1343,6 +1344,32 @@ mod test {
 
         let parsed = sdp_parser().parse(sdp);
         assert!(parsed.is_ok());
+    }
+
+    #[test]
+    fn bare_static_comfort_noise_pt_is_resolved() {
+        let sdp = "v=0\r\n\
+        o=- 1 1 IN IP4 127.0.0.1\r\n\
+        s=-\r\n\
+        t=0 0\r\n\
+        m=audio 9 UDP/TLS/RTP/SAVPF 0 13\r\n\
+        c=IN IP4 0.0.0.0\r\n\
+        a=setup:actpass\r\n\
+        a=sendrecv\r\n\
+        a=mid:0\r\n\
+        a=rtpmap:0 PCMU/8000\r\n\
+        ";
+
+        let (sdp, _) = sdp_parser()
+            .parse(sdp)
+            .expect("static PT 13 must not require an a=rtpmap line");
+        let params = sdp.media_lines[0].rtp_params();
+
+        assert!(params.iter().any(|p| {
+            p.pt() == 13.into()
+                && p.spec().codec == Codec::ComfortNoise
+                && p.spec().clock_rate == Frequency::EIGHT_KHZ
+        }));
     }
 
     #[test]

--- a/src/sdp/parser.rs
+++ b/src/sdp/parser.rs
@@ -1377,7 +1377,7 @@ mod test {
                 (0, Codec::PCMU, Frequency::EIGHT_KHZ),
                 (8, Codec::PCMA, Frequency::EIGHT_KHZ),
                 (9, Codec::G722, Frequency::SIXTEEN_KHZ),
-                (13, Codec::ComfortNoise, Frequency::EIGHT_KHZ),
+                (13, Codec::CN, Frequency::EIGHT_KHZ),
             ]
         );
     }

--- a/src/sdp/parser.rs
+++ b/src/sdp/parser.rs
@@ -1347,29 +1347,39 @@ mod test {
     }
 
     #[test]
-    fn bare_static_comfort_noise_pt_is_resolved() {
+    fn bare_static_audio_pts_are_resolved() {
         let sdp = "v=0\r\n\
         o=- 1 1 IN IP4 127.0.0.1\r\n\
         s=-\r\n\
         t=0 0\r\n\
-        m=audio 9 UDP/TLS/RTP/SAVPF 0 13\r\n\
+        a=group:BUNDLE 0\r\n\
+        m=audio 9 UDP/TLS/RTP/SAVPF 0 8 9 13\r\n\
         c=IN IP4 0.0.0.0\r\n\
         a=setup:actpass\r\n\
         a=sendrecv\r\n\
         a=mid:0\r\n\
-        a=rtpmap:0 PCMU/8000\r\n\
         ";
 
         let (sdp, _) = sdp_parser()
             .parse(sdp)
-            .expect("static PT 13 must not require an a=rtpmap line");
+            .expect("static PTs must not require an a=rtpmap line");
+        sdp.assert_consistency()
+            .expect("bare static PTs are consistent");
         let params = sdp.media_lines[0].rtp_params();
 
-        assert!(params.iter().any(|p| {
-            p.pt() == 13.into()
-                && p.spec().codec == Codec::ComfortNoise
-                && p.spec().clock_rate == Frequency::EIGHT_KHZ
-        }));
+        let definitions: Vec<_> = params
+            .iter()
+            .map(|p| (*p.pt(), p.spec().codec, p.spec().clock_rate))
+            .collect();
+        assert_eq!(
+            definitions,
+            vec![
+                (0, Codec::PCMU, Frequency::EIGHT_KHZ),
+                (8, Codec::PCMA, Frequency::EIGHT_KHZ),
+                (9, Codec::G722, Frequency::SIXTEEN_KHZ),
+                (13, Codec::ComfortNoise, Frequency::EIGHT_KHZ),
+            ]
+        );
     }
 
     #[test]

--- a/tests/comfort-noise.rs
+++ b/tests/comfort-noise.rs
@@ -1,0 +1,243 @@
+use std::net::Ipv4Addr;
+use std::time::{Duration, Instant};
+
+mod common;
+use common::{TestRtc, init_crypto_default, init_log, negotiate, progress};
+use str0m::Rtc;
+use str0m::format::{Codec, CodecSpec, FormatParams, PayloadParams};
+use str0m::media::{Direction, Frequency, MediaKind, MediaTime, Mid};
+use str0m::rtp::RtpWrite;
+use str0m::{Event, RtcError};
+use tracing::{Span, info_span};
+
+#[test]
+fn negotiates_all_supported_clock_rates() {
+    init_log();
+    init_crypto_default();
+
+    let params = comfort_noise_params();
+    let (l, r) = with_params(info_span!("L"), &params, info_span!("R"), &params);
+
+    for rtc in [&l, &r] {
+        let negotiated: Vec<_> = rtc
+            .codec_config()
+            .iter()
+            .filter(|p| p.spec().codec == Codec::ComfortNoise)
+            .map(|p| (*p.pt(), p.spec().clock_rate.get()))
+            .collect();
+        assert_eq!(
+            negotiated,
+            vec![
+                (13, 8_000),
+                (96, 16_000),
+                (97, 24_000),
+                (98, 32_000),
+                (99, 48_000),
+            ]
+        );
+    }
+}
+
+#[test]
+fn frame_mode_round_trips_all_supported_clock_rates() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let params = comfort_noise_params();
+    let (mut l, mut r, mid) = connected_with_params(&params, false);
+
+    for (index, param) in params.iter().enumerate() {
+        let wallclock = l.start + l.duration();
+        let time = MediaTime::new(
+            param.spec().clock_rate.get() as u64,
+            param.spec().clock_rate,
+        );
+        l.writer(mid)
+            .unwrap()
+            .write(param.pt(), wallclock, time, vec![index as u8 + 1])?;
+        progress(&mut l, &mut r)?;
+    }
+
+    progress_until_cn_events(&mut l, &mut r, false)?;
+
+    let received: Vec<_> = r
+        .events
+        .iter()
+        .filter_map(|(_, event)| match event {
+            Event::MediaData(data) if data.params.spec().codec == Codec::ComfortNoise => Some((
+                *data.pt,
+                data.params.spec().clock_rate.get(),
+                data.data.as_ref().to_vec(),
+            )),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(received, expected_cn_events());
+    Ok(())
+}
+
+#[test]
+fn rtp_mode_round_trips_all_supported_clock_rates() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let params = comfort_noise_params();
+    let (mut l, mut r, mid) = connected_with_params(&params, true);
+    let ssrc = l.direct_api().stream_tx_by_mid(mid, None).unwrap().ssrc();
+
+    for (index, param) in params.iter().enumerate() {
+        let wallclock = l.start + l.duration();
+        let timestamp = param.spec().clock_rate.get();
+        l.direct_api()
+            .stream_tx(&ssrc)
+            .unwrap()
+            .write_rtp(RtpWrite::new(
+                param.pt(),
+                (index as u64 + 1).into(),
+                timestamp,
+                wallclock,
+                [index as u8 + 1],
+            ));
+        progress(&mut l, &mut r)?;
+    }
+
+    progress_until_cn_events(&mut l, &mut r, true)?;
+
+    let received: Vec<_> = r
+        .events
+        .iter()
+        .filter_map(|(_, event)| match event {
+            Event::RtpPacket(packet) => Some((
+                *packet.header.payload_type,
+                packet.time.frequency().get(),
+                packet.payload.as_ref().to_vec(),
+            )),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(received, expected_cn_events());
+    Ok(())
+}
+
+fn with_params(
+    span_l: Span,
+    params_l: &[PayloadParams],
+    span_r: Span,
+    params_r: &[PayloadParams],
+) -> (TestRtc, TestRtc) {
+    let mut l = build_params_with_mode(span_l, params_l, false);
+    let mut r = build_params_with_mode(span_r, params_r, false);
+
+    negotiate(&mut l, &mut r, |change| {
+        change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+    });
+
+    (l, r)
+}
+
+fn connected_with_params(params: &[PayloadParams], rtp_mode: bool) -> (TestRtc, TestRtc, Mid) {
+    let mut l = build_params_with_mode(info_span!("L"), params, rtp_mode);
+    let mut r = build_params_with_mode(info_span!("R"), params, rtp_mode);
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    let mid = negotiate(&mut l, &mut r, |change| {
+        change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None)
+    });
+
+    while !l.is_connected() || !r.is_connected() {
+        progress(&mut l, &mut r).expect("clean progress");
+    }
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    (l, r, mid)
+}
+
+fn build_params_with_mode(span: Span, params: &[PayloadParams], rtp_mode: bool) -> TestRtc {
+    let mut builder = Rtc::builder()
+        .clear_codecs()
+        .set_rtp_mode(rtp_mode)
+        .set_reordering_size_audio(0);
+    let config = builder.codec_config();
+    for param in params {
+        config.add_config(
+            param.pt(),
+            param.resend(),
+            param.spec().codec,
+            param.spec().clock_rate,
+            param.spec().channels,
+            param.spec().format,
+        );
+    }
+    TestRtc::new_with_rtc(span, builder.build(Instant::now()))
+}
+
+fn progress_until_cn_events(
+    l: &mut TestRtc,
+    r: &mut TestRtc,
+    rtp_mode: bool,
+) -> Result<(), RtcError> {
+    let deadline = l.duration() + Duration::from_secs(2);
+    while l.duration() < deadline {
+        let count = r
+            .events
+            .iter()
+            .filter(|(_, event)| {
+                if rtp_mode {
+                    matches!(event, Event::RtpPacket(_))
+                } else {
+                    matches!(
+                        event,
+                        Event::MediaData(data)
+                            if data.params.spec().codec == Codec::ComfortNoise
+                    )
+                }
+            })
+            .count();
+        if count == 5 {
+            return Ok(());
+        }
+        progress(l, r)?;
+    }
+
+    panic!("timed out waiting for all five Comfort Noise payloads");
+}
+
+fn comfort_noise(pt: u8, clock_rate: u32) -> PayloadParams {
+    PayloadParams::new(
+        pt.into(),
+        None,
+        CodecSpec {
+            codec: Codec::ComfortNoise,
+            channels: None,
+            clock_rate: Frequency::new(clock_rate).unwrap(),
+            format: FormatParams::default(),
+        },
+    )
+}
+
+fn comfort_noise_params() -> [PayloadParams; 5] {
+    [
+        comfort_noise(13, 8_000),
+        comfort_noise(96, 16_000),
+        comfort_noise(97, 24_000),
+        comfort_noise(98, 32_000),
+        comfort_noise(99, 48_000),
+    ]
+}
+
+fn expected_cn_events() -> Vec<(u8, u32, Vec<u8>)> {
+    vec![
+        (13, 8_000, vec![1]),
+        (96, 16_000, vec![2]),
+        (97, 24_000, vec![3]),
+        (98, 32_000, vec![4]),
+        (99, 48_000, vec![5]),
+    ]
+}

--- a/tests/comfort-noise.rs
+++ b/tests/comfort-noise.rs
@@ -78,6 +78,83 @@ fn frame_mode_round_trips_all_supported_clock_rates() -> Result<(), RtcError> {
 }
 
 #[test]
+fn frame_mode_switching_through_cn_does_not_stall_primary_audio() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let params = [pcmu(), comfort_noise(13, 8_000)];
+    let (mut l, mut r, mid) = connected_with_default_audio_reordering(&params);
+
+    for (pt, timestamp, payload) in [(0_u8, 0_u64, 1_u8), (13, 160, 42), (0, 320, 2)] {
+        let wallclock = l.start + l.duration();
+        l.writer(mid).unwrap().write(
+            pt.into(),
+            wallclock,
+            MediaTime::new(timestamp, Frequency::EIGHT_KHZ),
+            [payload],
+        )?;
+        progress(&mut l, &mut r)?;
+    }
+
+    let deadline = l.duration() + Duration::from_secs(2);
+    while l.duration() < deadline {
+        progress(&mut l, &mut r)?;
+    }
+
+    let received: Vec<_> = r
+        .events
+        .iter()
+        .filter_map(|(_, event)| match event {
+            Event::MediaData(data) => Some((data.params.spec().codec, data.data.as_ref().to_vec())),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        received,
+        vec![
+            (Codec::PCMU, vec![1]),
+            (Codec::ComfortNoise, vec![42]),
+            (Codec::PCMU, vec![2]),
+        ],
+        "the CN sequence number must not look like a lost PCMU packet"
+    );
+    Ok(())
+}
+
+#[test]
+fn frame_mode_cn_never_sets_marker_bit() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let params = [comfort_noise(13, 8_000)];
+    let (mut l, mut r, mid) = connected_with_params(&params, false);
+    let wallclock = l.start + l.duration();
+    l.writer(mid).unwrap().start_of_talkspurt(true).write(
+        params[0].pt(),
+        wallclock,
+        MediaTime::new(8_000, Frequency::EIGHT_KHZ),
+        [42],
+    )?;
+
+    let deadline = l.duration() + Duration::from_secs(2);
+    while l.duration() < deadline {
+        progress(&mut l, &mut r)?;
+        if let Some(data) = r.events.iter().find_map(|(_, event)| match event {
+            Event::MediaData(data) if data.params.spec().codec == Codec::ComfortNoise => Some(data),
+            _ => None,
+        }) {
+            assert!(
+                !data.audio_start_of_talk_spurt,
+                "an RFC 3389 CN packet must not carry the RTP marker bit"
+            );
+            return Ok(());
+        }
+    }
+
+    panic!("timed out waiting for Comfort Noise payload");
+}
+
+#[test]
 fn rtp_mode_round_trips_all_supported_clock_rates() -> Result<(), RtcError> {
     init_log();
     init_crypto_default();
@@ -138,8 +215,20 @@ fn with_params(
 }
 
 fn connected_with_params(params: &[PayloadParams], rtp_mode: bool) -> (TestRtc, TestRtc, Mid) {
-    let mut l = build_params_with_mode(info_span!("L"), params, rtp_mode);
-    let mut r = build_params_with_mode(info_span!("R"), params, rtp_mode);
+    connected_with_reordering(params, rtp_mode, Some(0))
+}
+
+fn connected_with_default_audio_reordering(params: &[PayloadParams]) -> (TestRtc, TestRtc, Mid) {
+    connected_with_reordering(params, false, None)
+}
+
+fn connected_with_reordering(
+    params: &[PayloadParams],
+    rtp_mode: bool,
+    reordering_size_audio: Option<usize>,
+) -> (TestRtc, TestRtc, Mid) {
+    let mut l = build_params(info_span!("L"), params, rtp_mode, reordering_size_audio);
+    let mut r = build_params(info_span!("R"), params, rtp_mode, reordering_size_audio);
 
     l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
     r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
@@ -160,10 +249,19 @@ fn connected_with_params(params: &[PayloadParams], rtp_mode: bool) -> (TestRtc, 
 }
 
 fn build_params_with_mode(span: Span, params: &[PayloadParams], rtp_mode: bool) -> TestRtc {
-    let mut builder = Rtc::builder()
-        .clear_codecs()
-        .set_rtp_mode(rtp_mode)
-        .set_reordering_size_audio(0);
+    build_params(span, params, rtp_mode, Some(0))
+}
+
+fn build_params(
+    span: Span,
+    params: &[PayloadParams],
+    rtp_mode: bool,
+    reordering_size_audio: Option<usize>,
+) -> TestRtc {
+    let mut builder = Rtc::builder().clear_codecs().set_rtp_mode(rtp_mode);
+    if let Some(size) = reordering_size_audio {
+        builder = builder.set_reordering_size_audio(size);
+    }
     let config = builder.codec_config();
     for param in params {
         config.add_config(
@@ -217,6 +315,19 @@ fn comfort_noise(pt: u8, clock_rate: u32) -> PayloadParams {
             codec: Codec::ComfortNoise,
             channels: None,
             clock_rate: Frequency::new(clock_rate).unwrap(),
+            format: FormatParams::default(),
+        },
+    )
+}
+
+fn pcmu() -> PayloadParams {
+    PayloadParams::new(
+        0.into(),
+        None,
+        CodecSpec {
+            codec: Codec::PCMU,
+            channels: None,
+            clock_rate: Frequency::EIGHT_KHZ,
             format: FormatParams::default(),
         },
     )

--- a/tests/comfort-noise.rs
+++ b/tests/comfort-noise.rs
@@ -22,7 +22,7 @@ fn negotiates_all_supported_clock_rates() {
         let negotiated: Vec<_> = rtc
             .codec_config()
             .iter()
-            .filter(|p| p.spec().codec == Codec::ComfortNoise)
+            .filter(|p| p.spec().codec == Codec::CN)
             .map(|p| (*p.pt(), p.spec().clock_rate.get()))
             .collect();
         assert_eq!(
@@ -64,7 +64,7 @@ fn frame_mode_round_trips_all_supported_clock_rates() -> Result<(), RtcError> {
         .events
         .iter()
         .filter_map(|(_, event)| match event {
-            Event::MediaData(data) if data.params.spec().codec == Codec::ComfortNoise => Some((
+            Event::MediaData(data) if data.params.spec().codec == Codec::CN => Some((
                 *data.pt,
                 data.params.spec().clock_rate.get(),
                 data.data.as_ref().to_vec(),
@@ -113,7 +113,7 @@ fn frame_mode_switching_through_cn_does_not_stall_primary_audio() -> Result<(), 
         received,
         vec![
             (Codec::PCMU, vec![1]),
-            (Codec::ComfortNoise, vec![42]),
+            (Codec::CN, vec![42]),
             (Codec::PCMU, vec![2]),
         ],
         "the CN sequence number must not look like a lost PCMU packet"
@@ -140,7 +140,7 @@ fn frame_mode_cn_never_sets_marker_bit() -> Result<(), RtcError> {
     while l.duration() < deadline {
         progress(&mut l, &mut r)?;
         if let Some(data) = r.events.iter().find_map(|(_, event)| match event {
-            Event::MediaData(data) if data.params.spec().codec == Codec::ComfortNoise => Some(data),
+            Event::MediaData(data) if data.params.spec().codec == Codec::CN => Some(data),
             _ => None,
         }) {
             assert!(
@@ -293,7 +293,7 @@ fn progress_until_cn_events(
                     matches!(
                         event,
                         Event::MediaData(data)
-                            if data.params.spec().codec == Codec::ComfortNoise
+                            if data.params.spec().codec == Codec::CN
                     )
                 }
             })
@@ -312,7 +312,7 @@ fn comfort_noise(pt: u8, clock_rate: u32) -> PayloadParams {
         pt.into(),
         None,
         CodecSpec {
-            codec: Codec::ComfortNoise,
+            codec: Codec::CN,
             channels: None,
             clock_rate: Frequency::new(clock_rate).unwrap(),
             format: FormatParams::default(),

--- a/tests/sdp-negotiation.rs
+++ b/tests/sdp-negotiation.rs
@@ -1,5 +1,5 @@
 use std::net::Ipv4Addr;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 mod common;
 use common::TestRtc;
@@ -17,8 +17,8 @@ use str0m::format::PayloadParams;
 use str0m::media::Direction;
 use str0m::media::Frequency;
 use str0m::media::MediaKind;
-use str0m::media::Pt;
-use str0m::rtp::{Extension, ExtensionMap};
+use str0m::media::{MediaTime, Pt};
+use str0m::rtp::{Extension, ExtensionMap, RtpWrite};
 use str0m::{Event, RtcError};
 use tracing::Span;
 use tracing::info_span;
@@ -113,13 +113,7 @@ pub fn comfort_noise_negotiates_all_supported_clock_rates() {
     init_log();
     init_crypto_default();
 
-    let params = [
-        comfort_noise(13, 8_000),
-        comfort_noise(96, 16_000),
-        comfort_noise(97, 24_000),
-        comfort_noise(98, 32_000),
-        comfort_noise(99, 48_000),
-    ];
+    let params = comfort_noise_params();
     let (l, r) = with_params(info_span!("L"), &params, info_span!("R"), &params);
 
     for rtc in [&l, &r] {
@@ -140,6 +134,89 @@ pub fn comfort_noise_negotiates_all_supported_clock_rates() {
             ]
         );
     }
+}
+
+#[test]
+pub fn comfort_noise_frame_mode_round_trips_all_supported_clock_rates() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let params = comfort_noise_params();
+    let (mut l, mut r, mid) = connected_with_params(&params, false);
+
+    for (index, param) in params.iter().enumerate() {
+        let wallclock = l.start + l.duration();
+        let time = MediaTime::new(
+            param.spec().clock_rate.get() as u64,
+            param.spec().clock_rate,
+        );
+        l.writer(mid)
+            .unwrap()
+            .write(param.pt(), wallclock, time, vec![index as u8 + 1])?;
+        progress(&mut l, &mut r)?;
+    }
+
+    progress_until_cn_events(&mut l, &mut r, false)?;
+
+    let received: Vec<_> = r
+        .events
+        .iter()
+        .filter_map(|(_, event)| match event {
+            Event::MediaData(data) if data.params.spec().codec == Codec::ComfortNoise => Some((
+                *data.pt,
+                data.params.spec().clock_rate.get(),
+                data.data.as_ref().to_vec(),
+            )),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(received, expected_cn_events());
+    Ok(())
+}
+
+#[test]
+pub fn comfort_noise_rtp_mode_round_trips_all_supported_clock_rates() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let params = comfort_noise_params();
+    let (mut l, mut r, mid) = connected_with_params(&params, true);
+    let ssrc = l.direct_api().stream_tx_by_mid(mid, None).unwrap().ssrc();
+
+    for (index, param) in params.iter().enumerate() {
+        let wallclock = l.start + l.duration();
+        let timestamp = param.spec().clock_rate.get();
+        l.direct_api()
+            .stream_tx(&ssrc)
+            .unwrap()
+            .write_rtp(RtpWrite::new(
+                param.pt(),
+                (index as u64 + 1).into(),
+                timestamp,
+                wallclock,
+                [index as u8 + 1],
+            ));
+        progress(&mut l, &mut r)?;
+    }
+
+    progress_until_cn_events(&mut l, &mut r, true)?;
+
+    let received: Vec<_> = r
+        .events
+        .iter()
+        .filter_map(|(_, event)| match event {
+            Event::RtpPacket(packet) => Some((
+                *packet.header.payload_type,
+                packet.time.frequency().get(),
+                packet.payload.as_ref().to_vec(),
+            )),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(received, expected_cn_events());
+    Ok(())
 }
 
 #[test]
@@ -1410,6 +1487,81 @@ fn build_params(span: Span, params: &[PayloadParams]) -> TestRtc {
     TestRtc::new_with_rtc(span, rtc)
 }
 
+fn connected_with_params(
+    params: &[PayloadParams],
+    rtp_mode: bool,
+) -> (TestRtc, TestRtc, str0m::media::Mid) {
+    let mut l = build_params_with_mode(info_span!("L"), params, rtp_mode);
+    let mut r = build_params_with_mode(info_span!("R"), params, rtp_mode);
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    let mid = negotiate(&mut l, &mut r, |change| {
+        change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None)
+    });
+
+    while !l.is_connected() || !r.is_connected() {
+        progress(&mut l, &mut r).expect("clean progress");
+    }
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    (l, r, mid)
+}
+
+fn build_params_with_mode(span: Span, params: &[PayloadParams], rtp_mode: bool) -> TestRtc {
+    let mut builder = Rtc::builder()
+        .clear_codecs()
+        .set_rtp_mode(rtp_mode)
+        .set_reordering_size_audio(0);
+    let config = builder.codec_config();
+    for param in params {
+        config.add_config(
+            param.pt(),
+            param.resend(),
+            param.spec().codec,
+            param.spec().clock_rate,
+            param.spec().channels,
+            param.spec().format,
+        );
+    }
+    TestRtc::new_with_rtc(span, builder.build(Instant::now()))
+}
+
+fn progress_until_cn_events(
+    l: &mut TestRtc,
+    r: &mut TestRtc,
+    rtp_mode: bool,
+) -> Result<(), RtcError> {
+    let deadline = l.duration() + Duration::from_secs(2);
+    while l.duration() < deadline {
+        let count = r
+            .events
+            .iter()
+            .filter(|(_, event)| {
+                if rtp_mode {
+                    matches!(event, Event::RtpPacket(_))
+                } else {
+                    matches!(
+                        event,
+                        Event::MediaData(data)
+                            if data.params.spec().codec == Codec::ComfortNoise
+                    )
+                }
+            })
+            .count();
+        if count == 5 {
+            return Ok(());
+        }
+        progress(l, r)?;
+    }
+
+    panic!("timed out waiting for all five Comfort Noise payloads");
+}
+
 fn build_exts(span: Span, exts: ExtensionMap) -> TestRtc {
     let mut b = Rtc::builder().clear_codecs();
     b = b.enable_vp8(true);
@@ -1458,6 +1610,26 @@ fn comfort_noise(pt: u8, clock_rate: u32) -> PayloadParams {
             format: FormatParams::default(),
         },
     )
+}
+
+fn comfort_noise_params() -> [PayloadParams; 5] {
+    [
+        comfort_noise(13, 8_000),
+        comfort_noise(96, 16_000),
+        comfort_noise(97, 24_000),
+        comfort_noise(98, 32_000),
+        comfort_noise(99, 48_000),
+    ]
+}
+
+fn expected_cn_events() -> Vec<(u8, u32, Vec<u8>)> {
+    vec![
+        (13, 8_000, vec![1]),
+        (96, 16_000, vec![2]),
+        (97, 24_000, vec![3]),
+        (98, 32_000, vec![4]),
+        (99, 48_000, vec![5]),
+    ]
 }
 
 fn vp8(pt: u8) -> PayloadParams {

--- a/tests/sdp-negotiation.rs
+++ b/tests/sdp-negotiation.rs
@@ -109,6 +109,40 @@ pub fn g722_offer_accepts_explicit_mono_channel() {
 }
 
 #[test]
+pub fn comfort_noise_negotiates_all_supported_clock_rates() {
+    init_log();
+    init_crypto_default();
+
+    let params = [
+        comfort_noise(13, 8_000),
+        comfort_noise(96, 16_000),
+        comfort_noise(97, 24_000),
+        comfort_noise(98, 32_000),
+        comfort_noise(99, 48_000),
+    ];
+    let (l, r) = with_params(info_span!("L"), &params, info_span!("R"), &params);
+
+    for rtc in [&l, &r] {
+        let negotiated: Vec<_> = rtc
+            .codec_config()
+            .iter()
+            .filter(|p| p.spec().codec == Codec::ComfortNoise)
+            .map(|p| (*p.pt(), p.spec().clock_rate.get()))
+            .collect();
+        assert_eq!(
+            negotiated,
+            vec![
+                (13, 8_000),
+                (96, 16_000),
+                (97, 24_000),
+                (98, 32_000),
+                (99, 48_000),
+            ]
+        );
+    }
+}
+
+#[test]
 pub fn answer_change_order() {
     init_log();
     init_crypto_default();
@@ -1408,6 +1442,19 @@ fn g722(pt: u8) -> PayloadParams {
             channels: None,
             // G722 is a 16 kHz codec, even though its RTP clock rate is 8000 Hz.
             clock_rate: Frequency::SIXTEEN_KHZ,
+            format: FormatParams::default(),
+        },
+    )
+}
+
+fn comfort_noise(pt: u8, clock_rate: u32) -> PayloadParams {
+    PayloadParams::new(
+        pt.into(),
+        None,
+        CodecSpec {
+            codec: Codec::ComfortNoise,
+            channels: None,
+            clock_rate: Frequency::new(clock_rate).unwrap(),
             format: FormatParams::default(),
         },
     )

--- a/tests/sdp-negotiation.rs
+++ b/tests/sdp-negotiation.rs
@@ -1,5 +1,5 @@
 use std::net::Ipv4Addr;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 mod common;
 use common::TestRtc;
@@ -17,8 +17,8 @@ use str0m::format::PayloadParams;
 use str0m::media::Direction;
 use str0m::media::Frequency;
 use str0m::media::MediaKind;
-use str0m::media::{MediaTime, Pt};
-use str0m::rtp::{Extension, ExtensionMap, RtpWrite};
+use str0m::media::Pt;
+use str0m::rtp::{Extension, ExtensionMap};
 use str0m::{Event, RtcError};
 use tracing::Span;
 use tracing::info_span;
@@ -106,117 +106,6 @@ pub fn g722_offer_accepts_explicit_mono_channel() {
     assert!(!answer_sdp.contains("m=audio 0"), "SDP was:\n{answer_sdp}");
 
     l.rtc.sdp_api().accept_answer(pending, answer).unwrap();
-}
-
-#[test]
-pub fn comfort_noise_negotiates_all_supported_clock_rates() {
-    init_log();
-    init_crypto_default();
-
-    let params = comfort_noise_params();
-    let (l, r) = with_params(info_span!("L"), &params, info_span!("R"), &params);
-
-    for rtc in [&l, &r] {
-        let negotiated: Vec<_> = rtc
-            .codec_config()
-            .iter()
-            .filter(|p| p.spec().codec == Codec::ComfortNoise)
-            .map(|p| (*p.pt(), p.spec().clock_rate.get()))
-            .collect();
-        assert_eq!(
-            negotiated,
-            vec![
-                (13, 8_000),
-                (96, 16_000),
-                (97, 24_000),
-                (98, 32_000),
-                (99, 48_000),
-            ]
-        );
-    }
-}
-
-#[test]
-pub fn comfort_noise_frame_mode_round_trips_all_supported_clock_rates() -> Result<(), RtcError> {
-    init_log();
-    init_crypto_default();
-
-    let params = comfort_noise_params();
-    let (mut l, mut r, mid) = connected_with_params(&params, false);
-
-    for (index, param) in params.iter().enumerate() {
-        let wallclock = l.start + l.duration();
-        let time = MediaTime::new(
-            param.spec().clock_rate.get() as u64,
-            param.spec().clock_rate,
-        );
-        l.writer(mid)
-            .unwrap()
-            .write(param.pt(), wallclock, time, vec![index as u8 + 1])?;
-        progress(&mut l, &mut r)?;
-    }
-
-    progress_until_cn_events(&mut l, &mut r, false)?;
-
-    let received: Vec<_> = r
-        .events
-        .iter()
-        .filter_map(|(_, event)| match event {
-            Event::MediaData(data) if data.params.spec().codec == Codec::ComfortNoise => Some((
-                *data.pt,
-                data.params.spec().clock_rate.get(),
-                data.data.as_ref().to_vec(),
-            )),
-            _ => None,
-        })
-        .collect();
-
-    assert_eq!(received, expected_cn_events());
-    Ok(())
-}
-
-#[test]
-pub fn comfort_noise_rtp_mode_round_trips_all_supported_clock_rates() -> Result<(), RtcError> {
-    init_log();
-    init_crypto_default();
-
-    let params = comfort_noise_params();
-    let (mut l, mut r, mid) = connected_with_params(&params, true);
-    let ssrc = l.direct_api().stream_tx_by_mid(mid, None).unwrap().ssrc();
-
-    for (index, param) in params.iter().enumerate() {
-        let wallclock = l.start + l.duration();
-        let timestamp = param.spec().clock_rate.get();
-        l.direct_api()
-            .stream_tx(&ssrc)
-            .unwrap()
-            .write_rtp(RtpWrite::new(
-                param.pt(),
-                (index as u64 + 1).into(),
-                timestamp,
-                wallclock,
-                [index as u8 + 1],
-            ));
-        progress(&mut l, &mut r)?;
-    }
-
-    progress_until_cn_events(&mut l, &mut r, true)?;
-
-    let received: Vec<_> = r
-        .events
-        .iter()
-        .filter_map(|(_, event)| match event {
-            Event::RtpPacket(packet) => Some((
-                *packet.header.payload_type,
-                packet.time.frequency().get(),
-                packet.payload.as_ref().to_vec(),
-            )),
-            _ => None,
-        })
-        .collect();
-
-    assert_eq!(received, expected_cn_events());
-    Ok(())
 }
 
 #[test]
@@ -1487,81 +1376,6 @@ fn build_params(span: Span, params: &[PayloadParams]) -> TestRtc {
     TestRtc::new_with_rtc(span, rtc)
 }
 
-fn connected_with_params(
-    params: &[PayloadParams],
-    rtp_mode: bool,
-) -> (TestRtc, TestRtc, str0m::media::Mid) {
-    let mut l = build_params_with_mode(info_span!("L"), params, rtp_mode);
-    let mut r = build_params_with_mode(info_span!("R"), params, rtp_mode);
-
-    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
-    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
-
-    let mid = negotiate(&mut l, &mut r, |change| {
-        change.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None)
-    });
-
-    while !l.is_connected() || !r.is_connected() {
-        progress(&mut l, &mut r).expect("clean progress");
-    }
-
-    let max = l.last.max(r.last);
-    l.last = max;
-    r.last = max;
-
-    (l, r, mid)
-}
-
-fn build_params_with_mode(span: Span, params: &[PayloadParams], rtp_mode: bool) -> TestRtc {
-    let mut builder = Rtc::builder()
-        .clear_codecs()
-        .set_rtp_mode(rtp_mode)
-        .set_reordering_size_audio(0);
-    let config = builder.codec_config();
-    for param in params {
-        config.add_config(
-            param.pt(),
-            param.resend(),
-            param.spec().codec,
-            param.spec().clock_rate,
-            param.spec().channels,
-            param.spec().format,
-        );
-    }
-    TestRtc::new_with_rtc(span, builder.build(Instant::now()))
-}
-
-fn progress_until_cn_events(
-    l: &mut TestRtc,
-    r: &mut TestRtc,
-    rtp_mode: bool,
-) -> Result<(), RtcError> {
-    let deadline = l.duration() + Duration::from_secs(2);
-    while l.duration() < deadline {
-        let count = r
-            .events
-            .iter()
-            .filter(|(_, event)| {
-                if rtp_mode {
-                    matches!(event, Event::RtpPacket(_))
-                } else {
-                    matches!(
-                        event,
-                        Event::MediaData(data)
-                            if data.params.spec().codec == Codec::ComfortNoise
-                    )
-                }
-            })
-            .count();
-        if count == 5 {
-            return Ok(());
-        }
-        progress(l, r)?;
-    }
-
-    panic!("timed out waiting for all five Comfort Noise payloads");
-}
-
 fn build_exts(span: Span, exts: ExtensionMap) -> TestRtc {
     let mut b = Rtc::builder().clear_codecs();
     b = b.enable_vp8(true);
@@ -1597,39 +1411,6 @@ fn g722(pt: u8) -> PayloadParams {
             format: FormatParams::default(),
         },
     )
-}
-
-fn comfort_noise(pt: u8, clock_rate: u32) -> PayloadParams {
-    PayloadParams::new(
-        pt.into(),
-        None,
-        CodecSpec {
-            codec: Codec::ComfortNoise,
-            channels: None,
-            clock_rate: Frequency::new(clock_rate).unwrap(),
-            format: FormatParams::default(),
-        },
-    )
-}
-
-fn comfort_noise_params() -> [PayloadParams; 5] {
-    [
-        comfort_noise(13, 8_000),
-        comfort_noise(96, 16_000),
-        comfort_noise(97, 24_000),
-        comfort_noise(98, 32_000),
-        comfort_noise(99, 48_000),
-    ]
-}
-
-fn expected_cn_events() -> Vec<(u8, u32, Vec<u8>)> {
-    vec![
-        (13, 8_000, vec![1]),
-        (96, 16_000, vec![2]),
-        (97, 24_000, vec![3]),
-        (98, 32_000, vec![4]),
-        (99, 48_000, vec![5]),
-    ]
 }
 
 fn vp8(pt: u8) -> PayloadParams {


### PR DESCRIPTION
Adds RFC 3389 Comfort Noise as a first-class audio codec. The opt-in helper configures static PT 13 at 8 kHz, while callers can configure 16/24/32/48 kHz with dynamic payload types through `CodecConfig::add_config`.

CN payloads pass through one per RTP packet and never set the marker bit. Coverage includes codec identity, configuration, payload round trips, and SDP negotiation at all five requested clock rates.

Closes #993
