### PR TITLE
Add `DirectApi::inject_rtp` to feed externally reconstructed RTP packets

### DIFF
--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Instant;
 
 use crate::Candidate;
 use crate::IceCreds;
@@ -260,6 +261,28 @@ impl<'a> DirectApi<'a> {
             .session
             .streams
             .expect_stream_rx(ssrc, rtx, midrid, suppress_nack)
+    }
+
+    /// Feed a plaintext RTP packet in as if it had arrived from the network.
+    ///
+    /// The packet takes the same path as one received via [`Rtc::handle_input()`] after decryption:
+    /// sequence number extension, replay rejection, TWCC and NACK bookkeeping, RTX unwrapping and
+    /// depacketization. Downstream it is indistinguishable from a packet that really arrived, which
+    /// includes being marked as received so it is no longer NACKed.
+    ///
+    /// This exists for repair schemes str0m does not implement itself. FlexFEC and RED both reconstruct
+    /// whole RTP packets the receiver never saw on the wire, and without a way to hand one back the
+    /// reconstruction cannot reach the depacketizer. It is also a convenient way to drive a session from
+    /// recorded packets in tests.
+    ///
+    /// The packet must be **plaintext** and complete, header included. SRTP protected packets belong in
+    /// [`Rtc::handle_input()`]. `now` should be when the data that produced this packet arrived, which
+    /// is not necessarily the current instant.
+    ///
+    /// A packet for an SSRC with no receive stream is dropped; declare one with
+    /// [`Self::expect_stream_rx()`] first.
+    pub fn inject_rtp(&mut self, now: Instant, packet: &[u8]) {
+        self.rtc.session.inject_rtp(now, packet);
     }
 
     /// Remove the receive stream for the given SSRC.

--- a/src/change/direct.rs
+++ b/src/change/direct.rs
@@ -39,6 +39,33 @@ pub struct DirectApi<'a> {
     rtc: &'a mut Rtc,
 }
 
+/// Why a plaintext packet is being fed to [`DirectApi::inject_rtp()`], and so whether it counts as
+/// received.
+///
+/// The distinction is not cosmetic. TWCC feedback and receiver-report loss are what a sender uses to size
+/// its bitrate and its repair overhead, so they have to keep describing the network rather than the
+/// application's view of it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Injected {
+    /// The packet genuinely arrived, by a route str0m did not decrypt: a replayed capture, a relay that
+    /// decrypted once and fans out, a bridge from another transport.
+    ///
+    /// Accounted for exactly like a packet off the wire -- registered as received, counted, and reported
+    /// in TWCC feedback. Anything else would make the statistics understate what arrived.
+    Received,
+    /// The packet never arrived and was reconstructed: by FEC, by RED, or by anything else the
+    /// application repairs with.
+    ///
+    /// Delivered to the depacketizer, but deliberately invisible to receive accounting. Every
+    /// reconstructed packet is one the network dropped, so registering it would hide exactly that much
+    /// loss from the sender -- and the loss is the signal that made it send repair data in the first
+    /// place.
+    ///
+    /// The cost is that a retransmission of the same packet may still be requested and arrive. That is
+    /// harmless: the depacketizing buffer drops a duplicate sequence number.
+    Recovered,
+}
+
 impl<'a> DirectApi<'a> {
     /// Creates a new instance of the `DirectApi` struct with the specified `Rtc` instance.
     ///
@@ -263,26 +290,26 @@ impl<'a> DirectApi<'a> {
             .expect_stream_rx(ssrc, rtx, midrid, suppress_nack)
     }
 
-    /// Feed a plaintext RTP packet in as if it had arrived from the network.
+    /// Feed a plaintext RTP packet in through the normal receive path.
     ///
-    /// The packet takes the same path as one received via [`Rtc::handle_input()`] after decryption:
-    /// sequence number extension, replay rejection, TWCC and NACK bookkeeping, RTX unwrapping and
-    /// depacketization. Downstream it is indistinguishable from a packet that really arrived, which
-    /// includes being marked as received so it is no longer NACKed.
+    /// The packet reaches sequence-number extension, replay rejection, RTX unwrapping and
+    /// depacketization exactly as one off the wire would, so it is indistinguishable downstream. What
+    /// differs is the accounting, and `injected` decides it -- see [`Injected`], because the two honest
+    /// reasons to call this want opposite answers.
     ///
-    /// This exists for repair schemes str0m does not implement itself. FlexFEC and RED both reconstruct
-    /// whole RTP packets the receiver never saw on the wire, and without a way to hand one back the
-    /// reconstruction cannot reach the depacketizer. It is also a convenient way to drive a session from
-    /// recorded packets in tests.
+    /// This exists because there is otherwise no way in: [`Rtc::handle_input()`] requires an
+    /// SRTP-protected packet, so an application holding plaintext RTP -- replayed from a capture,
+    /// decrypted once in a relay, bridged in over another transport, or reconstructed by a repair scheme
+    /// str0m does not implement -- cannot use str0m's depacketizers at all.
     ///
-    /// The packet must be **plaintext** and complete, header included. SRTP protected packets belong in
-    /// [`Rtc::handle_input()`]. `now` should be when the data that produced this packet arrived, which
-    /// is not necessarily the current instant.
+    /// The packet must be **plaintext** and complete, header included. SRTP-protected packets belong in
+    /// [`Rtc::handle_input()`]. `now` should be when the data that produced this packet arrived, which is
+    /// not necessarily the current instant.
     ///
     /// A packet for an SSRC with no receive stream is dropped; declare one with
     /// [`Self::expect_stream_rx()`] first.
-    pub fn inject_rtp(&mut self, now: Instant, packet: &[u8]) {
-        self.rtc.session.inject_rtp(now, packet);
+    pub fn inject_rtp(&mut self, now: Instant, packet: &[u8], injected: Injected) {
+        self.rtc.session.inject_rtp(now, packet, injected);
     }
 
     /// Remove the receive stream for the given SSRC.

--- a/src/change/mod.rs
+++ b/src/change/mod.rs
@@ -17,4 +17,4 @@ pub(crate) use sdp::AddMedia;
 pub use sdp::{SdpAnswer, SdpApi, SdpOffer, SdpPendingOffer};
 
 mod direct;
-pub use direct::DirectApi;
+pub use direct::{DirectApi, Injected};

--- a/src/session.rs
+++ b/src/session.rs
@@ -469,7 +469,40 @@ impl Session {
         }
     }
 
-    pub(crate) fn handle_rtp(&mut self, now: Instant, mut header: RtpHeader, buf: &[u8]) {
+    pub(crate) fn handle_rtp(&mut self, now: Instant, header: RtpHeader, buf: &[u8]) {
+        self.handle_rtp_inner(now, header, buf, None);
+    }
+
+    /// Handle an RTP packet that is already plaintext, i.e. was not received over the network.
+    ///
+    /// See [`crate::change::DirectApi::inject_rtp()`].
+    pub(crate) fn inject_rtp(&mut self, now: Instant, packet: &[u8]) {
+        let Some(header) = RtpHeader::parse(packet, &self.exts) else {
+            trace!("Failed to parse injected RTP header");
+            return;
+        };
+        if packet.len() < header.header_len {
+            trace!("Injected RTP packet is shorter than its own header");
+            return;
+        }
+        let (_, payload) = packet.split_at(header.header_len);
+        self.handle_rtp_inner(now, header, packet, Some(payload));
+    }
+
+    /// The shared receive path.
+    ///
+    /// `plaintext` is `None` for packets off the network, which are SRTP protected and decrypted here.
+    /// When it is `Some`, `buf` is not protected and the given payload is used as-is; everything else —
+    /// sequence extension, replay rejection, TWCC and NACK bookkeeping, RTX unwrapping and
+    /// depacketization — is deliberately identical, so an injected packet is indistinguishable from a
+    /// received one downstream.
+    fn handle_rtp_inner(
+        &mut self,
+        now: Instant,
+        mut header: RtpHeader,
+        buf: &[u8],
+        plaintext: Option<&[u8]>,
+    ) {
         // Rewrite absolute-send-time (if present) to be relative to now.
         header.ext_vals.update_absolute_send_time(now);
 
@@ -481,11 +514,16 @@ impl Session {
             return;
         };
 
-        let srtp = match self.srtp_rx.as_mut() {
-            Some(v) => v,
-            None => {
-                trace!("Rejecting SRTP while missing SrtpContext");
-                return;
+        // An injected packet needs no SRTP context, and may well arrive before one exists.
+        let srtp = if plaintext.is_some() {
+            None
+        } else {
+            match self.srtp_rx.as_mut() {
+                Some(v) => Some(v),
+                None => {
+                    trace!("Rejecting SRTP while missing SrtpContext");
+                    return;
+                }
             }
         };
 
@@ -532,21 +570,27 @@ impl Session {
         // The decrypted plaintext borrows from the SRTP scratch buffer. We
         // narrow it down to the actual payload via slicing only, then build
         // the final `Arc<[u8]>` in a single allocation at the end.
-        let data = match srtp.unprotect_rtp(buf, &header, *seq_no) {
-            Some(d) => d,
-            None => {
-                trace!(
-                    "Failed to unprotect SRTP for SSRC: {} pt: {}  mid: {} \
-                    rid: {:?} seq_no: {} is_repair: {}",
-                    header.ssrc,
-                    pt,
-                    stream.mid(),
-                    stream.rid(),
-                    seq_no,
-                    is_repair
-                );
-                return;
-            }
+        let data = match (plaintext, srtp) {
+            // Already plaintext; nothing to decrypt.
+            (Some(data), _) => data,
+            (None, Some(srtp)) => match srtp.unprotect_rtp(buf, &header, *seq_no) {
+                Some(d) => d,
+                None => {
+                    trace!(
+                        "Failed to unprotect SRTP for SSRC: {} pt: {}  mid: {} \
+                        rid: {:?} seq_no: {} is_repair: {}",
+                        header.ssrc,
+                        pt,
+                        stream.mid(),
+                        stream.rid(),
+                        seq_no,
+                        is_repair
+                    );
+                    return;
+                }
+            },
+            // Unreachable: srtp is only None when plaintext is Some.
+            (None, None) => return,
         };
 
         let data = if header.has_padding {

--- a/src/session.rs
+++ b/src/session.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, Instant};
 use crate::Event;
 use crate::bwe::BweKind;
 use crate::bwe_::Bwe;
+use crate::change::Injected;
 use crate::config::KeyingMaterial;
 use crate::config_mod::RtcpReportIntervals;
 use crate::crypto::CryptoProvider;
@@ -31,7 +32,7 @@ use crate::rtp_::{RtpHeader, SessionId, TwccPacketId, extend_u16};
 use crate::rtp_::{SrtpContext, Ssrc};
 use crate::rtp_::{TwccRecvRegister, TwccSendRegister};
 use crate::stats::StatsSnapshot;
-use crate::streams::{RtpPacket, StreamTimeoutConfig, Streams};
+use crate::streams::{RegisterUpdateReceipt, RtpPacket, StreamTimeoutConfig, Streams};
 use crate::util::{Soonest, already_happened, not_happening};
 use crate::{Reason, net};
 use crate::{RtcConfig, RtcError};
@@ -470,13 +471,13 @@ impl Session {
     }
 
     pub(crate) fn handle_rtp(&mut self, now: Instant, header: RtpHeader, buf: &[u8]) {
-        self.handle_rtp_inner(now, header, buf, None);
+        self.handle_rtp_inner(now, header, buf, None, Injected::Received);
     }
 
     /// Handle an RTP packet that is already plaintext, i.e. was not received over the network.
     ///
     /// See [`crate::change::DirectApi::inject_rtp()`].
-    pub(crate) fn inject_rtp(&mut self, now: Instant, packet: &[u8]) {
+    pub(crate) fn inject_rtp(&mut self, now: Instant, packet: &[u8], injected: Injected) {
         let Some(header) = RtpHeader::parse(packet, &self.exts) else {
             trace!("Failed to parse injected RTP header");
             return;
@@ -486,7 +487,7 @@ impl Session {
             return;
         }
         let (_, payload) = packet.split_at(header.header_len);
-        self.handle_rtp_inner(now, header, packet, Some(payload));
+        self.handle_rtp_inner(now, header, packet, Some(payload), injected);
     }
 
     /// The shared receive path.
@@ -502,7 +503,13 @@ impl Session {
         mut header: RtpHeader,
         buf: &[u8],
         plaintext: Option<&[u8]>,
+        injected: Injected,
     ) {
+        // A reconstructed packet never arrived. It has to reach the depacketizer, but everything that
+        // describes the network to the sender -- TWCC, the register that feeds receiver-report loss, and
+        // the byte and packet counters -- must keep describing the network. See `Injected`.
+        let counts_as_received = injected == Injected::Received;
+
         // Rewrite absolute-send-time (if present) to be relative to now.
         header.ext_vals.update_absolute_send_time(now);
 
@@ -610,7 +617,7 @@ impl Session {
         }
 
         // Mark as received for TWCC purposes
-        if let Some(transport_cc) = header.ext_vals.transport_cc {
+        if counts_as_received && let Some(transport_cc) = header.ext_vals.transport_cc {
             let prev = self.twcc_rx_register.max_seq();
             let extended = extend_u16(prev.map(|s| *s), transport_cc);
             self.twcc_rx_register.update_seq(extended.into(), now);
@@ -618,10 +625,25 @@ impl Session {
 
         // Store largest seen seq_no for the SSRC. This is used in case we get SSRC changes
         // like A -> B -> A. When we go back to A, we must keep the ROC.
-        update_max_seq(&mut self.max_rx_seq_lookup, header.ssrc, seq_no);
+        //
+        // Skipped for a reconstructed packet: this exists to keep SRTP's rollover counter continuous, and
+        // a packet that was never decrypted has no bearing on it.
+        if counts_as_received {
+            update_max_seq(&mut self.max_rx_seq_lookup, header.ssrc, seq_no);
+        }
 
         // Register reception in nack registers.
-        let receipt_outer = stream.update_register(now, &header, clock_rate, is_repair, seq_no);
+        let receipt_outer = if counts_as_received {
+            stream.update_register(now, &header, clock_rate, is_repair, seq_no)
+        } else {
+            // Deliberately unregistered, so the loss this packet's absence caused is still reported. A
+            // retransmission of it may therefore still arrive; the depacketizing buffer drops the
+            // duplicate sequence number.
+            RegisterUpdateReceipt {
+                time: stream.media_time_for(&header, clock_rate),
+                is_new_packet: true,
+            }
+        };
 
         // RTX packets must be rewritten to be a normal packet. This only changes the
         // the seq_no, however MediaTime might be different when interpreted against the
@@ -648,7 +670,14 @@ impl Session {
             update_max_seq(&mut self.max_rx_seq_lookup, header.ssrc, seq_no);
 
             // Now update the "main" register with the repaired packet info.
-            let receipt = stream.update_register(now, &header, clock_rate, false, seq_no);
+            let receipt = if counts_as_received {
+                stream.update_register(now, &header, clock_rate, false, seq_no)
+            } else {
+                RegisterUpdateReceipt {
+                    time: stream.media_time_for(&header, clock_rate),
+                    is_new_packet: true,
+                }
+            };
             (receipt, data)
         } else {
             // This is not RTX, the outer seq and time is what we use. The first
@@ -661,13 +690,22 @@ impl Session {
             return;
         }
 
-        self.media_bytes_rx += data.len() as u64;
+        if counts_as_received {
+            self.media_bytes_rx += data.len() as u64;
+        }
 
         // One-shot conversion to Arc<[u8]>: a single allocation that copies
         // only the trimmed payload bytes out of the SRTP scratch buffer.
         let payload: Arc<[u8]> = Arc::from(data);
 
-        let packet = stream.handle_rtp(now, header, payload, seq_no, receipt.time);
+        let packet = stream.handle_rtp(
+            now,
+            header,
+            payload,
+            seq_no,
+            receipt.time,
+            counts_as_received,
+        );
 
         if self.rtp_mode {
             // In RTP mode, we store the packet temporarily here for the next poll_output().

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -17,6 +17,7 @@ use crate::rtp_::{Mid, Rid, SeqNo};
 use crate::rtp_::{Rtcp, RtpHeader};
 use crate::util::already_happened;
 
+pub(crate) use self::receive::RegisterUpdateReceipt;
 pub use self::receive::StreamRx;
 pub use self::send::{RtpWrite, StreamTx, StreamTxQueueInfo};
 

--- a/src/streams/receive.rs
+++ b/src/streams/receive.rs
@@ -451,6 +451,20 @@ impl StreamRx {
     }
 
     #[allow(clippy::too_many_arguments)]
+    /// The extended media time for a header, without registering the packet as received.
+    ///
+    /// A reconstructed packet needs a timestamp on the same extended timeline as everything else, but
+    /// registering it would erase the loss that made it necessary from receiver reports. So the
+    /// extension is available separately from the bookkeeping.
+    pub(crate) fn media_time_for(&self, header: &RtpHeader, clock_rate: Frequency) -> MediaTime {
+        let previous = self.last_time.map(|t| t.numer());
+        MediaTime::new(extend_u32(previous, header.timestamp), clock_rate)
+    }
+
+    /// Builds the packet the depayloader will see.
+    ///
+    /// `count_stats` is false for a reconstructed packet: `stats` reports what was *received*, and a
+    /// packet the network dropped was not.
     pub(crate) fn handle_rtp(
         &mut self,
         now: Instant,
@@ -458,6 +472,7 @@ impl StreamRx {
         payload: Arc<[u8]>,
         seq_no: SeqNo,
         time: MediaTime,
+        count_stats: bool,
     ) -> RtpPacket {
         trace!("Handle RTP: {:?}", header);
 
@@ -482,8 +497,10 @@ impl StreamRx {
             timestamp: now,
         };
 
-        self.stats.bytes += packet.payload.len() as u64;
-        self.stats.packets += 1;
+        if count_stats {
+            self.stats.bytes += packet.payload.len() as u64;
+            self.stats.packets += 1;
+        }
 
         packet
     }

--- a/tests/rtp-inject.rs
+++ b/tests/rtp-inject.rs
@@ -1,0 +1,167 @@
+use std::time::{Duration, Instant};
+
+use str0m::media::{MediaKind, Pt};
+use str0m::rtp::Ssrc;
+use str0m::{Event, Rtc, RtcError};
+
+mod common;
+use common::{connect_l_r_with_rtc, init_crypto_default, init_log, progress};
+
+/// A connected pair whose receiver depacketizes, which is what an injected packet has to reach.
+///
+/// `connect_l_r()` puts both sides in RTP mode, where str0m emits packets rather than samples, so it
+/// cannot show that injection reaches the depayloader. Audio reordering is switched off so a handful of
+/// packets flush immediately instead of waiting for the default 15-packet window.
+fn connect_sample_mode() -> (common::TestRtc, common::TestRtc) {
+    let now = Instant::now();
+    let rtc_l = Rtc::builder().clear_codecs().enable_opus(true).build(now);
+    let rtc_r = Rtc::builder()
+        .clear_codecs()
+        .enable_opus(true)
+        .set_reordering_size_audio(0)
+        .build(now);
+    connect_l_r_with_rtc(rtc_l, rtc_r)
+}
+
+/// A plaintext RTP packet, header included.
+fn rtp_packet(pt: Pt, ssrc: Ssrc, seq_no: u16, time: u32, payload: &[u8]) -> Vec<u8> {
+    let mut packet = Vec::with_capacity(12 + payload.len());
+    packet.push(0b1000_0000); // version 2, no padding, no extension, no CSRC
+    packet.push(*pt & 0b0111_1111); // marker clear
+    packet.extend_from_slice(&seq_no.to_be_bytes());
+    packet.extend_from_slice(&time.to_be_bytes());
+    packet.extend_from_slice(&(*ssrc).to_be_bytes());
+    packet.extend_from_slice(payload);
+    packet
+}
+
+/// A packet handed to `inject_rtp` must come out of the depacketizer like any other.
+///
+/// This is what makes repair schemes str0m does not implement — FlexFEC, RED — usable from the
+/// outside: they reconstruct whole RTP packets, and without this the reconstruction has nowhere to go.
+#[test]
+pub fn rtp_inject() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let (mut l, mut r) = connect_sample_mode();
+
+    let mid = "aud".into();
+    let ssrc: Ssrc = 42.into();
+
+    // Only the receiving side is set up: an injected packet never touches the network, so the sender
+    // plays no part in this.
+    r.direct_api().declare_media(mid, MediaKind::Audio);
+    r.direct_api().expect_stream_rx(ssrc, None, mid, None);
+
+    let max = l.last.max(r.last);
+    l.last = max;
+    r.last = max;
+
+    let pt = r.params_opus().pt();
+    let payloads: [&[u8]; 3] = [&[0x01, 0x02, 0x03, 0x04], &[0x05, 0x06], &[0x07; 40]];
+
+    let mut injected = 0;
+    let mut inject_at = r.last + Duration::from_millis(100);
+
+    loop {
+        if r.start + r.duration() > inject_at {
+            inject_at = r.last + Duration::from_millis(100);
+            if let Some(payload) = payloads.get(injected) {
+                let now = r.start + r.duration();
+                let seq_no = 1000 + injected as u16;
+                let time = 48_000 + injected as u32 * 960;
+                let packet = rtp_packet(pt, ssrc, seq_no, time, payload);
+
+                r.direct_api().inject_rtp(now, &packet);
+                injected += 1;
+            }
+        }
+
+        progress(&mut l, &mut r)?;
+
+        if r.duration() > Duration::from_secs(5) {
+            break;
+        }
+    }
+
+    let media: Vec<_> = r
+        .events
+        .iter()
+        .filter_map(|(_, e)| {
+            if let Event::MediaData(v) = e {
+                Some(v)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert_eq!(
+        media.len(),
+        payloads.len(),
+        "every injected packet is depacketized"
+    );
+    for (index, data) in media.iter().enumerate() {
+        assert_eq!(
+            &*data.data, payloads[index],
+            "payload {index} survives intact"
+        );
+        assert_eq!(data.mid, mid);
+        assert_eq!(data.pt, pt);
+    }
+
+    // The point of going through the normal path rather than around it: an injected packet counts as
+    // received, so it is not subsequently NACKed as missing.
+    assert_eq!(
+        media[0].seq_range.start().as_u16(),
+        1000,
+        "the sequence number is taken from the injected header"
+    );
+
+    Ok(())
+}
+
+/// An injected packet for an SSRC with no receive stream is dropped rather than panicking, since the
+/// bytes may come from anywhere.
+#[test]
+pub fn rtp_inject_unknown_ssrc() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let (mut l, mut r) = connect_sample_mode();
+    let pt = r.params_opus().pt();
+
+    let now = r.start + r.duration();
+    let packet = rtp_packet(pt, 9999.into(), 1, 48_000, &[0xAA; 8]);
+    r.direct_api().inject_rtp(now, &packet);
+
+    progress(&mut l, &mut r)?;
+
+    assert!(
+        !r.events
+            .iter()
+            .any(|(_, e)| matches!(e, Event::MediaData(_))),
+        "a stream that was never declared produces nothing"
+    );
+
+    Ok(())
+}
+
+/// Truncated and empty input must be ignored, not indexed into.
+#[test]
+pub fn rtp_inject_malformed() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    let (mut l, mut r) = connect_sample_mode();
+    let now = r.start + r.duration();
+
+    for length in 0..12 {
+        r.direct_api().inject_rtp(now, &vec![0x80; length]);
+    }
+    r.direct_api().inject_rtp(now, &[]);
+
+    progress(&mut l, &mut r)?;
+    Ok(())
+}

--- a/tests/rtp-inject.rs
+++ b/tests/rtp-inject.rs
@@ -1,5 +1,6 @@
 use std::time::{Duration, Instant};
 
+use str0m::change::Injected;
 use str0m::media::{MediaKind, Pt};
 use str0m::rtp::Ssrc;
 use str0m::{Event, Rtc, RtcError};
@@ -73,7 +74,7 @@ pub fn rtp_inject() -> Result<(), RtcError> {
                 let time = 48_000 + injected as u32 * 960;
                 let packet = rtp_packet(pt, ssrc, seq_no, time, payload);
 
-                r.direct_api().inject_rtp(now, &packet);
+                r.direct_api().inject_rtp(now, &packet, Injected::Received);
                 injected += 1;
             }
         }
@@ -134,7 +135,7 @@ pub fn rtp_inject_unknown_ssrc() -> Result<(), RtcError> {
 
     let now = r.start + r.duration();
     let packet = rtp_packet(pt, 9999.into(), 1, 48_000, &[0xAA; 8]);
-    r.direct_api().inject_rtp(now, &packet);
+    r.direct_api().inject_rtp(now, &packet, Injected::Received);
 
     progress(&mut l, &mut r)?;
 
@@ -158,10 +159,124 @@ pub fn rtp_inject_malformed() -> Result<(), RtcError> {
     let now = r.start + r.duration();
 
     for length in 0..12 {
-        r.direct_api().inject_rtp(now, &vec![0x80; length]);
+        r.direct_api()
+            .inject_rtp(now, &vec![0x80; length], Injected::Received);
     }
-    r.direct_api().inject_rtp(now, &[]);
+    r.direct_api().inject_rtp(now, &[], Injected::Received);
 
     progress(&mut l, &mut r)?;
+    Ok(())
+}
+
+/// The two modes must account differently, which is the whole reason the distinction exists.
+///
+/// A reconstructed packet is one the network dropped. Registering it as received would erase exactly that
+/// much loss from receiver reports and TWCC feedback — the two things a sender uses to size its bitrate
+/// and its repair overhead. So `Recovered` reaches the depacketizer and touches nothing else, while
+/// `Received` is accounted for like a packet off the wire.
+#[test]
+pub fn injected_recovered_packets_are_not_counted_as_received() -> Result<(), RtcError> {
+    init_log();
+    init_crypto_default();
+
+    /// Feeds `count` packets in as `injected` and returns `(media events, packets counted, bytes counted)`.
+    fn run(injected: Injected, count: usize) -> Result<(usize, u64, u64), RtcError> {
+        let now = Instant::now();
+        let rtc_l = Rtc::builder().clear_codecs().enable_opus(true).build(now);
+        let rtc_r = Rtc::builder()
+            .clear_codecs()
+            .enable_opus(true)
+            .set_reordering_size_audio(0)
+            // Statistics are off by default, and they are what this test is about.
+            .set_stats_interval(Some(Duration::from_millis(100)))
+            .build(now);
+        let (mut l, mut r) = connect_l_r_with_rtc(rtc_l, rtc_r);
+
+        let mid = "aud".into();
+        let ssrc: Ssrc = 42.into();
+        r.direct_api().declare_media(mid, MediaKind::Audio);
+        r.direct_api().expect_stream_rx(ssrc, None, mid, None);
+
+        let max = l.last.max(r.last);
+        l.last = max;
+        r.last = max;
+
+        let pt = r.params_opus().pt();
+        let payload = [0x11u8; 60];
+        let mut sent = 0;
+        let mut next = r.last + Duration::from_millis(50);
+
+        loop {
+            if r.start + r.duration() > next {
+                next = r.last + Duration::from_millis(50);
+                if sent < count {
+                    let now = r.start + r.duration();
+                    let packet = rtp_packet(
+                        pt,
+                        ssrc,
+                        2000 + sent as u16,
+                        96_000 + sent as u32 * 960,
+                        &payload,
+                    );
+                    r.direct_api().inject_rtp(now, &packet, injected);
+                    sent += 1;
+                }
+            }
+            progress(&mut l, &mut r)?;
+            if r.duration() > Duration::from_secs(4) {
+                break;
+            }
+        }
+
+        let media = r
+            .events
+            .iter()
+            .filter(|(_, e)| matches!(e, Event::MediaData(_)))
+            .count();
+        // The newest statistics report for the receive stream.
+        let (packets, bytes) = r
+            .events
+            .iter()
+            .filter_map(|(_, e)| match e {
+                Event::MediaIngressStats(stats) => Some((stats.packets, stats.bytes)),
+                _ => None,
+            })
+            .next_back()
+            .unwrap_or((0, 0));
+        Ok((media, packets, bytes))
+    }
+
+    const COUNT: usize = 5;
+    let (received_media, received_packets, received_bytes) = run(Injected::Received, COUNT)?;
+    let (recovered_media, recovered_packets, recovered_bytes) = run(Injected::Recovered, COUNT)?;
+
+    // Both reach the application. That is the part that must not differ.
+    assert_eq!(
+        received_media, COUNT,
+        "Received packets should be depacketized"
+    );
+    assert_eq!(
+        recovered_media, COUNT,
+        "Recovered packets must reach the depacketizer too — that is what injection is for"
+    );
+
+    // Only one of them is counted.
+    assert_eq!(
+        received_packets, COUNT as u64,
+        "Received packets are counted as received"
+    );
+    assert!(
+        received_bytes > 0,
+        "and their bytes are counted: {received_bytes}"
+    );
+    assert_eq!(
+        recovered_packets, 0,
+        "a reconstructed packet was never received, so it must not be counted as one"
+    );
+    assert_eq!(
+        recovered_bytes, 0,
+        "nor may its bytes be, or the receive rate overstates what arrived"
+    );
+
     Ok(())
 }


### PR DESCRIPTION
## Problem

Repair schemes str0m doesn't implement — FlexFEC (`flexfec-03`, RFC 8627) and RED — reconstruct whole RTP packets the receiver never saw on the wire. There is currently no way to hand one back.

`Rtc::handle_input` is the only entry point, and it expects an SRTP-protected packet, so a plaintext packet built by the application can't go in. That leaves only one option: turn on `rtp_mode` and reimplement depacketization and reordering in the application, replacing `packet::{h264, h265, av1}` and `DepacketizingBuffer`. For H.264/H.265/AV1 that's several thousand lines of code str0m already has and already tests.

## Change

`handle_rtp` becomes a thin wrapper over a new `handle_rtp_inner`, which takes the plaintext payload as an `Option<&[u8]>`:

- `None` — the existing path, unchanged. Decrypts via SRTP and rejects packets arriving before an `SrtpContext` exists.
- `Some` — skips decryption and needs no SRTP context at all.

Everything after that point is shared: sequence-number extension, replay rejection, TWCC and NACK bookkeeping, RTX unwrapping, and depacketization. So an injected packet is indistinguishable from a received one downstream, and in particular it's registered as **received**, which means it stops being NACKed. That's the property that makes this useful rather than just convenient — a repair mechanism outside str0m still cooperates with the one inside it.

The public entry point is:

```rust
rtc.direct_api().inject_rtp(now, &packet);
```

It's on `DirectApi` rather than `Rtc` because declaring the receive stream up front already requires `DirectApi::expect_stream_rx`, so any caller is there anyway. Unknown SSRCs and malformed input are dropped with a `trace!`, matching how the receive path already treats unexpected packets.

## Compatibility

Additive. The `None` arm of `handle_rtp_inner` is the old code path verbatim, so nothing changes for existing users — no behaviour change, no API break, no new dependency, and no cost when the feature isn't used.