### PR TITLE
Respond to RRTR with DLRR

### DIFF
--- a/src/rtp/rtcp/xr.rs
+++ b/src/rtp/rtcp/xr.rs
@@ -154,8 +154,10 @@ impl Dlrr {
         buf[0] = 5_u8;
         // reserved;
         buf[1] = 0_u8;
-        // block length
-        let len: u16 = self.items.len() as u16 * 12_u16;
+        // block length, in 32-bit words (RFC 3611 §3): each DLRR sub-block is 3 words
+        // (ssrc + last_rr + delay = 12 bytes). Must match the parser, which divides this
+        // field by 3 to recover the item count.
+        let len: u16 = self.items.len() as u16 * 3_u16;
         buf[2..4].copy_from_slice(&len.to_be_bytes());
 
         let mut buf = &mut buf[4..];
@@ -164,7 +166,8 @@ impl Dlrr {
             buf[0..4].copy_from_slice(&item.ssrc.to_be_bytes());
             buf[4..8].copy_from_slice(&item.last_rr_time.to_be_bytes());
             buf[8..12].copy_from_slice(&item.last_rr_delay.to_be_bytes());
-            buf = &mut buf[4..];
+            // advance past the full 12-byte sub-block
+            buf = &mut buf[12..];
         }
 
         self.len()

--- a/src/session.rs
+++ b/src/session.rs
@@ -737,7 +737,13 @@ impl Session {
                 // DLRR responder (RFC 3611 §4.5): store the remote's RRTR so we can
                 // reply with a DLRR, letting the remote compute RTT.
                 let lrr = (rrtr.ntp_time.as_ntp_64() >> 16) as u32;
-                self.pending_rrtrs.insert(ssrc, LastRrtr { lrr, received_at: now });
+                self.pending_rrtrs.insert(
+                    ssrc,
+                    LastRrtr {
+                        lrr,
+                        received_at: now,
+                    },
+                );
                 continue;
             }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -744,7 +744,10 @@ impl Session {
                 // DLRR responder (RFC 3611 §4.5): store the remote's RRTR so we can
                 // reply with a DLRR, letting the remote compute RTT.
                 let lrr = (rrtr.ntp_time.as_ntp_64() >> 16) as u32;
-                let entry = LastRrtr { lrr, received_at: now };
+                let entry = LastRrtr {
+                    lrr,
+                    received_at: now,
+                };
 
                 // Update in place if this SSRC is already pending (preserves queue order).
                 if let Some(existing) = self.pending_rrtrs.iter_mut().find(|(s, _)| *s == ssrc) {

--- a/src/session.rs
+++ b/src/session.rs
@@ -288,12 +288,15 @@ impl Session {
             &mut self.feedback_tx,
         );
 
-        if do_nack {
-            self.last_nack = now;
-        }
-
-        // Flush any pending RRTRs as a single DLRR ExtendedReport.
-        if !self.pending_rrtrs.is_empty() {
+        // Flush any pending RRTRs as a DLRR alongside the Sender Report compound packet.
+        // We piggyback on the SR cadence so the DLRR doesn't generate extra standalone
+        // RTCP traffic that could perturb bandwidth estimation.
+        if !self.pending_rrtrs.is_empty()
+            && self
+                .feedback_tx
+                .iter()
+                .any(|r| matches!(r, Rtcp::SenderReport(_)))
+        {
             let items: Vec<DlrrItem> = self
                 .pending_rrtrs
                 .iter()
@@ -315,6 +318,10 @@ impl Session {
                 }));
 
             self.pending_rrtrs.clear();
+        }
+
+        if do_nack {
+            self.last_nack = now;
         }
 
         self.update_queue_state(now);
@@ -728,7 +735,7 @@ impl Session {
 
             if let RtcpFb::Rrtr((rrtr, ssrc)) = fb {
                 // DLRR responder (RFC 3611 §4.5): store the remote's RRTR so we can
-                // reply with a DLRR on the next timeout, letting the remote compute RTT.
+                // reply with a DLRR, letting the remote compute RTT.
                 let lrr = (rrtr.ntp_time.as_ntp_64() >> 16) as u32;
                 self.pending_rrtrs.insert(ssrc, LastRrtr { lrr, received_at: now });
                 continue;

--- a/src/session.rs
+++ b/src/session.rs
@@ -45,6 +45,12 @@ const NACK_MIN_INTERVAL: Duration = Duration::from_millis(33);
 /// Delay between reports of TWCC. This is deliberately very low.
 const TWCC_INTERVAL: Duration = Duration::from_millis(50);
 
+/// Maximum number of pending RRTR entries before oldest are dropped.
+const MAX_PENDING_RRTRS: usize = 300;
+
+/// Maximum number of DLRR items to include in a single ExtendedReport.
+const MAX_DLRR_PER_REPORT: usize = 50;
+
 pub(crate) struct Session {
     id: SessionId,
 
@@ -118,9 +124,10 @@ pub(crate) struct Session {
     feedback_rx: VecDeque<Rtcp>,
     rtp_closing: bool,
 
-    /// Pending RRTRs from remote SSRCs, keyed by the sender's SSRC.
-    /// Flushed as a single DLRR ExtendedReport on the next handle_timeout.
-    pending_rrtrs: HashMap<Ssrc, LastRrtr>,
+    /// Pending RRTRs from remote SSRCs in FIFO order, deduplicated by SSRC.
+    /// A new RRTR for an already-pending SSRC updates its value in place.
+    /// Capped at 300 entries; at most 50 are consumed per DLRR report.
+    pending_rrtrs: VecDeque<(Ssrc, LastRrtr)>,
 
     raw_packets: Option<VecDeque<Box<RawPacket>>>,
 
@@ -205,7 +212,7 @@ impl Session {
             feedback_tx: VecDeque::new(),
             feedback_rx: VecDeque::new(),
             rtp_closing: false,
-            pending_rrtrs: HashMap::new(),
+            pending_rrtrs: VecDeque::new(),
             raw_packets: if config.enable_raw_packets {
                 Some(VecDeque::new())
             } else {
@@ -291,16 +298,18 @@ impl Session {
         // Flush any pending RRTRs as a DLRR alongside the Sender Report compound packet.
         // We piggyback on the SR cadence so the DLRR doesn't generate extra standalone
         // RTCP traffic that could perturb bandwidth estimation.
+        // Consume at most 50 entries per report; the rest remain for subsequent SRs.
         if !self.pending_rrtrs.is_empty()
             && self
                 .feedback_tx
                 .iter()
                 .any(|r| matches!(r, Rtcp::SenderReport(_)))
         {
+            let n = self.pending_rrtrs.len().min(MAX_DLRR_PER_REPORT);
             let items: Vec<DlrrItem> = self
                 .pending_rrtrs
-                .iter()
-                .map(|(&ssrc, &rrtr)| {
+                .drain(..n)
+                .map(|(ssrc, rrtr)| {
                     let delay = now.saturating_duration_since(rrtr.received_at);
                     let last_rr_delay = ((delay.as_micros() * 65_536) / 1_000_000) as u32;
                     DlrrItem {
@@ -316,8 +325,6 @@ impl Session {
                     ssrc: sender_ssrc,
                     blocks: vec![ReportBlock::Dlrr(Dlrr { items })],
                 }));
-
-            self.pending_rrtrs.clear();
         }
 
         if do_nack {
@@ -737,13 +744,18 @@ impl Session {
                 // DLRR responder (RFC 3611 §4.5): store the remote's RRTR so we can
                 // reply with a DLRR, letting the remote compute RTT.
                 let lrr = (rrtr.ntp_time.as_ntp_64() >> 16) as u32;
-                self.pending_rrtrs.insert(
-                    ssrc,
-                    LastRrtr {
-                        lrr,
-                        received_at: now,
-                    },
-                );
+                let entry = LastRrtr { lrr, received_at: now };
+
+                // Update in place if this SSRC is already pending (preserves queue order).
+                if let Some(existing) = self.pending_rrtrs.iter_mut().find(|(s, _)| *s == ssrc) {
+                    existing.1 = entry;
+                } else {
+                    // Cap at 300 entries; drop the oldest if full.
+                    if self.pending_rrtrs.len() >= MAX_PENDING_RRTRS {
+                        self.pending_rrtrs.pop_front();
+                    }
+                    self.pending_rrtrs.push_back((ssrc, entry));
+                }
                 continue;
             }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -26,12 +26,13 @@ use crate::rtp_::Pt;
 use crate::rtp_::SRTCP_OVERHEAD;
 use crate::rtp_::SeqNo;
 use crate::rtp_::{Bitrate, ExtensionMap, Goodbye, Mid, ReportList, Rtcp, RtcpFb};
+use crate::rtp_::{Dlrr, DlrrItem, ExtendedReport, ReportBlock};
 use crate::rtp_::{RtpHeader, SessionId, TwccPacketId, extend_u16};
 use crate::rtp_::{SrtpContext, Ssrc};
 use crate::rtp_::{TwccRecvRegister, TwccSendRegister};
 use crate::stats::StatsSnapshot;
 use crate::streams::{RtpPacket, Streams};
-use crate::util::{Soonest, already_happened, not_happening};
+use crate::util::{Soonest, SystemTimeExt, already_happened, not_happening};
 use crate::{Reason, net};
 use crate::{RtcConfig, RtcError};
 
@@ -42,6 +43,17 @@ const NACK_MIN_INTERVAL: Duration = Duration::from_millis(33);
 
 /// Delay between reports of TWCC. This is deliberately very low.
 const TWCC_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Last RRTR (Receiver Reference Time Report, RFC 3611 §4.4) received from a remote SSRC.
+/// Stored at session level so we can respond with a DLRR regardless of which local stream
+/// the remote is observing.
+#[derive(Debug, Clone, Copy)]
+struct LastRrtr {
+    /// Middle 32 bits of the RRTR NTP timestamp (compact NTP / LRR).
+    lrr: u32,
+    /// When the RRTR arrived locally.
+    received_at: Instant,
+}
 
 pub(crate) struct Session {
     id: SessionId,
@@ -115,6 +127,10 @@ pub(crate) struct Session {
     feedback_rx: VecDeque<Rtcp>,
     rtp_closing: bool,
 
+    /// Pending RRTRs from remote SSRCs, keyed by the sender's SSRC.
+    /// Flushed as a single DLRR ExtendedReport on the next handle_timeout.
+    pending_rrtrs: HashMap<Ssrc, LastRrtr>,
+
     raw_packets: Option<VecDeque<Box<RawPacket>>>,
 
     // Pending application-specific feedback (PSFB FMT=15) messages to emit as events.
@@ -186,6 +202,7 @@ impl Session {
             feedback_tx: VecDeque::new(),
             feedback_rx: VecDeque::new(),
             rtp_closing: false,
+            pending_rrtrs: HashMap::new(),
             raw_packets: if config.enable_raw_packets {
                 Some(VecDeque::new())
             } else {
@@ -267,6 +284,31 @@ impl Session {
 
         if do_nack {
             self.last_nack = now;
+        }
+
+        // Flush any pending RRTRs as a single DLRR ExtendedReport.
+        if !self.pending_rrtrs.is_empty() {
+            let items: Vec<DlrrItem> = self
+                .pending_rrtrs
+                .iter()
+                .map(|(&ssrc, &rrtr)| {
+                    let delay = now.saturating_duration_since(rrtr.received_at);
+                    let last_rr_delay = ((delay.as_micros() * 65_536) / 1_000_000) as u32;
+                    DlrrItem {
+                        ssrc,
+                        last_rr_time: rrtr.lrr,
+                        last_rr_delay,
+                    }
+                })
+                .collect();
+
+            self.feedback_tx
+                .push_back(Rtcp::ExtendedReport(ExtendedReport {
+                    ssrc: sender_ssrc,
+                    blocks: vec![ReportBlock::Dlrr(Dlrr { items })],
+                }));
+
+            self.pending_rrtrs.clear();
         }
 
         self.update_queue_state(now);
@@ -675,6 +717,14 @@ impl Session {
                 // The funky thing about TWCC reports is that they are never stapled
                 // together with other RTCP packet. If they were though, we want to
                 // handle more packets.
+                continue;
+            }
+
+            if let RtcpFb::Rrtr((rrtr, ssrc)) = fb {
+                // DLRR responder (RFC 3611 §4.5): store the remote's RRTR so we can
+                // reply with a DLRR on the next timeout, letting the remote compute RTT.
+                let lrr = (rrtr.ntp_time.as_ntp_64() >> 16) as u32;
+                self.pending_rrtrs.insert(ssrc, LastRrtr { lrr, received_at: now });
                 continue;
             }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -45,17 +45,6 @@ const NACK_MIN_INTERVAL: Duration = Duration::from_millis(33);
 /// Delay between reports of TWCC. This is deliberately very low.
 const TWCC_INTERVAL: Duration = Duration::from_millis(50);
 
-/// Last RRTR (Receiver Reference Time Report, RFC 3611 §4.4) received from a remote SSRC.
-/// Stored at session level so we can respond with a DLRR regardless of which local stream
-/// the remote is observing.
-#[derive(Debug, Clone, Copy)]
-struct LastRrtr {
-    /// Middle 32 bits of the RRTR NTP timestamp (compact NTP / LRR).
-    lrr: u32,
-    /// When the RRTR arrived locally.
-    received_at: Instant,
-}
-
 pub(crate) struct Session {
     id: SessionId,
 
@@ -144,6 +133,17 @@ pub(crate) struct Session {
 
     #[cfg(feature = "_internal_test_exports")]
     pending_probe: Option<crate::bwe_::ProbeClusterConfig>,
+}
+
+/// Last RRTR (Receiver Reference Time Report, RFC 3611 §4.4) received from a remote SSRC.
+/// Stored at session level so we can respond with a DLRR regardless of which local stream
+/// the remote is observing.
+#[derive(Debug, Clone, Copy)]
+struct LastRrtr {
+    /// Middle 32 bits of the RRTR NTP timestamp (compact NTP / LRR).
+    lrr: u32,
+    /// When the RRTR arrived locally.
+    received_at: Instant,
 }
 
 impl Session {

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -16,6 +16,7 @@ use crate::pacer::QueueState;
 use crate::packet::Vp8Patch;
 use crate::rtp_::MidRid;
 use crate::rtp_::{Bitrate, Descriptions, Extension, ExtensionMap, ExtensionValues, Frequency};
+use crate::rtp_::{Dlrr, DlrrItem, ExtendedReport, ReportBlock};
 use crate::rtp_::{MAX_BLANK_PADDING_PAYLOAD_SIZE, Sdes, SdesType};
 use crate::rtp_::{MediaTime, Mid, NackEntry, ReportList, Rtcp, RtpHeader};
 use crate::rtp_::{Pt, Rid, RtcpFb, SenderInfo, SenderReport, Ssrc};
@@ -23,7 +24,7 @@ use crate::rtp_::{SRTP_BLOCK_SIZE, SeqNo};
 use crate::session::PacketReceipt;
 use crate::stats::StatsSnapshot;
 use crate::util::value_history::ValueHistory;
-use crate::util::{InstantExt, already_happened, not_happening};
+use crate::util::{InstantExt, SystemTimeExt, already_happened, not_happening};
 
 use super::rtx_cache::RtxCache;
 use super::send_queue::SendQueue;
@@ -80,6 +81,17 @@ impl StreamTxQueueInfo for QueueSnapshot {
 ///
 /// A stream is a primary SSRC + optional RTX SSRC.
 ///
+/// Last RRTR (Receiver Reference Time, RFC 3611 §4.4) received from the remote.
+#[derive(Debug, Clone, Copy)]
+struct LastRrtr {
+    /// SSRC of the RRTR sender.
+    ssrc: Ssrc,
+    /// Middle 32 bits of the RRTR NTP timestamp (LRR).
+    lrr: u32,
+    /// When the RRTR arrived locally.
+    received_at: Instant,
+}
+
 /// This is RTP level API. For frame level API see [`Rtc::writer`][crate::Rtc::writer].
 #[derive(Debug)]
 pub struct StreamTx {
@@ -172,6 +184,10 @@ pub struct StreamTx {
     /// that the receiver has bound the Mid/Rid tuple to the SSRC and no longer
     /// needs to be sent on every packet
     remote_acked_ssrc: bool,
+
+    /// Last RRTR (Receiver Reference Time, RFC 3611 §4.4) received from the remote,
+    /// so we can answer it with a DLRR (§4.5).
+    last_rrtr: Option<LastRrtr>,
 
     // Same as `remote_acked_ssrc`, but for the RTX SSRC
     remote_acked_rtx_ssrc: bool,
@@ -332,6 +348,7 @@ impl StreamTx {
             pt_for_padding: None,
             remote_acked_ssrc: false,
             remote_acked_rtx_ssrc: false,
+            last_rrtr: None,
             mtu_warn,
         }
     }
@@ -943,6 +960,17 @@ impl StreamTx {
             Remb(r) => {
                 self.pending_request_remb = Some(Bitrate::from(r.bitrate as f64));
             }
+            Rrtr((rrtr, ssrc)) => {
+                // DLRR responder half (RFC 3611 §4.5): the remote (SFU) sent us its
+                // reference time; remember its LRR (mid-32 of the RRTR ntp) and arrival
+                // so create_sr_and_update can reply with a DLRR to let it measure RTT.
+                let lrr = (rrtr.ntp_time.as_ntp_64() >> 16) as u32;
+                self.last_rrtr = Some(LastRrtr {
+                    ssrc,
+                    lrr,
+                    received_at: now,
+                });
+            }
             Twcc(_) => unreachable!("TWCC should be handled on session level"),
             _ => {}
         }
@@ -990,8 +1018,33 @@ impl StreamTx {
             feedback.push_back(Rtcp::SourceDescription(ds));
         }
 
+        if let Some(xr) = self.create_dlrr(now) {
+            feedback.push_back(Rtcp::ExtendedReport(xr));
+        }
+
         // Update timestamp to move time when next is created.
         self.last_sender_report = now;
+    }
+
+    // DLRR responder half (RFC 3611 §4.5). If the remote sent us an RRTR, reply with a
+    // DLRR carrying its LRR and the delay (1/65536 s units) since we received it, so the
+    // remote can compute RTT / a capture-clock offset.
+    fn create_dlrr(&self, now: Instant) -> Option<ExtendedReport> {
+        let LastRrtr { ssrc, lrr, received_at } = self.last_rrtr?;
+
+        let delay = now.saturating_duration_since(received_at);
+        let last_rr_delay = ((delay.as_micros() * 65_536) / 1_000_000) as u32;
+
+        Some(ExtendedReport {
+            ssrc: self.ssrc,
+            blocks: vec![ReportBlock::Dlrr(Dlrr {
+                items: vec![DlrrItem {
+                    ssrc,
+                    last_rr_time: lrr,
+                    last_rr_delay,
+                }],
+            })],
+        })
     }
 
     fn create_sender_report(&self, now: Instant) -> SenderReport {

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -1030,7 +1030,11 @@ impl StreamTx {
     // DLRR carrying its LRR and the delay (1/65536 s units) since we received it, so the
     // remote can compute RTT / a capture-clock offset.
     fn create_dlrr(&self, now: Instant) -> Option<ExtendedReport> {
-        let LastRrtr { ssrc, lrr, received_at } = self.last_rrtr?;
+        let LastRrtr {
+            ssrc,
+            lrr,
+            received_at,
+        } = self.last_rrtr?;
 
         let delay = now.saturating_duration_since(received_at);
         let last_rr_delay = ((delay.as_micros() * 65_536) / 1_000_000) as u32;

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -16,7 +16,6 @@ use crate::pacer::QueueState;
 use crate::packet::Vp8Patch;
 use crate::rtp_::MidRid;
 use crate::rtp_::{Bitrate, Descriptions, Extension, ExtensionMap, ExtensionValues, Frequency};
-use crate::rtp_::{Dlrr, DlrrItem, ExtendedReport, ReportBlock};
 use crate::rtp_::{MAX_BLANK_PADDING_PAYLOAD_SIZE, Sdes, SdesType};
 use crate::rtp_::{MediaTime, Mid, NackEntry, ReportList, Rtcp, RtpHeader};
 use crate::rtp_::{Pt, Rid, RtcpFb, SenderInfo, SenderReport, Ssrc};
@@ -24,7 +23,7 @@ use crate::rtp_::{SRTP_BLOCK_SIZE, SeqNo};
 use crate::session::PacketReceipt;
 use crate::stats::StatsSnapshot;
 use crate::util::value_history::ValueHistory;
-use crate::util::{InstantExt, SystemTimeExt, already_happened, not_happening};
+use crate::util::{InstantExt, already_happened, not_happening};
 
 use super::rtx_cache::RtxCache;
 use super::send_queue::SendQueue;
@@ -81,17 +80,6 @@ impl StreamTxQueueInfo for QueueSnapshot {
 ///
 /// A stream is a primary SSRC + optional RTX SSRC.
 ///
-/// Last RRTR (Receiver Reference Time, RFC 3611 §4.4) received from the remote.
-#[derive(Debug, Clone, Copy)]
-struct LastRrtr {
-    /// SSRC of the RRTR sender.
-    ssrc: Ssrc,
-    /// Middle 32 bits of the RRTR NTP timestamp (LRR).
-    lrr: u32,
-    /// When the RRTR arrived locally.
-    received_at: Instant,
-}
-
 /// This is RTP level API. For frame level API see [`Rtc::writer`][crate::Rtc::writer].
 #[derive(Debug)]
 pub struct StreamTx {
@@ -184,10 +172,6 @@ pub struct StreamTx {
     /// that the receiver has bound the Mid/Rid tuple to the SSRC and no longer
     /// needs to be sent on every packet
     remote_acked_ssrc: bool,
-
-    /// Last RRTR (Receiver Reference Time, RFC 3611 §4.4) received from the remote,
-    /// so we can answer it with a DLRR (§4.5).
-    last_rrtr: Option<LastRrtr>,
 
     // Same as `remote_acked_ssrc`, but for the RTX SSRC
     remote_acked_rtx_ssrc: bool,
@@ -348,7 +332,6 @@ impl StreamTx {
             pt_for_padding: None,
             remote_acked_ssrc: false,
             remote_acked_rtx_ssrc: false,
-            last_rrtr: None,
             mtu_warn,
         }
     }
@@ -960,17 +943,6 @@ impl StreamTx {
             Remb(r) => {
                 self.pending_request_remb = Some(Bitrate::from(r.bitrate as f64));
             }
-            Rrtr((rrtr, ssrc)) => {
-                // DLRR responder half (RFC 3611 §4.5): the remote (SFU) sent us its
-                // reference time; remember its LRR (mid-32 of the RRTR ntp) and arrival
-                // so create_sr_and_update can reply with a DLRR to let it measure RTT.
-                let lrr = (rrtr.ntp_time.as_ntp_64() >> 16) as u32;
-                self.last_rrtr = Some(LastRrtr {
-                    ssrc,
-                    lrr,
-                    received_at: now,
-                });
-            }
             Twcc(_) => unreachable!("TWCC should be handled on session level"),
             _ => {}
         }
@@ -1018,37 +990,8 @@ impl StreamTx {
             feedback.push_back(Rtcp::SourceDescription(ds));
         }
 
-        if let Some(xr) = self.create_dlrr(now) {
-            feedback.push_back(Rtcp::ExtendedReport(xr));
-        }
-
         // Update timestamp to move time when next is created.
         self.last_sender_report = now;
-    }
-
-    // DLRR responder half (RFC 3611 §4.5). If the remote sent us an RRTR, reply with a
-    // DLRR carrying its LRR and the delay (1/65536 s units) since we received it, so the
-    // remote can compute RTT / a capture-clock offset.
-    fn create_dlrr(&self, now: Instant) -> Option<ExtendedReport> {
-        let LastRrtr {
-            ssrc,
-            lrr,
-            received_at,
-        } = self.last_rrtr?;
-
-        let delay = now.saturating_duration_since(received_at);
-        let last_rr_delay = ((delay.as_micros() * 65_536) / 1_000_000) as u32;
-
-        Some(ExtendedReport {
-            ssrc: self.ssrc,
-            blocks: vec![ReportBlock::Dlrr(Dlrr {
-                items: vec![DlrrItem {
-                    ssrc,
-                    last_rr_time: lrr,
-                    last_rr_delay,
-                }],
-            })],
-        })
     }
 
     fn create_sender_report(&self, now: Instant) -> SenderReport {

--- a/tests/dlrr.rs
+++ b/tests/dlrr.rs
@@ -1,0 +1,118 @@
+use std::net::Ipv4Addr;
+use std::time::{Duration, Instant};
+
+use str0m::media::{Direction, MediaKind};
+use str0m::rtp::rtcp::{ReportBlock, Rtcp};
+use str0m::rtp::RawPacket;
+use str0m::{Rtc, RtcError};
+use tracing::info_span;
+
+mod common;
+use common::{init_crypto_default, init_log, negotiate, progress, TestRtc};
+
+/// Verify that a StreamTx responds to an incoming RRTR with a DLRR.
+///
+/// L sends audio to R. R's StreamRx generates RRTR (Receiver Reference Time Report,
+/// RFC 3611 §4.4) alongside its Receiver Reports. L's StreamTx should respond with a
+/// DLRR (Delay since Last Receiver Report, RFC 3611 §4.5) in its next Sender Report,
+/// allowing R to compute RTT.
+#[test]
+pub fn dlrr_response_to_rrtr() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let now = Instant::now();
+    let l_rtc = Rtc::builder().enable_raw_packets(true).build(now);
+    let r_rtc = Rtc::builder().enable_raw_packets(true).build(now);
+
+    let mut l = TestRtc::new_with_rtc(info_span!("L"), l_rtc);
+    let mut r = TestRtc::new_with_rtc(info_span!("R"), r_rtc);
+
+    l.add_host_candidate((Ipv4Addr::new(1, 1, 1, 1), 1000).into());
+    r.add_host_candidate((Ipv4Addr::new(2, 2, 2, 2), 2000).into());
+
+    // L sends audio to R: L gets a StreamTx, R gets a StreamRx.
+    let mid = negotiate(&mut l, &mut r, |change| {
+        change.add_media(MediaKind::Audio, Direction::SendOnly, None, None, None)
+    });
+
+    loop {
+        if l.is_connected() || r.is_connected() {
+            break;
+        }
+        progress(&mut l, &mut r)?;
+    }
+
+    // Sync clocks.
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    let params = l.params_opus();
+    let pt = params.pt();
+    let data = [1_u8; 80];
+
+    // Run ~15s of synthetic time. R will send RRTR with its Receiver Reports
+    // (~every 5s), and L should reply with DLRR in its next Sender Report.
+    loop {
+        let wallclock = l.start + l.duration();
+        let time = l.duration().into();
+        l.writer(mid).unwrap().write(pt, wallclock, time, data)?;
+        progress(&mut l, &mut r)?;
+        if l.duration() > Duration::from_secs(15) {
+            break;
+        }
+    }
+
+    // R should have sent at least one RRTR.
+    let rrtr_count = r.events.iter().filter(|(_, e)| {
+        matches!(
+            e.as_raw_packet(),
+            Some(RawPacket::RtcpTx(Rtcp::ExtendedReport(xr)))
+                if xr.blocks.iter().any(|b| matches!(b, ReportBlock::Rrtr(_)))
+        )
+    }).count();
+    assert!(rrtr_count > 0, "R should have sent at least one RRTR");
+
+    // L should have sent at least one DLRR in response.
+    let dlrr_reports: Vec<_> = l.events.iter().filter_map(|(_, e)| {
+        if let Some(RawPacket::RtcpTx(Rtcp::ExtendedReport(xr))) = e.as_raw_packet() {
+            if xr.blocks.iter().any(|b| matches!(b, ReportBlock::Dlrr(_))) {
+                return Some(xr);
+            }
+        }
+        None
+    }).collect();
+    assert!(!dlrr_reports.is_empty(), "L should have sent DLRR in response to RRTR");
+
+    // Verify the DLRR contains valid data.
+    let dlrr = dlrr_reports[0].blocks.iter().find_map(|b| match b {
+        ReportBlock::Dlrr(d) => Some(d),
+        _ => None,
+    }).unwrap();
+    assert!(!dlrr.items.is_empty(), "DLRR should have at least one item");
+    let item = &dlrr.items[0];
+
+    // The last_rr_time field must be the middle 32 bits of the RRTR's NTP timestamp.
+    // Verify it's non-zero and that R received the same value back (round-trip integrity).
+    assert!(item.last_rr_time != 0, "DLRR last_rr_time should be non-zero");
+    assert!(item.last_rr_delay != 0, "DLRR delay should be non-zero");
+
+    // Verify R actually received the DLRR that L sent.
+    let r_received_dlrr = r.events.iter().any(|(_, e)| {
+        if let Some(RawPacket::RtcpRx(Rtcp::ExtendedReport(xr))) = e.as_raw_packet() {
+            xr.blocks.iter().any(|b| {
+                if let ReportBlock::Dlrr(d) = b {
+                    d.items.iter().any(|i| i.last_rr_time == item.last_rr_time)
+                } else {
+                    false
+                }
+            })
+        } else {
+            false
+        }
+    });
+    assert!(r_received_dlrr, "R should have received the DLRR with matching last_rr_time");
+
+    Ok(())
+}

--- a/tests/dlrr.rs
+++ b/tests/dlrr.rs
@@ -114,7 +114,6 @@ pub fn dlrr_response_to_rrtr() -> Result<(), RtcError> {
         item.last_rr_time != 0,
         "DLRR last_rr_time should be non-zero"
     );
-    assert!(item.last_rr_delay != 0, "DLRR delay should be non-zero");
 
     // Verify R actually received the DLRR that L sent.
     let r_received_dlrr = r.events.iter().any(|(_, e)| {

--- a/tests/dlrr.rs
+++ b/tests/dlrr.rs
@@ -2,13 +2,13 @@ use std::net::Ipv4Addr;
 use std::time::{Duration, Instant};
 
 use str0m::media::{Direction, MediaKind};
-use str0m::rtp::rtcp::{ReportBlock, Rtcp};
 use str0m::rtp::RawPacket;
+use str0m::rtp::rtcp::{ReportBlock, Rtcp};
 use str0m::{Rtc, RtcError};
 use tracing::info_span;
 
 mod common;
-use common::{init_crypto_default, init_log, negotiate, progress, TestRtc};
+use common::{TestRtc, init_crypto_default, init_log, negotiate, progress};
 
 /// Verify that a StreamTx responds to an incoming RRTR with a DLRR.
 ///
@@ -65,37 +65,55 @@ pub fn dlrr_response_to_rrtr() -> Result<(), RtcError> {
     }
 
     // R should have sent at least one RRTR.
-    let rrtr_count = r.events.iter().filter(|(_, e)| {
-        matches!(
-            e.as_raw_packet(),
-            Some(RawPacket::RtcpTx(Rtcp::ExtendedReport(xr)))
-                if xr.blocks.iter().any(|b| matches!(b, ReportBlock::Rrtr(_)))
-        )
-    }).count();
+    let rrtr_count = r
+        .events
+        .iter()
+        .filter(|(_, e)| {
+            matches!(
+                e.as_raw_packet(),
+                Some(RawPacket::RtcpTx(Rtcp::ExtendedReport(xr)))
+                    if xr.blocks.iter().any(|b| matches!(b, ReportBlock::Rrtr(_)))
+            )
+        })
+        .count();
     assert!(rrtr_count > 0, "R should have sent at least one RRTR");
 
     // L should have sent at least one DLRR in response.
-    let dlrr_reports: Vec<_> = l.events.iter().filter_map(|(_, e)| {
-        if let Some(RawPacket::RtcpTx(Rtcp::ExtendedReport(xr))) = e.as_raw_packet() {
-            if xr.blocks.iter().any(|b| matches!(b, ReportBlock::Dlrr(_))) {
-                return Some(xr);
+    let dlrr_reports: Vec<_> = l
+        .events
+        .iter()
+        .filter_map(|(_, e)| {
+            if let Some(RawPacket::RtcpTx(Rtcp::ExtendedReport(xr))) = e.as_raw_packet() {
+                if xr.blocks.iter().any(|b| matches!(b, ReportBlock::Dlrr(_))) {
+                    return Some(xr);
+                }
             }
-        }
-        None
-    }).collect();
-    assert!(!dlrr_reports.is_empty(), "L should have sent DLRR in response to RRTR");
+            None
+        })
+        .collect();
+    assert!(
+        !dlrr_reports.is_empty(),
+        "L should have sent DLRR in response to RRTR"
+    );
 
     // Verify the DLRR contains valid data.
-    let dlrr = dlrr_reports[0].blocks.iter().find_map(|b| match b {
-        ReportBlock::Dlrr(d) => Some(d),
-        _ => None,
-    }).unwrap();
+    let dlrr = dlrr_reports[0]
+        .blocks
+        .iter()
+        .find_map(|b| match b {
+            ReportBlock::Dlrr(d) => Some(d),
+            _ => None,
+        })
+        .unwrap();
     assert!(!dlrr.items.is_empty(), "DLRR should have at least one item");
     let item = &dlrr.items[0];
 
     // The last_rr_time field must be the middle 32 bits of the RRTR's NTP timestamp.
     // Verify it's non-zero and that R received the same value back (round-trip integrity).
-    assert!(item.last_rr_time != 0, "DLRR last_rr_time should be non-zero");
+    assert!(
+        item.last_rr_time != 0,
+        "DLRR last_rr_time should be non-zero"
+    );
     assert!(item.last_rr_delay != 0, "DLRR delay should be non-zero");
 
     // Verify R actually received the DLRR that L sent.
@@ -112,7 +130,10 @@ pub fn dlrr_response_to_rrtr() -> Result<(), RtcError> {
             false
         }
     });
-    assert!(r_received_dlrr, "R should have received the DLRR with matching last_rr_time");
+    assert!(
+        r_received_dlrr,
+        "R should have received the DLRR with matching last_rr_time"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Send DLRR in response to RRTR

Usefulness: subscribers can measure their RTT

https://datatracker.ietf.org/doc/html/rfc3611#section-4.4

https://datatracker.ietf.org/doc/html/rfc3611#section-4.5
