### PR TITLE
Expose bwe overusing flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Expose bwe overusing flag #1018
   * Expose the latest send queue information on `StreamTx` #1005
   * Fix VP9 non-flexible SS advertising a bogus R=0 GOF for single-layer streams #999
   * Support G722 audio codec (16 kHz codec with 8 kHz RTP clock per RFC 3551) #992

--- a/src/bwe/api.rs
+++ b/src/bwe/api.rs
@@ -54,4 +54,15 @@ impl<'a> Bwe<'a> {
     pub fn reset(&mut self, init_bitrate: Bitrate) {
         self.0.session.reset_bwe(init_bitrate);
     }
+
+    /// Whether the delay-based controller currently signals overuse.
+    ///
+    /// This is `true` while the congestion detector observes a rising delay trend, i.e. the
+    /// link is genuinely congested rather than merely application-limited. It lets a bitrate
+    /// allocator tell apart an estimate that fell because the link shrank (must react) from
+    /// one that fell only because less was being sent (safe to hold), since both look
+    /// identical from the estimate alone.
+    pub fn is_overusing(&self) -> bool {
+        self.0.session.bwe_is_overusing()
+    }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1069,6 +1069,13 @@ impl Session {
         }
     }
 
+    pub fn bwe_is_overusing(&self) -> bool {
+        self.bwe
+            .as_ref()
+            .map(|bwe| bwe.is_overusing())
+            .unwrap_or(false)
+    }
+
     #[allow(dead_code)]
     pub fn line_count(&self) -> usize {
         self.medias.len() + if self.app.is_some() { 1 } else { 0 }


### PR DESCRIPTION
Distinguishes network congestion from ALR.

SFU and BWE bitrate calculations can diverge during VBR/screenshare. Without this flag, BWE misinterprets congestion as ALR.