### PR TITLE
Make RTCP report intervals configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Make audio and video RTCP report intervals configurable #1021
   * Stop padding media packets, no crypto need it #1023
   * Reset SCTP streams when closing data channels and safely reuse stream IDs #1010
   * Fix small padding invisible to the pacer #1020

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,7 +42,7 @@ pub struct RtcConfig {
     pub(crate) codec_config: CodecConfig,
     pub(crate) exts: ExtensionMap,
     pub(crate) stats_interval: Option<Duration>,
-    pub(crate) rtcp_report_intervals: RtcpReportIntervals,
+    pub(crate) intervals: RtcpReportIntervals,
     pub(crate) bwe_config: Option<BweConfig>,
     pub(crate) reordering_size_audio: usize,
     pub(crate) reordering_size_video: usize,
@@ -401,13 +401,13 @@ impl RtcConfig {
     /// Panics if `interval` is zero.
     pub fn set_rtcp_report_interval_audio(mut self, interval: Duration) -> Self {
         assert!(!interval.is_zero());
-        self.rtcp_report_intervals.audio = interval;
+        self.intervals.audio = interval;
         self
     }
 
     /// Returns the interval between RTCP sender/receiver reports for audio streams.
     pub fn rtcp_report_interval_audio(&self) -> Duration {
-        self.rtcp_report_intervals.audio
+        self.intervals.audio
     }
 
     /// Sets the interval between RTCP sender/receiver reports for video streams.
@@ -419,13 +419,13 @@ impl RtcConfig {
     /// Panics if `interval` is zero.
     pub fn set_rtcp_report_interval_video(mut self, interval: Duration) -> Self {
         assert!(!interval.is_zero());
-        self.rtcp_report_intervals.video = interval;
+        self.intervals.video = interval;
         self
     }
 
     /// Returns the interval between RTCP sender/receiver reports for video streams.
     pub fn rtcp_report_interval_video(&self) -> Duration {
-        self.rtcp_report_intervals.video
+        self.intervals.video
     }
 
     /// Enables estimation of available bandwidth (BWE).
@@ -755,7 +755,7 @@ impl Default for RtcConfig {
             codec_config: CodecConfig::new_with_defaults(),
             exts: ExtensionMap::standard(),
             stats_interval: None,
-            rtcp_report_intervals: RtcpReportIntervals {
+            intervals: RtcpReportIntervals {
                 audio: Duration::from_secs(5),
                 video: Duration::from_secs(1),
             },

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,8 @@ pub struct RtcConfig {
     pub(crate) codec_config: CodecConfig,
     pub(crate) exts: ExtensionMap,
     pub(crate) stats_interval: Option<Duration>,
+    pub(crate) rtcp_report_interval_audio: Duration,
+    pub(crate) rtcp_report_interval_video: Duration,
     pub(crate) bwe_config: Option<BweConfig>,
     pub(crate) reordering_size_audio: usize,
     pub(crate) reordering_size_video: usize,
@@ -385,6 +387,42 @@ impl RtcConfig {
         self.stats_interval
     }
 
+    /// Sets the interval between RTCP sender/receiver reports for audio streams.
+    ///
+    /// Defaults to 5 seconds.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `interval` is zero.
+    pub fn set_rtcp_report_interval_audio(mut self, interval: Duration) -> Self {
+        assert!(!interval.is_zero());
+        self.rtcp_report_interval_audio = interval;
+        self
+    }
+
+    /// Returns the interval between RTCP sender/receiver reports for audio streams.
+    pub fn rtcp_report_interval_audio(&self) -> Duration {
+        self.rtcp_report_interval_audio
+    }
+
+    /// Sets the interval between RTCP sender/receiver reports for video streams.
+    ///
+    /// Defaults to 1 second.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `interval` is zero.
+    pub fn set_rtcp_report_interval_video(mut self, interval: Duration) -> Self {
+        assert!(!interval.is_zero());
+        self.rtcp_report_interval_video = interval;
+        self
+    }
+
+    /// Returns the interval between RTCP sender/receiver reports for video streams.
+    pub fn rtcp_report_interval_video(&self) -> Duration {
+        self.rtcp_report_interval_video
+    }
+
     /// Enables estimation of available bandwidth (BWE).
     ///
     /// None disables the BWE. This is an estimation of the send bandwidth, not receive.
@@ -712,6 +750,8 @@ impl Default for RtcConfig {
             codec_config: CodecConfig::new_with_defaults(),
             exts: ExtensionMap::standard(),
             stats_interval: None,
+            rtcp_report_interval_audio: Duration::from_secs(5),
+            rtcp_report_interval_video: Duration::from_secs(1),
             bwe_config: None,
             reordering_size_audio: 15,
             reordering_size_video: 30,

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,8 +42,7 @@ pub struct RtcConfig {
     pub(crate) codec_config: CodecConfig,
     pub(crate) exts: ExtensionMap,
     pub(crate) stats_interval: Option<Duration>,
-    pub(crate) rtcp_report_interval_audio: Duration,
-    pub(crate) rtcp_report_interval_video: Duration,
+    pub(crate) rtcp_report_intervals: RtcpReportIntervals,
     pub(crate) bwe_config: Option<BweConfig>,
     pub(crate) reordering_size_audio: usize,
     pub(crate) reordering_size_video: usize,
@@ -60,6 +59,12 @@ pub struct RtcConfig {
 #[derive(Debug, Clone)]
 pub(crate) struct BweConfig {
     pub(crate) initial_bitrate: Bitrate,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RtcpReportIntervals {
+    pub(crate) audio: Duration,
+    pub(crate) video: Duration,
 }
 
 impl RtcConfig {
@@ -396,13 +401,13 @@ impl RtcConfig {
     /// Panics if `interval` is zero.
     pub fn set_rtcp_report_interval_audio(mut self, interval: Duration) -> Self {
         assert!(!interval.is_zero());
-        self.rtcp_report_interval_audio = interval;
+        self.rtcp_report_intervals.audio = interval;
         self
     }
 
     /// Returns the interval between RTCP sender/receiver reports for audio streams.
     pub fn rtcp_report_interval_audio(&self) -> Duration {
-        self.rtcp_report_interval_audio
+        self.rtcp_report_intervals.audio
     }
 
     /// Sets the interval between RTCP sender/receiver reports for video streams.
@@ -414,13 +419,13 @@ impl RtcConfig {
     /// Panics if `interval` is zero.
     pub fn set_rtcp_report_interval_video(mut self, interval: Duration) -> Self {
         assert!(!interval.is_zero());
-        self.rtcp_report_interval_video = interval;
+        self.rtcp_report_intervals.video = interval;
         self
     }
 
     /// Returns the interval between RTCP sender/receiver reports for video streams.
     pub fn rtcp_report_interval_video(&self) -> Duration {
-        self.rtcp_report_interval_video
+        self.rtcp_report_intervals.video
     }
 
     /// Enables estimation of available bandwidth (BWE).
@@ -750,8 +755,10 @@ impl Default for RtcConfig {
             codec_config: CodecConfig::new_with_defaults(),
             exts: ExtensionMap::standard(),
             stats_interval: None,
-            rtcp_report_interval_audio: Duration::from_secs(5),
-            rtcp_report_interval_video: Duration::from_secs(1),
+            rtcp_report_intervals: RtcpReportIntervals {
+                audio: Duration::from_secs(5),
+                video: Duration::from_secs(1),
+            },
             bwe_config: None,
             reordering_size_audio: 15,
             reordering_size_video: 30,

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,12 @@ pub(crate) struct RtcpReportIntervals {
     pub(crate) video: Duration,
 }
 
+impl RtcpReportIntervals {
+    pub(crate) fn for_audio(self, audio: bool) -> Duration {
+        if audio { self.audio } else { self.video }
+    }
+}
+
 impl RtcConfig {
     /// Creates a new default config.
     pub fn new() -> Self {

--- a/src/session.rs
+++ b/src/session.rs
@@ -150,7 +150,12 @@ impl Session {
         Session {
             id,
             medias: vec![],
-            streams: Streams::new(enable_stats, *config.mtu.end()),
+            streams: Streams::new(
+                enable_stats,
+                *config.mtu.end(),
+                config.rtcp_report_interval_audio,
+                config.rtcp_report_interval_video,
+            ),
             app: None,
             reordering_size_audio: config.reordering_size_audio,
             reordering_size_video: config.reordering_size_video,

--- a/src/session.rs
+++ b/src/session.rs
@@ -7,6 +7,7 @@ use crate::Event;
 use crate::bwe::BweKind;
 use crate::bwe_::Bwe;
 use crate::config::KeyingMaterial;
+use crate::config_mod::RtcpReportIntervals;
 use crate::crypto::CryptoProvider;
 use crate::crypto::dtls::SrtpProfile;
 use crate::format::CodecConfig;
@@ -30,7 +31,7 @@ use crate::rtp_::{RtpHeader, SessionId, TwccPacketId, extend_u16};
 use crate::rtp_::{SrtpContext, Ssrc};
 use crate::rtp_::{TwccRecvRegister, TwccSendRegister};
 use crate::stats::StatsSnapshot;
-use crate::streams::{RtpPacket, Streams};
+use crate::streams::{RtpPacket, StreamTimeoutConfig, Streams};
 use crate::util::{Soonest, already_happened, not_happening};
 use crate::{Reason, net};
 use crate::{RtcConfig, RtcError};
@@ -59,6 +60,7 @@ pub(crate) struct Session {
 
     reordering_size_audio: usize,
     reordering_size_video: usize,
+    rtcp_report_intervals: RtcpReportIntervals,
     pub send_buffer_audio: usize,
     pub send_buffer_video: usize,
 
@@ -150,15 +152,11 @@ impl Session {
         Session {
             id,
             medias: vec![],
-            streams: Streams::new(
-                enable_stats,
-                *config.mtu.end(),
-                config.rtcp_report_interval_audio,
-                config.rtcp_report_interval_video,
-            ),
+            streams: Streams::new(enable_stats, *config.mtu.end()),
             app: None,
             reordering_size_audio: config.reordering_size_audio,
             reordering_size_video: config.reordering_size_video,
+            rtcp_report_intervals: config.rtcp_report_intervals,
             send_buffer_audio: config.send_buffer_audio,
             send_buffer_video: config.send_buffer_video,
             exts: config.exts.clone(),
@@ -266,7 +264,10 @@ impl Session {
             sender_ssrc,
             do_nack,
             &self.medias,
-            &self.codec_config,
+            StreamTimeoutConfig {
+                codecs: &self.codec_config,
+                report_intervals: self.rtcp_report_intervals,
+            },
             &mut self.feedback_tx,
         );
 
@@ -1012,7 +1013,7 @@ impl Session {
     }
 
     fn regular_feedback_at(&self) -> Option<Instant> {
-        self.streams.regular_feedback_at()
+        self.streams.regular_feedback_at(self.rtcp_report_intervals)
     }
 
     fn paused_at(&self) -> Option<Instant> {

--- a/src/session.rs
+++ b/src/session.rs
@@ -60,7 +60,7 @@ pub(crate) struct Session {
 
     reordering_size_audio: usize,
     reordering_size_video: usize,
-    rtcp_report_intervals: RtcpReportIntervals,
+    intervals: RtcpReportIntervals,
     pub send_buffer_audio: usize,
     pub send_buffer_video: usize,
 
@@ -156,7 +156,7 @@ impl Session {
             app: None,
             reordering_size_audio: config.reordering_size_audio,
             reordering_size_video: config.reordering_size_video,
-            rtcp_report_intervals: config.rtcp_report_intervals,
+            intervals: config.intervals,
             send_buffer_audio: config.send_buffer_audio,
             send_buffer_video: config.send_buffer_video,
             exts: config.exts.clone(),
@@ -266,7 +266,7 @@ impl Session {
             &self.medias,
             StreamTimeoutConfig {
                 codecs: &self.codec_config,
-                report_intervals: self.rtcp_report_intervals,
+                intervals: self.intervals,
             },
             &mut self.feedback_tx,
         );
@@ -1013,7 +1013,7 @@ impl Session {
     }
 
     fn regular_feedback_at(&self) -> Option<Instant> {
-        self.streams.regular_feedback_at(self.rtcp_report_intervals)
+        self.streams.regular_feedback_at(self.intervals)
     }
 
     fn paused_at(&self) -> Option<Instant> {

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
+use crate::config_mod::RtcpReportIntervals;
 use crate::format::CodecConfig;
 use crate::format::PayloadParams;
 use crate::media::{KeyframeRequest, Media, SenderFeedback};
@@ -29,6 +30,15 @@ mod send_queue;
 mod send_stats;
 
 pub(crate) use send::{DEFAULT_RTX_CACHE_DURATION, DEFAULT_RTX_RATIO_CAP};
+
+pub(crate) struct StreamTimeoutConfig<'a> {
+    pub(crate) codecs: &'a CodecConfig,
+    pub(crate) report_intervals: RtcpReportIntervals,
+}
+
+fn rtcp_report_interval(audio: bool, config: RtcpReportIntervals) -> Duration {
+    if audio { config.audio } else { config.video }
+}
 
 /// Packet of RTP data.
 ///
@@ -148,12 +158,6 @@ pub(crate) struct Streams {
     /// Threshold above which an outgoing RTP packet triggers an MTU warning. Used as a
     /// hard cap when selecting RTX cache entries for spurious padding.
     mtu_warn: usize,
-
-    /// Time between regular RTCP sender/receiver reports for audio streams.
-    rtcp_report_interval_audio: Duration,
-
-    /// Time between regular RTCP sender/receiver reports for video streams.
-    rtcp_report_interval_video: Duration,
 }
 
 /// Delay between cleaning up the RxLookup.
@@ -170,12 +174,7 @@ struct RxLookup {
 }
 
 impl Streams {
-    pub(crate) fn new(
-        enable_stats: bool,
-        mtu_warn: usize,
-        rtcp_report_interval_audio: Duration,
-        rtcp_report_interval_video: Duration,
-    ) -> Self {
+    pub(crate) fn new(enable_stats: bool, mtu_warn: usize) -> Self {
         Self {
             streams_rx: Default::default(),
             rx_lookup: Default::default(),
@@ -186,16 +185,6 @@ impl Streams {
             any_nack_active: None,
             enable_stats,
             mtu_warn,
-            rtcp_report_interval_audio,
-            rtcp_report_interval_video,
-        }
-    }
-
-    fn rtcp_report_interval(&self, audio: bool) -> Duration {
-        if audio {
-            self.rtcp_report_interval_audio
-        } else {
-            self.rtcp_report_interval_video
         }
     }
 
@@ -411,13 +400,13 @@ impl Streams {
         None
     }
 
-    pub(crate) fn regular_feedback_at(&self) -> Option<Instant> {
+    pub(crate) fn regular_feedback_at(&self, config: RtcpReportIntervals) -> Option<Instant> {
         let r = self.streams_rx.values().map(|s| {
-            let interval = self.rtcp_report_interval(s.is_audio());
+            let interval = rtcp_report_interval(s.is_audio(), config);
             s.receiver_report_at(interval)
         });
         let s = self.streams_tx.values().map(|s| {
-            let interval = self.rtcp_report_interval(s.is_audio());
+            let interval = rtcp_report_interval(s.is_audio(), config);
             s.sender_report_at(interval)
         });
         r.chain(s).min()
@@ -445,12 +434,17 @@ impl Streams {
         sender_ssrc: Ssrc,
         do_nack: bool,
         medias: &[Media],
-        config: &CodecConfig,
+        config: StreamTimeoutConfig<'_>,
         feedback: &mut VecDeque<Rtcp>,
     ) {
+        let StreamTimeoutConfig {
+            codecs,
+            report_intervals,
+        } = config;
+
         self.mids_to_report.clear(); // Clear for checking StreamRx.
         for stream in self.streams_rx.values() {
-            let interval = self.rtcp_report_interval(stream.is_audio());
+            let interval = rtcp_report_interval(stream.is_audio(), report_intervals);
             if stream.need_rr(now, interval) {
                 self.mids_to_report.push(stream.mid());
             }
@@ -474,7 +468,7 @@ impl Streams {
 
         self.mids_to_report.clear(); // start over for StreamTx.
         for stream in self.streams_tx.values() {
-            let interval = self.rtcp_report_interval(stream.is_audio());
+            let interval = rtcp_report_interval(stream.is_audio(), report_intervals);
             if stream.need_sr(now, interval) {
                 self.mids_to_report.push(stream.mid());
             }
@@ -491,7 +485,7 @@ impl Streams {
             // Finding the first (main) PT that also has RTX for the Media is expensive,
             // this closure is run only when needed.
             // The unwrap is okay because we cannot have StreamTx with a Mid without the corresponding Media.
-            let get_media = move || (medias.iter().find(|m| m.mid() == mid).unwrap(), config);
+            let get_media = move || (medias.iter().find(|m| m.mid() == mid).unwrap(), codecs);
 
             stream.handle_timeout(now, get_media);
         }

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -30,21 +30,6 @@ mod send_stats;
 
 pub(crate) use send::{DEFAULT_RTX_CACHE_DURATION, DEFAULT_RTX_RATIO_CAP};
 
-// Time between regular receiver reports.
-// https://www.rfc-editor.org/rfc/rfc8829#section-5.1.2
-// Should technically be 4 seconds according to spec, but libWebRTC
-// expects video to be every second, and audio every 5 seconds.
-const RR_INTERVAL_VIDEO: Duration = Duration::from_millis(1000);
-const RR_INTERVAL_AUDIO: Duration = Duration::from_millis(5000);
-
-fn rr_interval(audio: bool) -> Duration {
-    if audio {
-        RR_INTERVAL_AUDIO
-    } else {
-        RR_INTERVAL_VIDEO
-    }
-}
-
 /// Packet of RTP data.
 ///
 /// As emitted by [`Event::RtpPacket`][crate::Event::RtpPacket] when using rtp mode.
@@ -163,6 +148,12 @@ pub(crate) struct Streams {
     /// Threshold above which an outgoing RTP packet triggers an MTU warning. Used as a
     /// hard cap when selecting RTX cache entries for spurious padding.
     mtu_warn: usize,
+
+    /// Time between regular RTCP sender/receiver reports for audio streams.
+    rtcp_report_interval_audio: Duration,
+
+    /// Time between regular RTCP sender/receiver reports for video streams.
+    rtcp_report_interval_video: Duration,
 }
 
 /// Delay between cleaning up the RxLookup.
@@ -179,7 +170,12 @@ struct RxLookup {
 }
 
 impl Streams {
-    pub(crate) fn new(enable_stats: bool, mtu_warn: usize) -> Self {
+    pub(crate) fn new(
+        enable_stats: bool,
+        mtu_warn: usize,
+        rtcp_report_interval_audio: Duration,
+        rtcp_report_interval_video: Duration,
+    ) -> Self {
         Self {
             streams_rx: Default::default(),
             rx_lookup: Default::default(),
@@ -190,6 +186,16 @@ impl Streams {
             any_nack_active: None,
             enable_stats,
             mtu_warn,
+            rtcp_report_interval_audio,
+            rtcp_report_interval_video,
+        }
+    }
+
+    fn rtcp_report_interval(&self, audio: bool) -> Duration {
+        if audio {
+            self.rtcp_report_interval_audio
+        } else {
+            self.rtcp_report_interval_video
         }
     }
 
@@ -406,8 +412,14 @@ impl Streams {
     }
 
     pub(crate) fn regular_feedback_at(&self) -> Option<Instant> {
-        let r = self.streams_rx.values().map(|s| s.receiver_report_at());
-        let s = self.streams_tx.values().map(|s| s.sender_report_at());
+        let r = self.streams_rx.values().map(|s| {
+            let interval = self.rtcp_report_interval(s.is_audio());
+            s.receiver_report_at(interval)
+        });
+        let s = self.streams_tx.values().map(|s| {
+            let interval = self.rtcp_report_interval(s.is_audio());
+            s.sender_report_at(interval)
+        });
         r.chain(s).min()
     }
 
@@ -438,7 +450,8 @@ impl Streams {
     ) {
         self.mids_to_report.clear(); // Clear for checking StreamRx.
         for stream in self.streams_rx.values() {
-            if stream.need_rr(now) {
+            let interval = self.rtcp_report_interval(stream.is_audio());
+            if stream.need_rr(now, interval) {
                 self.mids_to_report.push(stream.mid());
             }
         }
@@ -461,7 +474,8 @@ impl Streams {
 
         self.mids_to_report.clear(); // start over for StreamTx.
         for stream in self.streams_tx.values() {
-            if stream.need_sr(now) {
+            let interval = self.rtcp_report_interval(stream.is_audio());
+            if stream.need_sr(now, interval) {
                 self.mids_to_report.push(stream.mid());
             }
         }

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -396,15 +396,9 @@ impl Streams {
         None
     }
 
-    pub(crate) fn regular_feedback_at(&self, intervals: RtcpReportIntervals) -> Option<Instant> {
-        let r = self
-            .streams_rx
-            .values()
-            .map(|s| s.receiver_report_at(intervals));
-        let s = self
-            .streams_tx
-            .values()
-            .map(|s| s.sender_report_at(intervals));
+    pub(crate) fn regular_feedback_at(&self, i: RtcpReportIntervals) -> Option<Instant> {
+        let r = self.streams_rx.values().map(|s| s.receiver_report_at(i));
+        let s = self.streams_tx.values().map(|s| s.sender_report_at(i));
         r.chain(s).min()
     }
 

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -36,14 +36,6 @@ pub(crate) struct StreamTimeoutConfig<'a> {
     pub(crate) intervals: RtcpReportIntervals,
 }
 
-fn rtcp_report_interval(audio: bool, intervals: RtcpReportIntervals) -> Duration {
-    if audio {
-        intervals.audio
-    } else {
-        intervals.video
-    }
-}
-
 /// Packet of RTP data.
 ///
 /// As emitted by [`Event::RtpPacket`][crate::Event::RtpPacket] when using rtp mode.
@@ -405,14 +397,14 @@ impl Streams {
     }
 
     pub(crate) fn regular_feedback_at(&self, intervals: RtcpReportIntervals) -> Option<Instant> {
-        let r = self.streams_rx.values().map(|s| {
-            let interval = rtcp_report_interval(s.is_audio(), intervals);
-            s.receiver_report_at(interval)
-        });
-        let s = self.streams_tx.values().map(|s| {
-            let interval = rtcp_report_interval(s.is_audio(), intervals);
-            s.sender_report_at(interval)
-        });
+        let r = self
+            .streams_rx
+            .values()
+            .map(|s| s.receiver_report_at(intervals));
+        let s = self
+            .streams_tx
+            .values()
+            .map(|s| s.sender_report_at(intervals));
         r.chain(s).min()
     }
 
@@ -445,8 +437,7 @@ impl Streams {
 
         self.mids_to_report.clear(); // Clear for checking StreamRx.
         for stream in self.streams_rx.values() {
-            let interval = rtcp_report_interval(stream.is_audio(), intervals);
-            if stream.need_rr(now, interval) {
+            if stream.need_rr(now, intervals) {
                 self.mids_to_report.push(stream.mid());
             }
         }
@@ -469,8 +460,7 @@ impl Streams {
 
         self.mids_to_report.clear(); // start over for StreamTx.
         for stream in self.streams_tx.values() {
-            let interval = rtcp_report_interval(stream.is_audio(), intervals);
-            if stream.need_sr(now, interval) {
+            if stream.need_sr(now, intervals) {
                 self.mids_to_report.push(stream.mid());
             }
         }

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -33,11 +33,15 @@ pub(crate) use send::{DEFAULT_RTX_CACHE_DURATION, DEFAULT_RTX_RATIO_CAP};
 
 pub(crate) struct StreamTimeoutConfig<'a> {
     pub(crate) codecs: &'a CodecConfig,
-    pub(crate) report_intervals: RtcpReportIntervals,
+    pub(crate) intervals: RtcpReportIntervals,
 }
 
-fn rtcp_report_interval(audio: bool, config: RtcpReportIntervals) -> Duration {
-    if audio { config.audio } else { config.video }
+fn rtcp_report_interval(audio: bool, intervals: RtcpReportIntervals) -> Duration {
+    if audio {
+        intervals.audio
+    } else {
+        intervals.video
+    }
 }
 
 /// Packet of RTP data.
@@ -400,13 +404,13 @@ impl Streams {
         None
     }
 
-    pub(crate) fn regular_feedback_at(&self, config: RtcpReportIntervals) -> Option<Instant> {
+    pub(crate) fn regular_feedback_at(&self, intervals: RtcpReportIntervals) -> Option<Instant> {
         let r = self.streams_rx.values().map(|s| {
-            let interval = rtcp_report_interval(s.is_audio(), config);
+            let interval = rtcp_report_interval(s.is_audio(), intervals);
             s.receiver_report_at(interval)
         });
         let s = self.streams_tx.values().map(|s| {
-            let interval = rtcp_report_interval(s.is_audio(), config);
+            let interval = rtcp_report_interval(s.is_audio(), intervals);
             s.sender_report_at(interval)
         });
         r.chain(s).min()
@@ -437,14 +441,11 @@ impl Streams {
         config: StreamTimeoutConfig<'_>,
         feedback: &mut VecDeque<Rtcp>,
     ) {
-        let StreamTimeoutConfig {
-            codecs,
-            report_intervals,
-        } = config;
+        let StreamTimeoutConfig { codecs, intervals } = config;
 
         self.mids_to_report.clear(); // Clear for checking StreamRx.
         for stream in self.streams_rx.values() {
-            let interval = rtcp_report_interval(stream.is_audio(), report_intervals);
+            let interval = rtcp_report_interval(stream.is_audio(), intervals);
             if stream.need_rr(now, interval) {
                 self.mids_to_report.push(stream.mid());
             }
@@ -468,7 +469,7 @@ impl Streams {
 
         self.mids_to_report.clear(); // start over for StreamTx.
         for stream in self.streams_tx.values() {
-            let interval = rtcp_report_interval(stream.is_audio(), report_intervals);
+            let interval = rtcp_report_interval(stream.is_audio(), intervals);
             if stream.need_sr(now, interval) {
                 self.mids_to_report.push(stream.mid());
             }

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -14,9 +14,9 @@ use crate::stats::{MediaIngressStats, RemoteEgressStats, StatsSnapshot};
 use crate::util::{InstantExt, SystemTimeExt};
 use crate::util::{already_happened, calculate_rtt};
 
+use super::RtpPacket;
 use super::StreamPaused;
 use super::register::ReceiverRegister;
-use super::{RtpPacket, rr_interval};
 
 /// Incoming encoded stream.
 ///
@@ -239,9 +239,12 @@ impl StreamRx {
         self.suppress_nack = suppress;
     }
 
-    pub(crate) fn receiver_report_at(&self) -> Instant {
-        let is_audio = self.rtx.is_none(); // this is maybe not correct, but it's all we got.
-        self.last_receiver_report + rr_interval(is_audio)
+    pub(crate) fn is_audio(&self) -> bool {
+        self.rtx.is_none() // this is maybe not correct, but it's all we got.
+    }
+
+    pub(crate) fn receiver_report_at(&self, interval: Duration) -> Instant {
+        self.last_receiver_report + interval
     }
 
     pub(crate) fn handle_rtcp(&mut self, now: Instant, fb: RtcpFb) {
@@ -558,12 +561,12 @@ impl StreamRx {
         x
     }
 
-    pub(crate) fn need_rr(&self, now: Instant) -> bool {
+    pub(crate) fn need_rr(&self, now: Instant, interval: Duration) -> bool {
         if self.ssrc.is_probe() {
             return false;
         }
 
-        now >= self.receiver_report_at()
+        now >= self.receiver_report_at(interval)
     }
 
     pub(crate) fn create_rr_and_update(
@@ -888,5 +891,17 @@ mod tests {
             "expected repaired media time to move forward"
         );
         assert!(!stream.paused);
+    }
+
+    #[test]
+    fn receiver_report_uses_supplied_interval() {
+        let mut stream = StreamRx::new(7.into(), MidRid("mid".into(), None), false);
+        let now = Instant::now();
+        stream.last_receiver_report = now;
+
+        assert_eq!(
+            stream.receiver_report_at(Duration::from_millis(750)),
+            now + Duration::from_millis(750)
+        );
     }
 }

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -2,6 +2,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use crate::config_mod::RtcpReportIntervals;
 use crate::media::KeyframeRequestKind;
 use crate::rtp_::MidRid;
 use crate::rtp_::{Bitrate, DlrrItem, ExtendedReport, extend_u32};
@@ -239,12 +240,12 @@ impl StreamRx {
         self.suppress_nack = suppress;
     }
 
-    pub(crate) fn is_audio(&self) -> bool {
+    fn is_audio(&self) -> bool {
         self.rtx.is_none() // this is maybe not correct, but it's all we got.
     }
 
-    pub(crate) fn receiver_report_at(&self, interval: Duration) -> Instant {
-        self.last_receiver_report + interval
+    pub(crate) fn receiver_report_at(&self, intervals: RtcpReportIntervals) -> Instant {
+        self.last_receiver_report + intervals.for_audio(self.is_audio())
     }
 
     pub(crate) fn handle_rtcp(&mut self, now: Instant, fb: RtcpFb) {
@@ -561,12 +562,12 @@ impl StreamRx {
         x
     }
 
-    pub(crate) fn need_rr(&self, now: Instant, interval: Duration) -> bool {
+    pub(crate) fn need_rr(&self, now: Instant, intervals: RtcpReportIntervals) -> bool {
         if self.ssrc.is_probe() {
             return false;
         }
 
-        now >= self.receiver_report_at(interval)
+        now >= self.receiver_report_at(intervals)
     }
 
     pub(crate) fn create_rr_and_update(
@@ -894,13 +895,16 @@ mod tests {
     }
 
     #[test]
-    fn receiver_report_uses_supplied_interval() {
+    fn receiver_report_uses_supplied_intervals() {
         let mut stream = StreamRx::new(7.into(), MidRid("mid".into(), None), false);
         let now = Instant::now();
         stream.last_receiver_report = now;
 
         assert_eq!(
-            stream.receiver_report_at(Duration::from_millis(750)),
+            stream.receiver_report_at(RtcpReportIntervals {
+                audio: Duration::from_millis(750),
+                video: Duration::from_millis(500),
+            }),
             now + Duration::from_millis(750)
         );
     }

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
+use crate::config_mod::RtcpReportIntervals;
 use crate::format::CodecConfig;
 use crate::format::PayloadParams;
 use crate::io::DATAGRAM_MAX_PACKET_SIZE;
@@ -892,16 +893,16 @@ impl StreamTx {
         })
     }
 
-    pub(crate) fn is_audio(&self) -> bool {
+    fn is_audio(&self) -> bool {
         self.kind.is_some_and(|kind| kind.is_audio())
     }
 
-    pub(crate) fn sender_report_at(&self, interval: Duration) -> Instant {
+    pub(crate) fn sender_report_at(&self, intervals: RtcpReportIntervals) -> Instant {
         if self.kind.is_none() {
             // First handle_timeout sets the kind. No sender report until then.
             return not_happening();
         }
-        self.last_sender_report + interval
+        self.last_sender_report + intervals.for_audio(self.is_audio())
     }
 
     pub(crate) fn poll_keyframe_request(&mut self) -> Option<KeyframeRequestKind> {
@@ -977,8 +978,8 @@ impl StreamTx {
         Some(())
     }
 
-    pub(crate) fn need_sr(&self, now: Instant, interval: Duration) -> bool {
-        now >= self.sender_report_at(interval)
+    pub(crate) fn need_sr(&self, now: Instant, intervals: RtcpReportIntervals) -> bool {
+        now >= self.sender_report_at(intervals)
     }
 
     pub(crate) fn create_sr_and_update(&mut self, now: Instant, feedback: &mut VecDeque<Rtcp>) {
@@ -1312,14 +1313,17 @@ mod test {
     }
 
     #[test]
-    fn sender_report_uses_supplied_interval() {
+    fn sender_report_uses_supplied_intervals() {
         let mut stream = StreamTx::new(42.into(), None, MidRid(Mid::from("0"), None), false, 1200);
         let now = Instant::now();
         stream.kind = Some(MediaKind::Audio);
         stream.last_sender_report = now;
 
         assert_eq!(
-            stream.sender_report_at(Duration::from_millis(750)),
+            stream.sender_report_at(RtcpReportIntervals {
+                audio: Duration::from_millis(750),
+                video: Duration::from_millis(500),
+            }),
             now + Duration::from_millis(750)
         );
     }

--- a/src/streams/send.rs
+++ b/src/streams/send.rs
@@ -25,10 +25,10 @@ use crate::stats::StatsSnapshot;
 use crate::util::value_history::ValueHistory;
 use crate::util::{InstantExt, already_happened, not_happening};
 
+use super::RtpPacket;
 use super::rtx_cache::RtxCache;
 use super::send_queue::SendQueue;
 use super::send_stats::StreamTxStats;
-use super::{RtpPacket, rr_interval};
 
 /// The smallest size of padding for which we attempt to use a spurious resend. For padding
 /// requests smaller than this we use blank packets instead.
@@ -892,12 +892,16 @@ impl StreamTx {
         })
     }
 
-    pub(crate) fn sender_report_at(&self) -> Instant {
-        let Some(kind) = self.kind else {
+    pub(crate) fn is_audio(&self) -> bool {
+        self.kind.is_some_and(|kind| kind.is_audio())
+    }
+
+    pub(crate) fn sender_report_at(&self, interval: Duration) -> Instant {
+        if self.kind.is_none() {
             // First handle_timeout sets the kind. No sender report until then.
             return not_happening();
-        };
-        self.last_sender_report + rr_interval(kind.is_audio())
+        }
+        self.last_sender_report + interval
     }
 
     pub(crate) fn poll_keyframe_request(&mut self) -> Option<KeyframeRequestKind> {
@@ -973,8 +977,8 @@ impl StreamTx {
         Some(())
     }
 
-    pub(crate) fn need_sr(&self, now: Instant) -> bool {
-        now >= self.sender_report_at()
+    pub(crate) fn need_sr(&self, now: Instant, interval: Duration) -> bool {
+        now >= self.sender_report_at(interval)
     }
 
     pub(crate) fn create_sr_and_update(&mut self, now: Instant, feedback: &mut VecDeque<Rtcp>) {
@@ -1305,5 +1309,18 @@ mod test {
 
         assert_eq!(snapshot.byte_size, 240);
         assert_eq!(snapshot.packet_count, 1);
+    }
+
+    #[test]
+    fn sender_report_uses_supplied_interval() {
+        let mut stream = StreamTx::new(42.into(), None, MidRid(Mid::from("0"), None), false, 1200);
+        let now = Instant::now();
+        stream.kind = Some(MediaKind::Audio);
+        stream.last_sender_report = now;
+
+        assert_eq!(
+            stream.sender_report_at(Duration::from_millis(750)),
+            now + Duration::from_millis(750)
+        );
     }
 }

--- a/tests/config-validation.rs
+++ b/tests/config-validation.rs
@@ -237,6 +237,43 @@ fn config_stats_interval_custom() -> Result<(), RtcError> {
     Ok(())
 }
 
+#[test]
+fn config_rtcp_report_intervals() {
+    let default_config = RtcConfig::new();
+    assert_eq!(
+        default_config.rtcp_report_interval_audio(),
+        Duration::from_secs(5)
+    );
+    assert_eq!(
+        default_config.rtcp_report_interval_video(),
+        Duration::from_secs(1)
+    );
+
+    let config = RtcConfig::new()
+        .set_rtcp_report_interval_audio(Duration::from_millis(750))
+        .set_rtcp_report_interval_video(Duration::from_millis(500));
+    assert_eq!(
+        config.rtcp_report_interval_audio(),
+        Duration::from_millis(750)
+    );
+    assert_eq!(
+        config.rtcp_report_interval_video(),
+        Duration::from_millis(500)
+    );
+}
+
+#[test]
+#[should_panic]
+fn config_rejects_zero_audio_rtcp_report_interval() {
+    RtcConfig::new().set_rtcp_report_interval_audio(Duration::ZERO);
+}
+
+#[test]
+#[should_panic]
+fn config_rejects_zero_video_rtcp_report_interval() {
+    RtcConfig::new().set_rtcp_report_interval_video(Duration::ZERO);
+}
+
 /// Test set_stats_interval(None) produces no stats events.
 #[test]
 fn config_stats_disabled() -> Result<(), RtcError> {


### PR DESCRIPTION
## Summary

- add per-`Rtc` audio and video RTCP sender/receiver report interval configuration
- preserve the existing 5 second audio and 1 second video defaults
- reject zero-duration intervals and cover defaults, overrides, and scheduling

Fixes #1021