### PR TITLE
Infinite loop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1620,8 +1620,14 @@ impl Rtc {
         // poll loop below in the same iteration.
         if let Some(timeout) = self.next_dtls_timeout {
             if timeout <= self.last_now {
-                let _ = self.dtls.handle_timeout(self.last_now);
                 self.next_dtls_timeout = None;
+
+                if let Err(error) = self.dtls.handle_timeout(self.last_now) {
+                    // A failed timer transition leaves DTLS unrecoverable. Close the
+                    // RTC so continued polling cannot expose the same due timeout again.
+                    self.disconnect();
+                    return Err(error.into());
+                }
             }
         }
 

--- a/tests/dtls-retransmit.rs
+++ b/tests/dtls-retransmit.rs
@@ -114,16 +114,51 @@ fn dtls_retransmit_emitted_in_same_poll_pass() {
 /// previously caused an immediate-wake loop after dimpl had exhausted its
 /// retry budget.
 #[test]
-fn terminal_dtls_timeout_does_not_rearm_expired_deadline() {
+fn terminal_dtls_12_to_auto_timeout_does_not_rearm_expired_deadline() {
+    terminal_dtls_timeout_does_not_rearm_expired_deadline_for(
+        DtlsVersion::Dtls12,
+        DtlsVersion::Auto,
+    );
+}
+
+#[test]
+fn terminal_dtls_13_to_auto_timeout_does_not_rearm_expired_deadline() {
+    terminal_dtls_timeout_does_not_rearm_expired_deadline_for(
+        DtlsVersion::Dtls13,
+        DtlsVersion::Auto,
+    );
+}
+
+#[test]
+fn terminal_dtls_auto_to_auto_timeout_does_not_rearm_expired_deadline() {
+    terminal_dtls_timeout_does_not_rearm_expired_deadline_for(DtlsVersion::Auto, DtlsVersion::Auto);
+}
+
+#[test]
+fn terminal_dtls_12_to_12_timeout_does_not_rearm_expired_deadline() {
+    terminal_dtls_timeout_does_not_rearm_expired_deadline_for(
+        DtlsVersion::Dtls12,
+        DtlsVersion::Dtls12,
+    );
+}
+
+#[test]
+fn terminal_dtls_13_to_13_timeout_does_not_rearm_expired_deadline() {
+    terminal_dtls_timeout_does_not_rearm_expired_deadline_for(
+        DtlsVersion::Dtls13,
+        DtlsVersion::Dtls13,
+    );
+}
+
+fn terminal_dtls_timeout_does_not_rearm_expired_deadline_for(
+    client_dtls: DtlsVersion,
+    server_dtls: DtlsVersion,
+) {
     init_crypto_default();
 
     let now = Instant::now();
-    let left_rtc = Rtc::builder()
-        .set_dtls_version(DtlsVersion::Dtls12)
-        .build(now);
-    let right_rtc = Rtc::builder()
-        .set_dtls_version(DtlsVersion::Dtls12)
-        .build(now);
+    let left_rtc = Rtc::builder().set_dtls_version(client_dtls).build(now);
+    let right_rtc = Rtc::builder().set_dtls_version(server_dtls).build(now);
     let mut left = TestRtc::new_with_rtc(info_span!("L"), left_rtc);
     let mut right = TestRtc::new_with_rtc(info_span!("R"), right_rtc);
 

--- a/tests/dtls-retransmit.rs
+++ b/tests/dtls-retransmit.rs
@@ -28,6 +28,8 @@ use std::net::Ipv4Addr;
 use std::time::{Duration, Instant};
 
 use netem::{NetemConfig, Probability, RandomLoss};
+use str0m::RtcError;
+use str0m::config::DtlsVersion;
 use str0m::{Candidate, Input, Output, Reason, Rtc};
 use tracing::info_span;
 
@@ -102,6 +104,135 @@ fn dtls_retransmit_emitted_in_same_poll_pass() {
         got_transmit,
         "poll_output should emit the DTLS retransmit in the same pass that runs handle_timeout"
     );
+}
+
+/// A terminal dimpl handshake timeout must be returned and must leave the
+/// `Rtc` inert rather than continually returning the expired DTLS deadline.
+///
+/// This runs for every dimpl-backed crypto provider. It drives the scheduler
+/// with the exact timeout returned by `Rtc`, which is the behavior that
+/// previously caused an immediate-wake loop after dimpl had exhausted its
+/// retry budget.
+#[test]
+fn terminal_dtls_timeout_does_not_rearm_expired_deadline() {
+    init_crypto_default();
+
+    let now = Instant::now();
+    let left_rtc = Rtc::builder()
+        .set_dtls_version(DtlsVersion::Dtls12)
+        .build(now);
+    let right_rtc = Rtc::builder()
+        .set_dtls_version(DtlsVersion::Dtls12)
+        .build(now);
+    let mut left = TestRtc::new_with_rtc(info_span!("L"), left_rtc);
+    let mut right = TestRtc::new_with_rtc(info_span!("R"), right_rtc);
+
+    // Responses from the passive peer are discarded after it receives the
+    // client's first flight, so the active peer retries until dimpl times out.
+    left.set_netem(
+        NetemConfig::new()
+            .loss(RandomLoss::new(Probability::new(1.0)))
+            .seed(1),
+    );
+
+    let host_left = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp").unwrap();
+    let host_right = Candidate::host((Ipv4Addr::new(2, 2, 2, 2), 2000).into(), "udp").unwrap();
+    left.add_local_candidate(host_left.clone());
+    left.add_remote_candidate(host_right.clone());
+    right.add_local_candidate(host_right);
+    right.add_remote_candidate(host_left);
+
+    let fingerprint_left = left.direct_api().local_dtls_fingerprint().clone();
+    let fingerprint_right = right.direct_api().local_dtls_fingerprint().clone();
+    left.direct_api().set_remote_fingerprint(fingerprint_right);
+    right.direct_api().set_remote_fingerprint(fingerprint_left);
+
+    let credentials_left = left.direct_api().local_ice_credentials();
+    let credentials_right = right.direct_api().local_ice_credentials();
+    left.direct_api()
+        .set_remote_ice_credentials(credentials_right);
+    right
+        .direct_api()
+        .set_remote_ice_credentials(credentials_left);
+
+    left.direct_api().set_ice_controlling(true);
+    right.direct_api().set_ice_controlling(false);
+    left.direct_api().start_dtls(true).unwrap();
+    right.direct_api().start_dtls(false).unwrap();
+
+    // Let the first flight reach the passive peer and its response be dropped.
+    let mut setup_steps = 0;
+    while left.rtc.last_timeout_reason() != Reason::DTLS {
+        progress(&mut left, &mut right).unwrap();
+        setup_steps += 1;
+        assert!(
+            setup_steps < 200,
+            "failed to reach a DTLS flight deadline (last reason: {:?})",
+            left.rtc.last_timeout_reason()
+        );
+    }
+
+    // Unlike TestRtc::progress, preserve an immediate timeout exactly. This
+    // models a scheduler that runs work scheduled for now without adding a
+    // retry delay of its own.
+    let mut last_now = left.last;
+    let mut terminal_error = None;
+    for _ in 0..1_000 {
+        left.rtc.handle_input(Input::Timeout(last_now)).unwrap();
+
+        loop {
+            match left.rtc.poll_output() {
+                Err(RtcError::Dtls(error)) => {
+                    terminal_error = Some(error);
+                    break;
+                }
+                Err(error) => panic!("unexpected RTC error: {error}"),
+                Ok(Output::Timeout(timeout)) => {
+                    last_now = timeout;
+                    break;
+                }
+                Ok(Output::Transmit(_)) => {
+                    // Drop each retransmitted DTLS flight.
+                }
+                Ok(Output::Event(_)) => {
+                    // ICE may report its disconnected state before DTLS gives up.
+                }
+            }
+        }
+
+        if terminal_error.is_some() {
+            break;
+        }
+    }
+
+    assert!(
+        terminal_error.is_some(),
+        "terminal dimpl timeout was not returned within the bounded scheduler run"
+    );
+    assert!(
+        !left.rtc.is_alive(),
+        "terminal DTLS error must close the RTC"
+    );
+
+    // After the error, callers that continue polling and feeding timeout input
+    // must not receive another due timeout, packet, or event.
+    let terminal_last_now = last_now;
+    for _ in 0..16 {
+        left.rtc
+            .handle_input(Input::Timeout(terminal_last_now))
+            .unwrap();
+
+        match left.rtc.poll_output().unwrap() {
+            Output::Timeout(timeout) => {
+                assert!(
+                    timeout > terminal_last_now,
+                    "closed RTC returned a timeout at or before its last input"
+                );
+            }
+            Output::Transmit(_) => panic!("closed RTC produced a DTLS transmission"),
+            Output::Event(event) => panic!("closed RTC produced an event: {event:?}"),
+        }
+    }
 }
 
 /// End-to-end: a DTLS handshake between two peers must complete even


### PR DESCRIPTION
**DTLS timeout errors could cause an immediate-wake loop**

When a dimpl-backed DTLS handshake exhausts its retry budget, `dimpl::Dtls::handle_timeout()` returns a terminal error such as a connect or handshake timeout. Before this fix, `Rtc::do_poll_output()` discarded that error.

Dimpl can still expose its expired timer after returning the error. As a result, str0m could return `Output::Timeout(last_now)`, and a caller whose scheduler immediately runs work scheduled for `now` would feed that same timeout back into `Rtc`. The cycle then repeated indefinitely:

```text
expired DTLS timer
-> dimpl handle_timeout() returns Err(...)
-> str0m ignores the error
-> dimpl reports the expired timer again
-> str0m returns an already-due Output::Timeout
-> scheduler immediately calls back into str0m
```

This can cause one outer event-loop iteration to execute an unbounded number of due tasks.

**Fix**

The shared DTLS timeout path now disarms the scheduled timeout before invoking the provider, and treats any `handle_timeout()` error as terminal:

```rust
self.next_dtls_timeout = None;

if let Err(error) = self.dtls.handle_timeout(self.last_now) {
    self.disconnect();
    return Err(error.into());
}
```

This makes the failure visible as `RtcError::Dtls`, sets `Rtc::is_alive()` to `false`, and makes later `handle_input()` / `poll_output()` calls inert. Continued polling returns only the normal far-future timeout, with no DTLS transmissions or events.

**Why terminalize every `handle_timeout()` error?**

This is intentionally scoped to errors from advancing a due DTLS timer, not every DTLS error throughout str0m.

For dimpl, errors returned from `handle_timeout()` are fatal state-machine failures. The retryable `HandshakePending` condition applies to application-data and close operations, not timer handling. Once a timer transition fails, str0m cannot safely continue treating the DTLS instance as live.

Matching only `dimpl::Error::Timeout(...)` would be both weaker and more invasive:

- The current `Dtls` wrapper converts provider errors into `DtlsError`, losing the structured dimpl variant on this path.
- Preserving and classifying that variant would require additional error-plumbing work.
- More importantly, another fatal timer-processing error would still leave `Rtc` alive and potentially expose stale timing state.

Failing closed is therefore the safe behavior: surface the error, terminalize the `Rtc`, and prevent a caller that continues polling from spinning on an expired deadline.

**Regression coverage**

The new integration test in dtls-retransmit.rs forces a DTLS 1.2 handshake to time out by dropping peer responses. It verifies that str0m:

- returns `Err(RtcError::Dtls(_))`;
- becomes not alive;
- remains inert through repeated timeout inputs and output polls;
- produces no already-due timeout, DTLS transmission, or event after the error.