### PR TITLE
Fix Clippy

### DIFF
--- a/src/bwe/alr_detector/detector.rs
+++ b/src/bwe/alr_detector/detector.rs
@@ -229,7 +229,7 @@ mod tests {
         // Simulate bursty encoder: alternate between large and small frames
         let mut time = now;
         for i in 0..100 {
-            time = time + Duration::from_millis(33); // ~30fps
+            time += Duration::from_millis(33); // ~30fps
 
             if i % 10 == 0 {
                 // Keyframe: 10x normal size

--- a/src/bwe/probe/estimator.rs
+++ b/src/bwe/probe/estimator.rs
@@ -516,10 +516,10 @@ mod test {
             // send spaced 4ms, recv spaced 4ms (same ordering)
             crate::rtp_::TwccSendRecord::test_new(
                 pid,
-                base + Duration::from_millis(i as u64 * 4),
+                base + Duration::from_millis(i * 4),
                 1200,
-                base + Duration::from_millis(i as u64 * 4 + 1),
-                Some(base + Duration::from_millis(i as u64 * 4 + 2)),
+                base + Duration::from_millis(i * 4 + 1),
+                Some(base + Duration::from_millis(i * 4 + 2)),
             )
         });
 
@@ -529,9 +529,9 @@ mod test {
             let pid = TwccPacketId::with_cluster(seq, cluster);
             crate::rtp_::TwccSendRecord::test_new(
                 pid,
-                base + Duration::from_millis(100 + i as u64),
+                base + Duration::from_millis(100 + i),
                 1200,
-                base + Duration::from_millis(150 + i as u64),
+                base + Duration::from_millis(150 + i),
                 None, // lost
             )
         });
@@ -577,10 +577,10 @@ mod test {
                 let pid = TwccPacketId::with_cluster(seq, cluster);
                 crate::rtp_::TwccSendRecord::test_new(
                     pid,
-                    base + Duration::from_millis(i as u64 * 50),
+                    base + Duration::from_millis(i * 50),
                     1200,
-                    base + Duration::from_millis(250 + i as u64),
-                    Some(base + Duration::from_millis(300 + (i as u64 % 2))), // ~0-1ms spread
+                    base + Duration::from_millis(250 + i),
+                    Some(base + Duration::from_millis(300 + (i % 2))), // ~0-1ms spread
                 )
             })
             .collect();
@@ -611,8 +611,8 @@ mod test {
                     pid,
                     base, // identical send time for all
                     1200,
-                    base + Duration::from_millis(10 + i as u64),
-                    Some(base + Duration::from_millis(20 + i as u64)),
+                    base + Duration::from_millis(10 + i),
+                    Some(base + Duration::from_millis(20 + i)),
                 )
             })
             .collect();

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -690,12 +690,14 @@ mod tests {
         let sctp = RtcSctp::new(1200);
         let base: u16 = if sctp.is_client() { 0 } else { 1 };
 
-        let mut handler = ChannelHandler::default();
+        let mut handler = ChannelHandler {
+            closed_stream_ids: (base..=u16::MAX).step_by(2).collect(),
+            ..Default::default()
+        };
 
         // What the peer did: claim every stream id of our parity. Going through
         // `ensure_channel_id_for()` for each is the realistic route but is quadratic,
         // so seed the equivalent state directly.
-        handler.closed_stream_ids = (base..=u16::MAX).step_by(2).collect();
         assert_eq!(handler.closed_stream_ids.len(), 32768);
 
         // Now the local application asks for a data channel.

--- a/src/config.rs
+++ b/src/config.rs
@@ -864,6 +864,6 @@ mod tests {
     #[test]
     #[should_panic(expected = "mtu range start must be <= end")]
     fn set_mtu_panics_on_inverted_range() {
-        let _ = RtcConfig::default().set_mtu(1300..=1299);
+        let _ = RtcConfig::default().set_mtu(RangeInclusive::new(1300, 1299));
     }
 }

--- a/src/packet/av1.rs
+++ b/src/packet/av1.rs
@@ -817,7 +817,7 @@ mod test {
         let result = packetizer.packetize(100, &payload);
 
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().len(), 13 as usize);
+        assert_eq!(result.unwrap().len(), 13);
     }
 
     #[test]
@@ -1259,7 +1259,7 @@ mod test {
     fn packetize_respects_mtu() {
         // OBU header (frame-type, no size field) + payload bytes.
         let mut payload = vec![0x30u8];
-        payload.extend(std::iter::repeat(0xABu8).take(2000));
+        payload.extend(std::iter::repeat_n(0xABu8, 2000));
         for &mtu in &[100usize, 300, 600, 1200] {
             let mut packetizer = Av1Packetizer::default();
             let pkts = packetizer

--- a/src/packet/buffer_rx.rs
+++ b/src/packet/buffer_rx.rs
@@ -925,9 +925,7 @@ mod test {
         let depack = CodecDepacketizer::Boxed(Box::new(TestDepack));
         let mut buf = DepacketizingBuffer::new(depack, hold_back);
 
-        let mut step = 1;
-
-        for (seq, time, data, checks) in v {
+        for (step, (seq, time, data, checks)) in (1..).zip(v.iter()) {
             let meta = RtpMeta {
                 received: Instant::now(),
                 seq_no: (*seq).into(),
@@ -975,8 +973,6 @@ mod test {
                     step, depack.data, *ddata
                 );
             }
-
-            step += 1;
         }
     }
 

--- a/src/packet/h266.rs
+++ b/src/packet/h266.rs
@@ -1001,7 +1001,7 @@ mod test {
                 typ: u8,
             }
 
-            let tests = vec![
+            let tests = [
                 // S=1, type 7 (IDR_W_RADL)
                 TestType {
                     value: 0x87,
@@ -1086,14 +1086,14 @@ mod test {
         fn test_h266_single_nalunit_packet() -> Result<()> {
             // Valid single NAL (TRAIL, type 0) -> Annex-B out.
             let nal = make_nal(0, 5);
-            let (out, keyframe) = depacketize_all(&[nal.clone()])?;
+            let (out, keyframe) = depacketize_all(std::slice::from_ref(&nal))?;
             assert_eq!(&out[..4], &[0, 0, 0, 1]);
             assert_eq!(&out[4..], &nal[..]);
             assert!(!keyframe);
 
             // IDR single NAL flags keyframe.
             let idr = make_nal(H266NALU_IDR_W_RADL, 5);
-            let (out, keyframe) = depacketize_all(&[idr.clone()])?;
+            let (out, keyframe) = depacketize_all(std::slice::from_ref(&idr))?;
             assert_eq!(&out[4..], &idr[..]);
             assert!(keyframe);
 
@@ -1214,7 +1214,7 @@ mod test {
                 expect_err: bool, // all error cases expect ErrShortPacket
             }
 
-            let tests = vec![
+            let tests = [
                 // empty
                 TestType {
                     raw: &[],
@@ -2266,7 +2266,7 @@ mod test {
         fn test_h266_fu_preserves_layer_and_tid() -> Result<()> {
             // TRAIL (type 1) on layer 5, temporal sublayer tid=3.
             let mut nal = hdr(1, 5, 3).to_vec();
-            nal.extend(std::iter::repeat(0xAB).take(998));
+            nal.extend(std::iter::repeat_n(0xAB, 998));
 
             let mut pck = H266Packetizer::default();
             let packets = pck.packetize(100, &nal)?;
@@ -2294,7 +2294,7 @@ mod test {
         fn test_h266_fu_preserves_z_bit() -> Result<()> {
             let mut nal = hdr(1, 2, 1).to_vec();
             nal[0] |= 0b0100_0000; // set Z
-            nal.extend(std::iter::repeat(0xCD).take(500));
+            nal.extend(std::iter::repeat_n(0xCD, 500));
 
             let mut pck = H266Packetizer::default();
             let packets = pck.packetize(100, &nal)?;
@@ -2561,7 +2561,7 @@ mod test {
         fn test_h266_fu_preserves_all_header_flags() -> Result<()> {
             let mut nal = hdr(1, 1, 1).to_vec();
             nal[0] |= 0b1100_0000; // F + Z
-            nal.extend(std::iter::repeat(0x5A).take(400));
+            nal.extend(std::iter::repeat_n(0x5A, 400));
 
             let mut pck = H266Packetizer::default();
             let packets = pck.packetize(100, &nal)?;

--- a/src/packet/vp9.rs
+++ b/src/packet/vp9.rs
@@ -1086,13 +1086,13 @@ mod test {
             (
                 "ParseRefIdx",
                 &[
-                    0xD8,                              /* I:1 P:1 L:0 F:1
-                                                        * B:1 E:0 V:0 Z:0 */
-                    (0x80 | ((17 >> 8) & 0x7F)) as u8, // Two byte pictureID.
-                    17,                                // TL0PICIDX
-                    (17 << 1) | 1,                     // P_DIFF N:1
-                    (18 << 1) | 1,                     // P_DIFF N:1
-                    (127 << 1) | 0,                    // P_DIFF N:0
+                    0xD8,          /* I:1 P:1 L:0 F:1
+                                    * B:1 E:0 V:0 Z:0 */
+                    0x80,          // Two byte pictureID.
+                    17,            // TL0PICIDX
+                    (17 << 1) | 1, // P_DIFF N:1
+                    (18 << 1) | 1, // P_DIFF N:1
+                    127 << 1,      // P_DIFF N:0
                 ],
                 Vp9Depacketizer {
                     i: true,
@@ -1136,11 +1136,9 @@ mod test {
 
     #[test]
     fn test_vp9_packetizer_payload() -> Result<(), PacketError> {
-        let mut r0 = 8692;
         let mut rands = vec![];
-        for _ in 0..10 {
+        for r0 in 8692..8702 {
             rands.push(vec![(r0 >> 8) as u8 | 0x80, (r0 & 0xFF) as u8]);
-            r0 += 1;
         }
 
         // Non-flexible mode (F=0) header layout:
@@ -1269,7 +1267,7 @@ mod test {
         assert_eq!(pkt[0], 0xAE, "Keyframe flags should be 0xAE");
         // PID
         assert_eq!(pkt[1], (100 >> 8) as u8 | 0x80);
-        assert_eq!(pkt[2], 100 & 0xFF);
+        assert_eq!(pkt[2], 100);
         // L byte: TID=0, U=1, SID=0, D=0
         assert_eq!(pkt[3], 0x10);
         // tl0picidx = 1 (first frame)
@@ -1391,11 +1389,9 @@ mod test {
 
     #[test]
     fn test_vp9_packetizer_flexible_mode() -> Result<(), PacketError> {
-        let mut r0 = 8692;
         let mut rands = vec![];
-        for _ in 0..10 {
+        for r0 in 8692..8702 {
             rands.push(vec![(r0 >> 8) as u8 | 0x80, (r0 & 0xFF) as u8]);
-            r0 += 1;
         }
 
         // With VP9_FLEXIBLE_HEADER_SIZE=3, min productive MTU is 4.
@@ -1565,7 +1561,7 @@ mod test {
     fn packetize_respects_mtu() -> Result<(), PacketError> {
         // VP9 profile 0 keyframe header followed by payload bytes.
         let mut payload = vec![0x82u8];
-        payload.extend(std::iter::repeat(0xABu8).take(2000));
+        payload.extend(std::iter::repeat_n(0xABu8, 2000));
         for &mtu in &[100usize, 300, 600, 1200] {
             let mut pck = Vp9Packetizer {
                 initial_picture_id: 100,

--- a/src/packet/vp9.rs
+++ b/src/packet/vp9.rs
@@ -813,6 +813,7 @@ mod test {
     use super::*;
 
     #[test]
+    #[allow(clippy::erasing_op, clippy::identity_op)]
     fn test_vp9_packet_unmarshal() -> Result<(), PacketError> {
         let tests: Vec<(&str, &[u8], Vp9Depacketizer, &[u8], Option<PacketError>)> = vec![
             (
@@ -1086,13 +1087,13 @@ mod test {
             (
                 "ParseRefIdx",
                 &[
-                    0xD8,          /* I:1 P:1 L:0 F:1
-                                    * B:1 E:0 V:0 Z:0 */
-                    0x80,          // Two byte pictureID.
-                    17,            // TL0PICIDX
-                    (17 << 1) | 1, // P_DIFF N:1
-                    (18 << 1) | 1, // P_DIFF N:1
-                    127 << 1,      // P_DIFF N:0
+                    0xD8,                              /* I:1 P:1 L:0 F:1
+                                                        * B:1 E:0 V:0 Z:0 */
+                    (0x80 | ((17 >> 8) & 0x7F)) as u8, // Two byte pictureID.
+                    17,                                // TL0PICIDX
+                    (17 << 1) | 1,                     // P_DIFF N:1
+                    (18 << 1) | 1,                     // P_DIFF N:1
+                    (127 << 1) | 0,                    // P_DIFF N:0
                 ],
                 Vp9Depacketizer {
                     i: true,

--- a/src/rtp/srtp.rs
+++ b/src/rtp/srtp.rs
@@ -1173,7 +1173,7 @@ mod test {
                 rfc7714::PROTECTED_RTP_PACKET,
                 "failed to encrypted packet.\n{:02x?}\n{:02x?}",
                 out,
-                &rfc7714::PLAINTEXT_RTP_PACKET
+                rfc7714::PLAINTEXT_RTP_PACKET
             );
         }
 
@@ -1193,7 +1193,7 @@ mod test {
                 &rfc7714::PLAINTEXT_RTP_PACKET[12..],
                 "failed to decrypt packet.\n{:02x?}\n{:02x?}",
                 out,
-                &rfc7714::PLAINTEXT_RTP_PACKET
+                rfc7714::PLAINTEXT_RTP_PACKET
             );
         }
 
@@ -1401,7 +1401,7 @@ mod test {
                 rfc7714::PROTECTED_RTP_PACKET,
                 "failed to encrypted packet.\n{:02x?}\n{:02x?}",
                 out,
-                &rfc7714::PLAINTEXT_RTP_PACKET
+                rfc7714::PLAINTEXT_RTP_PACKET
             );
         }
 
@@ -1421,7 +1421,7 @@ mod test {
                 &rfc7714::PLAINTEXT_RTP_PACKET[12..],
                 "failed to decrypt packet.\n{:02x?}\n{:02x?}",
                 out,
-                &rfc7714::PLAINTEXT_RTP_PACKET
+                rfc7714::PLAINTEXT_RTP_PACKET
             );
         }
 

--- a/src/sdp/data.rs
+++ b/src/sdp/data.rs
@@ -1980,8 +1980,8 @@ f78dde68-7055-4e20-bb37-433803dd1ed1\r\n\
 
             let parsed = FormatParams::parse_line(&fmtp_str);
             assert!(parsed.stereo.is_none());
-            assert_eq!(parsed.stereo.unwrap_or(false), false);
-            assert_eq!(parsed.sprop_stereo.unwrap_or(false), false);
+            assert!(!parsed.stereo.unwrap_or(false));
+            assert!(!parsed.sprop_stereo.unwrap_or(false));
         }
     }
 

--- a/src/util/value_history.rs
+++ b/src/util/value_history.rs
@@ -56,7 +56,7 @@ where
     }
 }
 
-#[allow(clippy::unchecked_duration_subtraction)]
+#[allow(clippy::unchecked_time_subtraction)]
 #[cfg(test)]
 mod test {
     use std::time::{Duration, Instant};

--- a/tests/bwe/common.rs
+++ b/tests/bwe/common.rs
@@ -60,7 +60,7 @@ pub fn get_last_bwe_estimate(rtc: &TestRtc) -> Option<Bitrate> {
                 None
             }
         })
-        .last()
+        .next_back()
         .copied()
 }
 
@@ -74,6 +74,8 @@ pub struct BweTestContext {
     /// Accumulated byte budget for sending (smooths out timing variations)
     byte_budget: f64,
 }
+
+type ProbeCheck = Arc<dyn Fn(usize, &ProbeClusterConfig) -> bool>;
 
 #[derive(Clone)]
 pub enum Step {
@@ -100,7 +102,7 @@ pub enum Step {
     },
     CheckProbe {
         description: &'static str,
-        check: Arc<dyn Fn(usize, &ProbeClusterConfig) -> bool>,
+        check: ProbeCheck,
     },
     /// Assert no probes fired since last event_offset update
     AssertNoProbes { description: &'static str },

--- a/tests/bwe/simple.rs
+++ b/tests/bwe/simple.rs
@@ -99,7 +99,7 @@ pub fn bwe_wifi_normal() -> Result<(), RtcError> {
 
     let mut ctx = BweTestContext::new(&mut l, &mut r);
 
-    ctx.run_plan(&mut l, &mut r, &RAMP_UP_SINGLE)?;
+    ctx.run_plan(&mut l, &mut r, RAMP_UP_SINGLE)?;
 
     Ok(())
 }
@@ -120,7 +120,7 @@ pub fn bwe_wifi_congested() -> Result<(), RtcError> {
 
     let mut ctx = BweTestContext::new(&mut l, &mut r);
 
-    ctx.run_plan(&mut l, &mut r, &RAMP_UP_SINGLE)?;
+    ctx.run_plan(&mut l, &mut r, RAMP_UP_SINGLE)?;
 
     Ok(())
 }

--- a/tests/dtls-retransmit.rs
+++ b/tests/dtls-retransmit.rs
@@ -287,7 +287,7 @@ fn dtls_handshake_completes_under_packet_loss() {
     let lossy = NetemConfig::new()
         .loss(RandomLoss::new(Probability::new(0.3)))
         .seed(1);
-    l.set_netem(lossy.clone());
+    l.set_netem(lossy);
     r.set_netem(lossy);
 
     let host_l = Candidate::host((Ipv4Addr::new(1, 1, 1, 1), 1000).into(), "udp").unwrap();

--- a/tests/handshake-direct.rs
+++ b/tests/handshake-direct.rs
@@ -759,10 +759,8 @@ fn handle_event(
 ) {
     match event {
         Event::IceConnectionStateChange(ice_state) => match ice_state {
-            IceConnectionState::Checking => {
-                if timing.ice_checking.is_none() {
-                    timing.ice_checking = Some(Instant::now());
-                }
+            IceConnectionState::Checking if timing.ice_checking.is_none() => {
+                timing.ice_checking = Some(Instant::now());
             }
             IceConnectionState::Completed => {
                 timing.ice_completed = Some(Instant::now());

--- a/tests/handshake-direct.rs
+++ b/tests/handshake-direct.rs
@@ -207,8 +207,10 @@ fn run_direct_handshake(
                     &mut rtc,
                     false,
                     client_addr,
-                    remote_ice_ufrag,
-                    remote_ice_pwd,
+                    IceCreds {
+                        ufrag: remote_ice_ufrag,
+                        pass: remote_ice_pwd,
+                    },
                     remote_fingerprint,
                     snap.map(|(_, d)| d),
                     remote_sctp_init,
@@ -218,13 +220,15 @@ fn run_direct_handshake(
                 // Run the event loop with message exchange
                 run_rtc_loop_with_exchange(
                     &mut rtc,
-                    &span,
-                    &server_rx,
-                    &server_tx,
                     &mut timing,
                     false,
-                    &mut packets,
-                    &server_packets_sent_clone,
+                    RtcLoopIo {
+                        span: &span,
+                        incoming: &server_rx,
+                        outgoing: &server_tx,
+                        packets: &mut packets,
+                        packets_sent: &server_packets_sent_clone,
+                    },
                 )?;
 
                 timing.dtls_protocol_version = rtc.direct_api().dtls_protocol_version();
@@ -283,8 +287,10 @@ fn run_direct_handshake(
                     &mut rtc,
                     true,
                     server_addr,
-                    remote_ice_ufrag,
-                    remote_ice_pwd,
+                    IceCreds {
+                        ufrag: remote_ice_ufrag,
+                        pass: remote_ice_pwd,
+                    },
                     remote_fingerprint,
                     snap.map(|(_, d)| d),
                     remote_sctp_init,
@@ -294,13 +300,15 @@ fn run_direct_handshake(
                 // Run the event loop with message exchange
                 run_rtc_loop_with_exchange(
                     &mut rtc,
-                    &span,
-                    &client_rx,
-                    &client_tx,
                     &mut timing,
                     true,
-                    &mut packets,
-                    &client_packets_sent_clone,
+                    RtcLoopIo {
+                        span: &span,
+                        incoming: &client_rx,
+                        outgoing: &client_tx,
+                        packets: &mut packets,
+                        packets_sent: &client_packets_sent_clone,
+                    },
                 )?;
 
                 timing.dtls_protocol_version = rtc.direct_api().dtls_protocol_version();
@@ -449,8 +457,7 @@ fn configure_rtc(
     rtc: &mut Rtc,
     is_client: bool,
     remote_addr: SocketAddr,
-    remote_ice_ufrag: String,
-    remote_ice_pwd: String,
+    remote_ice_credentials: IceCreds,
     remote_fingerprint: String,
     local_init_data: Option<str0m::channel::SctpInitData>,
     remote_sctp_init: Option<Vec<u8>>,
@@ -473,10 +480,7 @@ fn configure_rtc(
         direct_api.set_ice_lite(!is_client);
         direct_api.set_ice_controlling(is_client);
 
-        direct_api.set_remote_ice_credentials(IceCreds {
-            ufrag: remote_ice_ufrag,
-            pass: remote_ice_pwd,
-        });
+        direct_api.set_remote_ice_credentials(remote_ice_credentials);
 
         let fingerprint: Fingerprint = remote_fingerprint
             .parse()
@@ -627,16 +631,20 @@ enum DataExchangeState {
     Complete,
 }
 
+struct RtcLoopIo<'a> {
+    span: &'a Span,
+    incoming: &'a Receiver<Message>,
+    outgoing: &'a Sender<Message>,
+    packets: &'a mut Vec<PcapPacket>,
+    packets_sent: &'a AtomicUsize,
+}
+
 /// Run the Rtc event loop with message exchange capability
 fn run_rtc_loop_with_exchange(
     rtc: &mut Rtc,
-    span: &Span,
-    incoming: &Receiver<Message>,
-    outgoing: &Sender<Message>,
     timing: &mut TimingReport,
     is_client: bool,
-    packets: &mut Vec<PcapPacket>,
-    packets_sent: &AtomicUsize,
+    io: RtcLoopIo<'_>,
 ) -> Result<(), RtcError> {
     let mut state = DataExchangeState::WaitingForChannelOpen;
     let mut channel_id: Option<ChannelId> = None;
@@ -653,20 +661,20 @@ fn run_rtc_loop_with_exchange(
         }
 
         let timeout = loop {
-            match span.in_scope(|| rtc.poll_output())? {
+            match io.span.in_scope(|| rtc.poll_output())? {
                 Output::Timeout(t) => break t,
                 Output::Transmit(t) => {
                     let data = t.contents.to_vec();
-                    packets_sent.fetch_add(1, Ordering::SeqCst);
+                    io.packets_sent.fetch_add(1, Ordering::SeqCst);
                     if SAVE_PCAP {
-                        packets.push(PcapPacket {
+                        io.packets.push(PcapPacket {
                             src: t.source,
                             dst: t.destination,
                             data: data.clone(),
                         });
                     }
                     // Send packet to other peer
-                    let _ = outgoing.send(Message::Packet {
+                    let _ = io.outgoing.send(Message::Packet {
                         proto: t.proto,
                         source: t.source,
                         destination: t.destination,
@@ -681,7 +689,7 @@ fn run_rtc_loop_with_exchange(
                         is_client,
                         &mut state,
                         &mut channel_id,
-                        outgoing,
+                        io.outgoing,
                     );
                     if state == DataExchangeState::Complete {
                         return Ok(());
@@ -694,7 +702,7 @@ fn run_rtc_loop_with_exchange(
         let wait = timeout.saturating_duration_since(now);
         println!("[{}] poll_output returned timeout in {:?}", role, wait);
 
-        match incoming.recv_timeout(wait) {
+        match io.incoming.recv_timeout(wait) {
             Ok(Message::Packet {
                 proto,
                 source,
@@ -703,7 +711,7 @@ fn run_rtc_loop_with_exchange(
             }) => {
                 println!("[{}] Received packet ({} bytes)", role, contents.len());
                 if SAVE_PCAP {
-                    packets.push(PcapPacket {
+                    io.packets.push(PcapPacket {
                         src: source,
                         dst: destination,
                         data: contents.clone(),
@@ -715,7 +723,8 @@ fn run_rtc_loop_with_exchange(
                     destination,
                     contents: contents.as_slice().try_into()?,
                 };
-                span.in_scope(|| rtc.handle_input(Input::Receive(Instant::now(), receive)))?;
+                io.span
+                    .in_scope(|| rtc.handle_input(Input::Receive(Instant::now(), receive)))?;
             }
             Ok(Message::Exit) => {
                 println!("[{}] Received Exit signal", role);
@@ -726,7 +735,8 @@ fn run_rtc_loop_with_exchange(
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {
                 println!("[{}] Timeout fired, calling handle_input(Timeout)", role);
-                span.in_scope(|| rtc.handle_input(Input::Timeout(Instant::now())))?;
+                io.span
+                    .in_scope(|| rtc.handle_input(Input::Timeout(Instant::now())))?;
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 println!("[{}] Channel disconnected", role);
@@ -858,13 +868,11 @@ fn write_pcap(path: &std::path::Path, packets: &[PcapPacket]) -> std::io::Result
         ip_header[8] = 64; // TTL
         ip_header[9] = 17; // protocol = UDP
         // checksum left as 0 (Wireshark will flag but still parse)
-        match pkt.src {
-            SocketAddr::V4(a) => ip_header[12..16].copy_from_slice(&a.ip().octets()),
-            _ => {}
+        if let SocketAddr::V4(a) = pkt.src {
+            ip_header[12..16].copy_from_slice(&a.ip().octets());
         }
-        match pkt.dst {
-            SocketAddr::V4(a) => ip_header[16..20].copy_from_slice(&a.ip().octets()),
-            _ => {}
+        if let SocketAddr::V4(a) = pkt.dst {
+            ip_header[16..20].copy_from_slice(&a.ip().octets());
         }
 
         // UDP header (8 bytes)

--- a/tests/ice-candidates.rs
+++ b/tests/ice-candidates.rs
@@ -518,7 +518,7 @@ fn ice_stun_max_retransmits() -> Result<(), RtcError> {
     // With max_retransmits=3, we should see limited retransmissions
     // The exact count depends on implementation details, but should be bounded
     // Key verification: count should be <= max_retransmits + 1 (initial + retransmits)
-    let expected_max = (max_retransmits + 1) as usize + 2; // +2 for timing tolerance
+    let expected_max = max_retransmits + 1 + 2; // +2 for timing tolerance
 
     assert!(
         transmit_count <= expected_max,

--- a/tests/keyframes.rs
+++ b/tests/keyframes.rs
@@ -418,9 +418,7 @@ pub fn test_h265_keyframes_detection() -> Result<(), RtcError> {
         .filter_map(|l| {
             let i = l.find("Seq=")?;
             let s = &l[i + 4..];
-            let end = s
-                .find(|c: char| !c.is_ascii_digit())
-                .unwrap_or_else(|| s.len());
+            let end = s.find(|c: char| !c.is_ascii_digit()).unwrap_or(s.len());
             s[..end].parse::<u16>().ok()
         })
         .collect();
@@ -523,9 +521,7 @@ pub fn test_h266_keyframes_detection() -> Result<(), RtcError> {
         .filter_map(|l| {
             let i = l.find("Seq=")?;
             let s = &l[i + 4..];
-            let end = s
-                .find(|c: char| !c.is_ascii_digit())
-                .unwrap_or_else(|| s.len());
+            let end = s.find(|c: char| !c.is_ascii_digit()).unwrap_or(s.len());
             s[..end].parse::<u16>().ok()
         })
         .collect();

--- a/tests/mediatime-backwards.rs
+++ b/tests/mediatime-backwards.rs
@@ -166,11 +166,9 @@ pub fn mediatime_backwards() -> Result<(), RtcError> {
                     problematic_ts = Some(header.timestamp);
                 }
             }
-            Event::StreamPaused(stream_paused) => {
-                if !stream_paused.paused {
-                    stream_unpaused_after_problematic = true;
-                    info!("Stream unpaused after receiving problematic packet");
-                }
+            Event::StreamPaused(stream_paused) if !stream_paused.paused => {
+                stream_unpaused_after_problematic = true;
+                info!("Stream unpaused after receiving problematic packet");
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary

Clean up the clippy warnings reported by `cargo clippy --all-targets`. All changes are in test code (unit tests under `src/` and integration tests under `tests/`); no production behavior changes.

- **`src/packet/vp9.rs`**: allow `clippy::erasing_op` and `clippy::identity_op` on `test_vp9_packet_unmarshal` so the fixture keeps its explicit bit-layout expressions (`N:0` etc.). Replace the hand-rolled `r0` counter loops with a range, and drop a redundant `& 0xFF` on a byte comparison.
- **`src/config.rs`**: construct the deliberately inverted MTU range with `RangeInclusive::new(1300, 1299)` to satisfy `reversed_empty_ranges` while keeping the expected-panic test.
- **`src/util/value_history.rs`**: the `unchecked_duration_subtraction` lint was renamed upstream; update the `allow` to `unchecked_time_subtraction`.
- **`tests/handshake-direct.rs`**: group the event-loop I/O handles into an `RtcLoopIo` struct and pass `IceCreds` directly to cut the argument count; use `if let` in `write_pcap`; collapse the ICE `Checking` arm into a match guard.
- **Elsewhere**: `repeat(x).take(n)` -> `repeat_n(x, n)`, `.last()` -> `.next_back()`, `&[x.clone()]` -> `slice::from_ref(&x)`, arrays instead of `vec!` for fixtures, and assorted needless borrows, casts, clones, `unwrap_or_else` -> `unwrap_or`, `assert_eq!(.., false)` -> `assert!(!..)`, a `Default` field reassign, a boxed `Fn` type alias, and a nested `if` folded into a match guard.

## Validation

- `cargo clippy --all-targets -- -D warnings` is clean on stable.
- `cargo test` passes.
- MSRV: `cargo msrv verify` and `cargo msrv verify -- cargo check --all-targets` pass on 1.85.0, and `cargo +1.85.0 test --tests` passes.
- `cargo fmt --all -- --check`
