### PR TITLE
send media packets unpadded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Stop padding media packets, no crypto need it #1023
   * Reset SCTP streams when closing data channels and safely reuse stream IDs #1010
   * Fix small padding invisible to the pacer #1020
   * Fix H.264 negotiation: accept a negotiable (downgradable) level and recognize the Constrained High profile #1016

--- a/src/rtp/header.rs
+++ b/src/rtp/header.rs
@@ -91,6 +91,7 @@ impl RtpHeader {
         buf[from + pad - 1] = pad as u8;
     }
 
+    #[allow(dead_code)] // unused since media packets are sent unpadded
     pub(crate) fn pad_packet(
         buf: &mut [u8],
         header_len: usize,

--- a/src/rtp/header.rs
+++ b/src/rtp/header.rs
@@ -91,23 +91,6 @@ impl RtpHeader {
         buf[from + pad - 1] = pad as u8;
     }
 
-    #[allow(dead_code)] // unused since media packets are sent unpadded
-    pub(crate) fn pad_packet(
-        buf: &mut [u8],
-        header_len: usize,
-        body_len: usize,
-        block_size: usize,
-    ) -> usize {
-        let pad_len = block_size - body_len % block_size;
-        if pad_len == block_size {
-            return 0;
-        }
-
-        Self::do_pad(buf, header_len + body_len, pad_len);
-
-        pad_len
-    }
-
     /// Write a packet consisting entirely of padding and write.
     pub fn create_padding_packet(
         buf: &mut [u8],

--- a/src/rtp/srtp.rs
+++ b/src/rtp/srtp.rs
@@ -240,13 +240,9 @@ impl SrtpContext {
 
         match &mut self.rtp {
             Derived::Aes128CmSha1_80 { key, salt, enc, .. } => {
-                assert!(
-                    input.len() % SRTP_BLOCK_SIZE == 0,
-                    "RTP body should be padded to 16 byte block size, {header:?} with \
-                    body length {} was not",
-                    input.len()
-                );
-
+                // arbitrary body lengths are fine: the output buffer below is
+                // allocated with the CTR scratch the ciphers need and truncated
+                // after encryption, so no 16-byte alignment is required.
                 let iv = Aes128CmSha1_80::rtp_iv(*salt, *header.ssrc, srtp_index);
 
                 // Allocate buffer with CTR padding (aws-lc-rs requirement)

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -647,15 +647,12 @@ impl StreamTx {
                     body_out[..body_len].copy_from_slice(pkt.payload.as_ref());
                 }
 
-                // pad for SRTP
-                let pad_len = RtpHeader::pad_packet(
-                    &mut buf[..],
-                    header_len,
-                    body_len + original_seq_len,
-                    SRTP_BLOCK_SIZE,
-                );
-
-                body_len + original_seq_len + pad_len
+                // media packets are sent unpadded: the SRTP ciphers handle
+                // arbitrary body lengths (the CTR scratch alignment is internal
+                // to protect_rtp), and RTP-level padding breaks SFUs that
+                // re-marshal forwarded packets without it while keeping the P
+                // bit (observed with LiveKit -> Chrome, str0m issue #1014)
+                body_len + original_seq_len
             }
             NextPacketKind::Blank(len) => {
                 let len = RtpHeader::create_padding_packet(


### PR DESCRIPTION
fixes #1014

Every outgoing media packet was padded to the 16-byte srtp block with the P bit set. `aes-ctr` is a stream cipher and doesn't need aligned input, so the padding only existed to satisfy the assert in `protect_rtp`. This drops the `pad_packet` call from the media send path and the assert with it. Pacer padding packets are untouched.

On the history question from the issue: the `assert` and `SRTP_BLOCK_SIZE` came in `1c968a30` (sep 2022), when the cipher was already `openssl aes_128_ctr`. The `pad_packet` call followed a week later in `a73562de` to satisfy the `assert`. None of the backends since (`rust-crypto`, `aws-lc-rs`, the `gcm` profiles) need block-aligned input either, so the padding never had a crypto reason.

I have verified against livekit: the publisher from the issue went from 31034 packets / 0 frames received in Chrome to normal playback with this patch. lib tests pass unchanged.