### PR TITLE
Add DirectApi::send_pli_feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  * Add `DirectApi::send_pli_feedback` to send a PLI with a chosen sender SSRC #1025
+
 # 0.22.0
 
   * Make audio and video RTCP report intervals configurable #1021

--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -408,4 +408,18 @@ impl<'a> DirectApi<'a> {
             .session
             .send_app_specific_feedback(sender_ssrc, media_ssrc, payload);
     }
+
+    /// Send a Picture Loss Indication (PLI, PT=206 FMT=1) for a media stream,
+    /// choosing the `sender_ssrc` of the outgoing RTCP feedback.
+    ///
+    /// The PLI is queued into the regular RTCP compound packet. The `sender_ssrc`
+    /// sets the feedback packet's sender SSRC. `media_ssrc` is the SSRC of the
+    /// stream a keyframe is requested for.
+    ///
+    /// Unlike requesting a keyframe on a local receive stream, this does not require a
+    /// receive stream for `media_ssrc` and lets the caller choose the sender SSRC, so it
+    /// can relay a keyframe request for a stream sourced by the remote peer.
+    pub fn send_pli_feedback(&mut self, sender_ssrc: Ssrc, media_ssrc: Ssrc) {
+        self.rtc.session.send_pli_feedback(sender_ssrc, media_ssrc);
+    }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -23,6 +23,7 @@ use crate::pacer::{Pacer, PacerImpl};
 use crate::rtp::{Extension, RawPacket};
 use crate::rtp_::Direction;
 use crate::rtp_::MidRid;
+use crate::rtp_::Pli;
 use crate::rtp_::Pt;
 use crate::rtp_::SRTCP_OVERHEAD;
 use crate::rtp_::SeqNo;
@@ -359,6 +360,16 @@ impl Session {
         };
         self.feedback_tx
             .push_back(Rtcp::AppSpecificFeedback(feedback));
+    }
+
+    /// Enqueue a Picture Loss Indication (PLI, PT=206 FMT=1) for `media_ssrc`, to be
+    /// sent as part of the regular RTCP compound packet. The feedback packet's sender
+    /// SSRC is set to `sender_ssrc`.
+    pub(crate) fn send_pli_feedback(&mut self, sender_ssrc: Ssrc, media_ssrc: Ssrc) {
+        self.feedback_tx.push_back(Rtcp::Pli(Pli {
+            sender_ssrc,
+            ssrc: media_ssrc,
+        }));
     }
 
     pub fn handle_rtp_receive(&mut self, now: Instant, message: &[u8]) {

--- a/tests/pli-feedback.rs
+++ b/tests/pli-feedback.rs
@@ -1,0 +1,65 @@
+use std::time::Duration;
+
+use str0m::media::MediaKind;
+use str0m::rtp::Ssrc;
+use str0m::{Event, RtcError};
+
+mod common;
+use common::{connect_l_r, init_crypto_default, init_log, progress};
+
+/// A PLI sent from one peer via [`DirectApi::send_pli_feedback`] is received by the
+/// other peer as an `Event::KeyframeRequest`.
+#[test]
+pub fn pli_feedback_direct_api() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let (mut l, mut r) = connect_l_r();
+
+    // R sources a video stream (ssrc_r) that L receives; L will request a keyframe for it.
+    let mid = "vid".into();
+    let ssrc_l: Ssrc = 100.into();
+    let ssrc_r: Ssrc = 200.into();
+
+    l.direct_api().declare_media(mid, MediaKind::Video);
+    l.direct_api().declare_stream_tx(ssrc_l, None, mid, None);
+    l.direct_api().expect_stream_rx(ssrc_r, None, mid, None);
+
+    r.direct_api().declare_media(mid, MediaKind::Video);
+    r.direct_api().declare_stream_tx(ssrc_r, None, mid, None);
+    r.direct_api().expect_stream_rx(ssrc_l, None, mid, None);
+
+    // Sync clocks
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    // L requests a keyframe for R's stream, choosing L's SSRC as the feedback sender.
+    l.direct_api().send_pli_feedback(ssrc_l, ssrc_r);
+
+    // Progress until R receives the keyframe request event.
+    let deadline = l.last + Duration::from_secs(5);
+    let mut received = false;
+
+    loop {
+        if l.last > deadline || r.last > deadline {
+            break;
+        }
+        progress(&mut l, &mut r)?;
+
+        for (_time, event) in r.events.drain(..) {
+            if let Event::KeyframeRequest(req) = event {
+                assert_eq!(req.mid, mid);
+                received = true;
+            }
+        }
+
+        if received {
+            break;
+        }
+    }
+
+    assert!(received, "R should have received a KeyframeRequest from L");
+
+    Ok(())
+}


### PR DESCRIPTION
Send a Picture Loss Indication (PLI, PT=206 FMT=1) for a media SSRC with a caller-chosen RTCP sender SSRC. Unlike requesting a keyframe on a local receive stream, this needs no receive stream for the media SSRC and lets the caller set the feedback's sender SSRC, so it can relay a keyframe request for a stream sourced by the remote peer.