### PR TITLE
fix(rtp): keep the voice activity bit out of the audio level's sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
   * Add RFC 2198 RED (redundant audio) support for all audio codecs #982
+  * Preserve the RFC 6464 audio-level voice activity bit when serializing #1032
 
 # 0.23.1
 

--- a/src/rtp/ext.rs
+++ b/src/rtp/ext.rs
@@ -664,7 +664,11 @@ impl Extension {
             AudioLevel => {
                 let v1 = ev.audio_level?;
                 let v2 = ev.voice_activity?;
-                buf[0] = if v2 { 0x80 } else { 0 } | (-(0x7f & v1) as u8);
+                // `v1` is negative, so masking it before negating leaves the
+                // sign bit in place: for -37 the expression `-(0x7f & v1)`
+                // yields 0xA5, which already has bit 7 set. Taking the
+                // magnitude first keeps the sign out of the V bit.
+                buf[0] = if v2 { 0x80 } else { 0 } | (v1.unsigned_abs() & 0x7f);
                 Some(1)
             }
             TransmissionTimeOffset => {
@@ -1579,5 +1583,32 @@ mod test {
             e1.iter_video().collect::<Vec<_>>(),
             vec![(12, &VideoOrientation), (14, &TransportSequenceNumber)]
         );
+    }
+
+    #[test]
+    fn audio_level_round_trip() {
+        // The V bit (voice activity) must survive serialization for every
+        // level on the scale, not just when it is set.
+        let mut exts = ExtensionMap::empty();
+        exts.set(1, Extension::AudioLevel);
+
+        for level in -127..=0 {
+            for voice_activity in [false, true] {
+                let ev = ExtensionValues {
+                    audio_level: Some(level),
+                    voice_activity: Some(voice_activity),
+                    ..Default::default()
+                };
+
+                let mut buf = vec![0_u8; 8];
+                exts.write_to(&mut buf[..], &ev, ExtensionsForm::OneByte);
+
+                let mut ev2 = ExtensionValues::default();
+                exts.parse(&buf, ExtensionsForm::OneByte, &mut ev2);
+
+                assert_eq!(ev2.audio_level, Some(level));
+                assert_eq!(ev2.voice_activity, Some(voice_activity));
+            }
+        }
     }
 }

--- a/src/rtp/header.rs
+++ b/src/rtp/header.rs
@@ -465,6 +465,10 @@ mod test {
         }
 
         let mut exts = ExtensionMap::empty();
+        // The expected bytes below carry the level with the V bit CLEAR, which
+        // is what `voice_activity: Some(false)` above asks for. They used to
+        // have bit 7 set (170 = 0xAA rather than 42 = 0x2A) because the
+        // serializer let the sign of the negative level spill into that bit.
         exts.set(3, Extension::AudioLevel);
 
         let buf1 = mk_header(47_000, 10_000, -42, false, &exts);
@@ -472,13 +476,13 @@ mod test {
         let buf3 = mk_header(47_002, 14_000, -44, false, &exts);
 
         let p1 = &[
-            144, 33, 183, 152, 0, 0, 39, 16, 0, 0, 0, 44, 0xBE, 0xDE, 0, 1, 48, 170, 0, 0,
+            144, 33, 183, 152, 0, 0, 39, 16, 0, 0, 0, 44, 0xBE, 0xDE, 0, 1, 48, 42, 0, 0,
         ];
         let p2 = &[
-            144, 161, 183, 153, 0, 0, 46, 224, 0, 0, 0, 44, 0xBE, 0xDE, 0, 1, 48, 171, 0, 0,
+            144, 161, 183, 153, 0, 0, 46, 224, 0, 0, 0, 44, 0xBE, 0xDE, 0, 1, 48, 43, 0, 0,
         ];
         let p3 = &[
-            144, 33, 183, 154, 0, 0, 54, 176, 0, 0, 0, 44, 0xBE, 0xDE, 0, 1, 48, 172, 0, 0,
+            144, 33, 183, 154, 0, 0, 54, 176, 0, 0, 0, 44, 0xBE, 0xDE, 0, 1, 48, 44, 0, 0,
         ];
 
         assert_eq!(&buf1, p1);
@@ -510,6 +514,8 @@ mod test {
         }
 
         let mut exts = ExtensionMap::empty();
+        // Same correction as above: the V bit is clear because the header
+        // asks for `voice_activity: Some(false)`.
         // An ID larger than 14 forces the 2-byte header extension form
         exts.set(15, Extension::AudioLevel);
 
@@ -518,13 +524,13 @@ mod test {
         let buf3 = mk_header(47_002, 14_000, -44, false, &exts);
 
         let p1 = &[
-            144, 33, 183, 152, 0, 0, 39, 16, 0, 0, 0, 44, 0x10, 0x00, 0, 1, 15, 1, 170, 0,
+            144, 33, 183, 152, 0, 0, 39, 16, 0, 0, 0, 44, 0x10, 0x00, 0, 1, 15, 1, 42, 0,
         ];
         let p2 = &[
-            144, 161, 183, 153, 0, 0, 46, 224, 0, 0, 0, 44, 0x10, 0x00, 0, 1, 15, 1, 171, 0,
+            144, 161, 183, 153, 0, 0, 46, 224, 0, 0, 0, 44, 0x10, 0x00, 0, 1, 15, 1, 43, 0,
         ];
         let p3 = &[
-            144, 33, 183, 154, 0, 0, 54, 176, 0, 0, 0, 44, 0x10, 0x00, 0, 1, 15, 1, 172, 0,
+            144, 33, 183, 154, 0, 0, 54, 176, 0, 0, 0, 44, 0x10, 0x00, 0, 1, 15, 1, 44, 0,
         ];
 
         assert_eq!(&buf1, p1);


### PR DESCRIPTION
## What

When serializing the RFC 6464 `ssrc-audio-level` extension, the voice activity
(V) bit is forced to `1` for every non-zero level. A header written with
`voice_activity: Some(false)` is parsed back as `Some(true)`.

The audio level itself is always written correctly — only the flag is lost.

## Why

```rust
buf[0] = if v2 { 0x80 } else { 0 } | (-(0x7f & v1) as u8);
```

`audio_level` is negative, so masking it before negating leaves the sign in
place. For `v1 = -37`:

| step | value |
|---|---|
| `v1` as bits | `0xDB` |
| `0x7f & v1` | `0x5B` = 128 − 37 |
| `-(0x5B)` as `u8` | `0xA5` = 128 + 37 |

Bit 7 is already set before the flag term is OR-ed in, and OR cannot clear it.
The low seven bits come out as the magnitude, which is why the level survived
and only the flag was lost — and why this went unnoticed: with
`voice_activity: Some(true)` everything matches.

## Fix

```rust
buf[0] = if v2 { 0x80 } else { 0 } | (v1.unsigned_abs() & 0x7f);
```

Checked exhaustively over the scale: of the 256 `(level, voice_activity)` pairs,
127 used to round-trip with the wrong flag — all with the flag `false` and a
non-zero level — and all 256 round-trip correctly now. The added test
`audio_level_round_trip` walks the whole scale and fails on `main`
(`left: Some(true), right: Some(false)`).

## Test changes

The two golden-byte tests in `rtp::header` encoded the old behaviour: they build
headers with `voice_activity: Some(false)` and expect `170` (`0xAA`) where the
correct byte is `42` (`0x2A`). Updated with a note explaining why, so the change
does not read as a loosened expectation.

The parsing tests are deliberately untouched: `0xAA` on the wire really does
mean "voice, level 42", and the parse side needs no change.

`cargo test --lib` is green (707 passed), `cargo fmt --check` clean.

## How it was found

Building an SFU on str0m. Our own test asserted that a declared "not speech"
flag survives forwarding, and it came back as speech every time. For an SFU this
matters: the point of RFC 6464 is to make forwarding decisions without
decrypting or decoding, and speaker detection that trusts the V bit cannot tell
speech from steady background noise.
