### PR TITLE
Fix H264 negotiation: negotiable level and Constrained High profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Fix H.264 negotiation: accept a negotiable (downgradable) level and recognize the Constrained High profile #1015
   * Expose the latest send queue information on `StreamTx` #1005
   * Fix VP9 non-flexible SS advertising a bogus R=0 GOF for single-layer streams #999
   * Support G722 audio codec (16 kHz codec with 8 kHz RTP clock per RFC 3551) #992

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-  * Fix H.264 negotiation: accept a negotiable (downgradable) level and recognize the Constrained High profile #1015
+  * Fix H.264 negotiation: accept a negotiable (downgradable) level and recognize the Constrained High profile #1016
   * Expose the latest send queue information on `StreamTx` #1005
   * Fix VP9 non-flexible SS advertising a bogus R=0 GOF for single-layer streams #999
   * Support G722 audio codec (16 kHz codec with 8 kHz RTP clock per RFC 3551) #992

--- a/src/format/payload_params.rs
+++ b/src/format/payload_params.rs
@@ -432,8 +432,13 @@ impl PayloadParams {
         }
 
         // RFC 6184 Section 8.2.2: the level is a negotiable (downgradable)
-        // parameter, so any level combination is allowed and the level
-        // difference only penalizes the score.
+        // parameter, so a level mismatch in either direction is allowed and
+        // only penalizes the match score rather than rejecting the payload.
+        //
+        // NOTE: this only affects *matching*. Unlike H.265/H.266, `update_param`
+        // does not narrow the answered H.264 level to `min(local, remote)`, so
+        // when `level-asymmetry-allowed` is absent we may answer with a level
+        // higher than the offer. See the note in `update_param`.
         let level_difference: usize = c0_profile_level
             .level()
             .ordinal()
@@ -449,9 +454,9 @@ impl PayloadParams {
     /// - **Profiles** must match exactly (no cross-profile compatibility)
     /// - **Tiers** must match exactly (Main vs High tier are distinct)
     /// - **Levels** penalize score by `|c0_level - c1_level|` but never reject.
-    ///   Both H.264 and H.265 tolerate level mismatches in either direction;
-    ///   for H.265, `update_param` narrows the negotiated level to
-    ///   `min(local, remote)` afterward.
+    ///   Both H.264 and H.265 tolerate level mismatches in either direction at
+    ///   match time. For H.265, `update_param` additionally narrows the
+    ///   negotiated level to `min(local, remote)` afterward; H.264 does not.
     ///
     /// # Matching Rules — Profile-only (at least one side lacks tier+level)
     ///
@@ -662,6 +667,13 @@ impl PayloadParams {
                 self.spec.format.sprop_max_don_diff = first.spec.format.sprop_max_don_diff;
             }
         }
+
+        // KNOWN LIMITATION: H.264 has no equivalent level-narrowing pass here.
+        // `match_h264_score` treats the level as negotiable, but we keep our
+        // locally configured `profile-level-id` in the answer instead of
+        // narrowing it to `min(local, remote)`. Per RFC 6184 §8.2.2, when
+        // `level-asymmetry-allowed` is not set the answer should use the lower
+        // level.
 
         let mut remote_pt = first.pt;
         let mut remote_rtx = first.resend;

--- a/src/format/payload_params.rs
+++ b/src/format/payload_params.rs
@@ -426,22 +426,18 @@ impl PayloadParams {
             .map(|l| l.try_into().ok())
             .unwrap_or(Some(H264ProfileLevel::FALLBACK))?;
 
-        // RFC 6184 Section 8.2.2: Profiles must match exactly, but we can decode
-        // bitstreams at our configured level or any lower level.
+        // RFC 6184 Section 8.2.2: Profiles must match exactly.
         if c0_profile_level.profile() != c1_profile_level.profile() {
             return None;
         }
 
-        // Reject if the offered level exceeds our configured capability
-        if c1_profile_level.level() > c0_profile_level.level() {
-            return None;
-        }
-
-        // Decrement score based on level difference
+        // RFC 6184 Section 8.2.2: the level is a negotiable (downgradable)
+        // parameter, so any level combination is allowed and the level
+        // difference only penalizes the score.
         let level_difference: usize = c0_profile_level
             .level()
             .ordinal()
-            .saturating_sub(c1_profile_level.level().ordinal());
+            .abs_diff(c1_profile_level.level().ordinal());
 
         Some(Self::EXACT_MATCH_SCORE.saturating_sub(level_difference))
     }
@@ -453,9 +449,9 @@ impl PayloadParams {
     /// - **Profiles** must match exactly (no cross-profile compatibility)
     /// - **Tiers** must match exactly (Main vs High tier are distinct)
     /// - **Levels** penalize score by `|c0_level - c1_level|` but never reject.
-    ///   Unlike H.264 (which rejects when `c1_level > c0_level`), H.265
-    ///   tolerates level mismatches in either direction because `update_param`
-    ///   narrows the negotiated level to `min(local, remote)` afterward.
+    ///   Both H.264 and H.265 tolerate level mismatches in either direction;
+    ///   for H.265, `update_param` narrows the negotiated level to
+    ///   `min(local, remote)` afterward.
     ///
     /// # Matching Rules — Profile-only (at least one side lacks tier+level)
     ///
@@ -840,12 +836,13 @@ mod test {
                     expected: Some(PayloadParams::EXACT_MATCH_SCORE - 2),
                     msg: "Same profile (CB), offered level 3.1 < configured 4.0 should match per RFC 6184",
                 },
-                // Test 3: Same profile, offered level higher -> should NOT match
+                // Test 3: Same profile, offered level higher -> should match (RFC 6184)
                 Case {
                     c0: h264_codec_spec(None, None, Some(0x42e01f)), // CB L3.1 (configured)
                     c1: h264_codec_spec(None, None, Some(0x42e028)), // CB L4.0 (offered)
-                    expected: None,
-                    msg: "Same profile (CB), offered level 4.0 > configured 3.1 should NOT match",
+                    expected: Some(PayloadParams::EXACT_MATCH_SCORE - 2),
+                    msg: "Same profile (CB), offered level 4.0 > configured 3.1 should match, \
+                    the level is negotiable per RFC 6184",
                 },
                 // Test 4: Different profiles -> should NOT match
                 Case {
@@ -882,12 +879,35 @@ mod test {
                     expected: Some(PayloadParams::EXACT_MATCH_SCORE - 1),
                     msg: "Same profile (Baseline), offered level 1 < configured 1B should match",
                 },
-                // Test 9: Baseline (not CB) offered higher level -> should not match (special Level1B case)
+                // Test 9: Baseline (not CB) offered higher level -> should match (special Level1B case)
                 Case {
                     c0: h264_codec_spec(None, None, Some(0x42000a)), // Baseline L1
                     c1: h264_codec_spec(None, None, Some(0x420000)), // Baseline Level1B
+                    expected: Some(PayloadParams::EXACT_MATCH_SCORE - 1),
+                    msg: "Same profile (Baseline), offered level 1B > configured 1 should match",
+                },
+                // Test 10: Offered Constrained Baseline level 5.2 is higher than
+                // the default configured 3.1. Must match.
+                Case {
+                    c0: h264_codec_spec(Some(true), Some(1), Some(0x42e01f)), // CB L3.1 (configured)
+                    c1: h264_codec_spec(Some(true), Some(1), Some(0x42e034)), // CB L5.2 (offered)
+                    expected: Some(PayloadParams::EXACT_MATCH_SCORE - 7),
+                    msg: "Same profile (CB), offered level 5.2 > configured 3.1 should match",
+                },
+                // Test 11: Constrained High (profile-iop 0x0C) must be recognized
+                // and match a configured Constrained High.
+                Case {
+                    c0: h264_codec_spec(Some(true), Some(1), Some(0x640c1f)), // CH L3.1 (configured)
+                    c1: h264_codec_spec(Some(true), Some(1), Some(0x640c34)), // CH L5.2 (offered)
+                    expected: Some(PayloadParams::EXACT_MATCH_SCORE - 7),
+                    msg: "Same profile (Constrained High), offered level 5.2 should match",
+                },
+                // Test 12: Constrained High is not the same profile as High.
+                Case {
+                    c0: h264_codec_spec(None, None, Some(0x64001f)), // High L3.1
+                    c1: h264_codec_spec(None, None, Some(0x640c1f)), // Constrained High L3.1
                     expected: None,
-                    msg: "Same profile (Baseline), offered level 1B > configured 1 should not match",
+                    msg: "Different profiles (High vs Constrained High) should NOT match",
                 },
             ];
 

--- a/src/packet/h264_profile.rs
+++ b/src/packet/h264_profile.rs
@@ -69,6 +69,12 @@ impl H264ProfileLevel {
             H264ProfileIdc::X64,
             BitPattern::new(*b"00000000"),
         ),
+        // Constrained High
+        (
+            H264Profile::ConstrainedHigh,
+            H264ProfileIdc::X64,
+            BitPattern::new(*b"00001100"),
+        ),
         (
             H264Profile::High10,
             H264ProfileIdc::X6E,
@@ -180,6 +186,7 @@ pub(crate) enum H264Profile {
     Main,
     Extended,
     High,
+    ConstrainedHigh,
     High10,
     High422,
     High444Predictive,
@@ -314,6 +321,54 @@ impl TryFrom<u8> for H264LevelIdc {
             x if (Level5_1 as u8) == x => Ok(Level5_1),
             x if (Level5_2 as u8) == x => Ok(Level5_2),
             _ => Err(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_profile_level_parsing() {
+        struct Case {
+            profile_level_id: u32,
+            expected: Option<(H264Profile, H264LevelIdc)>,
+            msg: &'static str,
+        }
+
+        let cases = [
+            // Test 1: High profile (no constraint flags) -> should parse
+            Case {
+                profile_level_id: 0x64001f,
+                expected: Some((H264Profile::High, H264LevelIdc::Level3_1)),
+                msg: "0x64001f should parse as High level 3.1",
+            },
+            // Test 2: Constrained High (constraint_set4_flag and
+            // constraint_set5_flag set) -> should parse
+            Case {
+                profile_level_id: 0x640c34,
+                expected: Some((H264Profile::ConstrainedHigh, H264LevelIdc::Level5_2)),
+                msg: "0x640c34 should parse as Constrained High level 5.2",
+            },
+            // Test 3: Undefined profile-iop combination -> should NOT parse
+            Case {
+                profile_level_id: 0x64101f,
+                expected: None,
+                msg: "0x64101f should not parse, profile-iop 0x10 is not defined for profile-idc 0x64",
+            },
+        ];
+
+        for Case {
+            profile_level_id,
+            expected,
+            msg,
+        } in cases.into_iter()
+        {
+            let parsed = H264ProfileLevel::try_from(profile_level_id)
+                .ok()
+                .map(|pl| (pl.profile(), pl.level()));
+            assert_eq!(parsed, expected, "{msg}");
         }
     }
 }

--- a/tests/sdp-negotiation.rs
+++ b/tests/sdp-negotiation.rs
@@ -689,6 +689,96 @@ fn offer_with_out_of_range_pt_is_rejected() {
     );
 }
 
+/// Regression test for issue #1015: an H.264 offer whose level exceeds the
+/// locally configured level must still negotiate. RFC 6184 §8.2.2 makes the
+/// level a negotiable (downgradable) parameter, so a remote `42e034`
+/// (Constrained Baseline, level 5.2) must match local `42e01f` (level 3.1)
+/// rather than reject the whole m-line; the Constrained High profile
+/// (`640c34`) must also parse instead of dropping the payload.
+#[test]
+fn h264_offer_with_higher_level_negotiates() {
+    init_log();
+    init_crypto_default();
+
+    // Only H.264 is enabled, so the video m-line survives *only* if an H.264
+    // payload negotiates. str0m's default H.264 config is at level 3.1.
+    let mut r = TestRtc::new_with_rtc(
+        info_span!("R"),
+        Rtc::builder()
+            .clear_codecs()
+            .enable_h264(true)
+            .build(Instant::now()),
+    );
+
+    // A remote offer (taken verbatim from Safari/WebKit) advertising
+    // Constrained High (640c34) and Constrained Baseline (42e034), both at
+    // level 5.2, in packetization modes 1 and 0.
+    let remote_offer = "\
+        v=0\r\n\
+        o=- 123456789 2 IN IP4 127.0.0.1\r\n\
+        s=-\r\n\
+        t=0 0\r\n\
+        a=group:BUNDLE 0\r\n\
+        a=msid-semantic:WMS *\r\n\
+        a=fingerprint:sha-256 00:00:00:00:00:00:00:00\
+        :00:00:00:00:00:00:00:00:00:00:00:00:00:00:00\
+        :00:00:00:00:00:00:00:00:00\r\n\
+        a=ice-ufrag:testufrag\r\n\
+        a=ice-pwd:testpassword12345678\r\n\
+        a=setup:actpass\r\n\
+        m=video 9 UDP/TLS/RTP/SAVPF 96 98 100 102\r\n\
+        c=IN IP4 0.0.0.0\r\n\
+        a=mid:0\r\n\
+        a=sendrecv\r\n\
+        a=rtcp-mux\r\n\
+        a=rtpmap:96 H264/90000\r\n\
+        a=fmtp:96 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c34\r\n\
+        a=rtpmap:98 H264/90000\r\n\
+        a=fmtp:98 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=640c34\r\n\
+        a=rtpmap:100 H264/90000\r\n\
+        a=fmtp:100 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e034\r\n\
+        a=rtpmap:102 H264/90000\r\n\
+        a=fmtp:102 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e034\r\n\
+        ";
+
+    let offer = SdpOffer::from_sdp_string(remote_offer).expect("offer should parse");
+    let answer = r
+        .span
+        .in_scope(|| r.rtc.sdp_api().accept_offer(offer).expect("should accept"));
+
+    let answer_sdp = answer.to_sdp_string();
+
+    // The video m-line must NOT be rejected (port 0). No local H.264 payload
+    // matches unless the level-5.2 offer is accepted against local level 3.1.
+    assert!(
+        !answer_sdp.contains("m=video 0 "),
+        "H.264 offer should negotiate, not reject the m-line:\n{answer_sdp}"
+    );
+
+    // The negotiated payload is str0m's Constrained Baseline (42e01f), matched
+    // against the remote's 42e034 with the level difference only penalizing the
+    // score per RFC 6184 §8.2.2.
+    assert!(
+        answer_sdp.contains("profile-level-id=42e01f"),
+        "Answer should negotiate Constrained Baseline (42e01f):\n{answer_sdp}"
+    );
+
+    // The answerer receives, so it adopts the remote's payload types. The
+    // Constrained Baseline packetization-mode=1 payload is PT 100 in the offer.
+    assert!(
+        answer_sdp.contains("a=rtpmap:100 H264/90000"),
+        "Answer should adopt the remote's Constrained Baseline PT 100:\n{answer_sdp}"
+    );
+
+    // The m-line stays active on the receiving side.
+    let mid = r._mids()[0];
+    assert_eq!(
+        r.media(mid).unwrap().direction(),
+        Direction::SendRecv,
+        "Video should stay active after negotiating the H.264 offer"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // SNAP (SCTP Negotiation Acceleration Protocol) tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Two independent fixes for #1015:

* match_h264_score no longer rejects an offer whose level differs from the locally configured level. RFC 6184 section 8.2.2 makes the level a negotiable (downgradable) parameter, so the level difference now only penalizes the match score (abs_diff), mirroring how match_h265_score already works. This makes e.g. Safari's Constrained Baseline 5.2 (42e034) match a local 42e01f.

* Recognize the Constrained High profile (profile_idc 0x64 with constraint_set4_flag and constraint_set5_flag, profile-iop 0x0C). WebKit offers profile-level-id=640c34, which previously failed to parse and unconditionally removed the payload from negotiation.