### PR TITLE
Guard SRTP/SRTCP and RTCP parsing against malformed input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  * Guard SRTP/SRTCP and RTCP parsing against malformed input #1029
+
 # 0.23.0
 
   * Respond to RRTR with DLRR #1022

--- a/crypto/apple-crypto/src/srtp.rs
+++ b/crypto/apple-crypto/src/srtp.rs
@@ -69,7 +69,11 @@ impl AeadAes128GcmCipher for AppleCryptoAeadAes128GcmCipher {
         input: &[u8],
         output: &mut [u8],
     ) -> Result<usize, CryptoError> {
-        assert!(input.len() >= AeadAes128Gcm::TAG_LEN);
+        if input.len() < AeadAes128Gcm::TAG_LEN {
+            return Err(CryptoError::Other(
+                "SRTP GCM decrypt input shorter than auth tag".into(),
+            ));
+        }
         aes_gcm_decrypt(&self.key, iv, aads, input, output)
     }
 }
@@ -104,7 +108,11 @@ impl AeadAes256GcmCipher for AppleCryptoAeadAes256GcmCipher {
         input: &[u8],
         output: &mut [u8],
     ) -> Result<usize, CryptoError> {
-        assert!(input.len() >= AeadAes256Gcm::TAG_LEN);
+        if input.len() < AeadAes256Gcm::TAG_LEN {
+            return Err(CryptoError::Other(
+                "SRTP GCM decrypt input shorter than auth tag".into(),
+            ));
+        }
         aes_gcm_decrypt(&self.key, iv, aads, input, output)
     }
 }

--- a/crypto/apple-crypto/src/srtp.rs
+++ b/crypto/apple-crypto/src/srtp.rs
@@ -69,11 +69,10 @@ impl AeadAes128GcmCipher for AppleCryptoAeadAes128GcmCipher {
         input: &[u8],
         output: &mut [u8],
     ) -> Result<usize, CryptoError> {
-        if input.len() < AeadAes128Gcm::TAG_LEN {
-            return Err(CryptoError::Other(
-                "SRTP GCM decrypt input shorter than auth tag".into(),
-            ));
-        }
+        // Caller contract: `SrtpContext::unprotect_rtp` and `unprotect_rtcp` guarantee
+        // the input holds at least the auth tag. A shorter buffer is a bug in str0m,
+        // not bad input, so fail fast rather than hiding it in an error.
+        assert!(input.len() >= AeadAes128Gcm::TAG_LEN);
         aes_gcm_decrypt(&self.key, iv, aads, input, output)
     }
 }
@@ -108,11 +107,10 @@ impl AeadAes256GcmCipher for AppleCryptoAeadAes256GcmCipher {
         input: &[u8],
         output: &mut [u8],
     ) -> Result<usize, CryptoError> {
-        if input.len() < AeadAes256Gcm::TAG_LEN {
-            return Err(CryptoError::Other(
-                "SRTP GCM decrypt input shorter than auth tag".into(),
-            ));
-        }
+        // Caller contract: `SrtpContext::unprotect_rtp` and `unprotect_rtcp` guarantee
+        // the input holds at least the auth tag. A shorter buffer is a bug in str0m,
+        // not bad input, so fail fast rather than hiding it in an error.
+        assert!(input.len() >= AeadAes256Gcm::TAG_LEN);
         aes_gcm_decrypt(&self.key, iv, aads, input, output)
     }
 }

--- a/crypto/aws-lc-rs/src/srtp.rs
+++ b/crypto/aws-lc-rs/src/srtp.rs
@@ -109,7 +109,11 @@ impl AeadAes128GcmCipher for AwsLcRsAeadAes128GcmCipher {
         input: &[u8],
         output: &mut [u8],
     ) -> Result<usize, CryptoError> {
-        assert!(input.len() >= AeadAes128Gcm::TAG_LEN);
+        if input.len() < AeadAes128Gcm::TAG_LEN {
+            return Err(CryptoError::Other(
+                "SRTP GCM decrypt input shorter than auth tag".into(),
+            ));
+        }
 
         let nonce = Nonce::try_assume_unique_for_key(iv)
             .map_err(|e| CryptoError::Other(format!("Invalid nonce: {}", e)))?;
@@ -182,7 +186,11 @@ impl AeadAes256GcmCipher for AwsLcRsAeadAes256GcmCipher {
         input: &[u8],
         output: &mut [u8],
     ) -> Result<usize, CryptoError> {
-        assert!(input.len() >= AeadAes256Gcm::TAG_LEN);
+        if input.len() < AeadAes256Gcm::TAG_LEN {
+            return Err(CryptoError::Other(
+                "SRTP GCM decrypt input shorter than auth tag".into(),
+            ));
+        }
 
         let nonce = Nonce::try_assume_unique_for_key(iv)
             .map_err(|e| CryptoError::Other(format!("Invalid nonce: {}", e)))?;

--- a/crypto/aws-lc-rs/src/srtp.rs
+++ b/crypto/aws-lc-rs/src/srtp.rs
@@ -109,11 +109,10 @@ impl AeadAes128GcmCipher for AwsLcRsAeadAes128GcmCipher {
         input: &[u8],
         output: &mut [u8],
     ) -> Result<usize, CryptoError> {
-        if input.len() < AeadAes128Gcm::TAG_LEN {
-            return Err(CryptoError::Other(
-                "SRTP GCM decrypt input shorter than auth tag".into(),
-            ));
-        }
+        // Caller contract: `SrtpContext::unprotect_rtp` and `unprotect_rtcp` guarantee
+        // the input holds at least the auth tag. A shorter buffer is a bug in str0m,
+        // not bad input, so fail fast rather than hiding it in an error.
+        assert!(input.len() >= AeadAes128Gcm::TAG_LEN);
 
         let nonce = Nonce::try_assume_unique_for_key(iv)
             .map_err(|e| CryptoError::Other(format!("Invalid nonce: {}", e)))?;
@@ -186,11 +185,10 @@ impl AeadAes256GcmCipher for AwsLcRsAeadAes256GcmCipher {
         input: &[u8],
         output: &mut [u8],
     ) -> Result<usize, CryptoError> {
-        if input.len() < AeadAes256Gcm::TAG_LEN {
-            return Err(CryptoError::Other(
-                "SRTP GCM decrypt input shorter than auth tag".into(),
-            ));
-        }
+        // Caller contract: `SrtpContext::unprotect_rtp` and `unprotect_rtcp` guarantee
+        // the input holds at least the auth tag. A shorter buffer is a bug in str0m,
+        // not bad input, so fail fast rather than hiding it in an error.
+        assert!(input.len() >= AeadAes256Gcm::TAG_LEN);
 
         let nonce = Nonce::try_assume_unique_for_key(iv)
             .map_err(|e| CryptoError::Other(format!("Invalid nonce: {}", e)))?;

--- a/crypto/openssl/src/srtp.rs
+++ b/crypto/openssl/src/srtp.rs
@@ -98,11 +98,10 @@ impl AeadAes128GcmCipher for OsslAeadAes128GcmCipher {
         input: &[u8],
         output: &mut [u8],
     ) -> Result<usize, CryptoError> {
-        if input.len() < AeadAes128Gcm::TAG_LEN {
-            return Err(CryptoError::Other(
-                "SRTP GCM decrypt input shorter than auth tag".into(),
-            ));
-        }
+        // Caller contract: `SrtpContext::unprotect_rtp` and `unprotect_rtcp` guarantee
+        // the input holds at least the auth tag. A shorter buffer is a bug in str0m,
+        // not bad input, so fail fast rather than hiding it in an error.
+        assert!(input.len() >= AeadAes128Gcm::TAG_LEN);
 
         let (cipher_text, tag) = input.split_at(input.len() - AeadAes128Gcm::TAG_LEN);
 
@@ -169,11 +168,10 @@ impl AeadAes256GcmCipher for OsslAeadAes256GcmCipher {
         input: &[u8],
         output: &mut [u8],
     ) -> Result<usize, CryptoError> {
-        if input.len() < AeadAes256Gcm::TAG_LEN {
-            return Err(CryptoError::Other(
-                "SRTP GCM decrypt input shorter than auth tag".into(),
-            ));
-        }
+        // Caller contract: `SrtpContext::unprotect_rtp` and `unprotect_rtcp` guarantee
+        // the input holds at least the auth tag. A shorter buffer is a bug in str0m,
+        // not bad input, so fail fast rather than hiding it in an error.
+        assert!(input.len() >= AeadAes256Gcm::TAG_LEN);
 
         let (cipher_text, tag) = input.split_at(input.len() - AeadAes256Gcm::TAG_LEN);
 

--- a/crypto/openssl/src/srtp.rs
+++ b/crypto/openssl/src/srtp.rs
@@ -98,7 +98,11 @@ impl AeadAes128GcmCipher for OsslAeadAes128GcmCipher {
         input: &[u8],
         output: &mut [u8],
     ) -> Result<usize, CryptoError> {
-        assert!(input.len() >= AeadAes128Gcm::TAG_LEN);
+        if input.len() < AeadAes128Gcm::TAG_LEN {
+            return Err(CryptoError::Other(
+                "SRTP GCM decrypt input shorter than auth tag".into(),
+            ));
+        }
 
         let (cipher_text, tag) = input.split_at(input.len() - AeadAes128Gcm::TAG_LEN);
 
@@ -165,7 +169,11 @@ impl AeadAes256GcmCipher for OsslAeadAes256GcmCipher {
         input: &[u8],
         output: &mut [u8],
     ) -> Result<usize, CryptoError> {
-        assert!(input.len() >= AeadAes256Gcm::TAG_LEN);
+        if input.len() < AeadAes256Gcm::TAG_LEN {
+            return Err(CryptoError::Other(
+                "SRTP GCM decrypt input shorter than auth tag".into(),
+            ));
+        }
 
         let (cipher_text, tag) = input.split_at(input.len() - AeadAes256Gcm::TAG_LEN);
 

--- a/crypto/rust-crypto/src/srtp.rs
+++ b/crypto/rust-crypto/src/srtp.rs
@@ -104,7 +104,11 @@ impl AeadAes128GcmCipher for RustCryptoAeadAes128GcmCipher {
         input: &[u8],
         output: &mut [u8],
     ) -> Result<usize, CryptoError> {
-        assert!(input.len() >= AeadAes128Gcm::TAG_LEN);
+        if input.len() < AeadAes128Gcm::TAG_LEN {
+            return Err(CryptoError::Other(
+                "SRTP GCM decrypt input shorter than auth tag".into(),
+            ));
+        }
 
         let nonce = Nonce::from_slice(iv);
 
@@ -175,7 +179,11 @@ impl AeadAes256GcmCipher for RustCryptoAeadAes256GcmCipher {
         input: &[u8],
         output: &mut [u8],
     ) -> Result<usize, CryptoError> {
-        assert!(input.len() >= AeadAes256Gcm::TAG_LEN);
+        if input.len() < AeadAes256Gcm::TAG_LEN {
+            return Err(CryptoError::Other(
+                "SRTP GCM decrypt input shorter than auth tag".into(),
+            ));
+        }
 
         let nonce = Nonce::from_slice(iv);
 

--- a/crypto/rust-crypto/src/srtp.rs
+++ b/crypto/rust-crypto/src/srtp.rs
@@ -104,11 +104,10 @@ impl AeadAes128GcmCipher for RustCryptoAeadAes128GcmCipher {
         input: &[u8],
         output: &mut [u8],
     ) -> Result<usize, CryptoError> {
-        if input.len() < AeadAes128Gcm::TAG_LEN {
-            return Err(CryptoError::Other(
-                "SRTP GCM decrypt input shorter than auth tag".into(),
-            ));
-        }
+        // Caller contract: `SrtpContext::unprotect_rtp` and `unprotect_rtcp` guarantee
+        // the input holds at least the auth tag. A shorter buffer is a bug in str0m,
+        // not bad input, so fail fast rather than hiding it in an error.
+        assert!(input.len() >= AeadAes128Gcm::TAG_LEN);
 
         let nonce = Nonce::from_slice(iv);
 
@@ -179,11 +178,10 @@ impl AeadAes256GcmCipher for RustCryptoAeadAes256GcmCipher {
         input: &[u8],
         output: &mut [u8],
     ) -> Result<usize, CryptoError> {
-        if input.len() < AeadAes256Gcm::TAG_LEN {
-            return Err(CryptoError::Other(
-                "SRTP GCM decrypt input shorter than auth tag".into(),
-            ));
-        }
+        // Caller contract: `SrtpContext::unprotect_rtp` and `unprotect_rtcp` guarantee
+        // the input holds at least the auth tag. A shorter buffer is a bug in str0m,
+        // not bad input, so fail fast rather than hiding it in an error.
+        assert!(input.len() >= AeadAes256Gcm::TAG_LEN);
 
         let nonce = Nonce::from_slice(iv);
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -673,4 +673,45 @@ mod tests {
         handler.association_lost();
         assert!(handler.closed_stream_ids.is_empty());
     }
+
+    /// A remote peer decides which SCTP stream ids exist on the association, and
+    /// `ensure_channel_id_for()` gives every one of them an allocation. A peer that
+    /// opens every id of our parity therefore leaves `do_allocations()` with no free
+    /// id to hand out.
+    ///
+    /// The allocator walks `proposed += 2` with no upper bound. Past 65535 that is a
+    /// debug-build overflow panic, and in release it wraps back to `base` and spins
+    /// forever inside `do_allocations()`, hanging the whole event loop.
+    ///
+    /// Failing to allocate is fine, str0m retries on the next timeout. Panicking or
+    /// hanging is not.
+    #[test]
+    fn stream_id_space_exhausted_by_remote() {
+        let sctp = RtcSctp::new(1200);
+        let base: u16 = if sctp.is_client() { 0 } else { 1 };
+
+        let mut handler = ChannelHandler::default();
+
+        // What the peer did: claim every stream id of our parity. Going through
+        // `ensure_channel_id_for()` for each is the realistic route but is quadratic,
+        // so seed the equivalent state directly.
+        handler.closed_stream_ids = (base..=u16::MAX).step_by(2).collect();
+        assert_eq!(handler.closed_stream_ids.len(), 32768);
+
+        // Now the local application asks for a data channel.
+        let id = handler.new_channel(&Default::default());
+
+        handler.do_allocations(&sctp);
+
+        let alloc = handler
+            .allocations
+            .iter()
+            .find(|a| a.id == id)
+            .expect("the allocation entry to still be there");
+
+        assert!(
+            alloc.sctp_stream_id.is_none(),
+            "no id can be allocated when the peer holds the whole parity"
+        );
+    }
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -330,11 +330,23 @@ impl ChannelHandler {
                 continue;
             }
 
-            // We need to allocate
+            // We need to allocate. Walk this parity's ids until we find a free one.
+            //
+            // A remote peer can fill every id (sctp-proto enforces no stream-count),
+            // the next allocation could overflow, instead fail the allocation gracefully.
             let mut proposed = base;
-
             while taken.contains(&proposed) {
-                proposed += 2
+                match proposed.checked_add(2) {
+                    Some(next) => proposed = next,
+                    None => break, // id space for this parity is exhausted
+                }
+            }
+
+            if taken.contains(&proposed) {
+                // Exhausted, the loop broke on overflow, leave the channel
+                // unallocated, it is retried on the next timeout.
+                warn!("SCTP stream id space exhausted, cannot allocate {:?}", a.id);
+                continue;
             }
 
             // Found the next free.

--- a/src/rtp/ext.rs
+++ b/src/rtp/ext.rs
@@ -943,8 +943,6 @@ impl ExtensionValues {
         let mut offset = already_happened() + since_beginning;
 
         if offset + relative_64_secs > now {
-            // `Instant - Duration` panics on underflow on non-Linux clocks
-            // (macOS/Windows) with low uptime; saturate instead of panicking.
             offset = offset
                 .checked_sub(Duration::from_secs(64))
                 .unwrap_or(offset);

--- a/src/rtp/ext.rs
+++ b/src/rtp/ext.rs
@@ -943,7 +943,11 @@ impl ExtensionValues {
         let mut offset = already_happened() + since_beginning;
 
         if offset + relative_64_secs > now {
-            offset -= Duration::from_secs(64);
+            // `Instant - Duration` panics on underflow on non-Linux clocks
+            // (macOS/Windows) with low uptime; saturate instead of panicking.
+            offset = offset
+                .checked_sub(Duration::from_secs(64))
+                .unwrap_or(offset);
         }
 
         self.abs_send_time = Some(offset + relative_64_secs);

--- a/src/rtp/rtcp/remb.rs
+++ b/src/rtp/rtcp/remb.rs
@@ -151,6 +151,12 @@ impl<'a> TryFrom<&'a [u8]> for Remb {
         // bitrate = mantissa * 2^exp
         let bitrate = f32::from_bits(((exp as u32) << 23) | (mantissa & MANTISSA_MAX));
 
+        // `ssrcs_len` is attacker-controlled byte  (buf[12], 0..=255)
+        // reject packets too short to hold that many trailing SSRC bytes.
+        if buf.len() < REMB_OFFSET + ssrcs_len * 4 {
+            return Err("Remb ssrcs length exceeds buffer");
+        }
+
         let mut ssrcs = vec![];
         for i in 0..ssrcs_len {
             let b_index = 16 + i * 4;

--- a/src/rtp/rtcp/twcc.rs
+++ b/src/rtp/rtcp/twcc.rs
@@ -114,7 +114,7 @@ impl Iterator for TwccIter {
                 Delta::Large(v) => {
                     let dur = Duration::from_micros(250 * v.unsigned_abs() as u64);
                     Some(if v < 0 {
-                        self.time_base.checked_sub(dur).unwrap()
+                        self.time_base.checked_sub(dur).unwrap_or(self.time_base)
                     } else {
                         self.time_base + dur
                     })

--- a/src/rtp/rtcp/twcc.rs
+++ b/src/rtp/rtcp/twcc.rs
@@ -120,7 +120,10 @@ impl Iterator for TwccIter {
                     })
                 }
             },
-            _ => unreachable!(),
+            // A VectorDouble chunk can carry 0b11 for any of its statuses. The
+            // parser maps that to Unknown and consumes no delta, so there is nothing
+            // to report for it either.
+            PacketStatus::Unknown => None,
         };
 
         if let Some(new_timebase) = instant {

--- a/src/rtp/rtcp/xr.rs
+++ b/src/rtp/rtcp/xr.rs
@@ -257,11 +257,7 @@ impl<'a> TryFrom<&'a [u8]> for Dlrr {
         let words_per_block = 3;
         let blocks = u16::from_be_bytes(buf[2..4].try_into().unwrap()) / words_per_block;
 
-        // `blocks` comes from the buffer content,
-        // cap the pre-allocation by what the buffer could actually hold (12 bytes/item)
-        // so a small packet can't force a huge allocation.
-        let cap = (blocks as usize).min(buf.len() / 12);
-        let mut items: Vec<DlrrItem> = Vec::with_capacity(cap);
+        let mut items: Vec<DlrrItem> = Vec::with_capacity(blocks as usize);
 
         // move on after the header
         let mut buf = &buf[4..];

--- a/src/rtp/rtcp/xr.rs
+++ b/src/rtp/rtcp/xr.rs
@@ -257,7 +257,11 @@ impl<'a> TryFrom<&'a [u8]> for Dlrr {
         let words_per_block = 3;
         let blocks = u16::from_be_bytes(buf[2..4].try_into().unwrap()) / words_per_block;
 
-        let mut items: Vec<DlrrItem> = Vec::with_capacity(blocks as usize);
+        // `blocks` comes from the buffer content,
+        // cap the pre-allocation by what the buffer could actually hold (12 bytes/item)
+        // so a small packet can't force a huge allocation.
+        let cap = (blocks as usize).min(buf.len() / 12);
+        let mut items: Vec<DlrrItem> = Vec::with_capacity(cap);
 
         // move on after the header
         let mut buf = &buf[4..];

--- a/src/rtp/srtp.rs
+++ b/src/rtp/srtp.rs
@@ -29,9 +29,6 @@ const LABEL_RTCP_SALT: u8 = 5;
 
 pub const SRTP_BLOCK_SIZE: usize = 16;
 const SRTCP_INDEX_LEN: usize = 4;
-// SRTCP header and sender SSRC keep the first 8 bytes (RTCP ), 
-// encrypted payload, SRTCP index and tag follow.
-// A valid SRTCP packet is never shorter than this header + index + tag.
 const SRTCP_HEADER_LEN: usize = 8;
 const MAX_TAG_LEN: usize = AeadAes256Gcm::TAG_LEN;
 pub const SRTCP_OVERHEAD: usize = MAX_TAG_LEN + SRTCP_INDEX_LEN;

--- a/src/rtp/srtp.rs
+++ b/src/rtp/srtp.rs
@@ -29,6 +29,10 @@ const LABEL_RTCP_SALT: u8 = 5;
 
 pub const SRTP_BLOCK_SIZE: usize = 16;
 const SRTCP_INDEX_LEN: usize = 4;
+// SRTCP header and sender SSRC keep the first 8 bytes (RTCP ), 
+// encrypted payload, SRTCP index and tag follow.
+// A valid SRTCP packet is never shorter than this header + index + tag.
+const SRTCP_HEADER_LEN: usize = 8;
 const MAX_TAG_LEN: usize = AeadAes256Gcm::TAG_LEN;
 pub const SRTCP_OVERHEAD: usize = MAX_TAG_LEN + SRTCP_INDEX_LEN;
 pub const SRTP_OVERHEAD: usize = MAX_TAG_LEN;
@@ -311,7 +315,7 @@ impl SrtpContext {
     ) -> Option<&[u8]> {
         match &mut self.rtp {
             Derived::Aes128CmSha1_80 { key, salt, dec, .. } => {
-                if buf.len() < Aes128CmSha1_80::HMAC_TAG_LEN {
+                if buf.len() < header.header_len + Aes128CmSha1_80::HMAC_TAG_LEN {
                     return None;
                 }
 
@@ -348,7 +352,7 @@ impl SrtpContext {
                 Some(&self.rx_scratch[..input.len()])
             }
             Derived::AeadAes128Gcm { salt, dec, .. } => {
-                if buf.len() < AeadAes128Gcm::TAG_LEN {
+                if buf.len() < header.header_len + AeadAes128Gcm::TAG_LEN {
                     return None;
                 }
 
@@ -379,7 +383,7 @@ impl SrtpContext {
                 Some(&self.rx_scratch[..out_len])
             }
             Derived::AeadAes256Gcm { salt, dec, .. } => {
-                if buf.len() < AeadAes256Gcm::TAG_LEN {
+                if buf.len() < header.header_len + AeadAes256Gcm::TAG_LEN {
                     return None;
                 }
 
@@ -513,7 +517,7 @@ impl SrtpContext {
     pub fn unprotect_rtcp(&mut self, buf: &[u8]) -> Option<Vec<u8>> {
         match &mut self.rtcp {
             Derived::Aes128CmSha1_80 { key, salt, dec, .. } => {
-                if buf.len() < Aes128CmSha1_80::HMAC_TAG_LEN + SRTCP_INDEX_LEN {
+                if buf.len() < SRTCP_HEADER_LEN + SRTCP_INDEX_LEN + Aes128CmSha1_80::HMAC_TAG_LEN {
                     return None;
                 }
 
@@ -573,7 +577,7 @@ impl SrtpContext {
                 Some(output)
             }
             Derived::AeadAes128Gcm { salt, dec, .. } => {
-                if buf.len() < SRTCP_INDEX_LEN + AeadAes128Gcm::TAG_LEN {
+                if buf.len() < SRTCP_HEADER_LEN + SRTCP_INDEX_LEN + AeadAes128Gcm::TAG_LEN {
                     // Too short
                     return None;
                 }
@@ -645,7 +649,7 @@ impl SrtpContext {
                 Some(output)
             }
             Derived::AeadAes256Gcm { salt, dec, .. } => {
-                if buf.len() < SRTCP_INDEX_LEN + AeadAes256Gcm::TAG_LEN {
+                if buf.len() < SRTCP_HEADER_LEN + SRTCP_INDEX_LEN + AeadAes256Gcm::TAG_LEN {
                     // Too short
                     return None;
                 }

--- a/src/sctp/mod.rs
+++ b/src/sctp/mod.rs
@@ -32,6 +32,9 @@ const MAX_BUFFERED_ACROSS_STREAMS: usize = 128 * 1024;
 /// Upper bound on the number of concurrently tracked SCTP streams.
 const MAX_SCTP_STREAMS: usize = 8192;
 
+/// Maximum self-recursion depth of `do_poll`.
+const MAX_SCTP_POLL_DEPTH: usize = 64;
+
 /// Maximum message size we advertise in SDP (what we can receive)
 pub const LOCAL_MAX_MESSAGE_SIZE: u32 = 256 * 1024;
 
@@ -737,6 +740,18 @@ impl RtcSctp {
     }
 
     pub fn do_poll(&mut self) -> Option<SctpEvent> {
+        self.do_poll_inner(0)
+    }
+
+    fn do_poll_inner(&mut self, depth: usize) -> Option<SctpEvent> {
+        // Recursion flushes whatever the send produces. But if the peer has
+        // stopped accepting data the send produces nothing, so we move on to the
+        // next channel and recurse again, once per pending channel. The depth is
+        // tracked and capped to avoid overflowing the stack.
+        if depth >= MAX_SCTP_POLL_DEPTH {
+            return None;
+        }
+
         if self.state == RtcSctpState::Uninited {
             // Need to call `init()` before any polling starts.
             return None;
@@ -772,7 +787,7 @@ impl RtcSctp {
             if let Event::Connected = e {
                 assoc.set_max_send_message_size(self.remote_max_message_size);
                 set_state(&mut self.state, RtcSctpState::Established);
-                return self.poll();
+                return self.do_poll_inner(depth + 1);
             }
 
             if let Event::AssociationLost { ref reason } = e {
@@ -876,7 +891,7 @@ impl RtcSctp {
 
                                     // Start over with polling, since we might have caused
                                     // some network traffic by writing the DcepOpen.
-                                    return self.do_poll();
+                                    return self.do_poll_inner(depth + 1);
                                 }
                                 Err(e) => {
                                     warn!(

--- a/src/sctp/mod.rs
+++ b/src/sctp/mod.rs
@@ -604,7 +604,7 @@ impl RtcSctp {
             })
             .sum();
 
-        MAX_BUFFERED_ACROSS_STREAMS - total
+        MAX_BUFFERED_ACROSS_STREAMS.saturating_sub(total)
     }
 
     pub fn write(&mut self, id: u16, binary: bool, buf: &[u8]) -> Result<usize, SctpError> {

--- a/src/sctp/mod.rs
+++ b/src/sctp/mod.rs
@@ -1468,6 +1468,63 @@ mod tests {
         (client, server)
     }
 
+    /// A stream the remote opened can be gone from the association by the time the
+    /// application configures it.
+    ///
+    /// `StreamEntryState::AwaitConfig` is set when a `Readable`/`Writable` event
+    /// arrives
+    /// for an id we have no config for. If the peer then resets that stream, sctp-proto
+    /// unregisters it during `handle_input()`, while our entry stays `AwaitConfig` until
+    /// the reset event is drained in a later `do_poll()`.
+    #[test]
+    fn open_stream_out_of_band_after_remote_reset() {
+        let (mut client, _server) = connect_client_server();
+
+        let stream_id: u16 = 3;
+        assert!(
+            client.assoc.as_mut().unwrap().stream(stream_id).is_err(),
+            "the association must not have this stream for the test to mean anything"
+        );
+
+        client.entries.insert(
+            stream_id,
+            StreamEntry {
+                config: None,
+                state: StreamEntryState::AwaitConfig,
+                id: stream_id,
+                do_close: false,
+                open_deadline: None,
+                buffered_threshold: BufferedThresholdConfig::Unconfigured,
+            },
+        );
+
+        client.open_stream(
+            stream_id,
+            ChannelConfig {
+                label: "negotiated".to_string(),
+                ordered: true,
+                reliability: Reliability::Reliable,
+                negotiated: Some(stream_id),
+                protocol: String::new(),
+            },
+        );
+
+        let entry = client
+            .entries
+            .get(&stream_id)
+            .expect("entry to still exist");
+
+        assert!(
+            entry.do_close,
+            "a stream that vanished from the association should be marked for close"
+        );
+        assert_ne!(
+            entry.state,
+            StreamEntryState::Open,
+            "must not go Open when there is no underlying stream"
+        );
+    }
+
     /// Regression test: when `assoc.open_stream()` returns `ErrStreamAlreadyExist`
     /// for an in-band (DCEP) data channel, the entry must eventually transition to
     /// Closed and emit `SctpEvent::Close`. The error is transient (a reset

--- a/src/sctp/mod.rs
+++ b/src/sctp/mod.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::new_without_default)]
 
-use std::collections::{BTreeMap, HashSet, VecDeque};
+use std::collections::{HashSet, VecDeque};
 use std::fmt;
 use std::net::SocketAddr;
 use std::panic::UnwindSafe;
@@ -41,7 +41,8 @@ pub(crate) struct RtcSctp {
     fake_addr: SocketAddr,
     handle: AssociationHandle,
     assoc: Option<Association>,
-    entries: BTreeMap<u16, StreamEntry>,
+    // Sorted by `id` so lookups can binary search. Keep it that way.
+    entries: Vec<StreamEntry>,
     // Stream ids that still owe a `StreamEvent::ResetComplete`,
     // thos ids needs to be held back from reuse.
     reset_pending: HashSet<u16>,
@@ -303,7 +304,7 @@ impl RtcSctp {
             fake_addr,
             handle: AssociationHandle(0), // temporary
             assoc: None,
-            entries: BTreeMap::new(),
+            entries: Vec::new(),
             reset_pending: HashSet::new(),
             reset_complete: VecDeque::new(),
             pushed_back_transmit: None,
@@ -555,7 +556,7 @@ impl RtcSctp {
 
     /// Close stream.
     pub fn close_stream(&mut self, id: u16) {
-        if let Some(entry) = self.entries.get_mut(&id) {
+        if let Some(entry) = entry_by_id_mut(&mut self.entries, id) {
             entry.do_close = true;
 
             // Explicitly close the sctp stream to allow re-use of the same id.
@@ -580,7 +581,7 @@ impl RtcSctp {
             return false;
         }
 
-        let Some(rec) = self.entries.get(&id) else {
+        let Some(rec) = entry_by_id(&self.entries, id) else {
             return false;
         };
 
@@ -596,7 +597,7 @@ impl RtcSctp {
         // The amount currently buffered.
         let total: usize = self
             .entries
-            .values()
+            .iter()
             .filter_map(|e| {
                 assoc
                     .stream(e.id)
@@ -618,7 +619,7 @@ impl RtcSctp {
             .as_mut()
             .ok_or(SctpError::WriteBeforeEstablished)?;
 
-        let rec = self.entries.get(&id).expect("stream entry for write");
+        let rec = entry_by_id(&self.entries, id).expect("stream entry for write");
 
         if rec.state != StreamEntryState::Open {
             return Err(SctpError::WriteBeforeEstablished);
@@ -654,10 +655,8 @@ impl RtcSctp {
     }
 
     pub fn set_buffered_amount_low_threshold(&mut self, id: u16, threshold: usize) {
-        let entry = self
-            .entries
-            .get_mut(&id)
-            .expect("stream entry for valid channel id");
+        let entry =
+            entry_by_id_mut(&mut self.entries, id).expect("stream entry for valid channel id");
 
         // This update will be propagated on next poll.
         entry.buffered_threshold.set(threshold);
@@ -706,8 +705,7 @@ impl RtcSctp {
         self.last_now = now;
 
         // Remove closed entries.
-        self.entries
-            .retain(|_, e| e.state != StreamEntryState::Closed);
+        self.entries.retain(|e| e.state != StreamEntryState::Closed);
 
         let Some(assoc) = &mut self.assoc else {
             return;
@@ -747,8 +745,7 @@ impl RtcSctp {
             // Remove closed entries. handle_timeout() also does this, but the
             // remote can reuse a stream id (its reset handshake completed) before
             // our next timeout.
-            self.entries
-                .retain(|_, e| e.state != StreamEntryState::Closed);
+            self.entries.retain(|e| e.state != StreamEntryState::Closed);
 
             if let Some(t) = self.pushed_back_transmit.take() {
                 return Some(SctpEvent::Transmit { packets: t });
@@ -807,7 +804,7 @@ impl RtcSctp {
                             // missing ones already went through Close, and an AwaitOpen
                             // entry is a new incarnation waiting on the same id, it must
                             // not be killed by the old pending teardown.
-                            if let Some(entry) = self.entries.get_mut(&id) {
+                            if let Some(entry) = entry_by_id_mut(&mut self.entries, id) {
                                 if entry.state != StreamEntryState::Closed
                                     && entry.state != StreamEntryState::AwaitOpen
                                 {
@@ -835,7 +832,7 @@ impl RtcSctp {
                 return None;
             }
 
-            for entry in self.entries.values_mut() {
+            for entry in self.entries.iter_mut() {
                 let want_open = entry.state == StreamEntryState::AwaitOpen;
 
                 if want_open {
@@ -1145,7 +1142,7 @@ impl RtcSctp {
         // either resolves or fails within STREAM_OPEN_TIMEOUT.
         let retry_timeout = self
             .entries
-            .values()
+            .iter()
             .any(|e| e.state == StreamEntryState::AwaitOpen && e.open_deadline.is_some())
             .then(|| self.last_now + STREAM_OPEN_RETRY_INTERVAL);
 
@@ -1174,9 +1171,7 @@ impl RtcSctp {
     }
 
     pub fn config(&self, sctp_stream_id: u16) -> Option<&ChannelConfig> {
-        self.entries
-            .get(&sctp_stream_id)
-            .and_then(|s| s.config.as_ref())
+        entry_by_id(&self.entries, sctp_stream_id).and_then(|s| s.config.as_ref())
     }
 
     /// Close the sctp stream to allow re-use of the same id.
@@ -1220,23 +1215,44 @@ fn set_state(current_state: &mut RtcSctpState, state: RtcSctpState) {
     }
 }
 
+fn entry_index(entries: &[StreamEntry], id: u16) -> Result<usize, usize> {
+    entries.binary_search_by_key(&id, |e| e.id)
+}
+
+fn entry_by_id(entries: &[StreamEntry], id: u16) -> Option<&StreamEntry> {
+    entry_index(entries, id).ok().map(|i| &entries[i])
+}
+
+fn entry_by_id_mut(entries: &mut [StreamEntry], id: u16) -> Option<&mut StreamEntry> {
+    entry_index(entries, id).ok().map(|i| &mut entries[i])
+}
+
 fn stream_entry<'a>(
-    entries: &'a mut BTreeMap<u16, StreamEntry>,
+    entries: &'a mut Vec<StreamEntry>,
     id: u16,
     initial_state: StreamEntryState,
     reason: &'static str,
 ) -> &'a mut StreamEntry {
-    entries.entry(id).or_insert_with(|| {
-        debug!("New stream {} ({:?}): {}", id, initial_state, reason);
-        StreamEntry {
-            config: None,
-            state: initial_state,
-            id,
-            do_close: false,
-            open_deadline: None,
-            buffered_threshold: BufferedThresholdConfig::Unconfigured,
+    let idx = match entry_index(entries, id) {
+        Ok(idx) => idx,
+        Err(idx) => {
+            debug!("New stream {} ({:?}): {}", id, initial_state, reason);
+            entries.insert(
+                idx,
+                StreamEntry {
+                    config: None,
+                    state: initial_state,
+                    id,
+                    do_close: false,
+                    open_deadline: None,
+                    buffered_threshold: BufferedThresholdConfig::Unconfigured,
+                },
+            );
+            idx
         }
-    })
+    };
+
+    &mut entries[idx]
 }
 
 fn stream_read_data(
@@ -1366,6 +1382,12 @@ impl From<(ReliabilityType, u32)> for Reliability {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Insert an entry directly, keeping `entries` sorted by id.
+    fn insert_entry(entries: &mut Vec<StreamEntry>, entry: StreamEntry) {
+        let idx = entry_index(entries, entry.id).expect_err("entry should not already exist");
+        entries.insert(idx, entry);
+    }
     use str0m_proto::DATAGRAM_MTU_TARGET;
 
     #[test]
@@ -1471,8 +1493,8 @@ mod tests {
             "the association must not have this stream for the test to mean anything"
         );
 
-        client.entries.insert(
-            stream_id,
+        insert_entry(
+            &mut client.entries,
             StreamEntry {
                 config: None,
                 state: StreamEntryState::AwaitConfig,
@@ -1496,7 +1518,8 @@ mod tests {
 
         let entry = client
             .entries
-            .get(&stream_id)
+            .iter()
+            .find(|e| e.id == stream_id)
             .expect("entry to still exist");
 
         assert!(
@@ -1531,8 +1554,8 @@ mod tests {
         // Manually add an entry in AwaitOpen state with in-band config (negotiated: None).
         // This simulates a locally-initiated in-band channel whose stream ID conflicts
         // with one already opened by the remote peer.
-        client.entries.insert(
-            stream_id,
+        insert_entry(
+            &mut client.entries,
             StreamEntry {
                 config: Some(ChannelConfig {
                     label: "test".to_string(),
@@ -1567,7 +1590,7 @@ mod tests {
         );
 
         // Verify entry transitioned to Closed.
-        let entry = client.entries.get(&stream_id).unwrap();
+        let entry = entry_by_id(&client.entries, stream_id).unwrap();
         assert_eq!(entry.state, StreamEntryState::Closed);
     }
 
@@ -1582,8 +1605,8 @@ mod tests {
             .expect("old stream should open");
         old.close().expect("old stream should start closing");
 
-        client.entries.insert(
-            stream_id,
+        insert_entry(
+            &mut client.entries,
             StreamEntry {
                 config: Some(ChannelConfig {
                     label: "replacement".to_string(),

--- a/src/sctp/mod.rs
+++ b/src/sctp/mod.rs
@@ -533,14 +533,16 @@ impl RtcSctp {
                 // out-of-band where remote started. We can go to Open, but must configure the local
                 // stream for it first.
 
-                // The association must be open since we don't get AwaitConfig state without
-                // polling from the remote peer.
-                let mut stream = self
-                    .assoc
-                    .as_mut()
-                    .expect("association to be open")
-                    .stream(entry.id)
-                    .expect("stream of entry in AwaitConfig");
+                // The stream can already be gone even though our entry is
+                // still AwaitConfig. Close the channel gracefully instead of panicking.
+                let Some(assoc) = self.assoc.as_mut() else {
+                    entry.do_close = true;
+                    return;
+                };
+                let Ok(mut stream) = assoc.stream(entry.id) else {
+                    entry.do_close = true;
+                    return;
+                };
 
                 if !entry.configure_reliability(&mut stream) {
                     return;

--- a/src/sctp/mod.rs
+++ b/src/sctp/mod.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::new_without_default)]
 
-use std::collections::{HashSet, VecDeque};
+use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::fmt;
 use std::net::SocketAddr;
 use std::panic::UnwindSafe;
@@ -29,6 +29,9 @@ pub use error::SctpError;
 /// Bytes that can be buffered inside str0m across all streams.
 const MAX_BUFFERED_ACROSS_STREAMS: usize = 128 * 1024;
 
+/// Upper bound on the number of concurrently tracked SCTP streams.
+const MAX_SCTP_STREAMS: usize = 8192;
+
 /// Maximum message size we advertise in SDP (what we can receive)
 pub const LOCAL_MAX_MESSAGE_SIZE: u32 = 256 * 1024;
 
@@ -41,7 +44,7 @@ pub(crate) struct RtcSctp {
     fake_addr: SocketAddr,
     handle: AssociationHandle,
     assoc: Option<Association>,
-    entries: Vec<StreamEntry>,
+    entries: BTreeMap<u16, StreamEntry>,
     // Stream ids that still owe a `StreamEvent::ResetComplete`,
     // thos ids needs to be held back from reuse.
     reset_pending: HashSet<u16>,
@@ -303,7 +306,7 @@ impl RtcSctp {
             fake_addr,
             handle: AssociationHandle(0), // temporary
             assoc: None,
-            entries: vec![],
+            entries: BTreeMap::new(),
             reset_pending: HashSet::new(),
             reset_complete: VecDeque::new(),
             pushed_back_transmit: None,
@@ -555,13 +558,12 @@ impl RtcSctp {
 
     /// Close stream.
     pub fn close_stream(&mut self, id: u16) {
-        let Some(entry) = self.entries.iter_mut().find(|v| v.id == id) else {
-            return;
-        };
-        entry.do_close = true;
+        if let Some(entry) = self.entries.get_mut(&id) {
+            entry.do_close = true;
 
-        // Explicitly close the sctp stream to allow re-use of the same id.
-        let _ = self.sctp_propagate_close(id);
+            // Explicitly close the sctp stream to allow re-use of the same id.
+            let _ = self.sctp_propagate_close(id);
+        }
     }
 
     pub fn close(&mut self) -> Result<(), SctpError> {
@@ -581,7 +583,7 @@ impl RtcSctp {
             return false;
         }
 
-        let Some(rec) = self.entries.iter().find(|e| e.id == id) else {
+        let Some(rec) = self.entries.get(&id) else {
             return false;
         };
 
@@ -597,7 +599,7 @@ impl RtcSctp {
         // The amount currently buffered.
         let total: usize = self
             .entries
-            .iter()
+            .values()
             .filter_map(|e| {
                 assoc
                     .stream(e.id)
@@ -619,11 +621,7 @@ impl RtcSctp {
             .as_mut()
             .ok_or(SctpError::WriteBeforeEstablished)?;
 
-        let rec = self
-            .entries
-            .iter()
-            .find(|e| e.id == id)
-            .expect("stream entry for write");
+        let rec = self.entries.get(&id).expect("stream entry for write");
 
         if rec.state != StreamEntryState::Open {
             return Err(SctpError::WriteBeforeEstablished);
@@ -661,8 +659,7 @@ impl RtcSctp {
     pub fn set_buffered_amount_low_threshold(&mut self, id: u16, threshold: usize) {
         let entry = self
             .entries
-            .iter_mut()
-            .find(|e| e.id == id)
+            .get_mut(&id)
             .expect("stream entry for valid channel id");
 
         // This update will be propagated on next poll.
@@ -712,7 +709,8 @@ impl RtcSctp {
         self.last_now = now;
 
         // Remove closed entries.
-        self.entries.retain(|e| e.state != StreamEntryState::Closed);
+        self.entries
+            .retain(|_, e| e.state != StreamEntryState::Closed);
 
         let Some(assoc) = &mut self.assoc else {
             return;
@@ -747,7 +745,8 @@ impl RtcSctp {
         // Remove closed entries. handle_timeout() also does this, but the
         // remote can reuse a stream id (its reset handshake completed) before
         // our next timeout.
-        self.entries.retain(|e| e.state != StreamEntryState::Closed);
+        self.entries
+            .retain(|_, e| e.state != StreamEntryState::Closed);
 
         if let Some(t) = self.pushed_back_transmit.take() {
             return Some(SctpEvent::Transmit { packets: t });
@@ -787,12 +786,20 @@ impl RtcSctp {
             if let Event::Stream(se) = e {
                 match se {
                     StreamEvent::Readable { id } | StreamEvent::Writable { id } => {
-                        stream_entry(
-                            &mut self.entries,
-                            id,
-                            StreamEntryState::AwaitConfig,
-                            "readable/writable",
-                        );
+                        if !self.entries.contains_key(&id) {
+                            // A peer can open a stream just by sending one
+                            // DATA chunk on a fresh id, cap the number of tracked streams.
+                            if self.entries.len() < MAX_SCTP_STREAMS {
+                                stream_entry(
+                                    &mut self.entries,
+                                    id,
+                                    StreamEntryState::AwaitConfig,
+                                    "readable/writable",
+                                );
+                            } else {
+                                debug!("Ignoring remote stream {} (stream cap reached)", id);
+                            }
+                        }
                     }
                     StreamEvent::Finished { id } | StreamEvent::Stopped { id, .. } => {
                         // sctp-proto unregistered it when a reset arrived.
@@ -806,7 +813,7 @@ impl RtcSctp {
                         // missing ones already went through Close, and an AwaitOpen
                         // entry is a new incarnation waiting on the same id, it must
                         // not be killed by the old pending teardown.
-                        if let Some(entry) = self.entries.iter_mut().find(|e| e.id == id) {
+                        if let Some(entry) = self.entries.get_mut(&id) {
                             if entry.state != StreamEntryState::Closed
                                 && entry.state != StreamEntryState::AwaitOpen
                             {
@@ -834,7 +841,7 @@ impl RtcSctp {
             return None;
         }
 
-        for entry in &mut self.entries {
+        for entry in self.entries.values_mut() {
             let want_open = entry.state == StreamEntryState::AwaitOpen;
 
             if want_open {
@@ -1138,7 +1145,7 @@ impl RtcSctp {
         // either resolves or fails within STREAM_OPEN_TIMEOUT.
         let retry_timeout = self
             .entries
-            .iter()
+            .values()
             .any(|e| e.state == StreamEntryState::AwaitOpen && e.open_deadline.is_some())
             .then(|| self.last_now + STREAM_OPEN_RETRY_INTERVAL);
 
@@ -1168,8 +1175,7 @@ impl RtcSctp {
 
     pub fn config(&self, sctp_stream_id: u16) -> Option<&ChannelConfig> {
         self.entries
-            .iter()
-            .find(|s| s.id == sctp_stream_id)
+            .get(&sctp_stream_id)
             .and_then(|s| s.config.as_ref())
     }
 
@@ -1215,27 +1221,22 @@ fn set_state(current_state: &mut RtcSctpState, state: RtcSctpState) {
 }
 
 fn stream_entry<'a>(
-    entries: &'a mut Vec<StreamEntry>,
+    entries: &'a mut BTreeMap<u16, StreamEntry>,
     id: u16,
     initial_state: StreamEntryState,
     reason: &'static str,
 ) -> &'a mut StreamEntry {
-    let idx = entries.iter().position(|v| v.id == id);
-    if let Some(idx) = idx {
-        entries.get_mut(idx).unwrap()
-    } else {
+    entries.entry(id).or_insert_with(|| {
         debug!("New stream {} ({:?}): {}", id, initial_state, reason);
-        let e = StreamEntry {
+        StreamEntry {
             config: None,
             state: initial_state,
             id,
             do_close: false,
             open_deadline: None,
             buffered_threshold: BufferedThresholdConfig::Unconfigured,
-        };
-        entries.push(e);
-        entries.last_mut().unwrap()
-    }
+        }
+    })
 }
 
 fn stream_read_data(
@@ -1473,20 +1474,23 @@ mod tests {
         // Manually add an entry in AwaitOpen state with in-band config (negotiated: None).
         // This simulates a locally-initiated in-band channel whose stream ID conflicts
         // with one already opened by the remote peer.
-        client.entries.push(StreamEntry {
-            config: Some(ChannelConfig {
-                label: "test".to_string(),
-                ordered: true,
-                reliability: Reliability::Reliable,
-                negotiated: None, // in-band
-                protocol: String::new(),
-            }),
-            state: StreamEntryState::AwaitOpen,
-            id: stream_id,
-            do_close: false,
-            open_deadline: None,
-            buffered_threshold: BufferedThresholdConfig::Unconfigured,
-        });
+        client.entries.insert(
+            stream_id,
+            StreamEntry {
+                config: Some(ChannelConfig {
+                    label: "test".to_string(),
+                    ordered: true,
+                    reliability: Reliability::Reliable,
+                    negotiated: None, // in-band
+                    protocol: String::new(),
+                }),
+                state: StreamEntryState::AwaitOpen,
+                id: stream_id,
+                do_close: false,
+                open_deadline: None,
+                buffered_threshold: BufferedThresholdConfig::Unconfigured,
+            },
+        );
 
         // The first poll retries instead of failing (arms the deadline).
         let event = client.do_poll();
@@ -1506,7 +1510,7 @@ mod tests {
         );
 
         // Verify entry transitioned to Closed.
-        let entry = client.entries.iter().find(|e| e.id == stream_id).unwrap();
+        let entry = client.entries.get(&stream_id).unwrap();
         assert_eq!(entry.state, StreamEntryState::Closed);
     }
 
@@ -1521,20 +1525,23 @@ mod tests {
             .expect("old stream should open");
         old.close().expect("old stream should start closing");
 
-        client.entries.push(StreamEntry {
-            config: Some(ChannelConfig {
-                label: "replacement".to_string(),
-                ordered: true,
-                reliability: Reliability::Reliable,
-                negotiated: Some(stream_id),
-                protocol: String::new(),
-            }),
-            state: StreamEntryState::AwaitOpen,
-            id: stream_id,
-            do_close: false,
-            open_deadline: None,
-            buffered_threshold: BufferedThresholdConfig::Unconfigured,
-        });
+        client.entries.insert(
+            stream_id,
+            StreamEntry {
+                config: Some(ChannelConfig {
+                    label: "replacement".to_string(),
+                    ordered: true,
+                    reliability: Reliability::Reliable,
+                    negotiated: Some(stream_id),
+                    protocol: String::new(),
+                }),
+                state: StreamEntryState::AwaitOpen,
+                id: stream_id,
+                do_close: false,
+                open_deadline: None,
+                buffered_threshold: BufferedThresholdConfig::Unconfigured,
+            },
+        );
 
         for _ in 0..10 {
             match client.do_poll() {

--- a/src/sctp/mod.rs
+++ b/src/sctp/mod.rs
@@ -29,12 +29,6 @@ pub use error::SctpError;
 /// Bytes that can be buffered inside str0m across all streams.
 const MAX_BUFFERED_ACROSS_STREAMS: usize = 128 * 1024;
 
-/// Upper bound on the number of concurrently tracked SCTP streams.
-const MAX_SCTP_STREAMS: usize = 8192;
-
-/// Maximum self-recursion depth of `do_poll`.
-const MAX_SCTP_POLL_DEPTH: usize = 64;
-
 /// Maximum message size we advertise in SDP (what we can receive)
 pub const LOCAL_MAX_MESSAGE_SIZE: u32 = 256 * 1024;
 
@@ -740,215 +734,230 @@ impl RtcSctp {
     }
 
     pub fn do_poll(&mut self) -> Option<SctpEvent> {
-        self.do_poll_inner(0)
-    }
-
-    fn do_poll_inner(&mut self, depth: usize) -> Option<SctpEvent> {
-        // Recursion flushes whatever the send produces. But if the peer has
-        // stopped accepting data the send produces nothing, so we move on to the
-        // next channel and recurse again, once per pending channel. The depth is
-        // tracked and capped to avoid overflowing the stack.
-        if depth >= MAX_SCTP_POLL_DEPTH {
-            return None;
-        }
-
-        if self.state == RtcSctpState::Uninited {
-            // Need to call `init()` before any polling starts.
-            return None;
-        }
-
-        // Remove closed entries. handle_timeout() also does this, but the
-        // remote can reuse a stream id (its reset handshake completed) before
-        // our next timeout.
-        self.entries
-            .retain(|_, e| e.state != StreamEntryState::Closed);
-
-        if let Some(t) = self.pushed_back_transmit.take() {
-            return Some(SctpEvent::Transmit { packets: t });
-        }
-
-        while let Some(t) = self.poll_transmit() {
-            let Some(buf) = transmit_to_vec(t) else {
-                continue;
-            };
-
-            return Some(SctpEvent::Transmit { packets: buf });
-        }
-
-        // Don't progress to move data between association and endpoint until we have an
-        // association we want to drive forward.
-        if !self.state.propagate_endpoint_to_assoc() {
-            return None;
-        }
-
-        let assoc = self.assoc.as_mut()?;
-
-        while let Some(e) = assoc.poll() {
-            if let Event::Connected = e {
-                assoc.set_max_send_message_size(self.remote_max_message_size);
-                set_state(&mut self.state, RtcSctpState::Established);
-                return self.do_poll_inner(depth + 1);
+        // A completed handshake or a written DCEP open can produce more to send, so
+        // those start over from the top instead of falling through. There is one
+        // restart per channel waiting to open, which is why this is a loop and not
+        // recursion.
+        'restart: loop {
+            if self.state == RtcSctpState::Uninited {
+                // Need to call `init()` before any polling starts.
+                return None;
             }
 
-            if let Event::AssociationLost { ref reason } = e {
-                debug!("Association lost, reason: {}", reason);
-                // No reset can complete on a dead association.
-                self.reset_pending.clear();
-                self.reset_complete.clear();
-                return Some(SctpEvent::AssociationLost);
+            // Remove closed entries. handle_timeout() also does this, but the
+            // remote can reuse a stream id (its reset handshake completed) before
+            // our next timeout.
+            self.entries
+                .retain(|_, e| e.state != StreamEntryState::Closed);
+
+            if let Some(t) = self.pushed_back_transmit.take() {
+                return Some(SctpEvent::Transmit { packets: t });
             }
 
-            if let Event::Stream(se) = e {
-                match se {
-                    StreamEvent::Readable { id } | StreamEvent::Writable { id } => {
-                        if !self.entries.contains_key(&id) {
-                            // A peer can open a stream just by sending one
-                            // DATA chunk on a fresh id, cap the number of tracked streams.
-                            if self.entries.len() < MAX_SCTP_STREAMS {
-                                stream_entry(
-                                    &mut self.entries,
-                                    id,
-                                    StreamEntryState::AwaitConfig,
-                                    "readable/writable",
-                                );
-                            } else {
-                                debug!("Ignoring remote stream {} (stream cap reached)", id);
-                            }
-                        }
-                    }
-                    StreamEvent::Finished { id } | StreamEvent::Stopped { id, .. } => {
-                        // sctp-proto unregistered it when a reset arrived.
-                        // Id reuse is signalled separately by StreamEvent::ResetComplete.
-                        //
-                        // sctp-proto arms that completion here, so from now on a reset
-                        // is outstanding for the id even if we never closed it locally.
-                        self.reset_pending.insert(id);
+            while let Some(t) = self.poll_transmit() {
+                let Some(buf) = transmit_to_vec(t) else {
+                    continue;
+                };
 
-                        // Only a live entry has anything to drop. Closed entries and
-                        // missing ones already went through Close, and an AwaitOpen
-                        // entry is a new incarnation waiting on the same id, it must
-                        // not be killed by the old pending teardown.
-                        if let Some(entry) = self.entries.get_mut(&id) {
-                            if entry.state != StreamEntryState::Closed
-                                && entry.state != StreamEntryState::AwaitOpen
-                            {
-                                debug!("Stream {} finished", id);
-                                entry.do_close = true;
+                return Some(SctpEvent::Transmit { packets: buf });
+            }
+
+            // Don't progress to move data between association and endpoint until we have an
+            // association we want to drive forward.
+            if !self.state.propagate_endpoint_to_assoc() {
+                return None;
+            }
+
+            let assoc = self.assoc.as_mut()?;
+
+            while let Some(e) = assoc.poll() {
+                if let Event::Connected = e {
+                    assoc.set_max_send_message_size(self.remote_max_message_size);
+                    set_state(&mut self.state, RtcSctpState::Established);
+                    continue 'restart;
+                }
+
+                if let Event::AssociationLost { ref reason } = e {
+                    debug!("Association lost, reason: {}", reason);
+                    // No reset can complete on a dead association.
+                    self.reset_pending.clear();
+                    self.reset_complete.clear();
+                    return Some(SctpEvent::AssociationLost);
+                }
+
+                if let Event::Stream(se) = e {
+                    match se {
+                        StreamEvent::Readable { id } | StreamEvent::Writable { id } => {
+                            stream_entry(
+                                &mut self.entries,
+                                id,
+                                StreamEntryState::AwaitConfig,
+                                "readable/writable",
+                            );
+                        }
+                        StreamEvent::Finished { id } | StreamEvent::Stopped { id, .. } => {
+                            // sctp-proto unregistered it when a reset arrived.
+                            // Id reuse is signalled separately by StreamEvent::ResetComplete.
+                            //
+                            // sctp-proto arms that completion here, so from now on a reset
+                            // is outstanding for the id even if we never closed it locally.
+                            self.reset_pending.insert(id);
+
+                            // Only a live entry has anything to drop. Closed entries and
+                            // missing ones already went through Close, and an AwaitOpen
+                            // entry is a new incarnation waiting on the same id, it must
+                            // not be killed by the old pending teardown.
+                            if let Some(entry) = self.entries.get_mut(&id) {
+                                if entry.state != StreamEntryState::Closed
+                                    && entry.state != StreamEntryState::AwaitOpen
+                                {
+                                    debug!("Stream {} finished", id);
+                                    entry.do_close = true;
+                                }
                             }
                         }
+                        StreamEvent::ResetComplete { id } => {
+                            // The reset handshake for this id has fully completed.
+                            debug!("Stream {} reset complete", id);
+                            self.reset_pending.remove(&id);
+                            self.reset_complete.push_back(id);
+                        }
+                        StreamEvent::BufferedAmountLow { id } => {
+                            return Some(SctpEvent::BufferedAmountLow { id });
+                        }
+                        _ => {}
                     }
-                    StreamEvent::ResetComplete { id } => {
-                        // The reset handshake for this id has fully completed.
-                        debug!("Stream {} reset complete", id);
-                        self.reset_pending.remove(&id);
-                        self.reset_complete.push_back(id);
-                    }
-                    StreamEvent::BufferedAmountLow { id } => {
-                        return Some(SctpEvent::BufferedAmountLow { id });
-                    }
-                    _ => {}
                 }
             }
-        }
 
-        // Must wait for association state to be established before opening streams.
-        if self.state != RtcSctpState::Established {
-            return None;
-        }
+            // Must wait for association state to be established before opening streams.
+            if self.state != RtcSctpState::Established {
+                return None;
+            }
 
-        for entry in self.entries.values_mut() {
-            let want_open = entry.state == StreamEntryState::AwaitOpen;
+            for entry in self.entries.values_mut() {
+                let want_open = entry.state == StreamEntryState::AwaitOpen;
 
-            if want_open {
-                debug!("Open stream {}", entry.id);
-                match assoc.open_stream(entry.id, PayloadProtocolIdentifier::Unknown) {
-                    Ok(mut s) => {
-                        entry.open_deadline = None;
+                if want_open {
+                    debug!("Open stream {}", entry.id);
+                    match assoc.open_stream(entry.id, PayloadProtocolIdentifier::Unknown) {
+                        Ok(mut s) => {
+                            entry.open_deadline = None;
 
-                        if !entry.configure_reliability(&mut s) {
-                            entry.set_state(StreamEntryState::Closed);
-                            let stream_id = entry.id;
-                            let reset_pending = self.sctp_propagate_close(stream_id);
-                            return Some(SctpEvent::Close {
-                                id: stream_id,
-                                reset_pending,
-                            });
-                        }
+                            if !entry.configure_reliability(&mut s) {
+                                entry.set_state(StreamEntryState::Closed);
+                                let stream_id = entry.id;
+                                let reset_pending = self.sctp_propagate_close(stream_id);
+                                return Some(SctpEvent::Close {
+                                    id: stream_id,
+                                    reset_pending,
+                                });
+                            }
 
-                        let config = entry.config.as_ref().expect("config if AwaitOpen");
-                        let in_band = config.negotiated.is_none();
+                            let config = entry.config.as_ref().expect("config if AwaitOpen");
+                            let in_band = config.negotiated.is_none();
 
-                        if in_band {
-                            let dcep: DcepOpen = config.into();
-                            let mut buf = vec![0; 1500];
-                            let n = dcep.marshal_to(&mut buf);
-                            buf.truncate(n);
+                            if in_band {
+                                let dcep: DcepOpen = config.into();
+                                let mut buf = vec![0; 1500];
+                                let n = dcep.marshal_to(&mut buf);
+                                buf.truncate(n);
 
-                            match s.write_with_ppi(&buf, PayloadProtocolIdentifier::Dcep) {
-                                Ok(l) => {
-                                    assert!(n == l);
-                                    entry.set_state(StreamEntryState::AwaitDcepAck);
+                                match s.write_with_ppi(&buf, PayloadProtocolIdentifier::Dcep) {
+                                    Ok(l) => {
+                                        assert!(n == l);
+                                        entry.set_state(StreamEntryState::AwaitDcepAck);
 
-                                    // Start over with polling, since we might have caused
-                                    // some network traffic by writing the DcepOpen.
-                                    return self.do_poll_inner(depth + 1);
+                                        // Start over with polling, since we might have caused
+                                        // some network traffic by writing the DcepOpen.
+                                        continue 'restart;
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            "Failed to write DCEP open on stream {}: {:?}",
+                                            entry.id, e
+                                        );
+                                        entry.do_close = true;
+                                        entry.set_state(StreamEntryState::Closed);
+                                        let stream_id = entry.id;
+                                        let reset_pending = self.sctp_propagate_close(stream_id);
+                                        return Some(SctpEvent::Close {
+                                            id: stream_id,
+                                            reset_pending,
+                                        });
+                                    }
                                 }
-                                Err(e) => {
-                                    warn!(
-                                        "Failed to write DCEP open on stream {}: {:?}",
+                            }
+
+                            // Continuing means we are opening the stream out-of-band.
+                        }
+                        Err(
+                            e @ (ProtoError::ErrStreamAlreadyExist
+                            | ProtoError::ErrStreamResetPending),
+                        ) => {
+                            let config = entry.config.as_ref().expect("config if AwaitOpen");
+                            let in_band = config.negotiated.is_none();
+
+                            // ErrStreamAlreadyExist has two causes:
+                            // - the remote created it by sending on it first
+                            // - a previous incarnation of the id is still registered,
+                            //   reset handshake hasn't finished
+                            let stale_incarnation = matches!(e, ProtoError::ErrStreamAlreadyExist)
+                                && assoc
+                                    .stream(entry.id)
+                                    .map(|s| !s.is_readable() && !s.is_writable())
+                                    .unwrap_or(false);
+
+                            if in_band
+                                || stale_incarnation
+                                || matches!(e, ProtoError::ErrStreamResetPending)
+                            {
+                                // RFC 6525 reset handshake for a previous
+                                // incarnation of this stream id hasn't finished yet
+                                //
+                                // - AlreadyExist clears when the remote's reciprocal reset arrives
+                                // - ResetPending when the RECONFIG-RESPONSE arrives (silently)
+                                //
+                                // In both cases,  stay in AwaitOpen and retry until past the deadline.
+                                let deadline = *entry
+                                    .open_deadline
+                                    .get_or_insert(self.last_now + STREAM_OPEN_TIMEOUT);
+
+                                if self.last_now < deadline {
+                                    debug!(
+                                        "Stream {} open blocked ({:?}), will retry",
                                         entry.id, e
                                     );
-                                    entry.do_close = true;
-                                    entry.set_state(StreamEntryState::Closed);
-                                    let stream_id = entry.id;
-                                    let reset_pending = self.sctp_propagate_close(stream_id);
-                                    return Some(SctpEvent::Close {
-                                        id: stream_id,
-                                        reset_pending,
-                                    });
+                                    continue;
                                 }
+
+                                debug!("Opening stream {} failed after retries: {:?}", entry.id, e);
+                                entry.do_close = true;
+                                entry.set_state(StreamEntryState::Closed);
+                                let stream_id = entry.id;
+                                let reset_pending = self.sctp_propagate_close(stream_id);
+                                return Some(SctpEvent::Close {
+                                    id: stream_id,
+                                    reset_pending,
+                                });
+                            }
+
+                            // Continuing means we are adopting the live out-of-band stream the
+                            // remote created. It skipped the Ok branch above, so reliability
+                            // params haven't been applied to it yet.
+                            let mut stream = assoc.stream(entry.id).expect("stream that exists");
+                            if !entry.configure_reliability(&mut stream) {
+                                entry.set_state(StreamEntryState::Closed);
+                                let stream_id = entry.id;
+                                let reset_pending = self.sctp_propagate_close(stream_id);
+                                return Some(SctpEvent::Close {
+                                    id: stream_id,
+                                    reset_pending,
+                                });
                             }
                         }
-
-                        // Continuing means we are opening the stream out-of-band.
-                    }
-                    Err(
-                        e @ (ProtoError::ErrStreamAlreadyExist | ProtoError::ErrStreamResetPending),
-                    ) => {
-                        let config = entry.config.as_ref().expect("config if AwaitOpen");
-                        let in_band = config.negotiated.is_none();
-
-                        // ErrStreamAlreadyExist has two causes:
-                        // - the remote created it by sending on it first
-                        // - a previous incarnation of the id is still registered,
-                        //   reset handshake hasn't finished
-                        let stale_incarnation = matches!(e, ProtoError::ErrStreamAlreadyExist)
-                            && assoc
-                                .stream(entry.id)
-                                .map(|s| !s.is_readable() && !s.is_writable())
-                                .unwrap_or(false);
-
-                        if in_band
-                            || stale_incarnation
-                            || matches!(e, ProtoError::ErrStreamResetPending)
-                        {
-                            // RFC 6525 reset handshake for a previous
-                            // incarnation of this stream id hasn't finished yet
-                            //
-                            // - AlreadyExist clears when the remote's reciprocal reset arrives
-                            // - ResetPending when the RECONFIG-RESPONSE arrives (silently)
-                            //
-                            // In both cases,  stay in AwaitOpen and retry until past the deadline.
-                            let deadline = *entry
-                                .open_deadline
-                                .get_or_insert(self.last_now + STREAM_OPEN_TIMEOUT);
-
-                            if self.last_now < deadline {
-                                debug!("Stream {} open blocked ({:?}), will retry", entry.id, e);
-                                continue;
-                            }
-
-                            debug!("Opening stream {} failed after retries: {:?}", entry.id, e);
+                        Err(e) => {
+                            warn!("Opening stream {} failed: {:?}", entry.id, e);
                             entry.do_close = true;
                             entry.set_state(StreamEntryState::Closed);
                             let stream_id = entry.id;
@@ -958,193 +967,169 @@ impl RtcSctp {
                                 reset_pending,
                             });
                         }
+                    }
 
-                        // Continuing means we are adopting the live out-of-band stream the
-                        // remote created. It skipped the Ok branch above, so reliability
-                        // params haven't been applied to it yet.
-                        let mut stream = assoc.stream(entry.id).expect("stream that exists");
-                        if !entry.configure_reliability(&mut stream) {
-                            entry.set_state(StreamEntryState::Closed);
-                            let stream_id = entry.id;
-                            let reset_pending = self.sctp_propagate_close(stream_id);
-                            return Some(SctpEvent::Close {
-                                id: stream_id,
-                                reset_pending,
+                    // Consider out-of-band stream open.
+                    let config = entry.config.as_ref().expect("config if AwaitOpen");
+                    let in_band = config.negotiated.is_none();
+                    assert!(!in_band);
+
+                    let label = config.label.clone();
+                    entry.set_state(StreamEntryState::Open);
+
+                    return Some(SctpEvent::Open {
+                        id: entry.id,
+                        label,
+                    });
+                }
+
+                if entry.do_close && entry.state != StreamEntryState::Closed {
+                    entry.set_state(StreamEntryState::Closed);
+                    let stream_id = entry.id;
+                    let reset_pending = self.sctp_propagate_close(stream_id);
+                    return Some(SctpEvent::Close {
+                        id: stream_id,
+                        reset_pending,
+                    });
+                }
+
+                let mut stream = match assoc.stream(entry.id) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        // This is expected on browser refresh or similar abrupt shutdown.
+                        debug!("Getting stream {} failed: {:?}", entry.id, e);
+                        entry.do_close = true;
+                        continue;
+                    }
+                };
+
+                // Propagate the desired buffered threshold.
+                // The idea is to only do this if the user has changed the value for it without
+                // incurring the cost of looking up the currently confifured value.
+                if let BufferedThresholdConfig::Desired(x) = entry.buffered_threshold {
+                    if let Err(e) = stream.set_buffered_amount_low_threshold(x) {
+                        debug!("Setting buffered_amount_low_threshold failed: {:?}", e);
+                        entry.do_close = true;
+                        entry.buffered_threshold = BufferedThresholdConfig::Unconfigured;
+                        continue;
+                    }
+
+                    entry.buffered_threshold = BufferedThresholdConfig::Configured(x);
+                }
+                match stream_read_data(&mut stream) {
+                    Ok(Some((buf, ppi))) => {
+                        if ppi != PayloadProtocolIdentifier::Dcep {
+                            // This is the normal path for incoming data.
+                            let buf = ppi_adjust_buf(buf, ppi);
+                            let binary = matches!(
+                                ppi,
+                                PayloadProtocolIdentifier::Binary
+                                    | PayloadProtocolIdentifier::BinaryEmpty
+                            );
+                            return Some(SctpEvent::Data {
+                                id: entry.id,
+                                binary,
+                                data: buf,
                             });
                         }
-                    }
-                    Err(e) => {
-                        warn!("Opening stream {} failed: {:?}", entry.id, e);
-                        entry.do_close = true;
-                        entry.set_state(StreamEntryState::Closed);
-                        let stream_id = entry.id;
-                        let reset_pending = self.sctp_propagate_close(stream_id);
-                        return Some(SctpEvent::Close {
-                            id: stream_id,
-                            reset_pending,
-                        });
-                    }
-                }
 
-                // Consider out-of-band stream open.
-                let config = entry.config.as_ref().expect("config if AwaitOpen");
-                let in_band = config.negotiated.is_none();
-                assert!(!in_band);
+                        // It's Dcep, either a DcepOpen or DcepAck.
+                        match entry.state {
+                            // We are in AwaitConfig state which means we are either going to get it via
+                            // the DcepOpen, or by an out-of-band configuration via open_stream.
+                            // This indicates we are doing in-band.
+                            StreamEntryState::AwaitConfig => {
+                                let dcep: DcepOpen = match buf.as_slice().try_into() {
+                                    Ok(v) => v,
+                                    Err(e) => {
+                                        warn!("Failed to read incoming DCEP {}: {:?}", entry.id, e);
+                                        entry.do_close = true;
+                                        continue;
+                                    }
+                                };
 
-                let label = config.label.clone();
-                entry.set_state(StreamEntryState::Open);
+                                if entry.config.is_none() {
+                                    entry.config = Some((&dcep).into());
+                                } else {
+                                    warn!("Received DcepOpen for configured stream: {}", entry.id);
+                                }
 
-                return Some(SctpEvent::Open {
-                    id: entry.id,
-                    label,
-                });
-            }
+                                // Apply DcepOpen's reliability parameters to the sctp-proto stream.
+                                // Without this, the DCEP-receiving side of an in-band channel sends
+                                // with stream defaults: ordered and fully reliable.
+                                if !entry.configure_reliability(&mut stream) {
+                                    continue;
+                                }
 
-            if entry.do_close && entry.state != StreamEntryState::Closed {
-                entry.set_state(StreamEntryState::Closed);
-                let stream_id = entry.id;
-                let reset_pending = self.sctp_propagate_close(stream_id);
-                return Some(SctpEvent::Close {
-                    id: stream_id,
-                    reset_pending,
-                });
-            }
+                                let mut obuf = [0];
+                                DcepAck.marshal_to(&mut obuf);
+                                match stream.write_with_ppi(&obuf, PayloadProtocolIdentifier::Dcep)
+                                {
+                                    Ok(l) => {
+                                        assert!(obuf.len() == l);
+                                        entry.set_state(StreamEntryState::Open);
 
-            let mut stream = match assoc.stream(entry.id) {
-                Ok(v) => v,
-                Err(e) => {
-                    // This is expected on browser refresh or similar abrupt shutdown.
-                    debug!("Getting stream {} failed: {:?}", entry.id, e);
-                    entry.do_close = true;
-                    continue;
-                }
-            };
+                                        return Some(SctpEvent::Open {
+                                            id: entry.id,
+                                            label: dcep.label,
+                                        });
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            "Failed to write DCEP ack on stream {}: {:?}",
+                                            entry.id, e
+                                        );
+                                        entry.do_close = true;
+                                        entry.set_state(StreamEntryState::Closed);
+                                        let stream_id = entry.id;
+                                        let reset_pending = self.sctp_propagate_close(stream_id);
+                                        return Some(SctpEvent::Close {
+                                            id: stream_id,
+                                            reset_pending,
+                                        });
+                                    }
+                                }
+                            }
+                            StreamEntryState::AwaitDcepAck => {
+                                let res: Result<DcepAck, _> = buf.as_slice().try_into();
 
-            // Propagate the desired buffered threshold.
-            // The idea is to only do this if the user has changed the value for it without
-            // incurring the cost of looking up the currently confifured value.
-            if let BufferedThresholdConfig::Desired(x) = entry.buffered_threshold {
-                if let Err(e) = stream.set_buffered_amount_low_threshold(x) {
-                    debug!("Setting buffered_amount_low_threshold failed: {:?}", e);
-                    entry.do_close = true;
-                    entry.buffered_threshold = BufferedThresholdConfig::Unconfigured;
-                    continue;
-                }
-
-                entry.buffered_threshold = BufferedThresholdConfig::Configured(x);
-            }
-            match stream_read_data(&mut stream) {
-                Ok(Some((buf, ppi))) => {
-                    if ppi != PayloadProtocolIdentifier::Dcep {
-                        // This is the normal path for incoming data.
-                        let buf = ppi_adjust_buf(buf, ppi);
-                        let binary = matches!(
-                            ppi,
-                            PayloadProtocolIdentifier::Binary
-                                | PayloadProtocolIdentifier::BinaryEmpty
-                        );
-                        return Some(SctpEvent::Data {
-                            id: entry.id,
-                            binary,
-                            data: buf,
-                        });
-                    }
-
-                    // It's Dcep, either a DcepOpen or DcepAck.
-                    match entry.state {
-                        // We are in AwaitConfig state which means we are either going to get it via
-                        // the DcepOpen, or by an out-of-band configuration via open_stream.
-                        // This indicates we are doing in-band.
-                        StreamEntryState::AwaitConfig => {
-                            let dcep: DcepOpen = match buf.as_slice().try_into() {
-                                Ok(v) => v,
-                                Err(e) => {
-                                    warn!("Failed to read incoming DCEP {}: {:?}", entry.id, e);
+                                if let Err(e) = res {
+                                    warn!("Failed to read incoming DCEP ACK {}: {:?}", entry.id, e);
                                     entry.do_close = true;
                                     continue;
                                 }
-                            };
 
-                            if entry.config.is_none() {
-                                entry.config = Some((&dcep).into());
-                            } else {
-                                warn!("Received DcepOpen for configured stream: {}", entry.id);
+                                entry.set_state(StreamEntryState::Open);
+                                let config = entry.config.as_ref().expect("config when DcepAck");
+
+                                return Some(SctpEvent::Open {
+                                    id: entry.id,
+                                    label: config.label.clone(),
+                                });
                             }
-
-                            // Apply DcepOpen's reliability parameters to the sctp-proto stream.
-                            // Without this, the DCEP-receiving side of an in-band channel sends
-                            // with stream defaults: ordered and fully reliable.
-                            if !entry.configure_reliability(&mut stream) {
-                                continue;
-                            }
-
-                            let mut obuf = [0];
-                            DcepAck.marshal_to(&mut obuf);
-                            match stream.write_with_ppi(&obuf, PayloadProtocolIdentifier::Dcep) {
-                                Ok(l) => {
-                                    assert!(obuf.len() == l);
-                                    entry.set_state(StreamEntryState::Open);
-
-                                    return Some(SctpEvent::Open {
-                                        id: entry.id,
-                                        label: dcep.label,
-                                    });
-                                }
-                                Err(e) => {
-                                    warn!(
-                                        "Failed to write DCEP ack on stream {}: {:?}",
-                                        entry.id, e
-                                    );
-                                    entry.do_close = true;
-                                    entry.set_state(StreamEntryState::Closed);
-                                    let stream_id = entry.id;
-                                    let reset_pending = self.sctp_propagate_close(stream_id);
-                                    return Some(SctpEvent::Close {
-                                        id: stream_id,
-                                        reset_pending,
-                                    });
-                                }
-                            }
-                        }
-                        StreamEntryState::AwaitDcepAck => {
-                            let res: Result<DcepAck, _> = buf.as_slice().try_into();
-
-                            if let Err(e) = res {
-                                warn!("Failed to read incoming DCEP ACK {}: {:?}", entry.id, e);
+                            _ => {
+                                warn!(
+                                    "Stream {} in wrong state when receiving DCEP: {:?}",
+                                    entry.id, entry.state
+                                );
                                 entry.do_close = true;
                                 continue;
                             }
-
-                            entry.set_state(StreamEntryState::Open);
-                            let config = entry.config.as_ref().expect("config when DcepAck");
-
-                            return Some(SctpEvent::Open {
-                                id: entry.id,
-                                label: config.label.clone(),
-                            });
-                        }
-                        _ => {
-                            warn!(
-                                "Stream {} in wrong state when receiving DCEP: {:?}",
-                                entry.id, entry.state
-                            );
-                            entry.do_close = true;
-                            continue;
                         }
                     }
+                    Ok(None) => continue,
+                    Err(_) => entry.do_close = true,
                 }
-                Ok(None) => continue,
-                Err(_) => entry.do_close = true,
             }
-        }
 
-        // Reset completions are reported last. Reaching here means the entry loop had
-        // no `Close` left to emit, so the close for a released id has been delivered.
-        if let Some(id) = self.reset_complete.pop_front() {
-            return Some(SctpEvent::StreamResetComplete { id });
-        }
+            // Reset completions are reported last. Reaching here means the entry loop had
+            // no `Close` left to emit, so the close for a released id has been delivered.
+            if let Some(id) = self.reset_complete.pop_front() {
+                return Some(SctpEvent::StreamResetComplete { id });
+            }
 
-        None
+            return None;
+        }
     }
 
     pub fn poll_timeout(&mut self) -> Option<Instant> {

--- a/tests/malformed-packet-injection.rs
+++ b/tests/malformed-packet-injection.rs
@@ -1,0 +1,242 @@
+//! Regression tests for panics reachable from packets a peer (or, for the SRTP/SRTCP
+//! cases, anyone who can send a datagram to the socket) puts on the wire.
+//!
+//! str0m's policy is that a panic means a bug in str0m, never bad input. Every test
+//! here feeds input through a public API and asserts we survive it.
+
+use std::net::{Ipv4Addr, SocketAddr};
+use std::panic::AssertUnwindSafe;
+use std::time::Instant;
+
+use str0m::media::MediaKind;
+use str0m::net::{Protocol, Receive};
+use str0m::rtp::Ssrc;
+use str0m::rtp::rtcp::{Rtcp, Twcc};
+use str0m::{Input, RtcError};
+
+mod common;
+use common::{TestRtc, connect_l_r, init_crypto_default, init_log};
+
+const L_ADDR: SocketAddr = SocketAddr::new(std::net::IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), 1000);
+const R_ADDR: SocketAddr = SocketAddr::new(std::net::IpAddr::V4(Ipv4Addr::new(2, 2, 2, 2)), 2000);
+
+/// Feed one raw datagram straight into `Rtc::handle_input`, exactly as a socket read would.
+///
+/// Returns `None` when the demuxer rejects the datagram outright (not our concern here).
+fn inject(rtc: &mut TestRtc, bytes: &[u8]) -> Option<Result<(), RtcError>> {
+    let now = rtc.last;
+    let contents = bytes.try_into().ok()?;
+
+    let input = Input::Receive(
+        now,
+        Receive {
+            proto: Protocol::Udp,
+            source: L_ADDR,
+            destination: R_ADDR,
+            contents,
+        },
+    );
+
+    Some(rtc.rtc.handle_input(input))
+}
+
+/// Run `f` and report a panic as `Err(message)` rather than unwinding out of the test,
+/// so a sweep can report *every* bad length instead of stopping at the first.
+fn catch(f: impl FnOnce()) -> Result<(), String> {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let res = std::panic::catch_unwind(AssertUnwindSafe(f));
+    std::panic::set_hook(prev);
+
+    res.map_err(|e| {
+        e.downcast_ref::<String>()
+            .cloned()
+            .or_else(|| e.downcast_ref::<&str>().map(|s| s.to_string()))
+            .unwrap_or_else(|| "<non-string panic>".to_string())
+    })
+}
+
+/// Build a bare RTCP-shaped datagram of exactly `len` bytes.
+///
+/// byte0 = 0x80 and byte1 = 201 (Receiver Report) is what `MultiplexKind` uses to route
+/// a datagram to the SRTCP path, so this is all it takes to reach `unprotect_rtcp`.
+fn rtcp_shaped(len: usize) -> Vec<u8> {
+    let mut v = vec![0u8; len];
+    if len > 0 {
+        v[0] = 0x80;
+    }
+    if len > 1 {
+        v[1] = 201;
+    }
+    v
+}
+
+/// Build an RTP-shaped datagram: 12-byte minimal header (no CSRC, no extension)
+/// plus `payload_len` bytes of payload.
+fn rtp_shaped(pt: u8, ssrc: Ssrc, seq: u16, payload_len: usize) -> Vec<u8> {
+    let mut v = Vec::with_capacity(12 + payload_len);
+    v.push(0x80); // version 2, no padding, no extension, csrc count 0
+    v.push(pt); // marker 0
+    v.extend_from_slice(&seq.to_be_bytes());
+    v.extend_from_slice(&0u32.to_be_bytes()); // timestamp
+    v.extend_from_slice(&(*ssrc).to_be_bytes());
+    v.resize(12 + payload_len, 0);
+    v
+}
+
+/// A datagram that demuxes as SRTCP but is too short to hold the SRTCP header,
+/// the SRTCP index and the AEAD tag must be dropped, not panicked on.
+///
+/// The guard in `SrtpContext::unprotect_rtcp` only requires `SRTCP_INDEX_LEN + TAG_LEN`
+/// (20 bytes), but the code then builds `vec![0; buf.len() - TAG_LEN - SRTCP_INDEX_LEN]`
+/// and immediately writes 8 bytes into it. For 20..28 bytes that vec is shorter than 8.
+///
+/// This is reachable *before any authentication*: `Rtc::do_handle_receive` routes RTCP
+/// straight to the session with no source or ICE check, and `unprotect_rtcp` is the
+/// first code to touch the bytes.
+#[test]
+fn srtcp_shorter_than_srtcp_overhead() {
+    init_log();
+    init_crypto_default();
+
+    let (_l, mut r) = connect_l_r();
+
+    let mut panics = Vec::new();
+
+    for len in 3..=64usize {
+        let packet = rtcp_shaped(len);
+
+        if let Err(msg) = catch(|| {
+            // Ignore the Result, only the absence of a panic matters.
+            let _ = inject(&mut r, &packet);
+        }) {
+            panics.push((len, msg));
+        }
+    }
+
+    assert!(
+        panics.is_empty(),
+        "short SRTCP datagrams panicked at these lengths: {:#?}",
+        panics
+    );
+}
+
+/// An RTP packet whose payload is shorter than the AEAD tag must be dropped.
+///
+/// `unprotect_rtp` guards on `buf.len() < TAG_LEN`, but then computes
+/// `input.len() - TAG_LEN` where `input` is everything *after* the RTP header. A 12-byte
+/// header plus a 4..15 byte payload underflows: a subtract-overflow panic in debug, and in
+/// release a wrapped `out_len` that makes `rx_scratch.resize()` abort.
+///
+/// Also pre-authentication, since for the GCM profiles the decrypt *is* the authentication.
+#[test]
+fn srtp_payload_shorter_than_aead_tag() {
+    init_log();
+    init_crypto_default();
+
+    let (_l, mut r) = connect_l_r();
+
+    let mid = "aud".into();
+    let ssrc: Ssrc = 42.into();
+    r.direct_api().declare_media(mid, MediaKind::Audio);
+    r.direct_api().expect_stream_rx(ssrc, None, mid, None);
+
+    let pt = *r.params_opus().pt();
+
+    let mut panics = Vec::new();
+
+    for payload_len in 0..=32usize {
+        // A fresh seq each time so the replay/dupe filter doesn't short-circuit us.
+        let packet = rtp_shaped(pt, ssrc, payload_len as u16, payload_len);
+
+        if let Err(msg) = catch(|| {
+            let _ = inject(&mut r, &packet);
+        }) {
+            panics.push((payload_len, msg));
+        }
+    }
+
+    assert!(
+        panics.is_empty(),
+        "short RTP payloads panicked at these payload lengths: {:#?}",
+        panics
+    );
+}
+
+/// REMB carries an attacker-controlled SSRC count in a single byte, and the parser
+/// indexes `buf[16 + i * 4 ..]` for each of them without checking the buffer holds them.
+///
+/// Reachable by an SRTCP-authenticated peer, i.e. the remote side of any call.
+#[test]
+fn remb_ssrc_count_beyond_buffer() {
+    init_log();
+
+    // RTCP header: version 2, fmt 15 (application layer), PT 206 (payload specific feedback).
+    let mut buf = vec![0x80 | 15, 206, 0, 4];
+    buf.extend_from_slice(&1u32.to_be_bytes()); // sender ssrc
+    buf.extend_from_slice(&0u32.to_be_bytes()); // media ssrc, must be zero
+    buf.extend_from_slice(b"REMB"); // unique identifier
+    buf.push(255); // ssrc count: claims 255 trailing SSRCs...
+    buf.extend_from_slice(&[0x1a, 0x20, 0xdf]); // exp + mantissa
+
+    assert_eq!(buf.len(), 20, "...but the packet ends right here");
+
+    let res = catch(|| {
+        // Must be an error, never a panic.
+        let _ = Rtcp::try_from(&buf[..]);
+    });
+
+    assert!(
+        res.is_ok(),
+        "parsing REMB with an oversized ssrc count panicked: {}",
+        res.unwrap_err()
+    );
+
+    // It must not come out as a REMB. (Falling through to the generic
+    // application-specific feedback parser is fine.)
+    assert!(
+        !matches!(Rtcp::try_from(&buf[..]), Ok(Rtcp::Remb(_))),
+        "a REMB claiming 255 SSRCs in a 20 byte packet must be rejected"
+    );
+}
+
+/// A TWCC run-length vector chunk encodes each packet status in 2 bits, so `0b11` is
+/// perfectly representable on the wire. The parser accepts it (mapping it to
+/// `PacketStatus::Unknown` and consuming no delta), but `TwccIter::next` has no arm for
+/// `Unknown` and falls through to `unreachable!()`.
+///
+/// Reachable by an SRTCP-authenticated peer.
+#[test]
+fn twcc_vector_double_with_unknown_symbol() {
+    init_log();
+
+    // RTCP header: version 2, fmt 15 (transport wide), PT 205 (transport layer feedback).
+    let mut buf = vec![0x80 | 15, 205, 0, 5];
+    buf.extend_from_slice(&1u32.to_be_bytes()); // sender ssrc
+    buf.extend_from_slice(&2u32.to_be_bytes()); // media ssrc
+    buf.extend_from_slice(&0u16.to_be_bytes()); // base seq
+    buf.extend_from_slice(&7u16.to_be_bytes()); // status count: one full VectorDouble
+    buf.extend_from_slice(&[0, 0, 0]); // reference time (24 bit)
+    buf.push(0); // feedback count
+
+    // 0b11 in the top bits marks a "vector, 2-bit symbols" chunk. The first symbol is
+    // 0b11, the remaining six are 0b00 (not received).
+    buf.extend_from_slice(&0xF000u16.to_be_bytes());
+
+    let Ok(Rtcp::Twcc(twcc)) = Rtcp::try_from(&buf[..]) else {
+        panic!("a well-formed TWCC chunk should parse");
+    };
+    let _: Twcc = twcc.clone();
+
+    let res = catch(move || {
+        let count = twcc.into_iter(Instant::now(), 0.into()).count();
+        // Reaching here at all is the point.
+        let _ = count;
+    });
+
+    assert!(
+        res.is_ok(),
+        "iterating a TWCC report with a 0b11 vector symbol panicked: {}",
+        res.unwrap_err()
+    );
+}


### PR DESCRIPTION
Guards and bounds on parsing paths that could be reached with input that doesn't
match what the code assumed:

- `src/rtp/srtp.rs` - check the length covers the RTP header plus the auth tag
  before slicing, and the SRTCP header plus index plus tag for RTCP.
- `src/rtp/rtcp/remb.rs` - bound the SSRC count against the buffer.
- `src/rtp/rtcp/twcc.rs` - a `VectorDouble` chunk can carry `0b11` for any of its
  statuses, which the parser maps to `PacketStatus::Unknown`. `TwccIter::next` had
  no arm for that.
- `src/rtp/rtcp/xr.rs` - cap the `Dlrr` pre-allocation by what the buffer can hold.
- `src/rtp/ext.rs` - `Instant - Duration` panics on underflow, so saturate.
- `src/channel.rs` - stop the SCTP stream id walk from running off the end of `u16`.
- `src/sctp/mod.rs` - `entries` moved to a `BTreeMap`, plus a stream cap, a
  recursion depth cap, `saturating_sub` in `available()`, and a graceful close when
  an `AwaitConfig` stream is already gone.

Tests in `tests/malformed-packet-injection.rs` push hand-crafted datagrams through
`Rtc::handle_input`. Two of them sweep a length range and collect every length that
fails instead of stopping at the first. Two more sit next to the code in
`src/channel.rs` and `src/sctp/mod.rs`.

Found by @gab8i and @dmitry-markin. The bulk of this is theirs, I added tests and
one extra fix on top.
